### PR TITLE
Implement verified native webOS brightness writes

### DIFF
--- a/crates/lg-buddy/src/dev.rs
+++ b/crates/lg-buddy/src/dev.rs
@@ -5,7 +5,7 @@ use crate::web_os::{
     WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsBacklightBrightness,
     WebOsBacklightBrightnessError, WebOsClient, WebOsControlError, WebOsEndpoint,
     WebOsForegroundApp, WebOsForegroundAppError, WebOsInputId, WebOsInputIdError, WebOsPowerState,
-    WebOsPowerStateError, WebOsScreenControlError,
+    WebOsPowerStateError, WebOsScreenControlError, WebOsSetBacklightBrightnessError,
 };
 use std::error::Error;
 use std::fmt;
@@ -23,6 +23,7 @@ const WEBOS_CONTROL_PROBE_PREFIX: &str = "LG Buddy WebOS Control Probe";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WebOsControlProbeCommand {
     SetInput,
+    SetBacklight(WebOsBacklightBrightness),
     ScreenOff,
     ScreenOn,
     PowerOff,
@@ -50,6 +51,20 @@ impl DevCommand {
                 let operation = args.next().ok_or(DevParseError::MissingControlOperation)?;
                 let operation = match operation.as_ref() {
                     "set-input" => WebOsControlProbeCommand::SetInput,
+                    "set-backlight" => {
+                        let value = args
+                            .next()
+                            .ok_or(DevParseError::MissingBacklightBrightness)?;
+                        let value = value.as_ref();
+                        let brightness = value
+                            .parse::<u8>()
+                            .ok()
+                            .and_then(|value| WebOsBacklightBrightness::new(value).ok())
+                            .ok_or_else(|| {
+                                DevParseError::InvalidBacklightBrightness(value.to_string())
+                            })?;
+                        WebOsControlProbeCommand::SetBacklight(brightness)
+                    }
                     "screen-off" => WebOsControlProbeCommand::ScreenOff,
                     "screen-on" => WebOsControlProbeCommand::ScreenOn,
                     "power-off" => WebOsControlProbeCommand::PowerOff,
@@ -75,6 +90,9 @@ impl DevCommand {
             Self::WebOsControlProbe(WebOsControlProbeCommand::SetInput) => {
                 "dev webos-control-probe set-input"
             }
+            Self::WebOsControlProbe(WebOsControlProbeCommand::SetBacklight(_)) => {
+                "dev webos-control-probe set-backlight"
+            }
             Self::WebOsControlProbe(WebOsControlProbeCommand::ScreenOff) => {
                 "dev webos-control-probe screen-off"
             }
@@ -93,6 +111,8 @@ pub enum DevParseError {
     MissingSubcommand,
     UnknownSubcommand(String),
     MissingControlOperation,
+    MissingBacklightBrightness,
+    InvalidBacklightBrightness(String),
     UnknownControlOperation(String),
     UnexpectedArguments {
         command: DevCommand,
@@ -110,6 +130,13 @@ impl fmt::Display for DevParseError {
             Self::MissingControlOperation => {
                 write!(f, "missing temporary webOS control probe operation")
             }
+            Self::MissingBacklightBrightness => {
+                write!(f, "missing temporary webOS backlight brightness")
+            }
+            Self::InvalidBacklightBrightness(value) => write!(
+                f,
+                "invalid temporary webOS backlight brightness `{value}`; expected 0-100"
+            ),
             Self::UnknownControlOperation(operation) => {
                 write!(f, "unknown temporary webOS control operation `{operation}`")
             }
@@ -136,10 +163,12 @@ pub enum DevError {
     PowerState(WebOsPowerStateError),
     ForegroundApp(WebOsForegroundAppError),
     BacklightBrightness(WebOsBacklightBrightnessError),
+    SetBacklightBrightness(WebOsSetBacklightBrightnessError),
     InputId(WebOsInputIdError),
     Control(WebOsControlError),
     ScreenControl(WebOsScreenControlError),
     PowerOffPrecondition { actual: WebOsPowerState },
+    BacklightWritePrecondition { actual: WebOsPowerState },
 }
 
 impl fmt::Display for DevError {
@@ -164,6 +193,9 @@ impl fmt::Display for DevError {
             Self::BacklightBrightness(source) => {
                 write!(f, "webOS read probe backlight read failed: {source}")
             }
+            Self::SetBacklightBrightness(source) => {
+                write!(f, "webOS control probe backlight write failed: {source}")
+            }
             Self::InputId(source) => write!(f, "invalid configured webOS input: {source}"),
             Self::Control(source) => write!(f, "webOS control probe failed: {source}"),
             Self::ScreenControl(source) => {
@@ -172,6 +204,10 @@ impl fmt::Display for DevError {
             Self::PowerOffPrecondition { actual } => write!(
                 f,
                 "refusing webOS power-off probe from power state {actual}; expected Active"
+            ),
+            Self::BacklightWritePrecondition { actual } => write!(
+                f,
+                "refusing webOS backlight-write probe from power state {actual}; expected Active"
             ),
         }
     }
@@ -189,10 +225,11 @@ impl Error for DevError {
             Self::PowerState(source) => Some(source),
             Self::ForegroundApp(source) => Some(source),
             Self::BacklightBrightness(source) => Some(source),
+            Self::SetBacklightBrightness(source) => Some(source),
             Self::InputId(source) => Some(source),
             Self::Control(source) => Some(source),
             Self::ScreenControl(source) => Some(source),
-            Self::PowerOffPrecondition { .. } => None,
+            Self::PowerOffPrecondition { .. } | Self::BacklightWritePrecondition { .. } => None,
         }
     }
 }
@@ -206,6 +243,9 @@ pub(crate) fn run_dev_command<W: Write>(
         DevCommand::WebOsReadProbe => run_webos_read_probe(writer),
         DevCommand::WebOsControlProbe(WebOsControlProbeCommand::SetInput) => {
             run_webos_set_input_probe(writer)
+        }
+        DevCommand::WebOsControlProbe(WebOsControlProbeCommand::SetBacklight(brightness)) => {
+            run_webos_set_backlight_probe(writer, brightness)
         }
         DevCommand::WebOsControlProbe(
             operation @ (WebOsControlProbeCommand::ScreenOff | WebOsControlProbeCommand::ScreenOn),
@@ -313,7 +353,9 @@ fn run_webos_screen_control_probe<W: Write>(
             match operation {
                 WebOsControlProbeCommand::ScreenOff => client.turn_screen_off(),
                 WebOsControlProbeCommand::ScreenOn => client.turn_screen_on(),
-                WebOsControlProbeCommand::SetInput | WebOsControlProbeCommand::PowerOff => {
+                WebOsControlProbeCommand::SetInput
+                | WebOsControlProbeCommand::SetBacklight(_)
+                | WebOsControlProbeCommand::PowerOff => {
                     unreachable!("screen probe operation")
                 }
             }
@@ -344,11 +386,52 @@ fn run_webos_power_off_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
     })
 }
 
+fn run_webos_set_backlight_probe<W: Write>(
+    writer: &mut W,
+    brightness: WebOsBacklightBrightness,
+) -> Result<(), DevError> {
+    let config_path = resolve_config_path_from_env().map_err(DevError::ConfigPath)?;
+    let config = load_config(&config_path).map_err(DevError::Config)?;
+    let owner = resolve_config_owner(&config_path).map_err(DevError::ConfigOwner)?;
+    let context = WebOsProbeContext::new(&config_path, config.tv_ip, owner)?;
+
+    run_webos_set_backlight_probe_with(
+        writer,
+        &context,
+        brightness,
+        |endpoint, token_store, on_auth_event, brightness| {
+            let mut client = WebOsClient::connect_authenticated(
+                endpoint,
+                WEBOS_CONNECT_TIMEOUT,
+                WEBOS_RESPONSE_TIMEOUT,
+                token_store,
+                on_auth_event,
+            )
+            .map_err(DevError::Authentication)?;
+            let power_state = client.power_state().map_err(DevError::PowerState)?;
+            require_active_backlight_write_state(&power_state)?;
+            client
+                .set_backlight_brightness(brightness)
+                .map_err(DevError::SetBacklightBrightness)
+        },
+    )
+}
+
 fn require_active_power_state(power_state: &WebOsPowerState) -> Result<(), DevError> {
     if power_state == &WebOsPowerState::Active {
         Ok(())
     } else {
         Err(DevError::PowerOffPrecondition {
+            actual: power_state.clone(),
+        })
+    }
+}
+
+fn require_active_backlight_write_state(power_state: &WebOsPowerState) -> Result<(), DevError> {
+    if power_state == &WebOsPowerState::Active {
+        Ok(())
+    } else {
+        Err(DevError::BacklightWritePrecondition {
             actual: power_state.clone(),
         })
     }
@@ -457,6 +540,36 @@ where
         },
     )?;
     writeln!(writer, "{WEBOS_CONTROL_PROBE_PREFIX}: input={input_id}").map_err(DevError::Io)
+}
+
+fn run_webos_set_backlight_probe_with<W, F>(
+    writer: &mut W,
+    context: &WebOsProbeContext,
+    brightness: WebOsBacklightBrightness,
+    probe: F,
+) -> Result<(), DevError>
+where
+    W: Write,
+    F: FnOnce(
+        WebOsEndpoint,
+        &PlatformAccessTokenStore,
+        &mut dyn FnMut(WebOsAuthenticationEvent),
+        WebOsBacklightBrightness,
+    ) -> Result<(), DevError>,
+{
+    execute_webos_probe(
+        writer,
+        context,
+        WEBOS_CONTROL_PROBE_PREFIX,
+        |endpoint, token_store, on_auth_event| {
+            probe(endpoint, token_store, on_auth_event, brightness)
+        },
+    )?;
+    writeln!(
+        writer,
+        "{WEBOS_CONTROL_PROBE_PREFIX}: backlight={brightness}"
+    )
+    .map_err(DevError::Io)
 }
 
 fn run_webos_screen_control_probe_with<W, F>(
@@ -568,8 +681,9 @@ fn write_auth_event<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{
-        require_active_power_state, run_webos_auth_probe_with, run_webos_power_off_probe_with,
-        run_webos_read_probe_with, run_webos_screen_control_probe_with,
+        require_active_backlight_write_state, require_active_power_state,
+        run_webos_auth_probe_with, run_webos_power_off_probe_with, run_webos_read_probe_with,
+        run_webos_screen_control_probe_with, run_webos_set_backlight_probe_with,
         run_webos_set_input_probe_with, DevCommand, DevError, DevParseError,
         WebOsControlProbeCommand, WebOsProbeContext, WebOsReadProbeResult,
     };
@@ -604,6 +718,14 @@ mod tests {
             DevCommand::parse(["webos-control-probe", "set-input"]),
             Ok(DevCommand::WebOsControlProbe(
                 WebOsControlProbeCommand::SetInput
+            ))
+        );
+        assert_eq!(
+            DevCommand::parse(["webos-control-probe", "set-backlight", "75"]),
+            Ok(DevCommand::WebOsControlProbe(
+                WebOsControlProbeCommand::SetBacklight(
+                    WebOsBacklightBrightness::new(75).expect("backlight brightness")
+                )
             ))
         );
         assert_eq!(
@@ -650,6 +772,16 @@ mod tests {
             DevCommand::parse(["webos-control-probe"]),
             Err(DevParseError::MissingControlOperation)
         );
+        assert_eq!(
+            DevCommand::parse(["webos-control-probe", "set-backlight"]),
+            Err(DevParseError::MissingBacklightBrightness)
+        );
+        for value in ["-1", "101", "bright"] {
+            assert_eq!(
+                DevCommand::parse(["webos-control-probe", "set-backlight", value]),
+                Err(DevParseError::InvalidBacklightBrightness(value.to_string()))
+            );
+        }
         assert_eq!(
             DevCommand::parse(["webos-control-probe", "other"]),
             Err(DevParseError::UnknownControlOperation("other".to_string()))
@@ -734,7 +866,8 @@ LG Buddy WebOS Auth Probe: power_state=Active Standby\n"
                 Ok(WebOsReadProbeResult {
                     power_state: WebOsPowerState::Active,
                     foreground_app: WebOsForegroundApp::from_test_app_id("com.webos.app.hdmi3"),
-                    backlight_brightness: WebOsBacklightBrightness::from_test_percent(100),
+                    backlight_brightness: WebOsBacklightBrightness::new(100)
+                        .expect("test backlight brightness"),
                 })
             },
         )
@@ -776,6 +909,36 @@ LG Buddy WebOS Read Probe: backlight=100\n"
             String::from_utf8(output).expect("UTF-8 output"),
             "LG Buddy WebOS Control Probe: using stored access token.\n\
 LG Buddy WebOS Control Probe: input=HDMI_3\n"
+        );
+    }
+
+    #[test]
+    fn set_backlight_probe_reports_verified_brightness_after_success() {
+        let context = probe_context();
+        let brightness = WebOsBacklightBrightness::new(75).expect("backlight brightness");
+        let mut output = Vec::new();
+
+        run_webos_set_backlight_probe_with(
+            &mut output,
+            &context,
+            brightness,
+            |endpoint, token_store, on_auth_event, observed_brightness| {
+                assert_eq!(endpoint.to_string(), "wss://192.0.2.42:3001/");
+                assert_eq!(
+                    token_store.token_path(),
+                    Path::new("/tmp/lg-buddy-dev-probe/tvs/primary/access-token.json")
+                );
+                assert_eq!(observed_brightness, brightness);
+                on_auth_event(WebOsAuthenticationEvent::UsingStoredAccessToken);
+                Ok(())
+            },
+        )
+        .expect("run set-backlight probe");
+
+        assert_eq!(
+            String::from_utf8(output).expect("UTF-8 output"),
+            "LG Buddy WebOS Control Probe: using stored access token.\n\
+LG Buddy WebOS Control Probe: backlight=75\n"
         );
     }
 
@@ -844,6 +1007,20 @@ LG Buddy WebOS Control Probe: power_off_from=Active\n"
         assert!(matches!(
             error,
             DevError::PowerOffPrecondition {
+                actual: WebOsPowerState::ScreenOff
+            }
+        ));
+    }
+
+    #[test]
+    fn backlight_write_probe_requires_active_power_state() {
+        assert!(require_active_backlight_write_state(&WebOsPowerState::Active).is_ok());
+
+        let error = require_active_backlight_write_state(&WebOsPowerState::ScreenOff)
+            .expect_err("screen-off TV should not accept the backlight-write probe");
+        assert!(matches!(
+            error,
+            DevError::BacklightWritePrecondition {
                 actual: WebOsPowerState::ScreenOff
             }
         ));

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -20,7 +20,10 @@ pub use client::{
 };
 pub use control::WebOsControlError;
 pub use input::{WebOsForegroundApp, WebOsForegroundAppError, WebOsInputId, WebOsInputIdError};
-pub use picture::{WebOsBacklightBrightness, WebOsBacklightBrightnessError};
+pub use picture::{
+    WebOsBacklightBrightness, WebOsBacklightBrightnessError, WebOsBacklightBrightnessValueError,
+    WebOsSetBacklightBrightnessError,
+};
 pub use power::{WebOsPowerState, WebOsPowerStateError};
 pub use screen::WebOsScreenControlError;
 

--- a/crates/lg-buddy/src/web_os/observed_behavior.rs
+++ b/crates/lg-buddy/src/web_os/observed_behavior.rs
@@ -1,7 +1,8 @@
-use super::test_support::{WebOsTestInput, WebOsTestServer};
+use super::test_support::{WebOsTestInput, WebOsTestScenario, WebOsTestServer};
 use super::{
-    WebOsAuthenticatedClientError, WebOsClientError, WebOsClientRegistrationError,
-    WebOsControlError, WebOsInputId, WebOsPowerState, WebOsScreenControlError,
+    WebOsAuthenticatedClientError, WebOsBacklightBrightness, WebOsClientError,
+    WebOsClientRegistrationError, WebOsControlError, WebOsInputId, WebOsPowerState,
+    WebOsScreenControlError, WebOsSetBacklightBrightnessError,
 };
 use crate::platform_access_token::PlatformAccessTokenAcquisitionError;
 use serde_json::json;
@@ -77,6 +78,58 @@ fn input_switch_changes_the_observed_foreground_app_and_picture_state() {
         90
     );
     assert_eq!(server.snapshot().input, WebOsTestInput::Hdmi2);
+
+    drop(client);
+    server.finish();
+}
+
+// Real-TV wire observation:
+// https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
+#[test]
+fn backlight_write_is_acknowledged_and_verified_through_independent_readback() {
+    let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+    let mut client = server
+        .connect_authenticated()
+        .expect("connect to observed webOS TV");
+    let requested = WebOsBacklightBrightness::new(75).expect("backlight brightness");
+
+    assert_eq!(
+        client
+            .backlight_brightness()
+            .expect("read initial backlight brightness")
+            .as_percent(),
+        90
+    );
+    client
+        .set_backlight_brightness(requested)
+        .expect("set and verify backlight brightness");
+    assert_eq!(
+        client
+            .backlight_brightness()
+            .expect("read resulting backlight brightness"),
+        requested
+    );
+
+    drop(client);
+    server.finish();
+}
+
+// Synthetic fault injection: the real TV applied the observed acknowledged write,
+// but callers must still detect a device that acknowledges without changing state.
+#[test]
+fn acknowledged_backlight_write_with_unchanged_state_is_typed_failure() {
+    let server =
+        WebOsTestServer::for_scenario(WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange);
+    let mut client = server
+        .connect_authenticated()
+        .expect("connect to synthetic unchanged-state TV");
+    let expected = WebOsBacklightBrightness::new(75).expect("backlight brightness");
+
+    assert!(matches!(
+        client.set_backlight_brightness(expected),
+        Err(WebOsSetBacklightBrightnessError::NotApplied { expected: error_expected, actual })
+            if error_expected == expected && actual.as_percent() == 100
+    ));
 
     drop(client);
     server.finish();

--- a/crates/lg-buddy/src/web_os/picture.rs
+++ b/crates/lg-buddy/src/web_os/picture.rs
@@ -1,22 +1,31 @@
-use super::{WebOsClient, WebOsClientError};
-use serde_json::{json, Value};
+use super::control::send_control_request;
+use super::{WebOsClient, WebOsClientError, WebOsControlError};
+use serde_json::{json, Map, Value};
 use std::error::Error;
 use std::fmt;
+use std::thread;
+use std::time::Duration;
 
 const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
-const MAX_BACKLIGHT_BRIGHTNESS: u64 = 100;
+const SET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/setSystemSettings";
+const SET_SYSTEM_SETTINGS_METHOD: &str = "setSystemSettings";
+const MAX_BACKLIGHT_BRIGHTNESS: u8 = 100;
+const BACKLIGHT_WRITE_READBACK_DELAY: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WebOsBacklightBrightness(u8);
 
 impl WebOsBacklightBrightness {
-    pub fn as_percent(self) -> u8 {
-        self.0
+    pub fn new(value: u8) -> Result<Self, WebOsBacklightBrightnessValueError> {
+        if value <= MAX_BACKLIGHT_BRIGHTNESS {
+            Ok(Self(value))
+        } else {
+            Err(WebOsBacklightBrightnessValueError { value })
+        }
     }
 
-    #[cfg(test)]
-    pub(crate) fn from_test_percent(value: u8) -> Self {
-        Self(value)
+    pub fn as_percent(self) -> u8 {
+        self.0
     }
 }
 
@@ -25,6 +34,23 @@ impl fmt::Display for WebOsBacklightBrightness {
         write!(f, "{}", self.0)
     }
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WebOsBacklightBrightnessValueError {
+    value: u8,
+}
+
+impl fmt::Display for WebOsBacklightBrightnessValueError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "webOS backlight brightness `{}` is outside 0-{MAX_BACKLIGHT_BRIGHTNESS}",
+            self.value
+        )
+    }
+}
+
+impl Error for WebOsBacklightBrightnessValueError {}
 
 #[derive(Debug)]
 pub enum WebOsBacklightBrightnessError {
@@ -121,6 +147,67 @@ impl Error for WebOsBacklightBrightnessError {
     }
 }
 
+#[derive(Debug)]
+pub enum WebOsSetBacklightBrightnessError {
+    Control {
+        source: WebOsControlError,
+    },
+    MissingMethod,
+    InvalidMethod,
+    UnexpectedMethod {
+        method: String,
+    },
+    Readback {
+        expected: WebOsBacklightBrightness,
+        source: WebOsBacklightBrightnessError,
+    },
+    NotApplied {
+        expected: WebOsBacklightBrightness,
+        actual: WebOsBacklightBrightness,
+    },
+}
+
+impl fmt::Display for WebOsSetBacklightBrightnessError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Control { source } => {
+                write!(f, "could not set webOS backlight brightness: {source}")
+            }
+            Self::MissingMethod => {
+                write!(f, "webOS backlight-write response has no method")
+            }
+            Self::InvalidMethod => {
+                write!(f, "webOS backlight-write response method is not a string")
+            }
+            Self::UnexpectedMethod { method } => write!(
+                f,
+                "webOS backlight-write response method `{method}` is not `{SET_SYSTEM_SETTINGS_METHOD}`"
+            ),
+            Self::Readback { expected, source } => write!(
+                f,
+                "webOS acknowledged backlight brightness {expected}, but verification failed: {source}"
+            ),
+            Self::NotApplied { expected, actual } => write!(
+                f,
+                "webOS acknowledged backlight brightness {expected}, but readback was {actual}"
+            ),
+        }
+    }
+}
+
+impl Error for WebOsSetBacklightBrightnessError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Control { source } => Some(source),
+            Self::Readback { source, .. } => Some(source),
+            Self::MissingMethod
+            | Self::InvalidMethod
+            | Self::UnexpectedMethod { .. }
+            | Self::NotApplied { .. } => None,
+        }
+    }
+}
+
 impl WebOsClient {
     pub fn backlight_brightness(
         &mut self,
@@ -135,6 +222,51 @@ impl WebOsClient {
             )
             .map_err(|source| WebOsBacklightBrightnessError::Request { source })?;
         parse_backlight_brightness_response(&response)
+    }
+
+    pub fn set_backlight_brightness(
+        &mut self,
+        brightness: WebOsBacklightBrightness,
+    ) -> Result<(), WebOsSetBacklightBrightnessError> {
+        let payload = send_control_request(
+            self,
+            SET_SYSTEM_SETTINGS_URI,
+            json!({
+                "category": "picture",
+                "settings": {"backlight": brightness.as_percent()},
+            }),
+        )
+        .map_err(|source| WebOsSetBacklightBrightnessError::Control { source })?;
+        validate_backlight_write_acknowledgement(&payload)?;
+
+        thread::sleep(BACKLIGHT_WRITE_READBACK_DELAY);
+        let actual = self.backlight_brightness().map_err(|source| {
+            WebOsSetBacklightBrightnessError::Readback {
+                expected: brightness,
+                source,
+            }
+        })?;
+        if actual != brightness {
+            return Err(WebOsSetBacklightBrightnessError::NotApplied {
+                expected: brightness,
+                actual,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+fn validate_backlight_write_acknowledgement(
+    payload: &Map<String, Value>,
+) -> Result<(), WebOsSetBacklightBrightnessError> {
+    match payload.get("method") {
+        Some(Value::String(method)) if method == SET_SYSTEM_SETTINGS_METHOD => Ok(()),
+        Some(Value::String(method)) => Err(WebOsSetBacklightBrightnessError::UnexpectedMethod {
+            method: method.clone(),
+        }),
+        Some(_) => Err(WebOsSetBacklightBrightnessError::InvalidMethod),
+        None => Err(WebOsSetBacklightBrightnessError::MissingMethod),
     }
 }
 
@@ -203,7 +335,7 @@ fn normalize_backlight_brightness(value: &Value) -> Result<u8, WebOsBacklightBri
             })
         }
     };
-    if !(0.0..=MAX_BACKLIGHT_BRIGHTNESS as f64).contains(&normalized) {
+    if !(0.0..=f64::from(MAX_BACKLIGHT_BRIGHTNESS)).contains(&normalized) {
         return Err(WebOsBacklightBrightnessError::BacklightOutOfRange {
             value: value.clone(),
         });
@@ -216,9 +348,60 @@ fn normalize_backlight_brightness(value: &Value) -> Result<u8, WebOsBacklightBri
 mod tests {
     use super::{
         normalize_backlight_brightness, parse_backlight_brightness_response,
-        WebOsBacklightBrightnessError,
+        validate_backlight_write_acknowledgement, WebOsBacklightBrightness,
+        WebOsBacklightBrightnessError, WebOsSetBacklightBrightnessError,
     };
     use serde_json::{json, Value};
+
+    #[test]
+    fn backlight_brightness_rejects_values_above_one_hundred() {
+        assert_eq!(
+            WebOsBacklightBrightness::new(0)
+                .expect("minimum brightness")
+                .as_percent(),
+            0
+        );
+        assert_eq!(
+            WebOsBacklightBrightness::new(100)
+                .expect("maximum brightness")
+                .as_percent(),
+            100
+        );
+        assert!(WebOsBacklightBrightness::new(101).is_err());
+    }
+
+    #[test]
+    fn observed_backlight_write_acknowledgement_is_accepted() {
+        let payload = json!({"method": "setSystemSettings", "returnValue": true});
+        validate_backlight_write_acknowledgement(payload.as_object().expect("object payload"))
+            .expect("observed acknowledgement");
+    }
+
+    #[test]
+    fn malformed_backlight_write_acknowledgements_are_typed_errors() {
+        for (payload, expected) in [
+            (json!({}), WebOsSetBacklightBrightnessError::MissingMethod),
+            (
+                json!({"method": 7}),
+                WebOsSetBacklightBrightnessError::InvalidMethod,
+            ),
+            (
+                json!({"method": "other"}),
+                WebOsSetBacklightBrightnessError::UnexpectedMethod {
+                    method: "other".to_string(),
+                },
+            ),
+        ] {
+            let actual = validate_backlight_write_acknowledgement(
+                payload.as_object().expect("object payload"),
+            )
+            .expect_err("acknowledgement should be rejected");
+            assert_eq!(
+                std::mem::discriminant(&actual),
+                std::mem::discriminant(&expected)
+            );
+        }
+    }
 
     #[test]
     fn malformed_backlight_payloads_are_typed_errors() {

--- a/crates/lg-buddy/src/web_os/registration.rs
+++ b/crates/lg-buddy/src/web_os/registration.rs
@@ -6,8 +6,8 @@ use std::sync::OnceLock;
 
 const REGISTRATION_MESSAGE_TYPE: &str = "register";
 const PAIRING_PROMPT_TYPE: &str = "PROMPT";
-// Keep probe grants limited to operations confirmed by hardware characterization.
-// Expanding permissions may invalidate stored client keys and require re-pairing.
+// Keep grants limited to envelopes confirmed by hardware characterization.
+// Changing this manifest may invalidate stored client keys and require re-pairing.
 const REGISTRATION_MANIFEST_JSON: &str = include_str!("registration_manifest.json");
 
 static REGISTRATION_MANIFEST: OnceLock<Value> = OnceLock::new();
@@ -349,29 +349,58 @@ mod tests {
     }
 
     #[test]
-    fn registration_request_without_token_uses_minimal_unsigned_probe_manifest() {
+    fn registration_request_without_token_uses_observed_write_capable_manifest() {
         let request =
             WebOsRegistrationRequest::new(REQUEST_ID, None).expect("registration request");
         let value = request.to_json_value();
-        let expected_manifest = json!({
-            "manifestVersion": 1,
-            "permissions": [
-                "CONTROL_POWER",
-                "CONTROL_TV_SCREEN",
-                "LAUNCH",
-                "READ_POWER_STATE",
-                "READ_RUNNING_APPS",
-                "READ_SETTINGS"
-            ],
-        });
+        let manifest = registration_manifest();
 
         assert_eq!(value["type"], "register");
         assert_eq!(value["id"], REQUEST_ID);
         assert_eq!(value["payload"]["client-key"], Value::Null);
         assert_eq!(value["payload"]["forcePairing"], false);
         assert_eq!(value["payload"]["pairingType"], "PROMPT");
-        assert_eq!(registration_manifest(), &expected_manifest);
-        assert_eq!(value["payload"]["manifest"], expected_manifest);
+        assert_eq!(manifest["appVersion"], "1.1");
+        assert_eq!(manifest["manifestVersion"], 1);
+        assert_eq!(
+            manifest["permissions"],
+            json!([
+                "CONTROL_POWER",
+                "CONTROL_TV_SCREEN",
+                "LAUNCH",
+                "READ_POWER_STATE",
+                "READ_RUNNING_APPS",
+                "READ_SETTINGS"
+            ])
+        );
+        assert_eq!(manifest["signatures"][0]["signatureVersion"], 1);
+        assert!(manifest["signatures"][0]["signature"]
+            .as_str()
+            .is_some_and(|signature| !signature.is_empty()));
+        assert_eq!(manifest["signed"]["appId"], "com.lge.test");
+        assert_eq!(manifest["signed"]["vendorId"], "com.lge");
+        assert_eq!(
+            manifest["signed"]["permissions"],
+            json!([
+                "TEST_SECURE",
+                "CONTROL_INPUT_TEXT",
+                "CONTROL_MOUSE_AND_KEYBOARD",
+                "READ_INSTALLED_APPS",
+                "READ_LGE_SDX",
+                "READ_NOTIFICATIONS",
+                "SEARCH",
+                "WRITE_SETTINGS",
+                "WRITE_NOTIFICATION_ALERT",
+                "CONTROL_POWER",
+                "READ_CURRENT_CHANNEL",
+                "READ_RUNNING_APPS",
+                "READ_UPDATE_INFO",
+                "UPDATE_FROM_REMOTE_APP",
+                "READ_LGE_TV_INPUT_EVENTS",
+                "READ_TV_CURRENT_TIME"
+            ])
+        );
+        assert_eq!(value["payload"]["manifest"], *manifest);
         assert_eq!(
             serde_json::from_str::<Value>(&request.to_json_string())
                 .expect("serialized registration request"),

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -778,18 +778,15 @@ fn permission_set(value: &Value, description: &str) -> HashSet<String> {
         .collect()
 }
 
-// Real-TV observations show that this envelope shape authorizes WRITE_SETTINGS,
-// while a minimal signed permission does not. The TV accepted a tampered signature.
+// Real-TV observations show that this exact signed envelope authorizes WRITE_SETTINGS.
+// Mutating either its signed payload or signature removes that authorization.
 fn has_observed_write_settings_envelope(manifest: &serde_json::Map<String, Value>) -> bool {
-    let mut actual = json!({
+    let actual = json!({
         "appVersion": manifest.get("appVersion"),
         "signatures": manifest.get("signatures"),
         "signed": manifest.get("signed"),
     });
-    let mut expected = write_settings_signed_envelope().clone();
-    normalize_envelope_signatures(&mut actual);
-    normalize_envelope_signatures(&mut expected);
-    actual == expected
+    actual == *write_settings_signed_envelope()
 }
 
 fn write_settings_signed_envelope() -> &'static Value {
@@ -797,20 +794,6 @@ fn write_settings_signed_envelope() -> &'static Value {
         serde_json::from_str(include_str!("write_settings_signed_envelope.json"))
             .expect("parse observed WRITE_SETTINGS registration envelope")
     })
-}
-
-fn normalize_envelope_signatures(envelope: &mut Value) {
-    let Some(signatures) = envelope.get_mut("signatures").and_then(Value::as_array_mut) else {
-        return;
-    };
-    for signature in signatures {
-        if let Some(value) = signature
-            .as_object_mut()
-            .and_then(|signature| signature.get_mut("signature"))
-        {
-            *value = json!("<not-validated-by-tv>");
-        }
-    }
 }
 
 fn require_top_level_permission(permissions: &WebOsTestPermissions, permission: &str, uri: &str) {
@@ -993,7 +976,7 @@ mod tests {
     }
 
     // Real-TV wire observation:
-    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
     #[test]
     fn observed_write_settings_envelope_changes_backlight_to_numeric_state() {
         let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
@@ -1023,13 +1006,27 @@ mod tests {
         server.finish();
     }
 
-    // Real-TV wire observation: changing the signature text did not remove authorization.
-    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181933079
+    // Real-TV wire observation: mutating a byte inside the signature removed authorization.
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
     #[test]
-    fn tampered_observed_signature_still_authorizes_backlight_write() {
+    fn tampered_observed_signature_does_not_authorize_backlight_write() {
         let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
         let mut envelope = write_settings_signed_envelope().clone();
-        envelope["signatures"][0]["signature"] = json!("tampered-signature");
+        let signature = envelope["signatures"][0]["signature"]
+            .as_str()
+            .expect("observed signature");
+        let encoded_signature_start = signature.rfind('.').expect("signature separator") + 1;
+        let replacement = if signature.as_bytes()[encoded_signature_start] == b'A' {
+            "B"
+        } else {
+            "A"
+        };
+        let mut tampered_signature = signature.to_string();
+        tampered_signature.replace_range(
+            encoded_signature_start..=encoded_signature_start,
+            replacement,
+        );
+        envelope["signatures"][0]["signature"] = json!(tampered_signature);
         let mut socket = connect_registered(&server, &["READ_SETTINGS"], Some(envelope));
 
         assert_eq!(
@@ -1038,10 +1035,44 @@ mod tests {
                 "request_0",
                 SET_SYSTEM_SETTINGS_URI,
                 json!({"category": "picture", "settings": {"backlight": 75}}),
-            )["payload"],
-            json!({"method": "setSystemSettings", "returnValue": true})
+            ),
+            json!({
+                "id": "request_0",
+                "type": "error",
+                "error": "401 insufficient permissions",
+                "payload": {},
+            })
         );
-        assert_eq!(read_backlight(&mut socket, "request_1"), json!(75));
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!("90"));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // Real-TV wire observation: reducing the signed permission list removed authorization.
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
+    #[test]
+    fn reduced_observed_signed_permissions_do_not_authorize_backlight_write() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let mut envelope = write_settings_signed_envelope().clone();
+        envelope["signed"]["permissions"] = json!(["WRITE_SETTINGS"]);
+        let mut socket = connect_registered(&server, &["READ_SETTINGS"], Some(envelope));
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            ),
+            json!({
+                "id": "request_0",
+                "type": "error",
+                "error": "401 insufficient permissions",
+                "payload": {},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!("90"));
 
         drop(socket);
         server.finish();

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -17,7 +17,7 @@ use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 use tungstenite::error::ProtocolError;
@@ -35,6 +35,7 @@ const TEST_PRIVATE_KEY_DER: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIB
 const GET_FOREGROUND_APP_URI: &str = "ssap://com.webos.applicationManager/getForegroundAppInfo";
 const GET_POWER_STATE_URI: &str = "ssap://com.webos.service.tvpower/power/getPowerState";
 const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
+const SET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/setSystemSettings";
 const SET_INPUT_URI: &str = "ssap://tv/switchInput";
 const TURN_OFF_SCREEN_URI: &str = "ssap://com.webos.service.tvpower/power/turnOffScreen";
 const TURN_ON_SCREEN_URI: &str = "ssap://com.webos.service.tvpower/power/turnOnScreen";
@@ -43,6 +44,7 @@ const TURN_ON_SCREEN_LEGACY_URI: &str = "ssap://com.webos.service.tv.power/turnO
 const POWER_OFF_URI: &str = "ssap://system/turnOff";
 
 static TEST_DIR_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+static WRITE_SETTINGS_SIGNED_ENVELOPE: OnceLock<Value> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(in crate::web_os) enum WebOsTestScenario {
@@ -59,6 +61,7 @@ pub(in crate::web_os) enum WebOsTestScenario {
     RegistrationTimeout,
     RegistrationMissingClientKey,
     PowerStatePermissionDenied,
+    BacklightWriteAcknowledgedWithoutChange,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -110,6 +113,12 @@ struct WebOsTestTv {
     backlight: Value,
 }
 
+#[derive(Default)]
+struct WebOsTestPermissions {
+    top_level: HashSet<String>,
+    write_settings_authorized: bool,
+}
+
 impl WebOsTestTv {
     fn new(power_state: WebOsPowerState, input: WebOsTestInput) -> Self {
         Self {
@@ -119,7 +128,12 @@ impl WebOsTestTv {
         }
     }
 
-    fn handle_request(&mut self, request: &Value, permissions: &HashSet<String>) -> Value {
+    fn handle_request(
+        &mut self,
+        request: &Value,
+        permissions: &WebOsTestPermissions,
+        apply_backlight_write: bool,
+    ) -> Value {
         assert_eq!(request["type"], "request", "expected webOS request frame");
         let request_id = request["id"].as_str().expect("webOS request ID");
         let uri = request["uri"].as_str().expect("webOS request URI");
@@ -129,7 +143,7 @@ impl WebOsTestTv {
 
         match uri {
             GET_POWER_STATE_URI => {
-                require_permission(permissions, "READ_POWER_STATE", uri);
+                require_top_level_permission(permissions, "READ_POWER_STATE", uri);
                 assert_eq!(payload, &json!({}));
                 assert_ne!(self.power_state, WebOsPowerState::PowerOff);
                 response(
@@ -141,7 +155,7 @@ impl WebOsTestTv {
                 )
             }
             GET_FOREGROUND_APP_URI => {
-                if !permissions.contains("READ_RUNNING_APPS") {
+                if !permissions.top_level.contains("READ_RUNNING_APPS") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
                 assert_eq!(payload, &json!({}));
@@ -157,7 +171,7 @@ impl WebOsTestTv {
                 )
             }
             GET_SYSTEM_SETTINGS_URI => {
-                if !permissions.contains("READ_SETTINGS") {
+                if !permissions.top_level.contains("READ_SETTINGS") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
                 assert_eq!(
@@ -178,8 +192,32 @@ impl WebOsTestTv {
                     }),
                 )
             }
+            SET_SYSTEM_SETTINGS_URI => {
+                if !permissions.write_settings_authorized {
+                    return webos_error(request_id, "401 insufficient permissions", json!({}));
+                }
+                assert_eq!(self.power_state, WebOsPowerState::Active);
+                let backlight = payload["settings"]["backlight"]
+                    .as_u64()
+                    .expect("set-system-settings backlight value");
+                assert!(backlight <= 100, "backlight must be between 0 and 100");
+                assert_eq!(
+                    payload,
+                    &json!({
+                        "category": "picture",
+                        "settings": {"backlight": backlight},
+                    })
+                );
+                if apply_backlight_write {
+                    self.backlight = json!(backlight);
+                }
+                response(
+                    request_id,
+                    json!({"method": "setSystemSettings", "returnValue": true}),
+                )
+            }
             SET_INPUT_URI => {
-                if !permissions.contains("LAUNCH") {
+                if !permissions.top_level.contains("LAUNCH") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
                 assert_eq!(self.power_state, WebOsPowerState::Active);
@@ -192,7 +230,7 @@ impl WebOsTestTv {
                 response(request_id, json!({"returnValue": true}))
             }
             TURN_OFF_SCREEN_URI => {
-                if !permissions.contains("CONTROL_TV_SCREEN") {
+                if !permissions.top_level.contains("CONTROL_TV_SCREEN") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
                 assert_eq!(payload, &json!({"standbyMode": "active"}));
@@ -204,7 +242,7 @@ impl WebOsTestTv {
                 )
             }
             TURN_ON_SCREEN_URI => {
-                if !permissions.contains("CONTROL_TV_SCREEN") {
+                if !permissions.top_level.contains("CONTROL_TV_SCREEN") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
                 assert_eq!(payload, &json!({"standbyMode": "active"}));
@@ -233,7 +271,7 @@ impl WebOsTestTv {
                 webos_error(request_id, "404 no such service or method", json!({}))
             }
             POWER_OFF_URI => {
-                require_permission(permissions, "CONTROL_POWER", uri);
+                require_top_level_permission(permissions, "CONTROL_POWER", uri);
                 assert_eq!(payload, &json!({}));
                 assert_eq!(self.power_state, WebOsPowerState::Active);
                 self.power_state = WebOsPowerState::PowerOff;
@@ -465,7 +503,9 @@ fn serve_connection<S>(
 
         let scenario = runtime.lock().expect("webOS test server state").scenario;
         let keep_open = match scenario {
-            WebOsTestScenario::StatefulTv | WebOsTestScenario::PowerStatePermissionDenied => {
+            WebOsTestScenario::StatefulTv
+            | WebOsTestScenario::PowerStatePermissionDenied
+            | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange => {
                 let response = {
                     let mut runtime = runtime.lock().expect("webOS test server state");
                     if scenario == WebOsTestScenario::PowerStatePermissionDenied
@@ -481,6 +521,7 @@ fn serve_connection<S>(
                             permissions
                                 .as_ref()
                                 .expect("webOS request sent before registration"),
+                            scenario != WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
                         )
                     }
                 };
@@ -499,7 +540,7 @@ fn handle_registration<S>(
     socket: &mut WebSocket<S>,
     request: &Value,
     runtime: &Arc<Mutex<WebOsTestRuntime>>,
-    permissions: &mut Option<HashSet<String>>,
+    permissions: &mut Option<WebOsTestPermissions>,
 ) -> bool
 where
     S: Read + Write,
@@ -525,22 +566,22 @@ where
     let manifest = payload["manifest"]
         .as_object()
         .expect("registration manifest");
-    *permissions = Some(
-        manifest["permissions"]
-            .as_array()
-            .expect("registration permissions")
-            .iter()
-            .map(|value| {
-                value
-                    .as_str()
-                    .expect("registration permission string")
-                    .to_string()
-            })
-            .collect(),
+    let top_level = permission_set(
+        manifest
+            .get("permissions")
+            .expect("registration permissions"),
+        "registration permission",
     );
+    let write_settings_authorized = has_observed_write_settings_envelope(manifest);
+    *permissions = Some(WebOsTestPermissions {
+        top_level,
+        write_settings_authorized,
+    });
 
     match scenario {
-        WebOsTestScenario::StatefulTv | WebOsTestScenario::PowerStatePermissionDenied => {
+        WebOsTestScenario::StatefulTv
+        | WebOsTestScenario::PowerStatePermissionDenied
+        | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange => {
             match payload["client-key"].as_str() {
                 Some(token) => send_json(socket, registration_response(request_id, token)),
                 None if payload["client-key"].is_null() => {
@@ -663,7 +704,8 @@ where
         | WebOsTestScenario::PairingRejected
         | WebOsTestScenario::RegistrationTimeout
         | WebOsTestScenario::RegistrationMissingClientKey
-        | WebOsTestScenario::PowerStatePermissionDenied => {
+        | WebOsTestScenario::PowerStatePermissionDenied
+        | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange => {
             panic!("scenario `{scenario:?}` requires registered stateful handling")
         }
     }
@@ -722,9 +764,58 @@ fn test_tls_config() -> Arc<ServerConfig> {
     )
 }
 
-fn require_permission(permissions: &HashSet<String>, permission: &str, uri: &str) {
+fn permission_set(value: &Value, description: &str) -> HashSet<String> {
+    value
+        .as_array()
+        .unwrap_or_else(|| panic!("{description}s must be an array"))
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .unwrap_or_else(|| panic!("{description} must be a string"))
+                .to_string()
+        })
+        .collect()
+}
+
+// Real-TV observations show that this envelope shape authorizes WRITE_SETTINGS,
+// while a minimal signed permission does not. The TV accepted a tampered signature.
+fn has_observed_write_settings_envelope(manifest: &serde_json::Map<String, Value>) -> bool {
+    let mut actual = json!({
+        "appVersion": manifest.get("appVersion"),
+        "signatures": manifest.get("signatures"),
+        "signed": manifest.get("signed"),
+    });
+    let mut expected = write_settings_signed_envelope().clone();
+    normalize_envelope_signatures(&mut actual);
+    normalize_envelope_signatures(&mut expected);
+    actual == expected
+}
+
+fn write_settings_signed_envelope() -> &'static Value {
+    WRITE_SETTINGS_SIGNED_ENVELOPE.get_or_init(|| {
+        serde_json::from_str(include_str!("write_settings_signed_envelope.json"))
+            .expect("parse observed WRITE_SETTINGS registration envelope")
+    })
+}
+
+fn normalize_envelope_signatures(envelope: &mut Value) {
+    let Some(signatures) = envelope.get_mut("signatures").and_then(Value::as_array_mut) else {
+        return;
+    };
+    for signature in signatures {
+        if let Some(value) = signature
+            .as_object_mut()
+            .and_then(|signature| signature.get_mut("signature"))
+        {
+            *value = json!("<not-validated-by-tv>");
+        }
+    }
+}
+
+fn require_top_level_permission(permissions: &WebOsTestPermissions, permission: &str, uri: &str) {
     assert!(
-        permissions.contains(permission),
+        permissions.top_level.contains(permission),
         "no missing-permission observation exists for `{uri}`; expected `{permission}`"
     );
 }
@@ -811,5 +902,233 @@ impl TestAccessTokenStore {
 impl Drop for TestAccessTokenStore {
     fn drop(&mut self) {
         let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        write_settings_signed_envelope, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
+        GET_SYSTEM_SETTINGS_URI, SET_SYSTEM_SETTINGS_URI,
+    };
+    use serde_json::{json, Value};
+    use std::net::TcpStream;
+    use tungstenite::stream::MaybeTlsStream;
+    use tungstenite::{connect, Message, WebSocket};
+
+    type TestClient = WebSocket<MaybeTlsStream<TcpStream>>;
+
+    fn connect_registered(
+        server: &WebOsTestServer,
+        top_level_permissions: &[&str],
+        signed_envelope: Option<Value>,
+    ) -> TestClient {
+        let (mut socket, _) = connect(server.endpoint().to_string()).expect("connect test client");
+        let mut manifest = json!({
+            "manifestVersion": 1,
+            "permissions": top_level_permissions,
+        });
+        if let Some(Value::Object(envelope)) = signed_envelope {
+            manifest
+                .as_object_mut()
+                .expect("test registration manifest")
+                .extend(envelope);
+        }
+        socket
+            .send(Message::text(
+                json!({
+                    "id": "register_0",
+                    "type": "register",
+                    "payload": {
+                        "client-key": "test-client-key",
+                        "forcePairing": false,
+                        "manifest": manifest,
+                        "pairingType": "PROMPT",
+                    },
+                })
+                .to_string(),
+            ))
+            .expect("send test registration");
+        assert_eq!(
+            read_json(&mut socket),
+            json!({
+                "id": "register_0",
+                "type": "registered",
+                "payload": {"client-key": "test-client-key"},
+            })
+        );
+        socket
+    }
+
+    fn exchange(socket: &mut TestClient, request_id: &str, uri: &str, payload: Value) -> Value {
+        socket
+            .send(Message::text(
+                json!({
+                    "id": request_id,
+                    "type": "request",
+                    "uri": uri,
+                    "payload": payload,
+                })
+                .to_string(),
+            ))
+            .expect("send test request");
+        read_json(socket)
+    }
+
+    fn read_json(socket: &mut TestClient) -> Value {
+        match socket.read().expect("read test response") {
+            Message::Text(text) => serde_json::from_str(text.as_str()).expect("test response JSON"),
+            other => panic!("expected text response, got {other:?}"),
+        }
+    }
+
+    fn read_backlight(socket: &mut TestClient, request_id: &str) -> Value {
+        exchange(
+            socket,
+            request_id,
+            GET_SYSTEM_SETTINGS_URI,
+            json!({"category": "picture", "keys": ["backlight"]}),
+        )["payload"]["settings"]["backlight"]
+            .clone()
+    }
+
+    // Real-TV wire observation:
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
+    #[test]
+    fn observed_write_settings_envelope_changes_backlight_to_numeric_state() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let mut socket = connect_registered(
+            &server,
+            &["READ_SETTINGS"],
+            Some(write_settings_signed_envelope().clone()),
+        );
+
+        assert_eq!(read_backlight(&mut socket, "request_0"), json!("90"));
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_1",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            ),
+            json!({
+                "id": "request_1",
+                "type": "response",
+                "payload": {"method": "setSystemSettings", "returnValue": true},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_2"), json!(75));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // Real-TV wire observation: changing the signature text did not remove authorization.
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181933079
+    #[test]
+    fn tampered_observed_signature_still_authorizes_backlight_write() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let mut envelope = write_settings_signed_envelope().clone();
+        envelope["signatures"][0]["signature"] = json!("tampered-signature");
+        let mut socket = connect_registered(&server, &["READ_SETTINGS"], Some(envelope));
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            )["payload"],
+            json!({"method": "setSystemSettings", "returnValue": true})
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!(75));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // Real-TV wire observation:
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
+    #[test]
+    fn top_level_write_settings_permission_does_not_authorize_backlight_write() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let mut socket = connect_registered(&server, &["READ_SETTINGS", "WRITE_SETTINGS"], None);
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            ),
+            json!({
+                "id": "request_0",
+                "type": "error",
+                "error": "401 insufficient permissions",
+                "payload": {},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!("90"));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // Real-TV wire observation: a bare signed permission claim remained unauthorized.
+    // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181933079
+    #[test]
+    fn minimal_signed_write_settings_permission_does_not_authorize_backlight_write() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let mut socket = connect_registered(
+            &server,
+            &["READ_SETTINGS"],
+            Some(json!({"signed": {"permissions": ["WRITE_SETTINGS"]}})),
+        );
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            ),
+            json!({
+                "id": "request_0",
+                "type": "error",
+                "error": "401 insufficient permissions",
+                "payload": {},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!("90"));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // Synthetic fault injection for defensive readback verification.
+    #[test]
+    fn acknowledged_backlight_write_can_leave_state_unchanged() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
+        );
+        let mut socket = connect_registered(
+            &server,
+            &["READ_SETTINGS"],
+            Some(write_settings_signed_envelope().clone()),
+        );
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            )["payload"],
+            json!({"method": "setSystemSettings", "returnValue": true})
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!(100));
+
+        drop(socket);
+        server.finish();
     }
 }

--- a/crates/lg-buddy/src/web_os/test_support/write_settings_signed_envelope.json
+++ b/crates/lg-buddy/src/web_os/test_support/write_settings_signed_envelope.json
@@ -1,14 +1,5 @@
 {
   "appVersion": "1.1",
-  "manifestVersion": 1,
-  "permissions": [
-    "CONTROL_POWER",
-    "CONTROL_TV_SCREEN",
-    "LAUNCH",
-    "READ_POWER_STATE",
-    "READ_RUNNING_APPS",
-    "READ_SETTINGS"
-  ],
   "signatures": [
     {
       "signature": "eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbmctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRyaMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQojoa7NQnAtw==",

--- a/docs/webos-testing.md
+++ b/docs/webos-testing.md
@@ -44,6 +44,8 @@ scenarios.
 Its stateful TV behavior includes:
 
 - changing the foreground application after an input switch
+- changing picture backlight after an authorized write and exposing the numeric
+  result through a later read
 - moving between `Active` and `Screen Off`
 - moving to `Power Off` and rejecting an immediate new registration
 


### PR DESCRIPTION
## Summary

- implement native webOS backlight writes through `settings/setSystemSettings`
- verify every acknowledged write through an independent delayed readback and return typed failures when it was not applied
- add the observed signed registration envelope required for protected settings writes
- teach the centralized stateful webOS test server the hardware-observed success and authorization behavior
- expose a temporary `dev webos-control-probe` command for direct validation without changing production TV routing

## Real-TV evidence

Validated on webOSTV 23 firmware 23.25.55. The native Rust client changed backlight from 100 to 95 and restored it to 100, with independent readback after both writes. The existing access token remained valid and the TV did not request re-pairing.

The authorization experiments also established that the signed payload and signature are one atomic artifact: mutating the signature or reducing the signed permission list produces `401 insufficient permissions`. The broad signed list is therefore retained as the minimum verified envelope, not as a claim that LG Buddy uses every listed capability.

## Compatibility

Production TV operations continue to use bscpylgtv. Native adapter integration remains deferred to #58.

## Validation

- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo test -p lg-buddy --lib` (576 passed, 1 ignored)
- `cargo test -p lg-buddy --test cucumber` (54 scenarios, 628 steps)
- real-TV native write and readback characterization recorded on #52

Closes #52
