### PR TITLE
Integrate TV-bound native webOS adapter

### DIFF
--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -1,13 +1,11 @@
 use std::env;
 use std::io::{self, Write};
 use std::net::Ipv4Addr;
-use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 use std::process::Output;
 use std::time::Duration;
 
-use crate::auth::resolve_bscpylgtv_auth_context_from_env;
 use crate::config::{load_config, resolve_config_path_from_env, Config};
 use crate::events::RuntimeEvent;
 use crate::lifecycle::ThreadSleeper;
@@ -16,9 +14,7 @@ use crate::notifications::{FreedesktopNotifier, Notification, NotificationError,
 use crate::state::{
     ScreenOwnershipMarker, StateScope, SystemSleepAttemptState, SystemSleepCycleState,
 };
-use crate::tv::{
-    BscpylgtvCommandClient, OledBrightness, TvClient, TvDevice, UserScopedBscpylgtvCommandLauncher,
-};
+use crate::tv::{build_tv_client, OledBrightness, TvClient, TvClientBuildOptions, TvDevice};
 use crate::wol::UdpWakeOnLanSender;
 use crate::{BrightnessCommand, RunError, StartupMode};
 
@@ -261,8 +257,12 @@ pub fn run_sleep_pre_for_event<W: Write>(
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
     let cycle_state =
         SystemSleepCycleState::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client =
-        build_tv_client(&config_path)?.with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT);
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production()
+            .with_legacy_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
+    )?;
     let sleeper = ThreadSleeper;
 
     lifecycle::handle_system_suspend_with(
@@ -280,7 +280,11 @@ pub fn run_sleep<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(&config_path)?;
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production(),
+    )?;
     let detector = JournalctlSleepDetector::default();
     let sleeper = ThreadSleeper;
 
@@ -295,8 +299,12 @@ pub fn run_nm_pre_down<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
     let attempt_state =
         SystemSleepAttemptState::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client =
-        build_tv_client(&config_path)?.with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT);
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production()
+            .with_legacy_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
+    )?;
     let sleeper = ThreadSleeper;
     let mut bus = match crate::session_bus::new_system_bus_client() {
         Ok(bus) => bus,
@@ -339,7 +347,11 @@ pub fn run_brightness<W: Write>(
             run_brightness_prompt_with(writer, &config, deps)
         }
         BrightnessCommand::Get | BrightnessCommand::Set(_) => {
-            let tv_client = build_tv_client(&config_path)?;
+            let tv_client = build_tv_client(
+                &config_path,
+                config.tv_ip,
+                TvClientBuildOptions::production(),
+            )?;
             run_brightness_command_with(writer, &config, command, &tv_client)
         }
     }
@@ -349,7 +361,11 @@ pub fn run_startup<W: Write>(writer: &mut W, mode: StartupMode) -> Result<(), Ru
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(&config_path)?;
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production(),
+    )?;
     let wol_sender = UdpWakeOnLanSender::default();
     let sleeper = ThreadSleeper;
     let network_waiter = NmOnlineNetworkWaiter::default();
@@ -369,7 +385,11 @@ pub fn run_system_resume<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
     let attempt_state =
         SystemSleepAttemptState::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(&config_path)?;
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production(),
+    )?;
     let wol_sender = UdpWakeOnLanSender::default();
     let sleeper = ThreadSleeper;
     let network_waiter = NmOnlineNetworkWaiter::default();
@@ -435,7 +455,11 @@ fn fail_open_nm_pre_down_after_system_bus_error<W: Write, E: std::fmt::Display>(
 pub fn run_shutdown<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
-    let tv_client = build_tv_client(&config_path)?;
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production(),
+    )?;
     let reboot_detector = SystemctlRebootDetector::default();
 
     lifecycle::run_shutdown_with(writer, &config, &tv_client, &reboot_detector)
@@ -443,17 +467,6 @@ pub fn run_shutdown<W: Write>(writer: &mut W) -> Result<(), RunError> {
 
 pub fn run_screen_on<W: Write>(writer: &mut W) -> Result<(), RunError> {
     crate::screen::run_screen_on_from_env(writer)
-}
-
-fn build_tv_client(
-    config_path: &Path,
-) -> Result<BscpylgtvCommandClient<UserScopedBscpylgtvCommandLauncher>, RunError> {
-    let auth_context =
-        resolve_bscpylgtv_auth_context_from_env(config_path).map_err(RunError::AuthContext)?;
-
-    Ok(BscpylgtvCommandClient::from_env()
-        .with_auth_context(auth_context)
-        .with_launcher(UserScopedBscpylgtvCommandLauncher))
 }
 
 fn run_brightness_command_with<W: Write, C: TvClient>(
@@ -1837,7 +1850,11 @@ mod tests {
     }
 
     fn client_for_mock(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
-        BscpylgtvCommandClient::with_args(mock.command_path(), mock.command_args())
+        BscpylgtvCommandClient::with_args(
+            std::net::Ipv4Addr::new(192, 0, 2, 42),
+            mock.command_path(),
+            mock.command_args(),
+        )
     }
 
     fn assert_call_commands(mock: &MockBscpylgtv, expected: &[&str]) {

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -27,7 +27,6 @@ pub use dev::{DevCommand, DevError, DevParseError, WebOsControlProbeCommand};
 pub use sources::desktop::{gnome, swayidle};
 pub use sources::linux::{logind, network_manager};
 
-use crate::auth::AuthContextError;
 use crate::backend::{
     configured_backend_from_env_or_config, detect_backend_from_system, BackendDetectionError,
     BackendSelectionError,
@@ -42,7 +41,7 @@ use crate::notifications::NotificationError;
 use crate::session::runner::{run_lifecycle_monitor, run_monitor};
 use crate::settings::{run_settings_command, SettingsCommand, SettingsError, SettingsParseError};
 use crate::state::StateDirError;
-use crate::tv::{OledBrightness, OledBrightnessParseError};
+use crate::tv::{OledBrightness, OledBrightnessParseError, TvClientBuildError};
 use crate::updates::{run_updates_command, UpdatesCommand, UpdatesError, UpdatesParseError};
 use std::fmt;
 use std::io::{self, Write};
@@ -156,7 +155,7 @@ impl fmt::Display for ParseError {
 pub enum RunError {
     Io(io::Error),
     Policy(String),
-    AuthContext(AuthContextError),
+    TvClientBuild(TvClientBuildError),
     ConfigPath(ConfigPathError),
     Config(ConfigError),
     StateDir(StateDirError),
@@ -176,7 +175,7 @@ impl fmt::Display for RunError {
         match self {
             Self::Io(err) => write!(f, "{err}"),
             Self::Policy(err) => write!(f, "{err}"),
-            Self::AuthContext(err) => write!(f, "{err}"),
+            Self::TvClientBuild(err) => write!(f, "{err}"),
             Self::ConfigPath(err) => write!(f, "{err}"),
             Self::Config(err) => write!(f, "{err}"),
             Self::StateDir(err) => write!(f, "{err}"),
@@ -201,7 +200,7 @@ impl std::error::Error for RunError {
         match self {
             Self::Io(err) => Some(err),
             Self::Policy(_) => None,
-            Self::AuthContext(err) => Some(err),
+            Self::TvClientBuild(err) => Some(err),
             Self::ConfigPath(err) => Some(err),
             Self::Config(err) => Some(err),
             Self::StateDir(err) => Some(err),
@@ -218,6 +217,12 @@ impl std::error::Error for RunError {
 impl From<io::Error> for RunError {
     fn from(value: io::Error) -> Self {
         Self::Io(value)
+    }
+}
+
+impl From<TvClientBuildError> for RunError {
+    fn from(value: TvClientBuildError) -> Self {
+        Self::TvClientBuild(value)
     }
 }
 

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -2833,7 +2833,11 @@ mod tests {
     }
 
     fn client_for_mock(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
-        BscpylgtvCommandClient::with_args(mock.command_path(), mock.command_args())
+        BscpylgtvCommandClient::with_args(
+            std::net::Ipv4Addr::new(192, 0, 2, 42),
+            mock.command_path(),
+            mock.command_args(),
+        )
     }
 
     fn assert_call_commands(mock: &MockBscpylgtv, expected: &[&str]) {

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -1,10 +1,8 @@
 use std::env;
 use std::io::{self, Write};
-use std::path::Path;
 use std::thread;
 use std::time::Duration;
 
-use crate::auth::resolve_bscpylgtv_auth_context_from_env;
 use crate::config::{
     load_config, resolve_config_path_from_env, Config, HdmiInput, MacAddress, ScreenRestorePolicy,
 };
@@ -17,9 +15,7 @@ use crate::policy::{
 use crate::runtime_phase::NoopRuntimePhaseProvider;
 use crate::runtime_phase::{LogindRuntimePhaseProvider, RuntimePhaseProvider, RuntimePhaseRead};
 use crate::state::{ScreenOwnershipMarker, StateScope};
-use crate::tv::{
-    BscpylgtvCommandClient, CurrentInput, TvClient, TvDevice, UserScopedBscpylgtvCommandLauncher,
-};
+use crate::tv::{build_tv_client, CurrentInput, TvClient, TvClientBuildOptions, TvDevice};
 use crate::wol::{UdpWakeOnLanSender, WakeOnLanSender};
 use crate::RunError;
 
@@ -181,7 +177,11 @@ pub(crate) fn run_screen_off_from_env_for_event<W: Write>(
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker =
         ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(&config_path)?;
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production(),
+    )?;
     let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
     let lifecycle_status =
         SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
@@ -215,7 +215,11 @@ pub(crate) fn run_screen_on_from_env_for_event<W: Write>(
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker =
         ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(&config_path)?;
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        TvClientBuildOptions::production(),
+    )?;
     let wol_sender = UdpWakeOnLanSender::default();
     let sleeper = ThreadSleeper;
     let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
@@ -1105,17 +1109,6 @@ fn screen_on_retry_delay(attempt: u32) -> Duration {
     )
 }
 
-fn build_tv_client(
-    config_path: &Path,
-) -> Result<BscpylgtvCommandClient<UserScopedBscpylgtvCommandLauncher>, RunError> {
-    let auth_context =
-        resolve_bscpylgtv_auth_context_from_env(config_path).map_err(RunError::AuthContext)?;
-
-    Ok(BscpylgtvCommandClient::from_env()
-        .with_auth_context(auth_context)
-        .with_launcher(UserScopedBscpylgtvCommandLauncher))
-}
-
 #[cfg(test)]
 mod tests {
     mod support {
@@ -1641,7 +1634,11 @@ mod tests {
     }
 
     fn client_for_mock(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
-        BscpylgtvCommandClient::with_args(mock.command_path(), mock.command_args())
+        BscpylgtvCommandClient::with_args(
+            std::net::Ipv4Addr::new(192, 0, 2, 42),
+            mock.command_path(),
+            mock.command_args(),
+        )
     }
 
     fn assert_call_commands(mock: &MockBscpylgtv, expected: &[&str]) {

--- a/crates/lg-buddy/src/sources/linux/network_manager.rs
+++ b/crates/lg-buddy/src/sources/linux/network_manager.rs
@@ -532,7 +532,11 @@ mod tests {
     }
 
     fn client_for_mock(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
-        BscpylgtvCommandClient::with_args(mock.command_path(), mock.command_args())
+        BscpylgtvCommandClient::with_args(
+            std::net::Ipv4Addr::new(192, 0, 2, 42),
+            mock.command_path(),
+            mock.command_args(),
+        )
     }
 
     fn rendered(output: &[u8]) -> String {

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -10,34 +10,41 @@ use std::process::{Command, Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::auth::{BscpylgtvAuthContext, SystemUser};
+use crate::auth::{
+    resolve_bscpylgtv_auth_context_from_env, resolve_config_owner, AuthContextError,
+    BscpylgtvAuthContext, SystemUser,
+};
 use crate::config::{HdmiInput, MacAddress};
+use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
+use crate::web_os::{WebOsEndpoint, WebOsTvClient};
 use crate::wol::{WakeOnLanError, WakeOnLanSender};
 
 pub const DEFAULT_BSCPYLGTV_COMMAND_PATH: &str = "/usr/bin/LG_Buddy_PIP/bin/bscpylgtvcommand";
 pub const OLED_BRIGHTNESS_MIN: u8 = 0;
 pub const OLED_BRIGHTNESS_MAX: u8 = 100;
+const DEFAULT_WEBOS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+const DEFAULT_WEBOS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CommandOutput {
+struct CommandOutput {
     stdout: String,
     stderr: String,
 }
 
 impl CommandOutput {
-    pub fn new(stdout: String, stderr: String) -> Self {
+    fn new(stdout: String, stderr: String) -> Self {
         Self { stdout, stderr }
     }
 
-    pub fn stdout(&self) -> &str {
+    fn stdout(&self) -> &str {
         &self.stdout
     }
 
-    pub fn stderr(&self) -> &str {
+    fn stderr(&self) -> &str {
         &self.stderr
     }
 
-    pub fn combined_output(&self) -> String {
+    fn combined_output(&self) -> String {
         match (self.stdout.is_empty(), self.stderr.is_empty()) {
             (false, false) => format!("{}{}", self.stdout, self.stderr),
             (false, true) => self.stdout.clone(),
@@ -47,84 +54,89 @@ impl CommandOutput {
     }
 }
 
-#[derive(Debug)]
-pub enum TvError {
-    Io {
-        command: &'static str,
-        source: io::Error,
-    },
-    CommandFailed {
-        command: &'static str,
-        status: Option<i32>,
-        output: CommandOutput,
-    },
-    InvalidOutput {
-        command: &'static str,
-        output: CommandOutput,
-        message: &'static str,
-    },
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TvOperation {
+    ReadInput,
+    SetInput,
+    ReadOledBrightness,
+    SetOledBrightness,
+    PowerOff,
+    BlankScreen,
+    UnblankScreen,
+}
+
+impl TvOperation {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ReadInput => "read input",
+            Self::SetInput => "set input",
+            Self::ReadOledBrightness => "read OLED brightness",
+            Self::SetOledBrightness => "set OLED brightness",
+            Self::PowerOff => "power off",
+            Self::BlankScreen => "blank screen",
+            Self::UnblankScreen => "unblank screen",
+        }
+    }
+}
+
+impl fmt::Display for TvOperation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TvErrorKind {
+    Transport,
+    Authentication,
+    Rejected,
+    InvalidResponse,
+    ScreenUnblankSubstateMismatch,
+    Internal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TvError {
+    operation: TvOperation,
+    kind: TvErrorKind,
+    detail: String,
 }
 
 impl fmt::Display for TvError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Io { command, source } => {
-                write!(f, "failed to run `{command}`: {source}")
-            }
-            Self::CommandFailed {
-                command,
-                status,
-                output,
-            } => {
-                write!(
-                    f,
-                    "`{command}` failed with status {}",
-                    status
-                        .map(|code| code.to_string())
-                        .unwrap_or_else(|| "terminated by signal".to_string())
-                )?;
-
-                let combined = output.combined_output();
-                if !combined.trim().is_empty() {
-                    write!(f, ": {}", combined.trim_end())?;
-                }
-
-                Ok(())
-            }
-            Self::InvalidOutput {
-                command,
-                output,
-                message,
-            } => {
-                write!(f, "invalid output from `{command}`: {message}")?;
-                let combined = output.combined_output();
-                if !combined.trim().is_empty() {
-                    write!(f, ": {}", combined.trim_end())?;
-                }
-                Ok(())
-            }
-        }
+        write!(f, "could not {}: {}", self.operation, self.detail)
     }
 }
 
-impl Error for TvError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        match self {
-            Self::Io { source, .. } => Some(source),
-            Self::CommandFailed { .. } | Self::InvalidOutput { .. } => None,
-        }
-    }
-}
+impl Error for TvError {}
 
 impl TvError {
-    pub fn indicates_screen_unblank_substate_mismatch(&self) -> bool {
-        match self {
-            Self::CommandFailed { output, .. } | Self::InvalidOutput { output, .. } => {
-                output.stderr().contains("errorCode': '-102'")
-                    || output.stdout().contains("errorCode': '-102'")
-            }
-            Self::Io { .. } => false,
+    pub fn operation(&self) -> TvOperation {
+        self.operation
+    }
+
+    pub fn kind(&self) -> TvErrorKind {
+        self.kind
+    }
+
+    pub fn detail(&self) -> &str {
+        &self.detail
+    }
+
+    pub(crate) fn new(
+        operation: TvOperation,
+        kind: TvErrorKind,
+        detail: impl Into<String>,
+    ) -> Self {
+        Self {
+            operation,
+            kind,
+            detail: detail.into(),
         }
+    }
+
+    pub fn indicates_screen_unblank_substate_mismatch(&self) -> bool {
+        self.kind == TvErrorKind::ScreenUnblankSubstateMismatch
     }
 }
 
@@ -191,17 +203,159 @@ impl fmt::Display for OledBrightness {
 }
 
 pub trait TvClient {
-    fn get_input(&self, tv_ip: Ipv4Addr) -> Result<String, TvError>;
-    fn get_oled_brightness(&self, tv_ip: Ipv4Addr) -> Result<OledBrightness, TvError>;
-    fn set_input(&self, tv_ip: Ipv4Addr, input: HdmiInput) -> Result<CommandOutput, TvError>;
-    fn set_oled_brightness(
-        &self,
-        tv_ip: Ipv4Addr,
-        brightness: OledBrightness,
-    ) -> Result<CommandOutput, TvError>;
-    fn power_off(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError>;
-    fn turn_screen_off(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError>;
-    fn turn_screen_on(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError>;
+    fn current_input(&self) -> Result<CurrentInput, TvError>;
+    fn oled_brightness(&self) -> Result<OledBrightness, TvError>;
+    fn set_input(&self, input: HdmiInput) -> Result<(), TvError>;
+    fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError>;
+    fn power_off(&self) -> Result<(), TvError>;
+    fn blank_screen(&self) -> Result<(), TvError>;
+    fn unblank_screen(&self) -> Result<(), TvError>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TvClientImplementation {
+    Bscpylgtv,
+    WebOs,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct TvClientBuildOptions {
+    implementation: TvClientImplementation,
+    legacy_command_timeout: Option<Duration>,
+}
+
+impl TvClientBuildOptions {
+    pub(crate) fn production() -> Self {
+        Self {
+            implementation: TvClientImplementation::Bscpylgtv,
+            legacy_command_timeout: None,
+        }
+    }
+
+    pub(crate) fn with_legacy_command_timeout(mut self, timeout: Duration) -> Self {
+        self.legacy_command_timeout = Some(timeout);
+        self
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn webos() -> Self {
+        Self {
+            implementation: TvClientImplementation::WebOs,
+            legacy_command_timeout: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum TvClientBuildError {
+    AuthContext(AuthContextError),
+    TokenStore(PlatformAccessTokenStoreError),
+}
+
+impl fmt::Display for TvClientBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::AuthContext(error) => write!(f, "{error}"),
+            Self::TokenStore(error) => write!(f, "{error}"),
+        }
+    }
+}
+
+impl Error for TvClientBuildError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::AuthContext(error) => Some(error),
+            Self::TokenStore(error) => Some(error),
+        }
+    }
+}
+
+pub(crate) enum SelectedTvClient {
+    Bscpylgtv(BscpylgtvCommandClient<UserScopedBscpylgtvCommandLauncher>),
+    WebOs(Box<WebOsTvClient>),
+}
+
+impl TvClient for SelectedTvClient {
+    fn current_input(&self) -> Result<CurrentInput, TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.current_input(),
+            Self::WebOs(client) => client.current_input(),
+        }
+    }
+
+    fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.oled_brightness(),
+            Self::WebOs(client) => client.oled_brightness(),
+        }
+    }
+
+    fn set_input(&self, input: HdmiInput) -> Result<(), TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.set_input(input),
+            Self::WebOs(client) => client.set_input(input),
+        }
+    }
+
+    fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.set_oled_brightness(brightness),
+            Self::WebOs(client) => client.set_oled_brightness(brightness),
+        }
+    }
+
+    fn power_off(&self) -> Result<(), TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.power_off(),
+            Self::WebOs(client) => client.power_off(),
+        }
+    }
+
+    fn blank_screen(&self) -> Result<(), TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.blank_screen(),
+            Self::WebOs(client) => client.blank_screen(),
+        }
+    }
+
+    fn unblank_screen(&self) -> Result<(), TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.unblank_screen(),
+            Self::WebOs(client) => client.unblank_screen(),
+        }
+    }
+}
+
+pub(crate) fn build_tv_client(
+    config_path: &Path,
+    tv_ip: Ipv4Addr,
+    options: TvClientBuildOptions,
+) -> Result<SelectedTvClient, TvClientBuildError> {
+    match options.implementation {
+        TvClientImplementation::Bscpylgtv => {
+            let auth_context = resolve_bscpylgtv_auth_context_from_env(config_path)
+                .map_err(TvClientBuildError::AuthContext)?;
+            let mut client = BscpylgtvCommandClient::from_env(tv_ip)
+                .with_auth_context(auth_context)
+                .with_launcher(UserScopedBscpylgtvCommandLauncher);
+            if let Some(timeout) = options.legacy_command_timeout {
+                client = client.with_command_timeout(timeout);
+            }
+            Ok(SelectedTvClient::Bscpylgtv(client))
+        }
+        TvClientImplementation::WebOs => {
+            let owner =
+                resolve_config_owner(config_path).map_err(TvClientBuildError::AuthContext)?;
+            let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
+                .map_err(TvClientBuildError::TokenStore)?;
+            Ok(SelectedTvClient::WebOs(Box::new(WebOsTvClient::new(
+                WebOsEndpoint::wss(tv_ip),
+                DEFAULT_WEBOS_CONNECT_TIMEOUT,
+                DEFAULT_WEBOS_RESPONSE_TIMEOUT,
+                token_store,
+            ))))
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -248,21 +402,18 @@ impl<'a, C: TvClient> TvDevice<'a, C> {
     pub fn input(&self) -> TvInput<'a, C> {
         TvInput {
             client: self.client,
-            tv_ip: self.tv_ip,
         }
     }
 
     pub fn screen(&self) -> TvScreen<'a, C> {
         TvScreen {
             client: self.client,
-            tv_ip: self.tv_ip,
         }
     }
 
     pub fn picture(&self) -> TvPicture<'a, C> {
         TvPicture {
             client: self.client,
-            tv_ip: self.tv_ip,
         }
     }
 
@@ -277,53 +428,45 @@ impl<'a, C: TvClient> TvDevice<'a, C> {
 #[derive(Debug, Clone, Copy)]
 pub struct TvInput<'a, C> {
     client: &'a C,
-    tv_ip: Ipv4Addr,
 }
 
 impl<'a, C: TvClient> TvInput<'a, C> {
     pub fn current(&self) -> Result<CurrentInput, TvError> {
-        self.client
-            .get_input(self.tv_ip)
-            .map(CurrentInput::from_raw)
+        self.client.current_input()
     }
 
-    pub fn set(&self, input: HdmiInput) -> Result<CommandOutput, TvError> {
-        self.client.set_input(self.tv_ip, input)
+    pub fn set(&self, input: HdmiInput) -> Result<(), TvError> {
+        self.client.set_input(input)
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TvScreen<'a, C> {
     client: &'a C,
-    tv_ip: Ipv4Addr,
 }
 
 impl<'a, C: TvClient> TvScreen<'a, C> {
-    pub fn blank(&self) -> Result<CommandOutput, TvError> {
-        self.client.turn_screen_off(self.tv_ip)
+    pub fn blank(&self) -> Result<(), TvError> {
+        self.client.blank_screen()
     }
 
-    pub fn unblank(&self) -> Result<CommandOutput, TvError> {
-        self.client.turn_screen_on(self.tv_ip)
+    pub fn unblank(&self) -> Result<(), TvError> {
+        self.client.unblank_screen()
     }
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct TvPicture<'a, C> {
     client: &'a C,
-    tv_ip: Ipv4Addr,
 }
 
 impl<'a, C: TvClient> TvPicture<'a, C> {
     pub fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
-        self.client.get_oled_brightness(self.tv_ip)
+        self.client.oled_brightness()
     }
 
-    pub fn set_oled_brightness(
-        &self,
-        brightness: OledBrightness,
-    ) -> Result<CommandOutput, TvError> {
-        self.client.set_oled_brightness(self.tv_ip, brightness)
+    pub fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError> {
+        self.client.set_oled_brightness(brightness)
     }
 }
 
@@ -342,8 +485,8 @@ impl<'a, C: TvClient> TvPower<'a, C> {
         sender.send_magic_packet_to(tv_mac, self.tv_ip)
     }
 
-    pub fn off(&self) -> Result<CommandOutput, TvError> {
-        self.client.power_off(self.tv_ip)
+    pub fn off(&self) -> Result<(), TvError> {
+        self.client.power_off()
     }
 }
 
@@ -480,6 +623,7 @@ impl BscpylgtvCommandLauncher for UserScopedBscpylgtvCommandLauncher {
 
 #[derive(Debug)]
 pub struct BscpylgtvCommandClient<L = DirectBscpylgtvCommandLauncher> {
+    tv_ip: Ipv4Addr,
     command_path: PathBuf,
     command_args: Vec<String>,
     auth_context: BscpylgtvAuthContext,
@@ -487,15 +631,10 @@ pub struct BscpylgtvCommandClient<L = DirectBscpylgtvCommandLauncher> {
     command_timeout: Option<Duration>,
 }
 
-impl Default for BscpylgtvCommandClient<DirectBscpylgtvCommandLauncher> {
-    fn default() -> Self {
-        Self::new(DEFAULT_BSCPYLGTV_COMMAND_PATH)
-    }
-}
-
 impl BscpylgtvCommandClient<DirectBscpylgtvCommandLauncher> {
-    pub fn new(command_path: impl Into<PathBuf>) -> Self {
+    pub fn new(tv_ip: Ipv4Addr, command_path: impl Into<PathBuf>) -> Self {
         Self {
+            tv_ip,
             command_path: command_path.into(),
             command_args: Vec::new(),
             auth_context: BscpylgtvAuthContext::default(),
@@ -504,12 +643,17 @@ impl BscpylgtvCommandClient<DirectBscpylgtvCommandLauncher> {
         }
     }
 
-    pub fn with_args<I, S>(command_path: impl Into<PathBuf>, command_args: I) -> Self
+    pub fn with_args<I, S>(
+        tv_ip: Ipv4Addr,
+        command_path: impl Into<PathBuf>,
+        command_args: I,
+    ) -> Self
     where
         I: IntoIterator<Item = S>,
         S: Into<String>,
     {
         Self {
+            tv_ip,
             command_path: command_path.into(),
             command_args: command_args.into_iter().map(Into::into).collect(),
             auth_context: BscpylgtvAuthContext::default(),
@@ -518,10 +662,10 @@ impl BscpylgtvCommandClient<DirectBscpylgtvCommandLauncher> {
         }
     }
 
-    pub fn from_env() -> Self {
+    pub fn from_env(tv_ip: Ipv4Addr) -> Self {
         match env::var_os("LG_BUDDY_BSCPYLGTV_COMMAND") {
-            Some(path) => Self::new(PathBuf::from(path)),
-            None => Self::default(),
+            Some(path) => Self::new(tv_ip, PathBuf::from(path)),
+            None => Self::new(tv_ip, DEFAULT_BSCPYLGTV_COMMAND_PATH),
         }
     }
 }
@@ -529,6 +673,7 @@ impl BscpylgtvCommandClient<DirectBscpylgtvCommandLauncher> {
 impl<L> BscpylgtvCommandClient<L> {
     pub fn with_launcher<T>(self, launcher: T) -> BscpylgtvCommandClient<T> {
         BscpylgtvCommandClient {
+            tv_ip: self.tv_ip,
             command_path: self.command_path,
             command_args: self.command_args,
             auth_context: self.auth_context,
@@ -551,6 +696,10 @@ impl<L> BscpylgtvCommandClient<L> {
         &self.command_path
     }
 
+    pub fn tv_ip(&self) -> Ipv4Addr {
+        self.tv_ip
+    }
+
     pub fn command_args(&self) -> &[String] {
         &self.command_args
     }
@@ -561,7 +710,6 @@ impl<L> BscpylgtvCommandClient<L> {
 
     fn build_invocation(
         &self,
-        tv_ip: Ipv4Addr,
         operation: &'static str,
         extra_args: &[&str],
     ) -> BscpylgtvInvocation {
@@ -572,7 +720,7 @@ impl<L> BscpylgtvCommandClient<L> {
             args.push(key_file_path.to_string_lossy().into_owned());
         }
 
-        args.push(tv_ip.to_string());
+        args.push(self.tv_ip.to_string());
         args.push(operation.to_string());
         args.extend(extra_args.iter().map(|arg| arg.to_string()));
 
@@ -717,76 +865,124 @@ fn current_euid() -> u32 {
 impl<L: BscpylgtvCommandLauncher> BscpylgtvCommandClient<L> {
     fn run_command(
         &self,
-        tv_ip: Ipv4Addr,
+        tv_operation: TvOperation,
         operation: &'static str,
         extra_args: &[&str],
     ) -> Result<CommandOutput, TvError> {
-        let invocation = self.build_invocation(tv_ip, operation, extra_args);
-        let output = self
-            .launcher
-            .run(&invocation)
-            .map_err(|source| TvError::Io {
-                command: operation,
-                source,
-            })?;
+        let invocation = self.build_invocation(operation, extra_args);
+        let output = self.launcher.run(&invocation).map_err(|source| {
+            TvError::new(
+                tv_operation,
+                TvErrorKind::Transport,
+                format!("failed to run `{operation}`: {source}"),
+            )
+        })?;
 
         let rendered = CommandOutput::new(output.stdout().to_string(), output.stderr().to_string());
 
         if output.is_success() {
             Ok(rendered)
         } else {
-            Err(TvError::CommandFailed {
-                command: operation,
-                status: output.status(),
-                output: rendered,
-            })
+            let combined = rendered.combined_output();
+            let status = output
+                .status()
+                .map(|code| code.to_string())
+                .unwrap_or_else(|| "terminated by signal".to_string());
+            let mut detail = format!("`{operation}` failed with status {status}");
+            if !combined.trim().is_empty() {
+                detail.push_str(": ");
+                detail.push_str(combined.trim_end());
+            }
+            let kind = if tv_operation == TvOperation::UnblankScreen
+                && (rendered.stderr().contains("errorCode': '-102'")
+                    || rendered.stdout().contains("errorCode': '-102'"))
+            {
+                TvErrorKind::ScreenUnblankSubstateMismatch
+            } else {
+                TvErrorKind::Rejected
+            };
+            Err(TvError::new(tv_operation, kind, detail))
         }
     }
 }
 
 impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
-    fn get_input(&self, tv_ip: Ipv4Addr) -> Result<String, TvError> {
-        let output = self.run_command(tv_ip, "get_input", &[])?;
-        last_non_empty_line(output.stdout()).ok_or(TvError::InvalidOutput {
-            command: "get_input",
-            output,
-            message: "expected a non-empty line in stdout",
+    fn current_input(&self) -> Result<CurrentInput, TvError> {
+        let output = self.run_command(TvOperation::ReadInput, "get_input", &[])?;
+        last_non_empty_line(output.stdout())
+            .map(CurrentInput::from_raw)
+            .ok_or_else(|| {
+                TvError::new(
+                    TvOperation::ReadInput,
+                    TvErrorKind::InvalidResponse,
+                    invalid_command_output_detail(
+                        "get_input",
+                        &output,
+                        "expected a non-empty line in stdout",
+                    ),
+                )
+            })
+    }
+
+    fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
+        let output =
+            self.run_command(TvOperation::ReadOledBrightness, "get_picture_settings", &[])?;
+        parse_backlight(output.stdout()).ok_or_else(|| {
+            TvError::new(
+                TvOperation::ReadOledBrightness,
+                TvErrorKind::InvalidResponse,
+                invalid_command_output_detail(
+                    "get_picture_settings",
+                    &output,
+                    "expected a backlight value in stdout",
+                ),
+            )
         })
     }
 
-    fn get_oled_brightness(&self, tv_ip: Ipv4Addr) -> Result<OledBrightness, TvError> {
-        let output = self.run_command(tv_ip, "get_picture_settings", &[])?;
-        parse_backlight(output.stdout()).ok_or(TvError::InvalidOutput {
-            command: "get_picture_settings",
-            output,
-            message: "expected a backlight value in stdout",
-        })
+    fn set_input(&self, input: HdmiInput) -> Result<(), TvError> {
+        self.run_command(TvOperation::SetInput, "set_input", &[input.as_str()])
+            .map(|_| ())
     }
 
-    fn set_input(&self, tv_ip: Ipv4Addr, input: HdmiInput) -> Result<CommandOutput, TvError> {
-        self.run_command(tv_ip, "set_input", &[input.as_str()])
-    }
-
-    fn set_oled_brightness(
-        &self,
-        tv_ip: Ipv4Addr,
-        brightness: OledBrightness,
-    ) -> Result<CommandOutput, TvError> {
+    fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError> {
         let backlight = format!("{{\"backlight\": {brightness}}}");
-        self.run_command(tv_ip, "set_settings", &["picture", backlight.as_str()])
+        self.run_command(
+            TvOperation::SetOledBrightness,
+            "set_settings",
+            &["picture", backlight.as_str()],
+        )
+        .map(|_| ())
     }
 
-    fn power_off(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError> {
-        self.run_command(tv_ip, "power_off", &[])
+    fn power_off(&self) -> Result<(), TvError> {
+        self.run_command(TvOperation::PowerOff, "power_off", &[])
+            .map(|_| ())
     }
 
-    fn turn_screen_off(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError> {
-        self.run_command(tv_ip, "turn_screen_off", &[])
+    fn blank_screen(&self) -> Result<(), TvError> {
+        self.run_command(TvOperation::BlankScreen, "turn_screen_off", &[])
+            .map(|_| ())
     }
 
-    fn turn_screen_on(&self, tv_ip: Ipv4Addr) -> Result<CommandOutput, TvError> {
-        self.run_command(tv_ip, "turn_screen_on", &[])
+    fn unblank_screen(&self) -> Result<(), TvError> {
+        self.run_command(TvOperation::UnblankScreen, "turn_screen_on", &[])
+            .map(|_| ())
     }
+}
+
+fn invalid_command_output_detail(
+    command: &'static str,
+    output: &CommandOutput,
+    message: &'static str,
+) -> String {
+    let mut detail = format!("invalid output from `{command}`: {message}");
+    let combined = output.combined_output();
+    if !combined.trim().is_empty() {
+        detail.push_str(": ");
+        detail.push_str(combined.trim_end());
+    }
+    detail
 }
 
 fn last_non_empty_line(output: &str) -> Option<String> {
@@ -824,10 +1020,11 @@ mod tests {
     }
 
     use super::{
-        build_user_scoped_launch_plan, current_euid, BscpylgtvCommandClient,
+        build_tv_client, build_user_scoped_launch_plan, current_euid, BscpylgtvCommandClient,
         BscpylgtvCommandLauncher, BscpylgtvInvocation, BscpylgtvLaunchResult, CommandOutput,
-        CurrentInput, OledBrightness, TvClient, TvDevice, TvError,
-        UserScopedBscpylgtvCommandLauncher, UserScopedLaunchPlan, DEFAULT_BSCPYLGTV_COMMAND_PATH,
+        CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvClientBuildOptions, TvDevice,
+        TvErrorKind, TvOperation, UserScopedBscpylgtvCommandLauncher, UserScopedLaunchPlan,
+        DEFAULT_BSCPYLGTV_COMMAND_PATH,
     };
     use crate::auth::{BscpylgtvAuthContext, SystemUser};
     use crate::config::{HdmiInput, MacAddress};
@@ -838,7 +1035,7 @@ mod tests {
     use std::path::Path;
     use std::rc::Rc;
     use std::time::Duration;
-    use support::{ExecutableScript, MockBscpylgtv};
+    use support::{ExecutableScript, MockBscpylgtv, TestConfigFile};
 
     #[test]
     fn oled_brightness_accepts_boundary_values() {
@@ -865,7 +1062,8 @@ mod tests {
 
     #[test]
     fn default_client_uses_expected_command_path() {
-        let client = BscpylgtvCommandClient::default();
+        let client =
+            BscpylgtvCommandClient::new(ip("192.168.1.42"), DEFAULT_BSCPYLGTV_COMMAND_PATH);
         assert_eq!(
             client.command_path(),
             Path::new(DEFAULT_BSCPYLGTV_COMMAND_PATH)
@@ -881,16 +1079,29 @@ mod tests {
     }
 
     #[test]
+    fn centralized_factory_can_build_both_internal_implementations() {
+        let config = TestConfigFile::new("tv-client-factory");
+        config.write_sample("HDMI_2");
+        let tv_ip = ip("192.0.2.42");
+
+        let production = build_tv_client(config.path(), tv_ip, TvClientBuildOptions::production())
+            .expect("build production TV client");
+        assert!(matches!(production, SelectedTvClient::Bscpylgtv(_)));
+
+        let webos = build_tv_client(config.path(), tv_ip, TvClientBuildOptions::webos())
+            .expect("build internal webOS TV client");
+        assert!(matches!(webos, SelectedTvClient::WebOs(_)));
+    }
+
+    #[test]
     fn get_input_uses_last_non_empty_stdout_line() {
         let mock = MockBscpylgtv::new("tv-get-input");
         mock.queue_success("get_input", "\nignored\ncom.webos.app.hdmi2\n");
 
-        let client = client_for_mock(&mock);
-        let input = client
-            .get_input(ip("192.168.1.42"))
-            .expect("get_input should succeed");
+        let client = client_for_mock(&mock, ip("192.168.1.42"));
+        let input = client.current_input().expect("get_input should succeed");
 
-        assert_eq!(input, "com.webos.app.hdmi2");
+        assert_eq!(input, CurrentInput::Hdmi(HdmiInput::Hdmi2));
         assert_eq!(
             mock.calls()
                 .into_iter()
@@ -909,28 +1120,22 @@ mod tests {
         let mock = MockBscpylgtv::new("tv-get-input-empty");
         mock.queue_success("get_input", "");
 
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("192.168.1.42"));
         let err = client
-            .get_input(ip("192.168.1.42"))
+            .current_input()
             .expect_err("empty output should fail");
 
-        match err {
-            TvError::InvalidOutput {
-                command, message, ..
-            } => {
-                assert_eq!(command, "get_input");
-                assert_eq!(message, "expected a non-empty line in stdout");
-            }
-            other => panic!("expected invalid output error, got {other:?}"),
-        }
+        assert_eq!(err.operation(), TvOperation::ReadInput);
+        assert_eq!(err.kind(), TvErrorKind::InvalidResponse);
+        assert!(err.detail().contains("expected a non-empty line in stdout"));
     }
 
     #[test]
     fn set_input_passes_expected_arguments() {
         let mock = MockBscpylgtv::new("tv-set-input");
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.5"));
         client
-            .set_input(ip("10.0.0.5"), HdmiInput::Hdmi3)
+            .set_input(HdmiInput::Hdmi3)
             .expect("set_input should succeed");
 
         assert_eq!(
@@ -949,9 +1154,9 @@ mod tests {
     #[test]
     fn set_oled_brightness_passes_expected_arguments() {
         let mock = MockBscpylgtv::new("tv-set-brightness");
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.5"));
         client
-            .set_oled_brightness(ip("10.0.0.5"), brightness(65))
+            .set_oled_brightness(brightness(65))
             .expect("set_oled_brightness should succeed");
 
         assert_eq!(
@@ -972,10 +1177,10 @@ mod tests {
     fn get_oled_brightness_reads_backlight_from_picture_settings() {
         let mock = MockBscpylgtv::new("tv-get-brightness");
         mock.set_backlight(72);
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.5"));
 
         let brightness = client
-            .get_oled_brightness(ip("10.0.0.5"))
+            .oled_brightness()
             .expect("get_oled_brightness should succeed");
 
         assert_eq!(brightness.as_percent(), 72);
@@ -996,21 +1201,17 @@ mod tests {
     fn get_oled_brightness_rejects_missing_backlight_value() {
         let mock = MockBscpylgtv::new("tv-get-brightness-invalid");
         mock.queue_success("get_picture_settings", "{'contrast': 85}\n");
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.5"));
 
         let err = client
-            .get_oled_brightness(ip("10.0.0.5"))
+            .oled_brightness()
             .expect_err("missing backlight should fail");
 
-        match err {
-            TvError::InvalidOutput {
-                command, message, ..
-            } => {
-                assert_eq!(command, "get_picture_settings");
-                assert_eq!(message, "expected a backlight value in stdout");
-            }
-            other => panic!("expected invalid output error, got {other:?}"),
-        }
+        assert_eq!(err.operation(), TvOperation::ReadOledBrightness);
+        assert_eq!(err.kind(), TvErrorKind::InvalidResponse);
+        assert!(err
+            .detail()
+            .contains("expected a backlight value in stdout"));
     }
 
     #[test]
@@ -1018,7 +1219,7 @@ mod tests {
         let mock = MockBscpylgtv::new("tv-device-current-hdmi");
         mock.set_input("HDMI_4");
 
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.7"));
         let tv = TvDevice::new(&client, ip("10.0.0.7"));
         let current = tv.input().current().expect("current input should parse");
 
@@ -1030,7 +1231,7 @@ mod tests {
         let mock = MockBscpylgtv::new("tv-device-current-other");
         mock.queue_success("get_input", "com.webos.app.youtube\n");
 
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.9"));
         let tv = TvDevice::new(&client, ip("10.0.0.9"));
         let current = tv.input().current().expect("current input should parse");
 
@@ -1043,7 +1244,7 @@ mod tests {
     #[test]
     fn tv_screen_blank_uses_domain_facade() {
         let mock = MockBscpylgtv::new("tv-device-screen-blank");
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.11"));
         let tv = TvDevice::new(&client, ip("10.0.0.11"));
         tv.screen().blank().expect("screen blank should succeed");
 
@@ -1063,7 +1264,7 @@ mod tests {
     #[test]
     fn tv_picture_set_oled_brightness_uses_domain_facade() {
         let mock = MockBscpylgtv::new("tv-device-picture-brightness");
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.12"));
         let tv = TvDevice::new(&client, ip("10.0.0.12"));
         tv.picture()
             .set_oled_brightness(brightness(40))
@@ -1086,7 +1287,7 @@ mod tests {
     fn tv_picture_reads_oled_brightness_via_domain_facade() {
         let mock = MockBscpylgtv::new("tv-device-picture-read-brightness");
         mock.set_backlight(33);
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.13"));
         let tv = TvDevice::new(&client, ip("10.0.0.13"));
 
         let brightness = tv
@@ -1110,7 +1311,7 @@ mod tests {
 
     #[test]
     fn tv_power_wake_uses_wake_on_lan_sender() {
-        let client = BscpylgtvCommandClient::default();
+        let client = BscpylgtvCommandClient::new(ip("10.0.0.15"), DEFAULT_BSCPYLGTV_COMMAND_PATH);
         let tv = TvDevice::new(&client, ip("10.0.0.15"));
         let sender = RecordingWakeOnLanSender::default();
         let mac = parse_mac("01:23:45:67:89:ab");
@@ -1123,27 +1324,18 @@ mod tests {
     }
 
     #[test]
-    fn command_failures_preserve_status_and_output() {
+    fn command_failures_preserve_diagnostics_without_exposing_command_output() {
         let mock = MockBscpylgtv::new("tv-command-failure");
         mock.queue_error("turn_screen_on", 7, "failure stderr\n");
-        let client = client_for_mock(&mock);
+        let client = client_for_mock(&mock, ip("10.0.0.8"));
         let err = client
-            .turn_screen_on(ip("10.0.0.8"))
+            .unblank_screen()
             .expect_err("turn_screen_on should fail");
 
-        match err {
-            TvError::CommandFailed {
-                command,
-                status,
-                output,
-            } => {
-                assert_eq!(command, "turn_screen_on");
-                assert_eq!(status, Some(7));
-                assert_eq!(output.stdout(), "");
-                assert_eq!(output.stderr(), "failure stderr\n");
-            }
-            other => panic!("expected command failure, got {other:?}"),
-        }
+        assert_eq!(err.operation(), TvOperation::UnblankScreen);
+        assert_eq!(err.kind(), TvErrorKind::Rejected);
+        assert!(err.detail().contains("failed with status 7"));
+        assert!(err.detail().contains("failure stderr"));
     }
 
     #[test]
@@ -1153,38 +1345,30 @@ mod tests {
             "slow-bscpylgtvcommand",
             "#!/bin/sh\nsleep 5\n",
         );
-        let client = BscpylgtvCommandClient::new(script.path())
+        let client = BscpylgtvCommandClient::new(ip("10.0.0.8"), script.path())
             .with_command_timeout(Duration::from_millis(100));
 
         let err = client
-            .get_input(ip("10.0.0.8"))
+            .current_input()
             .expect_err("slow command should time out");
 
-        match err {
-            TvError::Io { command, source } => {
-                assert_eq!(command, "get_input");
-                assert_eq!(source.kind(), io::ErrorKind::TimedOut);
-                assert!(
-                    source.to_string().contains("timed out after"),
-                    "io error was: {source}"
-                );
-            }
-            other => panic!("expected timeout io error, got {other:?}"),
-        }
+        assert_eq!(err.operation(), TvOperation::ReadInput);
+        assert_eq!(err.kind(), TvErrorKind::Transport);
+        assert!(err.detail().contains("timed out after"));
     }
 
     #[test]
     fn invocation_places_key_file_override_before_tv_ip() {
         let auth_context =
             BscpylgtvAuthContext::new().with_key_file_path("/tmp/lg-buddy/.aiopylgtv.sqlite");
-        let client = BscpylgtvCommandClient::with_args("/usr/bin/mock-bscpylgtv", ["--verbose"])
-            .with_auth_context(auth_context);
-
-        let invocation = client.build_invocation(
+        let client = BscpylgtvCommandClient::with_args(
             ip("192.168.1.42"),
-            "set_input",
-            &[HdmiInput::Hdmi2.as_str()],
-        );
+            "/usr/bin/mock-bscpylgtv",
+            ["--verbose"],
+        )
+        .with_auth_context(auth_context);
+
+        let invocation = client.build_invocation("set_input", &[HdmiInput::Hdmi2.as_str()]);
 
         assert_eq!(invocation.program(), Path::new("/usr/bin/mock-bscpylgtv"));
         assert_eq!(
@@ -1207,12 +1391,12 @@ mod tests {
         let auth_context = BscpylgtvAuthContext::new()
             .with_owner(SystemUser::new("vas", 1000, 1000, "/home/vas"))
             .with_key_file_path("/home/vas/.local/state/lg-buddy/.aiopylgtv.sqlite");
-        let client = BscpylgtvCommandClient::new("/usr/bin/mock-bscpylgtv")
+        let client = BscpylgtvCommandClient::new(ip("10.0.0.8"), "/usr/bin/mock-bscpylgtv")
             .with_auth_context(auth_context)
             .with_launcher(launcher.clone());
 
         client
-            .turn_screen_on(ip("10.0.0.8"))
+            .unblank_screen()
             .expect("custom launcher should succeed");
 
         assert_eq!(
@@ -1233,13 +1417,11 @@ mod tests {
     #[test]
     fn command_timeout_is_attached_to_launcher_invocation() {
         let launcher = RecordingLauncher::default();
-        let client = BscpylgtvCommandClient::new("/usr/bin/mock-bscpylgtv")
+        let client = BscpylgtvCommandClient::new(ip("10.0.0.8"), "/usr/bin/mock-bscpylgtv")
             .with_command_timeout(Duration::from_secs(3))
             .with_launcher(launcher.clone());
 
-        client
-            .power_off(ip("10.0.0.8"))
-            .expect("custom launcher should succeed");
+        client.power_off().expect("custom launcher should succeed");
 
         let calls = launcher.calls();
         assert_eq!(calls.len(), 1);
@@ -1248,26 +1430,22 @@ mod tests {
 
     #[test]
     fn direct_launcher_rejects_user_switch_requests_without_an_explicit_launcher() {
-        let client = BscpylgtvCommandClient::new("/usr/bin/mock-bscpylgtv").with_auth_context(
-            BscpylgtvAuthContext::new().with_owner(SystemUser::new("vas", 1000, 1000, "/home/vas")),
-        );
+        let client = BscpylgtvCommandClient::new(ip("10.0.0.8"), "/usr/bin/mock-bscpylgtv")
+            .with_auth_context(BscpylgtvAuthContext::new().with_owner(SystemUser::new(
+                "vas",
+                1000,
+                1000,
+                "/home/vas",
+            )));
         let err = client
-            .turn_screen_on(ip("10.0.0.8"))
+            .unblank_screen()
             .expect_err("direct launcher should reject owner-user requests");
 
-        match err {
-            TvError::Io { command, source } => {
-                assert_eq!(command, "turn_screen_on");
-                assert_eq!(source.kind(), io::ErrorKind::Unsupported);
-                assert!(
-                    source
-                        .to_string()
-                        .contains("cannot run `bscpylgtvcommand` as user `vas`"),
-                    "io error was: {source}"
-                );
-            }
-            other => panic!("expected io error, got {other:?}"),
-        }
+        assert_eq!(err.operation(), TvOperation::UnblankScreen);
+        assert_eq!(err.kind(), TvErrorKind::Transport);
+        assert!(err
+            .detail()
+            .contains("cannot run `bscpylgtvcommand` as user `vas`"));
     }
 
     #[test]
@@ -1455,8 +1633,8 @@ mod tests {
         value.parse().expect("parse mac address")
     }
 
-    fn client_for_mock(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
-        BscpylgtvCommandClient::with_args(mock.command_path(), mock.command_args())
+    fn client_for_mock(mock: &MockBscpylgtv, tv_ip: Ipv4Addr) -> BscpylgtvCommandClient {
+        BscpylgtvCommandClient::with_args(tv_ip, mock.command_path(), mock.command_args())
     }
 
     #[derive(Default)]

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -1,0 +1,602 @@
+use super::{
+    WebOsAuthenticatedClientError, WebOsBacklightBrightness, WebOsBacklightBrightnessError,
+    WebOsClient, WebOsClientError, WebOsControlError, WebOsEndpoint, WebOsForegroundAppError,
+    WebOsPowerState, WebOsPowerStateError, WebOsScreenControlError,
+    WebOsSetBacklightBrightnessError,
+};
+use crate::platform_access_token::{PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore};
+use crate::tv::{CurrentInput, OledBrightness, TvClient, TvError, TvErrorKind, TvOperation};
+use serde_json::Value;
+use std::fmt;
+use std::sync::{Mutex, MutexGuard};
+use std::time::Duration;
+
+pub struct WebOsTvClient {
+    endpoint: WebOsEndpoint,
+    connect_timeout: Duration,
+    response_timeout: Duration,
+    token_store: PlatformAccessTokenStore,
+    session: Mutex<Option<WebOsClient>>,
+}
+
+impl WebOsTvClient {
+    pub fn new(
+        endpoint: WebOsEndpoint,
+        connect_timeout: Duration,
+        response_timeout: Duration,
+        token_store: PlatformAccessTokenStore,
+    ) -> Self {
+        Self {
+            endpoint,
+            connect_timeout,
+            response_timeout,
+            token_store,
+            session: Mutex::new(None),
+        }
+    }
+
+    fn with_session<T>(
+        &self,
+        operation: TvOperation,
+        action: impl FnOnce(&mut WebOsClient) -> Result<T, WebOsAdapterFailure>,
+    ) -> Result<T, TvError> {
+        let mut session = self.lock_session(operation)?;
+        self.ensure_session(operation, &mut session)?;
+
+        let result = action(
+            session
+                .as_mut()
+                .expect("webOS session was initialized before the operation"),
+        );
+        match result {
+            Ok(value) => Ok(value),
+            Err(failure) => {
+                if failure.invalidates_session {
+                    *session = None;
+                }
+                Err(failure.into_tv_error(operation))
+            }
+        }
+    }
+
+    fn lock_session(
+        &self,
+        operation: TvOperation,
+    ) -> Result<MutexGuard<'_, Option<WebOsClient>>, TvError> {
+        self.session.lock().map_err(|_| {
+            TvError::new(
+                operation,
+                TvErrorKind::Internal,
+                "webOS session lock is poisoned",
+            )
+        })
+    }
+
+    fn ensure_session(
+        &self,
+        operation: TvOperation,
+        session: &mut Option<WebOsClient>,
+    ) -> Result<(), TvError> {
+        if session.is_some() {
+            return Ok(());
+        }
+
+        let client = WebOsClient::connect_authenticated(
+            self.endpoint,
+            self.connect_timeout,
+            self.response_timeout,
+            &self.token_store,
+            |_| {},
+        )
+        .map_err(|error| authenticated_client_failure(error).into_tv_error(operation))?;
+        *session = Some(client);
+        Ok(())
+    }
+
+    fn power_off_active_session(&self) -> Result<(), TvError> {
+        let operation = TvOperation::PowerOff;
+        let mut session = self.lock_session(operation)?;
+        self.ensure_session(operation, &mut session)?;
+
+        let power_state = match session
+            .as_mut()
+            .expect("webOS session was initialized before the operation")
+            .power_state()
+        {
+            Ok(power_state) => power_state,
+            Err(error) => {
+                let failure = power_state_failure(error);
+                if failure.invalidates_session {
+                    *session = None;
+                }
+                return Err(failure.into_tv_error(operation));
+            }
+        };
+
+        if power_state != WebOsPowerState::Active {
+            return Err(TvError::new(
+                operation,
+                TvErrorKind::Rejected,
+                format!(
+                    "native webOS power-off requires power state `Active`, but the TV reported `{power_state}`"
+                ),
+            ));
+        }
+
+        let client = session
+            .take()
+            .expect("webOS session was initialized before power-off");
+        client
+            .power_off()
+            .map_err(|error| control_failure(error).into_tv_error(operation))
+    }
+}
+
+impl TvClient for WebOsTvClient {
+    fn current_input(&self) -> Result<CurrentInput, TvError> {
+        self.with_session(TvOperation::ReadInput, |client| {
+            client
+                .foreground_app()
+                .map(|app| CurrentInput::from_raw(app.app_id().to_string()))
+                .map_err(foreground_app_failure)
+        })
+    }
+
+    fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
+        self.with_session(TvOperation::ReadOledBrightness, |client| {
+            let brightness = client
+                .backlight_brightness()
+                .map_err(backlight_brightness_failure)?;
+            OledBrightness::new(brightness.as_percent()).map_err(|error| {
+                WebOsAdapterFailure::new(
+                    TvErrorKind::InvalidResponse,
+                    format!("native webOS returned invalid OLED brightness: {error}"),
+                    false,
+                )
+            })
+        })
+    }
+
+    fn set_input(&self, input: crate::config::HdmiInput) -> Result<(), TvError> {
+        let input_id = super::WebOsInputId::new(input.as_str()).map_err(|error| {
+            TvError::new(
+                TvOperation::SetInput,
+                TvErrorKind::Internal,
+                format!("could not map configured input to webOS: {error}"),
+            )
+        })?;
+        self.with_session(TvOperation::SetInput, |client| {
+            client.switch_input(&input_id).map_err(control_failure)
+        })
+    }
+
+    fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError> {
+        let webos_brightness =
+            WebOsBacklightBrightness::new(brightness.as_percent()).map_err(|error| {
+                TvError::new(
+                    TvOperation::SetOledBrightness,
+                    TvErrorKind::Internal,
+                    format!("could not map OLED brightness to webOS: {error}"),
+                )
+            })?;
+        self.with_session(TvOperation::SetOledBrightness, |client| {
+            client
+                .set_backlight_brightness(webos_brightness)
+                .map_err(set_backlight_brightness_failure)
+        })
+    }
+
+    fn power_off(&self) -> Result<(), TvError> {
+        self.power_off_active_session()
+    }
+
+    fn blank_screen(&self) -> Result<(), TvError> {
+        self.with_session(TvOperation::BlankScreen, |client| {
+            client
+                .turn_screen_off()
+                .map(|_| ())
+                .map_err(screen_control_failure)
+        })
+    }
+
+    fn unblank_screen(&self) -> Result<(), TvError> {
+        self.with_session(TvOperation::UnblankScreen, |client| {
+            client.turn_screen_on().map(|_| ()).map_err(|error| {
+                if screen_unblank_substate_mismatch(&error) {
+                    WebOsAdapterFailure::new(
+                        TvErrorKind::ScreenUnblankSubstateMismatch,
+                        error.to_string(),
+                        false,
+                    )
+                } else {
+                    screen_control_failure(error)
+                }
+            })
+        })
+    }
+}
+
+struct WebOsAdapterFailure {
+    kind: TvErrorKind,
+    detail: String,
+    invalidates_session: bool,
+}
+
+impl WebOsAdapterFailure {
+    fn new(kind: TvErrorKind, detail: impl Into<String>, invalidates_session: bool) -> Self {
+        Self {
+            kind,
+            detail: detail.into(),
+            invalidates_session,
+        }
+    }
+
+    fn into_tv_error(self, operation: TvOperation) -> TvError {
+        TvError::new(operation, self.kind, self.detail)
+    }
+}
+
+fn authenticated_client_failure(error: WebOsAuthenticatedClientError) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsAuthenticatedClientError::Connect { source } => {
+            client_failure_with_detail(source, detail)
+        }
+        WebOsAuthenticatedClientError::Authentication { source } => match source {
+            PlatformAccessTokenAcquisitionError::Registration { source } => match source {
+                super::WebOsClientRegistrationError::Transport { source } => {
+                    client_failure_with_detail(source, detail)
+                }
+                super::WebOsClientRegistrationError::Protocol { .. }
+                | super::WebOsClientRegistrationError::StoredTokenRequiresPairing => {
+                    WebOsAdapterFailure::new(TvErrorKind::Authentication, detail, false)
+                }
+            },
+            PlatformAccessTokenAcquisitionError::Store { .. } => {
+                WebOsAdapterFailure::new(TvErrorKind::Authentication, detail, false)
+            }
+        },
+    }
+}
+
+fn client_failure_with_detail(
+    error: WebOsClientError,
+    detail: impl Into<String>,
+) -> WebOsAdapterFailure {
+    let detail = detail.into();
+    match error {
+        WebOsClientError::WebOs { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
+        }
+        WebOsClientError::InvalidTimeout { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Internal, detail, false)
+        }
+        WebOsClientError::MalformedJson { .. }
+        | WebOsClientError::InvalidFrameRoot
+        | WebOsClientError::MissingResponseId
+        | WebOsClientError::InvalidResponseId
+        | WebOsClientError::MissingMessageType
+        | WebOsClientError::InvalidMessageType
+        | WebOsClientError::MissingWebOsErrorMessage
+        | WebOsClientError::InvalidWebOsErrorMessage
+        | WebOsClientError::UnexpectedBinaryFrame
+        | WebOsClientError::UnexpectedRawFrame => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, true)
+        }
+        WebOsClientError::Connect { .. }
+        | WebOsClientError::ConfigureSocket { .. }
+        | WebOsClientError::Handshake { .. }
+        | WebOsClientError::HandshakeInterrupted
+        | WebOsClientError::RequestIdExhausted
+        | WebOsClientError::Send { .. }
+        | WebOsClientError::Timeout { .. }
+        | WebOsClientError::ConnectionClosed { .. }
+        | WebOsClientError::Receive { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Transport, detail, true)
+        }
+    }
+}
+
+fn foreground_app_failure(error: WebOsForegroundAppError) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsForegroundAppError::Request { source } => client_failure_with_detail(source, detail),
+        WebOsForegroundAppError::RequestRejected { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
+        }
+        WebOsForegroundAppError::MissingPayload
+        | WebOsForegroundAppError::InvalidPayload
+        | WebOsForegroundAppError::MissingReturnValue
+        | WebOsForegroundAppError::InvalidReturnValue
+        | WebOsForegroundAppError::MissingAppId
+        | WebOsForegroundAppError::InvalidAppId
+        | WebOsForegroundAppError::EmptyAppId => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
+        }
+    }
+}
+
+fn power_state_failure(error: WebOsPowerStateError) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsPowerStateError::Request { source } => client_failure_with_detail(source, detail),
+        WebOsPowerStateError::RequestRejected { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
+        }
+        WebOsPowerStateError::MissingPayload
+        | WebOsPowerStateError::InvalidPayload
+        | WebOsPowerStateError::MissingReturnValue
+        | WebOsPowerStateError::InvalidReturnValue
+        | WebOsPowerStateError::MissingState
+        | WebOsPowerStateError::InvalidState
+        | WebOsPowerStateError::EmptyState => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
+        }
+    }
+}
+
+fn control_failure(error: WebOsControlError) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsControlError::Request { source } => client_failure_with_detail(source, detail),
+        WebOsControlError::RequestRejected { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
+        }
+        WebOsControlError::MissingPayload
+        | WebOsControlError::InvalidPayload
+        | WebOsControlError::MissingReturnValue
+        | WebOsControlError::InvalidReturnValue => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
+        }
+    }
+}
+
+fn screen_control_failure(error: WebOsScreenControlError) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsScreenControlError::Control { source } => {
+            let mut failure = control_failure(source);
+            failure.detail = detail;
+            failure
+        }
+        WebOsScreenControlError::MissingState
+        | WebOsScreenControlError::InvalidState
+        | WebOsScreenControlError::EmptyState => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
+        }
+    }
+}
+
+fn backlight_brightness_failure(error: WebOsBacklightBrightnessError) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsBacklightBrightnessError::Request { source } => {
+            client_failure_with_detail(source, detail)
+        }
+        WebOsBacklightBrightnessError::RequestRejected { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
+        }
+        WebOsBacklightBrightnessError::MissingPayload
+        | WebOsBacklightBrightnessError::InvalidPayload
+        | WebOsBacklightBrightnessError::MissingReturnValue
+        | WebOsBacklightBrightnessError::InvalidReturnValue
+        | WebOsBacklightBrightnessError::MissingSettings
+        | WebOsBacklightBrightnessError::InvalidSettings
+        | WebOsBacklightBrightnessError::MissingBacklight
+        | WebOsBacklightBrightnessError::InvalidBacklight { .. }
+        | WebOsBacklightBrightnessError::BacklightOutOfRange { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
+        }
+    }
+}
+
+fn set_backlight_brightness_failure(
+    error: WebOsSetBacklightBrightnessError,
+) -> WebOsAdapterFailure {
+    let detail = error.to_string();
+    match error {
+        WebOsSetBacklightBrightnessError::Control { source } => {
+            let mut failure = control_failure(source);
+            failure.detail = detail;
+            failure
+        }
+        WebOsSetBacklightBrightnessError::Readback { source, .. } => {
+            let mut failure = backlight_brightness_failure(source);
+            failure.detail = detail;
+            failure
+        }
+        WebOsSetBacklightBrightnessError::NotApplied { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
+        }
+        WebOsSetBacklightBrightnessError::MissingMethod
+        | WebOsSetBacklightBrightnessError::InvalidMethod
+        | WebOsSetBacklightBrightnessError::UnexpectedMethod { .. } => {
+            WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
+        }
+    }
+}
+
+fn screen_unblank_substate_mismatch(error: &WebOsScreenControlError) -> bool {
+    let WebOsScreenControlError::Control { source } = error else {
+        return false;
+    };
+    match source {
+        WebOsControlError::Request {
+            source:
+                WebOsClientError::WebOs {
+                    payload: Some(payload),
+                    ..
+                },
+        }
+        | WebOsControlError::RequestRejected { payload, .. } => payload_error_code(payload) == -102,
+        _ => false,
+    }
+}
+
+fn payload_error_code(payload: &Value) -> i64 {
+    payload
+        .get("errorCode")
+        .and_then(|value| match value {
+            Value::Number(number) => number.as_i64(),
+            Value::String(value) => value.parse::<i64>().ok(),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+impl fmt::Debug for WebOsTvClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WebOsTvClient")
+            .field("endpoint", &self.endpoint)
+            .field("connect_timeout", &self.connect_timeout)
+            .field("response_timeout", &self.response_timeout)
+            .field("token_store", &self.token_store)
+            .field("session", &"<redacted>")
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::WebOsTvClient;
+    use crate::config::HdmiInput;
+    use crate::tv::{CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind};
+    use crate::web_os::test_support::{
+        TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
+    };
+    use crate::web_os::WebOsPowerState;
+    use std::time::Duration;
+
+    const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+    const RESPONSE_TIMEOUT: Duration = Duration::from_millis(500);
+
+    #[test]
+    fn complete_tv_contract_reuses_one_authenticated_session() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = SelectedTvClient::WebOs(Box::new(client_for_server(&server, &token_fixture)));
+
+        assert_eq!(server.snapshot().connection_count, 0);
+
+        assert_eq!(
+            client.current_input().expect("read current input"),
+            CurrentInput::Hdmi(HdmiInput::Hdmi3)
+        );
+        client.set_input(HdmiInput::Hdmi2).expect("switch input");
+        assert_eq!(
+            client.current_input().expect("read switched input"),
+            CurrentInput::Hdmi(HdmiInput::Hdmi2)
+        );
+        assert_eq!(
+            client
+                .oled_brightness()
+                .expect("read input-specific brightness")
+                .as_percent(),
+            90
+        );
+        client
+            .set_oled_brightness(brightness(42))
+            .expect("set brightness");
+        assert_eq!(
+            client
+                .oled_brightness()
+                .expect("read updated brightness")
+                .as_percent(),
+            42
+        );
+        client.blank_screen().expect("blank screen");
+        client.unblank_screen().expect("unblank screen");
+
+        assert_eq!(server.snapshot().connection_count, 1);
+        client.power_off().expect("power off active TV");
+
+        let snapshot = server.snapshot();
+        assert_eq!(snapshot.power_state, WebOsPowerState::PowerOff);
+        assert_eq!(snapshot.input, WebOsTestInput::Hdmi2);
+        assert_eq!(snapshot.connection_count, 1);
+        server.finish();
+    }
+
+    #[test]
+    fn ambiguous_write_is_not_replayed_and_later_operation_reconnects() {
+        let server = WebOsTestServer::for_scenario(WebOsTestScenario::CloseAfterFirstInputWrite);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server(&server, &token_fixture);
+
+        assert_eq!(
+            client.current_input().expect("establish initial session"),
+            CurrentInput::Hdmi(HdmiInput::Hdmi3)
+        );
+        let error = client
+            .set_input(HdmiInput::Hdmi2)
+            .expect_err("lost write response must be reported");
+
+        assert_eq!(error.kind(), TvErrorKind::Transport);
+        let after_failure = server.snapshot();
+        assert_eq!(after_failure.input, WebOsTestInput::Hdmi2);
+        assert_eq!(
+            after_failure.connection_count, 1,
+            "the failed effectful operation must not reconnect and replay"
+        );
+
+        assert_eq!(
+            client.current_input().expect("later operation reconnects"),
+            CurrentInput::Hdmi(HdmiInput::Hdmi2)
+        );
+        assert_eq!(server.snapshot().connection_count, 2);
+        server.finish();
+    }
+
+    #[test]
+    fn screen_unblank_substate_mismatch_is_typed_without_discarding_session() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server(&server, &token_fixture);
+
+        let error = client
+            .unblank_screen()
+            .expect_err("active screen cannot be unblanked");
+        assert_eq!(error.kind(), TvErrorKind::ScreenUnblankSubstateMismatch);
+        assert_eq!(
+            client
+                .current_input()
+                .expect("application rejection keeps healthy session"),
+            CurrentInput::Hdmi(HdmiInput::Hdmi3)
+        );
+        assert_eq!(server.snapshot().connection_count, 1);
+        server.finish();
+    }
+
+    #[test]
+    fn power_off_requires_active_state_and_keeps_rejected_session_usable() {
+        let server = WebOsTestServer::screen_off(WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server(&server, &token_fixture);
+
+        let error = client
+            .power_off()
+            .expect_err("screen-off state fails native power-off guard");
+        assert_eq!(error.kind(), TvErrorKind::Rejected);
+        client
+            .unblank_screen()
+            .expect("guard rejection keeps session usable");
+        assert_eq!(server.snapshot().connection_count, 1);
+        server.finish();
+    }
+
+    fn client_for_server(
+        server: &WebOsTestServer,
+        token_fixture: &TestAccessTokenStore,
+    ) -> WebOsTvClient {
+        WebOsTvClient::new(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            token_fixture.store().clone(),
+        )
+    }
+
+    fn brightness(value: u8) -> OledBrightness {
+        OledBrightness::new(value).expect("valid test brightness")
+    }
+}

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -1,5 +1,6 @@
 //! Native LG webOS protocol support.
 
+mod adapter;
 mod client;
 mod control;
 mod input;
@@ -13,6 +14,7 @@ mod screen;
 mod test_support;
 mod tls;
 
+pub use adapter::WebOsTvClient;
 pub(crate) use client::WebOsClientRegistration;
 pub use client::{
     WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,

--- a/crates/lg-buddy/src/web_os/test_support.rs
+++ b/crates/lg-buddy/src/web_os/test_support.rs
@@ -1,3 +1,5 @@
 mod test_server;
 
-pub(super) use test_server::{WebOsTestInput, WebOsTestScenario, WebOsTestServer};
+pub(super) use test_server::{
+    TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
+};

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -62,6 +62,7 @@ pub(in crate::web_os) enum WebOsTestScenario {
     RegistrationMissingClientKey,
     PowerStatePermissionDenied,
     BacklightWriteAcknowledgedWithoutChange,
+    CloseAfterFirstInputWrite,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -286,6 +287,7 @@ struct WebOsTestRuntime {
     tv: WebOsTestTv,
     scenario: WebOsTestScenario,
     connection_count: u64,
+    ambiguous_input_write_injected: bool,
 }
 
 pub(in crate::web_os) struct WebOsTestServer {
@@ -353,6 +355,7 @@ impl WebOsTestServer {
             tv: WebOsTestTv::new(power_state, input),
             scenario,
             connection_count: 0,
+            ambiguous_input_write_injected: false,
         }));
         let active_connection = Arc::new(Mutex::new(None));
         let stop = Arc::new(AtomicBool::new(false));
@@ -505,28 +508,48 @@ fn serve_connection<S>(
         let keep_open = match scenario {
             WebOsTestScenario::StatefulTv
             | WebOsTestScenario::PowerStatePermissionDenied
-            | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange => {
-                let response = {
-                    let mut runtime = runtime.lock().expect("webOS test server state");
-                    if scenario == WebOsTestScenario::PowerStatePermissionDenied
-                        && request["uri"] == GET_POWER_STATE_URI
+            | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
+            | WebOsTestScenario::CloseAfterFirstInputWrite => {
+                let response =
                     {
-                        webos_error_without_payload(
-                            request["id"].as_str().expect("webOS request ID"),
-                            "-401 not permitted",
-                        )
-                    } else {
-                        runtime.tv.handle_request(
+                        let mut runtime = runtime.lock().expect("webOS test server state");
+                        if scenario == WebOsTestScenario::PowerStatePermissionDenied
+                            && request["uri"] == GET_POWER_STATE_URI
+                        {
+                            Some(webos_error_without_payload(
+                                request["id"].as_str().expect("webOS request ID"),
+                                "-401 not permitted",
+                            ))
+                        } else if scenario == WebOsTestScenario::CloseAfterFirstInputWrite
+                            && request["uri"] == SET_INPUT_URI
+                            && !runtime.ambiguous_input_write_injected
+                        {
+                            runtime.tv.handle_request(
+                                &request,
+                                permissions
+                                    .as_ref()
+                                    .expect("webOS request sent before registration"),
+                                true,
+                            );
+                            runtime.ambiguous_input_write_injected = true;
+                            None
+                        } else {
+                            Some(runtime.tv.handle_request(
                             &request,
                             permissions
                                 .as_ref()
                                 .expect("webOS request sent before registration"),
                             scenario != WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
-                        )
+                        ))
+                        }
+                    };
+                match response {
+                    Some(response) => {
+                        send_json(&mut socket, response);
+                        true
                     }
-                };
-                send_json(&mut socket, response);
-                true
+                    None => false,
+                }
             }
             _ => handle_protocol_scenario(&mut socket, scenario, &request),
         };
@@ -581,16 +604,15 @@ where
     match scenario {
         WebOsTestScenario::StatefulTv
         | WebOsTestScenario::PowerStatePermissionDenied
-        | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange => {
-            match payload["client-key"].as_str() {
-                Some(token) => send_json(socket, registration_response(request_id, token)),
-                None if payload["client-key"].is_null() => {
-                    send_json(socket, pairing_prompt_response(request_id));
-                    send_json(socket, registration_response(request_id, TEST_ACCESS_TOKEN));
-                }
-                None => panic!("registration access token is neither a string nor null"),
+        | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
+        | WebOsTestScenario::CloseAfterFirstInputWrite => match payload["client-key"].as_str() {
+            Some(token) => send_json(socket, registration_response(request_id, token)),
+            None if payload["client-key"].is_null() => {
+                send_json(socket, pairing_prompt_response(request_id));
+                send_json(socket, registration_response(request_id, TEST_ACCESS_TOKEN));
             }
-        }
+            None => panic!("registration access token is neither a string nor null"),
+        },
         WebOsTestScenario::StoredTokenReplacement => {
             payload["client-key"]
                 .as_str()
@@ -705,7 +727,8 @@ where
         | WebOsTestScenario::RegistrationTimeout
         | WebOsTestScenario::RegistrationMissingClientKey
         | WebOsTestScenario::PowerStatePermissionDenied
-        | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange => {
+        | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
+        | WebOsTestScenario::CloseAfterFirstInputWrite => {
             panic!("scenario `{scenario:?}` requires registered stateful handling")
         }
     }
@@ -847,13 +870,13 @@ fn webos_error_without_payload(request_id: &str, error: &str) -> Value {
     })
 }
 
-struct TestAccessTokenStore {
+pub(in crate::web_os) struct TestAccessTokenStore {
     path: PathBuf,
     store: PlatformAccessTokenStore,
 }
 
 impl TestAccessTokenStore {
-    fn new() -> Self {
+    pub(in crate::web_os) fn new() -> Self {
         let sequence = TEST_DIR_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let path = std::env::temp_dir().join(format!(
             "lg-buddy-webos-test-server-{}-{sequence}",
@@ -877,7 +900,7 @@ impl TestAccessTokenStore {
         Self { path, store }
     }
 
-    fn store(&self) -> &PlatformAccessTokenStore {
+    pub(in crate::web_os) fn store(&self) -> &PlatformAccessTokenStore {
         &self.store
     }
 }

--- a/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
+++ b/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
@@ -1,7 +1,7 @@
 mod support;
 
 use lg_buddy::config::HdmiInput;
-use lg_buddy::tv::{BscpylgtvCommandClient, OledBrightness, TvClient, TvError};
+use lg_buddy::tv::{BscpylgtvCommandClient, CurrentInput, OledBrightness, TvClient, TvErrorKind};
 use std::net::Ipv4Addr;
 use support::MockBscpylgtv;
 
@@ -11,22 +11,21 @@ fn mock_get_input_matches_real_shape() {
     let client = mock_client(&mock);
 
     let input = client
-        .get_input(ip("10.0.0.39"))
+        .current_input()
         .expect("mock get_input should succeed");
 
-    assert_eq!(input, "com.webos.app.hdmi3");
+    assert_eq!(input, CurrentInput::Hdmi(HdmiInput::Hdmi3));
 }
 
 #[test]
-fn mock_set_input_returns_realistic_success_payload() {
+fn mock_set_input_succeeds_and_updates_state() {
     let mock = MockBscpylgtv::new("mock-set-input");
     let client = mock_client(&mock);
 
-    let output = client
-        .set_input(ip("10.0.0.39"), HdmiInput::Hdmi2)
+    client
+        .set_input(HdmiInput::Hdmi2)
         .expect("mock set_input should succeed");
 
-    assert_eq!(output.stdout(), "{'returnValue': True}\n");
     assert_eq!(mock.state_snapshot().input, "HDMI_2");
     assert!(mock.state_snapshot().screen_on);
 }
@@ -40,11 +39,10 @@ fn planned_set_input_success_preserves_normal_state_updates() {
     mock.queue_set_input_wake_success();
     let client = mock_client(&mock);
 
-    let output = client
-        .set_input(ip("10.0.0.39"), HdmiInput::Hdmi4)
+    client
+        .set_input(HdmiInput::Hdmi4)
         .expect("planned set_input should succeed");
 
-    assert_eq!(output.stdout(), "{'returnValue': True}\n");
     let state = mock.state_snapshot();
     assert!(state.power_on);
     assert!(state.screen_on);
@@ -56,11 +54,10 @@ fn mock_set_settings_updates_backlight() {
     let mock = MockBscpylgtv::new("mock-set-settings");
     let client = mock_client(&mock);
 
-    let output = client
-        .set_oled_brightness(ip("10.0.0.39"), brightness(70))
+    client
+        .set_oled_brightness(brightness(70))
         .expect("mock set_oled_brightness should succeed");
 
-    assert_eq!(output.stdout(), "{'returnValue': True}\n");
     assert_eq!(mock.state_snapshot().backlight, 70);
 }
 
@@ -71,7 +68,7 @@ fn mock_get_picture_settings_includes_backlight() {
     let client = mock_client(&mock);
 
     let brightness = client
-        .get_oled_brightness(ip("10.0.0.39"))
+        .oled_brightness()
         .expect("mock get_oled_brightness should succeed");
 
     assert_eq!(brightness.as_percent(), 62);
@@ -83,27 +80,20 @@ fn mock_turn_screen_on_substate_error_matches_real_traceback_shape() {
     let client = mock_client(&mock);
 
     let err = client
-        .turn_screen_on(ip("10.0.0.39"))
+        .unblank_screen()
         .expect_err("substate mismatch should fail");
 
-    match err {
-        TvError::CommandFailed { status, output, .. } => {
-            assert_eq!(status, Some(1));
-            assert!(
-                output
-                    .stderr()
-                    .contains("bscpylgtv.exceptions.PyLGTVCmdError"),
-                "stderr was: {}",
-                output.stderr()
-            );
-            assert!(
-                output.stderr().contains("errorCode': '-102'"),
-                "stderr was: {}",
-                output.stderr()
-            );
-        }
-        other => panic!("expected command failure, got {other:?}"),
-    }
+    assert_eq!(err.kind(), TvErrorKind::ScreenUnblankSubstateMismatch);
+    assert!(
+        err.detail().contains("bscpylgtv.exceptions.PyLGTVCmdError"),
+        "detail was: {}",
+        err.detail()
+    );
+    assert!(
+        err.detail().contains("errorCode': '-102'"),
+        "detail was: {}",
+        err.detail()
+    );
 }
 
 #[test]
@@ -112,18 +102,16 @@ fn mock_tracks_screen_and_power_state_transitions() {
     let client = mock_client(&mock);
 
     client
-        .turn_screen_off(ip("10.0.0.39"))
+        .blank_screen()
         .expect("turn_screen_off should succeed");
     assert!(!mock.state_snapshot().screen_on);
 
     client
-        .turn_screen_on(ip("10.0.0.39"))
+        .unblank_screen()
         .expect("turn_screen_on should succeed from blank state");
     assert!(mock.state_snapshot().screen_on);
 
-    client
-        .power_off(ip("10.0.0.39"))
-        .expect("power_off should succeed");
+    client.power_off().expect("power_off should succeed");
     let state = mock.state_snapshot();
     assert!(!state.power_on);
     assert!(!state.screen_on);
@@ -134,20 +122,14 @@ fn mock_rejects_input_queries_when_powered_off() {
     let mock = MockBscpylgtv::new("mock-powered-off-query");
     let client = mock_client(&mock);
 
-    client
-        .power_off(ip("10.0.0.39"))
-        .expect("power_off should succeed");
+    client.power_off().expect("power_off should succeed");
 
     let err = client
-        .get_input(ip("10.0.0.39"))
+        .current_input()
         .expect_err("get_input should fail when off");
 
-    match err {
-        TvError::CommandFailed { output, .. } => {
-            assert!(output.stderr().contains("TV is off"));
-        }
-        other => panic!("expected command failure, got {other:?}"),
-    }
+    assert_eq!(err.kind(), TvErrorKind::Rejected);
+    assert!(err.detail().contains("TV is off"));
 }
 
 #[test]
@@ -157,10 +139,10 @@ fn mock_records_invocations_and_can_override_outputs() {
     let client = mock_client(&mock);
 
     let input = client
-        .get_input(ip("10.0.0.39"))
+        .current_input()
         .expect("planned get_input should succeed");
 
-    assert_eq!(input, "com.webos.app.hdmi2");
+    assert_eq!(input, CurrentInput::Hdmi(HdmiInput::Hdmi2));
     assert_eq!(
         mock.calls()
             .into_iter()
@@ -175,7 +157,7 @@ fn mock_records_invocations_and_can_override_outputs() {
 }
 
 fn mock_client(mock: &MockBscpylgtv) -> BscpylgtvCommandClient {
-    BscpylgtvCommandClient::with_args(mock.command_path(), mock.command_args())
+    BscpylgtvCommandClient::with_args(ip("10.0.0.39"), mock.command_path(), mock.command_args())
 }
 
 fn ip(value: &str) -> Ipv4Addr {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -122,6 +122,7 @@ flowchart LR
 
     subgraph TVBoundary["TV Control Boundary"]
         BSCPY["bscpylgtvcommand"]
+        WEBOS["native webOS session"]
         LGTV["LG TV"]
     end
 
@@ -174,7 +175,8 @@ flowchart LR
     SCREEN --> WOL
     LIFECYCLE --> WOL
 
-    TV --> BSCPY --> LGTV
+    TV -->|"production-selected"| BSCPY --> LGTV
+    TV -.->|"internal / test"| WEBOS --> LGTV
     WOL -->|"magic packet"| LGTV
 ```
 
@@ -232,8 +234,12 @@ The intended split is:
   - ownership marker management
 - `tv.rs`
   - TV transport abstraction
-  - subprocess-backed `bscpylgtvcommand` client
-  - typed facade for input, screen, and power operations
+  - profile-bound `bscpylgtvcommand` adapter
+  - adapter-neutral errors and selected-client construction
+  - typed facade for input, screen, power, and brightness operations
+- `web_os/adapter.rs`
+  - profile-bound native webOS adapter
+  - lazy authenticated session ownership, serialization, reuse, and invalidation
 - `wol.rs`
   - native Wake-on-LAN packet generation and UDP send
 - `backend.rs`
@@ -485,13 +491,20 @@ The TV layer is intentionally split into two levels:
 - low-level transport trait: `TvClient`
 - higher-level domain facade: `TvDevice`
 
-`TvClient` models the transport operations that the current backend can actually perform:
+`TvClient` models adapter-neutral operations for one configured TV profile. The
+target address and implementation-specific credential context are bound when a
+client is constructed; policy cannot redirect a client by passing an address to
+an operation.
 
-- `get_input`
+The current contract covers:
+
+- `current_input`
 - `set_input`
+- `oled_brightness`
+- `set_oled_brightness`
 - `power_off`
-- `turn_screen_off`
-- `turn_screen_on`
+- `blank_screen`
+- `unblank_screen`
 
 `TvDevice` provides a more readable surface to policy code:
 
@@ -501,8 +514,14 @@ The TV layer is intentionally split into two levels:
 - `tv.screen().unblank()`
 - `tv.power().off()`
 - `tv.power().wake(...)`
+- `tv.picture().oled_brightness()`
+- `tv.picture().set_oled_brightness(...)`
 
-This keeps the subprocess client simple while giving command logic a typed domain API.
+Successful effectful operations return no transport-specific output. Failures
+are normalized into typed TV errors, including the screen-unblank substate
+mismatch that policy uses to select its full-wake fallback. Wake-on-LAN keeps
+the configured network identity at `TvDevice`; adapter operations do not accept
+targeting data.
 
 ### Transitional Backend
 
@@ -510,11 +529,20 @@ The current production-side TV backend is still `bscpylgtvcommand`.
 
 The Rust runtime talks to it through `BscpylgtvCommandClient`, which:
 
+- belongs to one configured TV address
 - shells out to the configured command path
-- preserves stdout, stderr, and exit status on failure
-- parses `get_input` output into a typed `CurrentInput`
+- keeps subprocess output and exit status inside the legacy adapter
+- maps reads and failures into the shared domain contract
 
-This is a transitional integration boundary. It keeps the runtime architecture independent from the current Python CLI without requiring a native WebOS client yet.
+`SelectedTvClient` is the internal delegation point for the legacy and native
+implementations. `WebOsTvClient` owns one lazily authenticated websocket
+session behind a mutex, reuses it while healthy, and discards it after transport
+or framing failure. It never replays an effectful operation after an ambiguous
+failure; a later policy operation may establish a new session.
+
+Production construction deliberately selects the legacy variant. The native
+variant is available for internal and scripted-server validation, but there is
+no end-user selection or configuration change at this stage.
 
 ## State Model
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -149,7 +149,7 @@ For the tagged GitHub release process, see [release-process.md](release-process.
 | `crates/lg-buddy/src/sources/desktop/gnome.rs` | GNOME backend integration |
 | `crates/lg-buddy/src/sources/desktop/swayidle.rs` | `swayidle` backend integration |
 | `crates/lg-buddy/src/tv.rs` | TV transport boundary and facade |
-| `crates/lg-buddy/src/web_os/` | Native webOS client, domain operations, and test support |
+| `crates/lg-buddy/src/web_os/` | Native webOS client, profile-bound TV adapter, domain operations, and test support |
 | `crates/lg-buddy/src/wol.rs` | Native Wake-on-LAN support |
 | `configure.sh` | Interactive configuration tool |
 | `install.sh` | Installer for an existing binary |

--- a/docs/webos-testing.md
+++ b/docs/webos-testing.md
@@ -114,10 +114,12 @@ behavior is part of the scenario. These tests should focus on LG Buddy outcomes:
 policy decisions, retries, state ownership, command results, and user-visible
 behavior. They should not know the normal webOS wire response shape.
 
-As the native client moves behind the TV domain boundary, the same server can
-support tests of `TvDevice`, command orchestration, and acceptance scenarios.
-The characterization suite remains responsible for documenting and guarding
-the observed device contract represented by the server.
+The profile-bound native adapter uses the same server to cover the complete
+`TvClient` contract, session reuse, transport invalidation, later reconnection,
+and ambiguous-write no-replay behavior. The server can also support higher-level
+tests of `TvDevice`, command orchestration, and acceptance scenarios. The
+characterization suite remains responsible for documenting and guarding the
+observed device contract represented by the server.
 
 A passing mock-backed functionality test proves LG Buddy behavior against the
 current device model. It is not evidence that an unverified device behavior is


### PR DESCRIPTION
## Summary

- bind each `TvClient` implementation to one configured TV and normalize the shared domain contract
- add `WebOsTvClient` with lazy authenticated session ownership, serialized reuse, failure invalidation, and no transparent replay of ambiguous writes
- centralize legacy/native construction while keeping bscpylgtv as the only production-selected implementation
- extend scripted-server coverage and update architecture/testing documentation

## Why

The native webOS operations from #50-#52 existed below the TV domain boundary but were not yet available as a real profile-bound adapter. This provides the internal integration seam required before the opt-in work in #53.

## User impact

No configuration or production behavior changes. Existing runtime entrypoints continue to select bscpylgtv.

## Validation

- `cargo test -p lg-buddy`
- `cargo clippy -p lg-buddy --all-targets -- -D warnings`
- `cargo build --release -p lg-buddy`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #58