### PR TITLE
Add experimental opt-in lg_webos TV platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ chmod +x ./install.sh
 ./install.sh
 ```
 
-The installer will prompt for your TV IP, MAC address, HDMI input, and session idle blanking details, then install the required services. System sleep/wake handling uses the lifecycle service plus NetworkManager pre-down gate as cooperating suspend sources unless you opt out in `config.env`.
+The installer will prompt for your TV IP, MAC address, HDMI input, TV control platform, and session idle blanking details, then install the required services. If you choose the native `lg_webos` platform, accept the pairing prompt on the TV during setup. System sleep/wake handling uses the lifecycle service plus NetworkManager pre-down gate as cooperating suspend sources unless you opt out in `config.env`.
 
-On first use, you may need to accept a pairing prompt on the TV:
+With the default `bscpylgtv` platform, you may instead see the pairing prompt on first use:
 
 <https://github.com/chros73/bscpylgtv/blob/master/docs/guides/first_use.md>
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ LG Buddy is mostly automatic after installation.
 
 - To inspect settings, run `lg-buddy settings list`
 - To change supported settings, use `lg-buddy settings set <key> <value>`
+- To inspect the active TV platform, run `lg-buddy settings get tv.platform`
 - To see the active desktop idle backend, run `lg-buddy detect-backend`
 - To inspect TV brightness, run `lg-buddy brightness get`
 - To set TV brightness directly, run `lg-buddy brightness set <0-100>`
@@ -127,6 +128,7 @@ the same file that manual editing and `configure.sh` use:
 ```bash
 lg-buddy settings describe tv.input
 lg-buddy settings set tv.input HDMI_2
+lg-buddy settings get tv.platform
 lg-buddy settings set screen.idle_blank disabled
 lg-buddy settings describe screen.restore_policy
 lg-buddy settings set screen.idle_timeout 600
@@ -143,6 +145,7 @@ Settings can also be edited directly in `config.env`:
 tvs_primary_ip=192.168.1.100
 tvs_primary_mac=aa:bb:cc:dd:ee:ff
 tvs_primary_input=HDMI_2
+tvs_primary_platform=bscpylgtv
 screen_idle_blank=enabled
 screen_backend=auto
 screen_idle_timeout=300
@@ -155,6 +158,24 @@ updates_channel=stable
 `tv_ip`, `tv_mac`, and `input` are still accepted as legacy single-TV keys, but
 new writes use the `tvs_primary_*` shape so the storage can grow later without
 changing the current single-TV settings interface.
+
+The TV platform defaults to `bscpylgtv`, including when
+`tvs_primary_platform` is absent from an existing profile. The experimental
+native Rust webOS platform is an explicit opt-in:
+
+```bash
+lg-buddy settings set tv.platform lg_webos
+```
+
+Before saving that selection, LG Buddy connects in the foreground, reuses or
+acquires the profile's native credential, and verifies it with a safe TV state
+read. Accept any pairing prompt on the TV. If pairing or verification fails,
+the previous platform remains selected. Background services never initiate
+pairing. Switch back with `lg-buddy settings set tv.platform bscpylgtv`.
+
+Use the settings command for native opt-in rather than editing
+`tvs_primary_platform` directly, because a direct edit bypasses credential
+preflight.
 
 If a direct `config.env` edit leaves a value malformed, `lg-buddy settings list`
 and `describe` show it as invalid instead of silently treating it as default or

--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -71,8 +71,43 @@ lg_buddy_config_get_raw() {
     sed -n "s/^${key}=//p" "$config_file" | tail -n1
 }
 
-lg_buddy_sanitize_config_value() {
-    printf '%s\n' "$1" | sed 's/#.*$//; s/^[[:space:]]*//; s/[[:space:]]*$//'
+lg_buddy_config_get_platform() {
+    local config_file="${1:-}"
+
+    [ -r "$config_file" ] || return 1
+
+    awk '
+        function trim(value) {
+            sub(/^[[:space:]]+/, "", value)
+            sub(/[[:space:]]+$/, "", value)
+            return value
+        }
+
+        {
+            line = trim($0)
+            if (line == "" || line ~ /^#/) {
+                next
+            }
+
+            separator = index(line, "=")
+            if (separator == 0 || trim(substr(line, 1, separator - 1)) != "tvs_primary_platform") {
+                next
+            }
+
+            value = substr(line, separator + 1)
+            sub(/#.*/, "", value)
+            last_value = trim(value)
+            found = 1
+        }
+
+        END {
+            if (found) {
+                print last_value
+            } else {
+                exit 1
+            }
+        }
+    ' "$config_file"
 }
 
 lg_buddy_config_get_valid() {
@@ -176,11 +211,21 @@ lg_buddy_load_config() {
     tv_ip="$(lg_buddy_config_get_valid_any '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_ip" "tv_ip")"
     tv_mac="$(lg_buddy_config_get_valid_any '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_mac" "tv_mac")"
     input="$(lg_buddy_config_get_valid_any '^HDMI_[1-4]$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_input" "input")"
-    tv_platform="$(lg_buddy_config_get_raw "tvs_primary_platform" "$LG_BUDDY_CONFIG_FILE")"
-    tv_platform="$(lg_buddy_sanitize_config_value "$tv_platform")"
-    if [ -z "$tv_platform" ]; then
-        tv_platform="$LG_BUDDY_DEFAULT_TV_PLATFORM"
-    elif ! [[ "$tv_platform" =~ ^(bscpylgtv|lg_webos)$ ]]; then
+    if tv_platform="$(lg_buddy_config_get_platform "$LG_BUDDY_CONFIG_FILE")"; then
+        if [ -z "$tv_platform" ]; then
+            echo "LG Buddy: invalid tv platform '$tv_platform'; expected bscpylgtv or lg_webos."
+            return 2
+        fi
+    else
+        config_platform_status=$?
+        if [ "$config_platform_status" -eq 1 ]; then
+            tv_platform="$LG_BUDDY_DEFAULT_TV_PLATFORM"
+        else
+            return "$config_platform_status"
+        fi
+    fi
+
+    if ! [[ "$tv_platform" =~ ^(bscpylgtv|lg_webos)$ ]]; then
         echo "LG Buddy: invalid tv platform '$tv_platform'; expected bscpylgtv or lg_webos."
         return 2
     fi

--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -8,6 +8,7 @@ else
     LG_BUDDY_INSTALL_DIR="/usr/lib/lg-buddy"
 fi
 LG_BUDDY_POINTER_FILE="${LG_BUDDY_INSTALL_DIR}/config-path"
+LG_BUDDY_DEFAULT_TV_PLATFORM="bscpylgtv"
 LG_BUDDY_DEFAULT_SCREEN_BACKEND="auto"
 LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK="enabled"
 LG_BUDDY_DEFAULT_IDLE_TIMEOUT=300
@@ -171,6 +172,13 @@ lg_buddy_load_config() {
     tv_ip="$(lg_buddy_config_get_valid_any '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_ip" "tv_ip")"
     tv_mac="$(lg_buddy_config_get_valid_any '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_mac" "tv_mac")"
     input="$(lg_buddy_config_get_valid_any '^HDMI_[1-4]$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_input" "input")"
+    tv_platform="$(lg_buddy_config_get_raw "tvs_primary_platform" "$LG_BUDDY_CONFIG_FILE")"
+    if [ -z "$tv_platform" ]; then
+        tv_platform="$LG_BUDDY_DEFAULT_TV_PLATFORM"
+    elif ! [[ "$tv_platform" =~ ^(bscpylgtv|lg_webos)$ ]]; then
+        echo "LG Buddy: invalid tv platform '$tv_platform'; expected bscpylgtv or lg_webos."
+        return 2
+    fi
     screen_backend="$(lg_buddy_config_get_valid "screen_backend" '^(auto|gnome|swayidle)$' "$LG_BUDDY_DEFAULT_SCREEN_BACKEND" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_blank="$(lg_buddy_config_get_valid "screen_idle_blank" '^(enabled|disabled)$' "$LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_config_get_valid "screen_idle_timeout" '^[0-9]+$' "$LG_BUDDY_DEFAULT_IDLE_TIMEOUT" "$LG_BUDDY_CONFIG_FILE")"

--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -71,6 +71,10 @@ lg_buddy_config_get_raw() {
     sed -n "s/^${key}=//p" "$config_file" | tail -n1
 }
 
+lg_buddy_sanitize_config_value() {
+    printf '%s\n' "$1" | sed 's/#.*$//; s/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
 lg_buddy_config_get_valid() {
     local key="$1"
     local regex="$2"
@@ -173,6 +177,7 @@ lg_buddy_load_config() {
     tv_mac="$(lg_buddy_config_get_valid_any '^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_mac" "tv_mac")"
     input="$(lg_buddy_config_get_valid_any '^HDMI_[1-4]$' "" "$LG_BUDDY_CONFIG_FILE" "tvs_primary_input" "input")"
     tv_platform="$(lg_buddy_config_get_raw "tvs_primary_platform" "$LG_BUDDY_CONFIG_FILE")"
+    tv_platform="$(lg_buddy_sanitize_config_value "$tv_platform")"
     if [ -z "$tv_platform" ]; then
         tv_platform="$LG_BUDDY_DEFAULT_TV_PLATFORM"
     elif ! [[ "$tv_platform" =~ ^(bscpylgtv|lg_webos)$ ]]; then

--- a/configure.sh
+++ b/configure.sh
@@ -43,6 +43,13 @@ validate_input() {
     esac
 }
 
+validate_tv_platform() {
+    case "$1" in
+        bscpylgtv|lg_webos) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 validate_backend() {
     case "$1" in
         auto|gnome|swayidle) return 0 ;;
@@ -94,8 +101,10 @@ current_screen_restore_policy="$LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY"
 current_system_sleep_wake_policy="$LG_BUDDY_DEFAULT_SYSTEM_SLEEP_WAKE_POLICY"
 current_update_auto_check="$LG_BUDDY_DEFAULT_UPDATE_AUTO_CHECK"
 current_update_channel="$LG_BUDDY_DEFAULT_UPDATE_CHANNEL"
+existing_config_loaded=0
 
 if lg_buddy_load_config >/dev/null 2>&1; then
+    existing_config_loaded=1
     current_tv_ip="$tv_ip"
     current_tv_mac="$tv_mac"
     current_input="$input"
@@ -120,6 +129,7 @@ if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
     tv_ip="${LG_BUDDY_TV_IP:-$current_tv_ip}"
     tv_mac="${LG_BUDDY_TV_MAC:-$current_tv_mac}"
     input="${LG_BUDDY_INPUT:-$current_input}"
+    tv_platform="${LG_BUDDY_TV_PLATFORM:-$current_tv_platform}"
     screen_backend="${LG_BUDDY_SCREEN_BACKEND:-$current_screen_backend}"
     screen_idle_blank="$current_screen_idle_blank"
     screen_idle_timeout="${LG_BUDDY_SCREEN_IDLE_TIMEOUT:-$current_screen_idle_timeout}"
@@ -144,6 +154,10 @@ if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
     }
     validate_input "$input" || {
         echo "LG_BUDDY_INPUT must be one of HDMI_1, HDMI_2, HDMI_3, or HDMI_4."
+        exit 1
+    }
+    validate_tv_platform "$tv_platform" || {
+        echo "LG_BUDDY_TV_PLATFORM must be one of bscpylgtv or lg_webos."
         exit 1
     }
     validate_backend "$screen_backend" || {
@@ -257,6 +271,25 @@ else
         esac
     done
 
+    echo "Choose the TV control platform:"
+    echo "  1) bscpylgtv  (Python compatibility platform)"
+    echo "  2) lg_webos   (native LG Buddy platform)"
+
+    case "$current_tv_platform" in
+        bscpylgtv) default_platform_choice="1" ;;
+        lg_webos) default_platform_choice="2" ;;
+        *) default_platform_choice="1" ;;
+    esac
+
+    while true; do
+        PLATFORM_CHOICE="$(prompt_with_default "Enter number (1-2)" "$default_platform_choice")"
+        case "$PLATFORM_CHOICE" in
+            1) tv_platform="bscpylgtv"; break ;;
+            2) tv_platform="lg_webos"; break ;;
+            *) echo "  Please enter 1 or 2." ;;
+        esac
+    done
+
     case "$current_screen_idle_blank" in
         enabled) default_idle_blank_choice="Y" ;;
         disabled) default_idle_blank_choice="n" ;;
@@ -338,7 +371,7 @@ echo "Configuration to apply:"
 echo "  TV IP:               $tv_ip"
 echo "  TV MAC:              $tv_mac"
 echo "  PC Input:            $input"
-echo "  TV Platform:         $current_tv_platform"
+echo "  TV Platform:         $tv_platform"
 echo "  Screen Idle Blank:   $screen_idle_blank"
 echo "  Screen Backend:      $screen_backend"
 echo "  Screen Idle Timeout: $screen_idle_timeout"
@@ -361,13 +394,15 @@ fi
 
 mkdir -p "$CONFIG_DIR"
 chmod 700 "$CONFIG_DIR"
+CONFIG_CANDIDATE="${CONFIG_FILE}.tmp.$$"
+trap 'rm -f -- "$CONFIG_CANDIDATE"' EXIT
 
-cat >"$CONFIG_FILE" <<EOF
+cat >"$CONFIG_CANDIDATE" <<EOF
 # LG Buddy configuration
 tvs_primary_ip=$tv_ip
 tvs_primary_mac=$tv_mac
 tvs_primary_input=$input
-tvs_primary_platform=$current_tv_platform
+tvs_primary_platform=bscpylgtv
 screen_idle_blank=$screen_idle_blank
 screen_backend=$screen_backend
 screen_idle_timeout=$screen_idle_timeout
@@ -377,7 +412,27 @@ updates_auto_check=$update_auto_check
 updates_channel=$update_channel
 EOF
 
-chmod 600 "$CONFIG_FILE"
+chmod 600 "$CONFIG_CANDIDATE"
+
+if [ "$tv_platform" = "lg_webos" ]; then
+    if [ "$existing_config_loaded" = "1" ] && [ "$current_tv_platform" = "lg_webos" ]; then
+        sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' \
+            "$CONFIG_CANDIDATE"
+    else
+        RUNTIME_BINARY="${LG_BUDDY_RUNTIME_BINARY:-$SCRIPT_DIR/lg-buddy}"
+        if [ ! -x "$RUNTIME_BINARY" ]; then
+            echo "LG Buddy runtime binary is required to pair the native webOS platform: $RUNTIME_BINARY"
+            exit 1
+        fi
+
+        echo "Pairing the native webOS platform..."
+        LG_BUDDY_CONFIG="$CONFIG_CANDIDATE" \
+            "$RUNTIME_BINARY" settings set tv.platform lg_webos
+    fi
+fi
+
+mv -f -- "$CONFIG_CANDIDATE" "$CONFIG_FILE"
+trap - EXIT
 echo "Configuration written to $CONFIG_FILE"
 
 if [ -f "$HOME/.config/systemd/user/LG_Buddy_screen.service" ]; then

--- a/configure.sh
+++ b/configure.sh
@@ -86,6 +86,7 @@ normalize_restore_policy() {
 current_tv_ip=""
 current_tv_mac=""
 current_input="HDMI_1"
+current_tv_platform="$LG_BUDDY_DEFAULT_TV_PLATFORM"
 current_screen_backend="$LG_BUDDY_DEFAULT_SCREEN_BACKEND"
 current_screen_idle_blank="$LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK"
 current_screen_idle_timeout="$LG_BUDDY_DEFAULT_IDLE_TIMEOUT"
@@ -98,6 +99,7 @@ if lg_buddy_load_config >/dev/null 2>&1; then
     current_tv_ip="$tv_ip"
     current_tv_mac="$tv_mac"
     current_input="$input"
+    current_tv_platform="$tv_platform"
     current_screen_backend="$screen_backend"
     current_screen_idle_blank="$screen_idle_blank"
     current_screen_idle_timeout="$screen_idle_timeout"
@@ -106,6 +108,12 @@ if lg_buddy_load_config >/dev/null 2>&1; then
     current_update_auto_check="$updates_auto_check"
     current_update_channel="$updates_channel"
     echo "Loaded existing configuration from $LG_BUDDY_CONFIG_FILE"
+else
+    config_load_status=$?
+    if [ "$config_load_status" -eq 2 ]; then
+        echo "Existing configuration contains an invalid TV platform; fix tvs_primary_platform before rerunning configure.sh."
+        exit 1
+    fi
 fi
 
 if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
@@ -330,6 +338,7 @@ echo "Configuration to apply:"
 echo "  TV IP:               $tv_ip"
 echo "  TV MAC:              $tv_mac"
 echo "  PC Input:            $input"
+echo "  TV Platform:         $current_tv_platform"
 echo "  Screen Idle Blank:   $screen_idle_blank"
 echo "  Screen Backend:      $screen_backend"
 echo "  Screen Idle Timeout: $screen_idle_timeout"
@@ -358,6 +367,7 @@ cat >"$CONFIG_FILE" <<EOF
 tvs_primary_ip=$tv_ip
 tvs_primary_mac=$tv_mac
 tvs_primary_input=$input
+tvs_primary_platform=$current_tv_platform
 screen_idle_blank=$screen_idle_blank
 screen_backend=$screen_backend
 screen_idle_timeout=$screen_idle_timeout

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -262,6 +262,7 @@ pub fn run_sleep_pre_for_event<W: Write>(
         config.tv_ip,
         config.tv_platform,
         TvClientBuildOptions::production()
+            .stored_token_only()
             .with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
     )?;
     let sleeper = ThreadSleeper;
@@ -285,7 +286,7 @@ pub fn run_sleep<W: Write>(writer: &mut W) -> Result<(), RunError> {
         &config_path,
         config.tv_ip,
         config.tv_platform,
-        TvClientBuildOptions::production(),
+        TvClientBuildOptions::production().stored_token_only(),
     )?;
     let detector = JournalctlSleepDetector::default();
     let sleeper = ThreadSleeper;
@@ -306,6 +307,7 @@ pub fn run_nm_pre_down<W: Write>(writer: &mut W) -> Result<(), RunError> {
         config.tv_ip,
         config.tv_platform,
         TvClientBuildOptions::production()
+            .stored_token_only()
             .with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
     )?;
     let sleeper = ThreadSleeper;
@@ -369,8 +371,16 @@ pub fn run_startup<W: Write>(writer: &mut W, mode: StartupMode) -> Result<(), Ru
         &config_path,
         config.tv_ip,
         config.tv_platform,
-        TvClientBuildOptions::production(),
+        TvClientBuildOptions::production().stored_token_only(),
     )?;
+    if !tv_client.can_authenticate_unattended()? {
+        marker.clear()?;
+        writeln!(
+            writer,
+            "LG Buddy Startup: No stored native TV credential; skipping unattended TV control."
+        )?;
+        return Ok(());
+    }
     let wol_sender = UdpWakeOnLanSender::default();
     let sleeper = ThreadSleeper;
     let network_waiter = NmOnlineNetworkWaiter::default();
@@ -394,21 +404,37 @@ pub fn run_system_resume<W: Write>(writer: &mut W) -> Result<(), RunError> {
         &config_path,
         config.tv_ip,
         config.tv_platform,
-        TvClientBuildOptions::production(),
+        TvClientBuildOptions::production().stored_token_only(),
     )?;
     let wol_sender = UdpWakeOnLanSender::default();
     let sleeper = ThreadSleeper;
     let network_waiter = NmOnlineNetworkWaiter::default();
 
-    let result = lifecycle::restore_after_system_sleep_with(
-        writer,
-        &config,
-        &marker,
-        &tv_client,
-        &wol_sender,
-        &sleeper,
-        &network_waiter,
-    );
+    let result = (|| -> Result<(), RunError> {
+        match tv_client.can_authenticate_unattended() {
+            Ok(true) => lifecycle::restore_after_system_sleep_with(
+                writer,
+                &config,
+                &marker,
+                &tv_client,
+                &wol_sender,
+                &sleeper,
+                &network_waiter,
+            ),
+            Ok(false) => {
+                marker.clear()?;
+                writeln!(
+                    writer,
+                    "LG Buddy System Resume: No stored native TV credential; skipping unattended TV control."
+                )?;
+                Ok(())
+            }
+            Err(err) => {
+                marker.clear()?;
+                Err(err.into())
+            }
+        }
+    })();
 
     let mut cleanup_error = None;
 
@@ -465,8 +491,15 @@ pub fn run_shutdown<W: Write>(writer: &mut W) -> Result<(), RunError> {
         &config_path,
         config.tv_ip,
         config.tv_platform,
-        TvClientBuildOptions::production(),
+        TvClientBuildOptions::production().stored_token_only(),
     )?;
+    if !tv_client.can_authenticate_unattended()? {
+        writeln!(
+            writer,
+            "LG Buddy Shutdown: No stored native TV credential; skipping unattended TV control."
+        )?;
+        return Ok(());
+    }
     let reboot_detector = SystemctlRebootDetector::default();
 
     lifecycle::run_shutdown_with(writer, &config, &tv_client, &reboot_detector)

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -260,6 +260,7 @@ pub fn run_sleep_pre_for_event<W: Write>(
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production()
             .with_legacy_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
     )?;
@@ -283,6 +284,7 @@ pub fn run_sleep<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production(),
     )?;
     let detector = JournalctlSleepDetector::default();
@@ -302,6 +304,7 @@ pub fn run_nm_pre_down<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production()
             .with_legacy_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
     )?;
@@ -350,6 +353,7 @@ pub fn run_brightness<W: Write>(
             let tv_client = build_tv_client(
                 &config_path,
                 config.tv_ip,
+                config.tv_platform,
                 TvClientBuildOptions::production(),
             )?;
             run_brightness_command_with(writer, &config, command, &tv_client)
@@ -364,6 +368,7 @@ pub fn run_startup<W: Write>(writer: &mut W, mode: StartupMode) -> Result<(), Ru
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production(),
     )?;
     let wol_sender = UdpWakeOnLanSender::default();
@@ -388,6 +393,7 @@ pub fn run_system_resume<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production(),
     )?;
     let wol_sender = UdpWakeOnLanSender::default();
@@ -458,6 +464,7 @@ pub fn run_shutdown<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production(),
     )?;
     let reboot_detector = SystemctlRebootDetector::default();
@@ -1837,6 +1844,7 @@ mod tests {
                 .parse::<MacAddress>()
                 .expect("parse mac"),
             input,
+            tv_platform: crate::config::TvPlatform::Bscpylgtv,
             screen_backend: ScreenBackend::Auto,
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -262,7 +262,7 @@ pub fn run_sleep_pre_for_event<W: Write>(
         config.tv_ip,
         config.tv_platform,
         TvClientBuildOptions::production()
-            .with_legacy_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
+            .with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
     )?;
     let sleeper = ThreadSleeper;
 
@@ -306,7 +306,7 @@ pub fn run_nm_pre_down<W: Write>(writer: &mut W) -> Result<(), RunError> {
         config.tv_ip,
         config.tv_platform,
         TvClientBuildOptions::production()
-            .with_legacy_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
+            .with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
     )?;
     let sleeper = ThreadSleeper;
     let mut bus = match crate::session_bus::new_system_bus_client() {

--- a/crates/lg-buddy/src/config.rs
+++ b/crates/lg-buddy/src/config.rs
@@ -150,6 +150,41 @@ pub enum SystemSleepWakePolicy {
     Disabled,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TvPlatform {
+    Bscpylgtv,
+    LgWebOs,
+}
+
+impl TvPlatform {
+    pub const DEFAULT: Self = Self::Bscpylgtv;
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Bscpylgtv => "bscpylgtv",
+            Self::LgWebOs => "lg_webos",
+        }
+    }
+}
+
+impl fmt::Display for TvPlatform {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for TvPlatform {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "bscpylgtv" => Ok(Self::Bscpylgtv),
+            "lg_webos" => Ok(Self::LgWebOs),
+            _ => Err(()),
+        }
+    }
+}
+
 impl SystemSleepWakePolicy {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -270,6 +305,7 @@ pub struct Config {
     pub tv_ip: Ipv4Addr,
     pub tv_mac: MacAddress,
     pub input: HdmiInput,
+    pub tv_platform: TvPlatform,
     pub screen_backend: ScreenBackend,
     pub screen_idle_timeout: u64,
     pub screen_restore_policy: ScreenRestorePolicy,
@@ -450,6 +486,17 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
                 })
         })?;
 
+    let tv_platform = match entries.get("tvs_primary_platform") {
+        None => TvPlatform::DEFAULT,
+        Some(value) => value
+            .parse::<TvPlatform>()
+            .map_err(|_| ConfigError::InvalidValue {
+                key: "tvs_primary_platform",
+                value: value.clone(),
+                expected: "one of bscpylgtv, lg_webos",
+            })?,
+    };
+
     let screen_backend = entries
         .get("screen_backend")
         .and_then(|value| value.parse::<ScreenBackend>().ok())
@@ -479,6 +526,7 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
         tv_ip,
         tv_mac,
         input,
+        tv_platform,
         screen_backend,
         screen_idle_timeout,
         screen_restore_policy,
@@ -532,7 +580,8 @@ mod tests {
     use super::{
         parse_config, parse_home_from_passwd_entries, resolve_config_path, Config, ConfigError,
         ConfigPathError, ConfigPathSources, HdmiInput, ScreenBackend, ScreenIdleBlankPolicy,
-        ScreenRestorePolicy, SystemSleepWakePolicy, DEFAULT_IDLE_TIMEOUT, MAX_IDLE_TIMEOUT,
+        ScreenRestorePolicy, SystemSleepWakePolicy, TvPlatform, DEFAULT_IDLE_TIMEOUT,
+        MAX_IDLE_TIMEOUT,
     };
     use std::path::Path;
 
@@ -630,6 +679,7 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
             tvs_primary_ip=192.168.1.42
             tvs_primary_mac=aa:bb:cc:dd:ee:ff
             tvs_primary_input=HDMI_2
+            tvs_primary_platform=lg_webos
             screen_backend=gnome
             screen_idle_timeout=450
             screen_restore_policy=aggressive
@@ -642,6 +692,7 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
         assert_eq!(config.tv_ip.to_string(), "192.168.1.42");
         assert_eq!(config.tv_mac.to_string(), "aa:bb:cc:dd:ee:ff");
         assert_eq!(config.input, HdmiInput::Hdmi2);
+        assert_eq!(config.tv_platform, TvPlatform::LgWebOs);
         assert_eq!(config.screen_backend, ScreenBackend::Gnome);
         assert_eq!(config.screen_idle_timeout, 450);
         assert_eq!(
@@ -727,6 +778,7 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
                 tv_ip: "192.168.1.42".parse().expect("ipv4"),
                 tv_mac: "aa:bb:cc:dd:ee:ff".parse().expect("mac"),
                 input: HdmiInput::Hdmi1,
+                tv_platform: TvPlatform::Bscpylgtv,
                 screen_backend: ScreenBackend::Auto,
                 screen_idle_timeout: DEFAULT_IDLE_TIMEOUT,
                 screen_restore_policy: ScreenRestorePolicy::MarkerOnly,
@@ -812,6 +864,38 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
         assert_eq!(
             config.system_sleep_wake_policy,
             SystemSleepWakePolicy::Enabled
+        );
+    }
+
+    #[test]
+    fn parse_defaults_missing_tv_platform_to_bscpylgtv() {
+        let config = parse_config(
+            "\
+            tv_ip=192.168.1.42
+            tv_mac=aa:bb:cc:dd:ee:ff
+            input=HDMI_1
+            ",
+        )
+        .expect("parse config with compatibility platform default");
+
+        assert_eq!(config.tv_platform, TvPlatform::Bscpylgtv);
+    }
+
+    #[test]
+    fn parse_rejects_invalid_explicit_tv_platform() {
+        let err = parse_config(
+            "\
+            tv_ip=192.168.1.42
+            tv_mac=aa:bb:cc:dd:ee:ff
+            input=HDMI_1
+            tvs_primary_platform=not-a-platform
+            ",
+        )
+        .expect_err("invalid explicit platform should fail");
+
+        assert_eq!(
+            err.to_string(),
+            "invalid value for `tvs_primary_platform`: `not-a-platform`; expected one of bscpylgtv, lg_webos"
         );
     }
 

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -16,7 +16,7 @@ use crate::state::{
     ScreenOwnershipMarker, SystemSleepAttemptLock, SystemSleepAttemptState,
     SystemSleepCycleOutcome, SystemSleepCycleState,
 };
-use crate::tv::{CurrentInput, TvClient, TvDevice};
+use crate::tv::{CurrentInput, TvClient, TvDevice, TvErrorKind};
 use crate::wol::{WakeOnLanSender, DEFAULT_WOL_PORT};
 use crate::{RunError, StartupMode};
 
@@ -674,15 +674,26 @@ pub(crate) fn run_startup_with_outcome<
         outcome.merge(select_lifecycle_input_restore(
             DecisionReasonCode::ManualRequest,
         ));
-        if tv.input().set(config.input).is_ok() {
-            outcome.merge(decide_restore_input_succeeded());
-            writeln!(
-                writer,
-                "LG Buddy Startup: TV turned on and set to {}.",
-                config.input.as_str()
-            )?;
-            writer.flush()?;
-            return Ok(outcome);
+        match tv.input().set(config.input) {
+            Ok(()) => {
+                outcome.merge(decide_restore_input_succeeded());
+                writeln!(
+                    writer,
+                    "LG Buddy Startup: TV turned on and set to {}.",
+                    config.input.as_str()
+                )?;
+                writer.flush()?;
+                return Ok(outcome);
+            }
+            Err(err) if err.kind() == TvErrorKind::Authentication => {
+                writeln!(
+                    writer,
+                    "LG Buddy Startup: Stored TV authentication is unavailable; skipping unattended TV control."
+                )?;
+                writer.flush()?;
+                return Ok(outcome);
+            }
+            Err(_) => {}
         }
 
         let retry_delay = startup_retry_delay(attempt);
@@ -787,6 +798,18 @@ pub(crate) fn run_shutdown_with_outcome<W: Write, C: TvClient, R: RebootDetector
                 ShutdownNext::QueryInput => unreachable!("input decision cannot request input"),
             }
         }
+        Err(err) if err.kind() == TvErrorKind::Authentication => {
+            writeln!(
+                writer,
+                "LG Buddy Shutdown: Stored TV authentication is unavailable; skipping power_off fallback."
+            )?;
+            outcome.merge(
+                PolicyOutcome::new().with_no_action(DecisionReason::with_detail(
+                    DecisionReasonCode::NotApplicable,
+                    err.to_string(),
+                )),
+            );
+        }
         Err(err) => {
             let decision = decide_shutdown_after_input(
                 config.input,
@@ -872,6 +895,18 @@ pub(crate) fn attempt_system_sleep_power_off_with_outcome<W: Write, C: TvClient,
                     outcome.merge(decision.outcome);
                 }
             }
+        }
+        Err(err) if err.kind() == TvErrorKind::Authentication => {
+            writeln!(
+                writer,
+                "LG Buddy Sleep Pre: Stored TV authentication is unavailable; skipping power_off fallback."
+            )?;
+            outcome.merge(
+                PolicyOutcome::new().with_no_action(DecisionReason::with_detail(
+                    DecisionReasonCode::NotApplicable,
+                    err.to_string(),
+                )),
+            );
         }
         Err(err) => {
             let decision = decide_system_sleep_after_input(
@@ -1250,6 +1285,13 @@ pub(crate) fn attempt_legacy_network_manager_sleep_with<
             marker.clear()?;
             return Ok(());
         }
+        Err(err) if err.kind() == TvErrorKind::Authentication => {
+            writeln!(
+                writer,
+                "LG Buddy Sleep: Stored TV authentication is unavailable; skipping power_off fallback."
+            )?;
+            return Ok(());
+        }
         Ok(_) | Err(_) => {}
     }
 
@@ -1331,17 +1373,33 @@ pub(crate) fn restore_after_system_sleep_with_outcome<
         outcome.merge(select_lifecycle_input_restore(
             DecisionReasonCode::RuntimeEvent,
         ));
-        if tv.input().set(config.input).is_ok() {
-            let success_outcome = decide_system_resume_input_succeeded();
-            apply_system_screen_marker_transitions(marker, &success_outcome)?;
-            outcome.merge(success_outcome);
-            writeln!(
-                writer,
-                "LG Buddy Startup: TV turned on and set to {}.",
-                config.input.as_str()
-            )?;
-            writer.flush()?;
-            return Ok(outcome);
+        match tv.input().set(config.input) {
+            Ok(()) => {
+                let success_outcome = decide_system_resume_input_succeeded();
+                apply_system_screen_marker_transitions(marker, &success_outcome)?;
+                outcome.merge(success_outcome);
+                writeln!(
+                    writer,
+                    "LG Buddy Startup: TV turned on and set to {}.",
+                    config.input.as_str()
+                )?;
+                writer.flush()?;
+                return Ok(outcome);
+            }
+            Err(err) if err.kind() == TvErrorKind::Authentication => {
+                writeln!(
+                    writer,
+                    "LG Buddy Startup: Stored TV authentication is unavailable; skipping unattended TV control."
+                )?;
+                writer.flush()?;
+                let unavailable_outcome = decide_system_resume_input_exhausted(
+                    "system resume skipped because stored TV authentication is unavailable",
+                );
+                apply_system_screen_marker_transitions(marker, &unavailable_outcome)?;
+                outcome.merge(unavailable_outcome);
+                return Ok(outcome);
+            }
+            Err(_) => {}
         }
 
         let retry_delay = startup_retry_delay(attempt);
@@ -1693,7 +1751,11 @@ fn query_current_input_with_retries<C: TvClient, Sl: Sleeper>(
         match tv.input().current() {
             Ok(current_input) => return Ok(current_input),
             Err(err) => {
+                let authentication_failed = err.kind() == TvErrorKind::Authentication;
                 last_err = Some(err);
+                if authentication_failed {
+                    break;
+                }
                 if attempt < retries {
                     sleeper.sleep(system_sleep_retry_delay());
                 }
@@ -1710,8 +1772,10 @@ fn retry_power_off<C: TvClient, Sl: Sleeper>(
     attempts: u32,
 ) -> bool {
     for attempt in 1..=attempts {
-        if tv.power().off().is_ok() {
-            return true;
+        match tv.power().off() {
+            Ok(()) => return true,
+            Err(err) if err.kind() == TvErrorKind::Authentication => return false,
+            Err(_) => {}
         }
 
         if attempt < attempts {

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -2820,6 +2820,7 @@ mod tests {
                 .parse::<MacAddress>()
                 .expect("parse mac"),
             input,
+            tv_platform: crate::config::TvPlatform::Bscpylgtv,
             screen_backend: ScreenBackend::Auto,
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,

--- a/crates/lg-buddy/src/platform_access_token.rs
+++ b/crates/lg-buddy/src/platform_access_token.rs
@@ -159,6 +159,7 @@ impl Error for PlatformAccessTokenStoreError {
 
 #[derive(Debug)]
 pub enum PlatformAccessTokenAcquisitionError {
+    MissingStoredToken,
     Store {
         source: PlatformAccessTokenStoreError,
     },
@@ -170,6 +171,10 @@ pub enum PlatformAccessTokenAcquisitionError {
 impl fmt::Display for PlatformAccessTokenAcquisitionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::MissingStoredToken => write!(
+                f,
+                "no stored platform access token is available; pair the TV from foreground settings by running `lg-buddy settings set tv.platform lg_webos`"
+            ),
             Self::Store { source } => write!(f, "platform access-token storage failed: {source}"),
             Self::Registration { source } => {
                 write!(f, "platform access-token registration failed: {source}")
@@ -181,6 +186,7 @@ impl fmt::Display for PlatformAccessTokenAcquisitionError {
 impl Error for PlatformAccessTokenAcquisitionError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
+            Self::MissingStoredToken => None,
             Self::Store { source } => Some(source),
             Self::Registration { source } => Some(source),
         }
@@ -248,6 +254,14 @@ impl PlatformAccessTokenStore {
         Ok(Some(token))
     }
 
+    pub(crate) fn load_stored(
+        &self,
+    ) -> Result<PlatformAccessToken, PlatformAccessTokenAcquisitionError> {
+        self.load()
+            .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?
+            .ok_or(PlatformAccessTokenAcquisitionError::MissingStoredToken)
+    }
+
     pub fn persist(
         &self,
         token: &PlatformAccessToken,
@@ -292,18 +306,25 @@ impl PlatformAccessTokenStore {
                     })?;
                 Ok(token)
             }
-            None => {
-                let token = registration
-                    .register(None, on_auth_event)
-                    .map_err(|source| PlatformAccessTokenAcquisitionError::Registration {
-                        source,
-                    })?;
-                self.persist(&token)
-                    .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?;
-                on_auth_event(WebOsAuthenticationEvent::AccessTokenPersisted);
-                Ok(token)
-            }
+            None => self.acquire_and_persist(registration, on_auth_event),
         }
+    }
+
+    pub(crate) fn acquire_and_persist<F>(
+        &self,
+        registration: &mut WebOsClientRegistration<'_>,
+        on_auth_event: &mut F,
+    ) -> Result<PlatformAccessToken, PlatformAccessTokenAcquisitionError>
+    where
+        F: FnMut(WebOsAuthenticationEvent),
+    {
+        let token = registration
+            .register(None, on_auth_event)
+            .map_err(|source| PlatformAccessTokenAcquisitionError::Registration { source })?;
+        self.persist(&token)
+            .map_err(|source| PlatformAccessTokenAcquisitionError::Store { source })?;
+        on_auth_event(WebOsAuthenticationEvent::AccessTokenPersisted);
+        Ok(token)
     }
 }
 
@@ -548,8 +569,9 @@ fn set_file_owner(
 #[cfg(test)]
 mod tests {
     use super::{
-        token_temp_path, PlatformAccessToken, PlatformAccessTokenError, PlatformAccessTokenStore,
-        PlatformAccessTokenStoreError, PlatformAccessTokenStoreOperation, TEMP_FILE_ATTEMPTS,
+        token_temp_path, PlatformAccessToken, PlatformAccessTokenAcquisitionError,
+        PlatformAccessTokenError, PlatformAccessTokenStore, PlatformAccessTokenStoreError,
+        PlatformAccessTokenStoreOperation, TEMP_FILE_ATTEMPTS,
     };
     use crate::auth::SystemUser;
     use std::fs;
@@ -658,6 +680,27 @@ mod tests {
         .expect("derive platform access-token store");
 
         assert_eq!(store.load().expect("load missing token"), None);
+    }
+
+    #[test]
+    fn stored_token_load_reports_actionable_missing_credential() {
+        let dir = TestDir::new("missing-stored-token");
+        let store = PlatformAccessTokenStore::for_primary_profile(
+            &dir.config_path(),
+            current_user(dir.path()),
+        )
+        .expect("derive platform access-token store");
+
+        let error = store
+            .load_stored()
+            .expect_err("runtime authentication must require a stored token");
+        assert!(matches!(
+            error,
+            PlatformAccessTokenAcquisitionError::MissingStoredToken
+        ));
+        assert!(error
+            .to_string()
+            .contains("pair the TV from foreground settings"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/platform_access_token.rs
+++ b/crates/lg-buddy/src/platform_access_token.rs
@@ -171,10 +171,7 @@ pub enum PlatformAccessTokenAcquisitionError {
 impl fmt::Display for PlatformAccessTokenAcquisitionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::MissingStoredToken => write!(
-                f,
-                "no stored platform access token is available; pair the TV from foreground settings by running `lg-buddy settings set tv.platform lg_webos`"
-            ),
+            Self::MissingStoredToken => write!(f, "no stored platform access token is available"),
             Self::Store { source } => write!(f, "platform access-token storage failed: {source}"),
             Self::Registration { source } => {
                 write!(f, "platform access-token registration failed: {source}")
@@ -683,7 +680,7 @@ mod tests {
     }
 
     #[test]
-    fn stored_token_load_reports_actionable_missing_credential() {
+    fn stored_token_load_reports_missing_credential_without_manual_repair_guidance() {
         let dir = TestDir::new("missing-stored-token");
         let store = PlatformAccessTokenStore::for_primary_profile(
             &dir.config_path(),
@@ -698,9 +695,10 @@ mod tests {
             error,
             PlatformAccessTokenAcquisitionError::MissingStoredToken
         ));
-        assert!(error
-            .to_string()
-            .contains("pair the TV from foreground settings"));
+        assert_eq!(
+            error.to_string(),
+            "no stored platform access token is available"
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -180,6 +180,7 @@ pub(crate) fn run_screen_off_from_env_for_event<W: Write>(
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production(),
     )?;
     let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
@@ -218,6 +219,7 @@ pub(crate) fn run_screen_on_from_env_for_event<W: Write>(
     let tv_client = build_tv_client(
         &config_path,
         config.tv_ip,
+        config.tv_platform,
         TvClientBuildOptions::production(),
     )?;
     let wol_sender = UdpWakeOnLanSender::default();
@@ -1625,6 +1627,7 @@ mod tests {
                 .parse::<MacAddress>()
                 .expect("parse mac"),
             input,
+            tv_platform: crate::config::TvPlatform::Bscpylgtv,
             screen_backend: ScreenBackend::Auto,
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -6,10 +6,17 @@ use std::io;
 use std::net::Ipv4Addr;
 use std::path::{Path, PathBuf};
 use std::process::{Command as ProcessCommand, Stdio};
+use std::time::Duration;
 
+use crate::auth::resolve_config_owner;
 use crate::config::{
     parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathError,
-    ConfigPathSources, MacAddress, DEFAULT_IDLE_TIMEOUT, MAX_IDLE_TIMEOUT,
+    ConfigPathSources, MacAddress, TvPlatform, DEFAULT_IDLE_TIMEOUT, MAX_IDLE_TIMEOUT,
+};
+use crate::platform_access_token::PlatformAccessTokenStore;
+use crate::web_os::{
+    WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsEndpoint,
+    WebOsPowerStateError,
 };
 
 const SETTINGS_SUBCOMMANDS: &[&str] = &["list", "describe", "get", "set", "unset"];
@@ -38,6 +45,7 @@ const SCREEN_RESTORE_POLICY_ALIASES: &[SettingAlias] = &[SettingAlias {
 }];
 
 const TV_INPUT_VALUES: &[&str] = &["HDMI_1", "HDMI_2", "HDMI_3", "HDMI_4"];
+const TV_PLATFORM_VALUES: &[&str] = &["bscpylgtv", "lg_webos"];
 const SCREEN_BACKEND_VALUES: &[&str] = &["auto", "gnome", "swayidle"];
 const SCREEN_IDLE_BLANK_VALUES: &[&str] = &["enabled", "disabled"];
 const SCREEN_RESTORE_POLICY_VALUES: &[&str] = &["conservative", "aggressive"];
@@ -81,6 +89,20 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
         operations: READ_SET_OPERATIONS,
         apply_strategy: ApplyStrategy::NoRuntimeApplyRequired,
         description: "HDMI input used by the primary configured TV.",
+    },
+    SettingDefinition {
+        key: "tv.platform",
+        storage_key: "tvs_primary_platform",
+        fallback_storage_keys: EMPTY_STORAGE_KEYS,
+        value_type: SettingType::Enum(EnumSettingType {
+            values: TV_PLATFORM_VALUES,
+            aliases: EMPTY_ALIASES,
+        }),
+        default_value: Some(SettingValue::Enum("bscpylgtv")),
+        mutability: SettingMutability::ReadWrite,
+        operations: READ_WRITE_OPERATIONS,
+        apply_strategy: ApplyStrategy::NoRuntimeApplyRequired,
+        description: "Control platform for the primary configured TV.",
     },
     SettingDefinition {
         key: "screen.backend",
@@ -990,25 +1012,133 @@ fn settings_enable_outcome(
     }
 }
 
+pub trait PlatformPreflight {
+    fn preflight(
+        &self,
+        platform: TvPlatform,
+        config_path: &Path,
+        tv_ip: Ipv4Addr,
+        writer: &mut dyn io::Write,
+    ) -> Result<(), String>;
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct WebOsPlatformPreflight;
+
+impl PlatformPreflight for WebOsPlatformPreflight {
+    fn preflight(
+        &self,
+        platform: TvPlatform,
+        config_path: &Path,
+        tv_ip: Ipv4Addr,
+        writer: &mut dyn io::Write,
+    ) -> Result<(), String> {
+        if platform != TvPlatform::LgWebOs {
+            return Ok(());
+        }
+
+        let owner = resolve_config_owner(config_path).map_err(|error| error.to_string())?;
+        let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
+            .map_err(|error| error.to_string())?;
+
+        let mut auth_write_error = None;
+        let mut client = {
+            let mut on_auth_event = |event| {
+                if auth_write_error.is_none() {
+                    auth_write_error =
+                        write_native_auth_event(writer, token_store.token_path(), event)
+                            .err()
+                            .map(|error| error.to_string());
+                }
+            };
+
+            WebOsClient::connect_authenticated(
+                WebOsEndpoint::wss(tv_ip),
+                Duration::from_secs(3),
+                Duration::from_secs(60),
+                &token_store,
+                &mut on_auth_event,
+            )
+            .map_err(|error: WebOsAuthenticatedClientError| error.to_string())?
+        };
+
+        if let Some(error) = auth_write_error {
+            return Err(format!("could not report native pairing progress: {error}"));
+        }
+
+        let power_state = client
+            .power_state()
+            .map_err(|error: WebOsPowerStateError| error.to_string())?;
+
+        writeln!(
+            writer,
+            "LG Buddy native webOS preflight succeeded: power_state={power_state}"
+        )
+        .map_err(|error| error.to_string())?;
+        writer.flush().map_err(|error| error.to_string())
+    }
+}
+
+fn write_native_auth_event(
+    writer: &mut dyn io::Write,
+    token_path: &Path,
+    event: WebOsAuthenticationEvent,
+) -> io::Result<()> {
+    match event {
+        WebOsAuthenticationEvent::UsingStoredAccessToken => {
+            writeln!(
+                writer,
+                "LG Buddy native webOS preflight: using stored access token."
+            )?;
+        }
+        WebOsAuthenticationEvent::PairingPrompt => {
+            writeln!(
+                writer,
+                "LG Buddy native webOS preflight: pairing required; accept the prompt on the TV."
+            )?;
+        }
+        WebOsAuthenticationEvent::AccessTokenPersisted => {
+            writeln!(
+                writer,
+                "LG Buddy native webOS preflight: stored access token at {}",
+                token_path.display()
+            )?;
+        }
+    }
+    writer.flush()
+}
+
 #[derive(Debug)]
-pub struct SettingsCommandRunner<C = SystemdUserServiceController> {
+pub struct SettingsCommandRunner<C = SystemdUserServiceController, P = WebOsPlatformPreflight> {
     store: SettingsStore,
     formatter: SettingsFormatter,
     applier: SettingsApplier<C>,
+    preflight: P,
 }
 
-impl SettingsCommandRunner<SystemdUserServiceController> {
+impl SettingsCommandRunner<SystemdUserServiceController, WebOsPlatformPreflight> {
     pub fn new(store: SettingsStore) -> Self {
         Self::with_applier(store, SettingsApplier::from_env())
     }
 }
 
-impl<C: ServiceController> SettingsCommandRunner<C> {
+impl<C: ServiceController> SettingsCommandRunner<C, WebOsPlatformPreflight> {
     pub fn with_applier(store: SettingsStore, applier: SettingsApplier<C>) -> Self {
+        Self::with_applier_and_preflight(store, applier, WebOsPlatformPreflight)
+    }
+}
+
+impl<C: ServiceController, P: PlatformPreflight> SettingsCommandRunner<C, P> {
+    pub fn with_applier_and_preflight(
+        store: SettingsStore,
+        applier: SettingsApplier<C>,
+        preflight: P,
+    ) -> Self {
         Self {
             store,
             formatter: SettingsFormatter,
             applier,
+            preflight,
         }
     }
 
@@ -1038,6 +1168,7 @@ impl<C: ServiceController> SettingsCommandRunner<C> {
             }
             SettingsCommand::Set { key, value } => {
                 let mutation = SettingsMutation::set(&self.store, &key, &value)?;
+                self.preflight_if_required(&mutation, writer)?;
                 let change = persist_settings_mutation(self.store.path(), mutation)?;
                 let apply = self.apply_after_persist(&change)?;
                 self.formatter.write_change(writer, &change, &apply)
@@ -1049,6 +1180,35 @@ impl<C: ServiceController> SettingsCommandRunner<C> {
                 self.formatter.write_change(writer, &change, &apply)
             }
         }
+    }
+
+    fn preflight_if_required<W: io::Write>(
+        &self,
+        mutation: &SettingsMutation,
+        writer: &mut W,
+    ) -> Result<(), SettingsError> {
+        if mutation.action() != SettingsMutationAction::Set
+            || mutation.key_name() != "tv.platform"
+            || mutation.new_value()?.as_enum() != Some(TvPlatform::LgWebOs.as_str())
+        {
+            return Ok(());
+        }
+
+        let tv_ip = match self.store.effective_by_name("tv.ip")?.required_value()? {
+            SettingValue::Ipv4(value) => value,
+            _ => {
+                return Err(SettingsError::MissingRequiredSetting {
+                    key: "tv.ip".to_string(),
+                });
+            }
+        };
+
+        self.preflight
+            .preflight(TvPlatform::LgWebOs, self.store.path(), tv_ip, writer)
+            .map_err(|message| SettingsError::PlatformPreflight {
+                key: mutation.key_name().to_string(),
+                message,
+            })
     }
 
     fn apply_after_persist(
@@ -1965,6 +2125,10 @@ pub enum SettingsError {
     Apply {
         message: String,
     },
+    PlatformPreflight {
+        key: String,
+        message: String,
+    },
     ApplyAfterPersist {
         key: String,
         path: PathBuf,
@@ -2010,6 +2174,10 @@ impl fmt::Display for SettingsError {
                 )
             }
             Self::Apply { message } => write!(f, "{message}"),
+            Self::PlatformPreflight { key, message } => write!(
+                f,
+                "could not enable platform setting `{key}` because native preflight failed: {message}"
+            ),
             Self::ApplyAfterPersist { key, path, message } => write!(
                 f,
                 "setting `{key}` was saved to `{}` but could not be applied: {message}. Restart LG Buddy or rerun the command after fixing the apply error.",
@@ -2050,6 +2218,7 @@ impl std::error::Error for SettingsError {
             Self::ReadConfig { .. }
             | Self::WriteConfig { .. }
             | Self::Apply { .. }
+            | Self::PlatformPreflight { .. }
             | Self::ApplyAfterPersist { .. }
             | Self::WriteOutput(_)
             | Self::InvalidKey { .. }
@@ -2224,12 +2393,12 @@ fn validate_storage_key(value: &str) -> Result<(), &'static str> {
 mod tests {
     use super::{
         format_effective_value, ApplyStrategy, ConfigEnvReader, ConfigPathResolver,
-        ServiceController, SettingKey, SettingMutability, SettingOperation, SettingSource,
-        SettingType, SettingValue, SettingsApplier, SettingsCommand, SettingsCommandRunner,
-        SettingsError, SettingsParseError, SettingsStore, UserServiceState, UserUnitEnableOutcome,
-        SETTINGS_REGISTRY,
+        PlatformPreflight, ServiceController, SettingKey, SettingMutability, SettingOperation,
+        SettingSource, SettingType, SettingValue, SettingsApplier, SettingsCommand,
+        SettingsCommandRunner, SettingsError, SettingsParseError, SettingsStore, UserServiceState,
+        UserUnitEnableOutcome, SETTINGS_REGISTRY,
     };
-    use crate::config::{ConfigPathSources, MAX_IDLE_TIMEOUT};
+    use crate::config::{ConfigPathSources, TvPlatform, MAX_IDLE_TIMEOUT};
     use std::cell::Cell;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -2255,6 +2424,7 @@ mod tests {
                 "tv.ip",
                 "tv.mac",
                 "tv.input",
+                "tv.platform",
                 "screen.backend",
                 "screen.idle_blank",
                 "screen.idle_timeout",
@@ -2280,6 +2450,7 @@ mod tests {
                 ("tv.ip", "tvs_primary_ip"),
                 ("tv.mac", "tvs_primary_mac"),
                 ("tv.input", "tvs_primary_input"),
+                ("tv.platform", "tvs_primary_platform"),
                 ("screen.backend", "screen_backend"),
                 ("screen.idle_blank", "screen_idle_blank"),
                 ("screen.idle_timeout", "screen_idle_timeout"),
@@ -2305,6 +2476,7 @@ mod tests {
                 "tv.ip | storage=tvs_primary_ip | fallbacks=tv_ip | type=ipv4 | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=IPv4 address of the primary configured TV.",
                 "tv.mac | storage=tvs_primary_mac | fallbacks=tv_mac | type=mac-address | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=MAC address of the primary configured TV for Wake-on-LAN.",
                 "tv.input | storage=tvs_primary_input | fallbacks=input | type=enum values=HDMI_1,HDMI_2,HDMI_3,HDMI_4 aliases=(none) | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=HDMI input used by the primary configured TV.",
+                "tv.platform | storage=tvs_primary_platform | fallbacks=(none) | type=enum values=bscpylgtv,lg_webos aliases=(none) | default=bscpylgtv | mutability=read-write | ops=get,describe,set,unset | apply=no-runtime-apply-required | description=Control platform for the primary configured TV.",
                 "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Screen backend selection for user-session blanking and restore behavior.",
                 "screen.idle_blank | storage=screen_idle_blank | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Idle-driven blanking and restore behavior for the configured screen.",
                 "screen.idle_timeout | storage=screen_idle_timeout | fallbacks=(none) | type=integer range=1..=86400 | default=300 | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Idle timeout in seconds before LG Buddy blanks the configured screen.",
@@ -2395,6 +2567,7 @@ mod tests {
 tv.ip=<missing> (missing, read-write, ops: get,describe,set)
 tv.mac=<missing> (missing, read-write, ops: get,describe,set)
 tv.input=<missing> (missing, read-write, ops: get,describe,set)
+tv.platform=bscpylgtv (default, read-write, ops: get,describe,set,unset)
 screen.backend=gnome (config.env, read-write, ops: get,describe,set,unset)
 screen.idle_blank=enabled (default, read-write, ops: get,describe,set,unset)
 screen.idle_timeout=300 (default, read-write, ops: get,describe,set,unset)
@@ -2499,6 +2672,18 @@ tv.input
   allowed values: HDMI_1, HDMI_2, HDMI_3, HDMI_4
   apply: no-runtime-apply-required
   description: HDMI input used by the primary configured TV.
+
+tv.platform
+  storage key: tvs_primary_platform
+  type: enum
+  current: bscpylgtv
+  source: default
+  default: bscpylgtv
+  mutability: read-write
+  supported operations: get, describe, set, unset
+  allowed values: bscpylgtv, lg_webos
+  apply: no-runtime-apply-required
+  description: Control platform for the primary configured TV.
 
 screen.backend
   storage key: screen_backend
@@ -3428,6 +3613,7 @@ tvs_primary_ip=192.0.2.43
                 "tv.ip",
                 "tv.mac",
                 "tv.input",
+                "tv.platform",
                 "screen.backend",
                 "screen.idle_blank",
                 "screen.idle_timeout",
@@ -3443,6 +3629,7 @@ tvs_primary_ip=192.0.2.43
                 "<missing>",
                 "<missing>",
                 "<missing>",
+                "bscpylgtv",
                 "gnome",
                 "enabled",
                 "300",
@@ -3458,6 +3645,7 @@ tvs_primary_ip=192.0.2.43
                 SettingSource::Missing,
                 SettingSource::Missing,
                 SettingSource::Missing,
+                SettingSource::Default,
                 SettingSource::ConfigEnv,
                 SettingSource::Default,
                 SettingSource::Default,
@@ -3573,6 +3761,128 @@ tvs_primary_ip=192.0.2.43
             input.parse_value("AV_1"),
             Err(SettingsError::InvalidValue { .. })
         ));
+    }
+
+    #[test]
+    fn tv_platform_values_are_validated() {
+        let platform = SETTINGS_REGISTRY.get_by_name("tv.platform").unwrap();
+
+        assert_eq!(
+            platform.parse_value("bscpylgtv"),
+            Ok(SettingValue::Enum("bscpylgtv"))
+        );
+        assert_eq!(
+            platform.parse_value("lg_webos"),
+            Ok(SettingValue::Enum("lg_webos"))
+        );
+        assert!(matches!(
+            platform.parse_value("native"),
+            Err(SettingsError::InvalidValue { .. })
+        ));
+    }
+
+    #[test]
+    fn settings_runner_requires_successful_native_preflight_before_persisting() {
+        let path = unique_test_path("platform-preflight");
+        fs::write(&path, "tv_ip=192.0.2.42\ntvs_primary_platform=bscpylgtv\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let preflight = FakePlatformPreflight::succeeding();
+        let calls = preflight.calls.clone();
+        let runner = SettingsCommandRunner::with_applier_and_preflight(
+            store,
+            SettingsApplier::new(FakeServiceController::missing()),
+            preflight,
+        );
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "tv.platform".to_string(),
+                    value: "lg_webos".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(calls.get(), 1);
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "tv_ip=192.0.2.42\ntvs_primary_platform=lg_webos\n"
+        );
+        assert!(String::from_utf8(output)
+            .unwrap()
+            .contains("native preflight succeeded"));
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn failed_native_preflight_leaves_platform_unchanged() {
+        let path = unique_test_path("platform-preflight-failure");
+        fs::write(&path, "tv_ip=192.0.2.42\ntvs_primary_platform=bscpylgtv\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let preflight = FakePlatformPreflight::failing();
+        let calls = preflight.calls.clone();
+        let runner = SettingsCommandRunner::with_applier_and_preflight(
+            store,
+            SettingsApplier::new(FakeServiceController::missing()),
+            preflight,
+        );
+        let mut output = Vec::new();
+
+        let error = runner
+            .run(
+                SettingsCommand::Set {
+                    key: "tv.platform".to_string(),
+                    value: "lg_webos".to_string(),
+                },
+                &mut output,
+            )
+            .expect_err("failed native preflight should block persistence");
+
+        assert_eq!(calls.get(), 1);
+        assert!(matches!(error, SettingsError::PlatformPreflight { .. }));
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "tv_ip=192.0.2.42\ntvs_primary_platform=bscpylgtv\n"
+        );
+        assert!(output.is_empty());
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn switching_to_bscpylgtv_skips_native_preflight() {
+        let path = unique_test_path("platform-legacy");
+        fs::write(&path, "tv_ip=192.0.2.42\ntvs_primary_platform=lg_webos\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let preflight = FakePlatformPreflight::failing();
+        let calls = preflight.calls.clone();
+        let runner = SettingsCommandRunner::with_applier_and_preflight(
+            store,
+            SettingsApplier::new(FakeServiceController::missing()),
+            preflight,
+        );
+        let mut output = Vec::new();
+
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "tv.platform".to_string(),
+                    value: "bscpylgtv".to_string(),
+                },
+                &mut output,
+            )
+            .unwrap();
+
+        assert_eq!(calls.get(), 0);
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "tv_ip=192.0.2.42\ntvs_primary_platform=bscpylgtv\n"
+        );
+
+        let _ = fs::remove_file(path);
     }
 
     #[test]
@@ -3767,6 +4077,48 @@ tvs_primary_ip=192.0.2.43
             .map(|operation| operation.as_str())
             .collect::<Vec<_>>()
             .join(",")
+    }
+
+    #[derive(Debug, Clone)]
+    struct FakePlatformPreflight {
+        calls: Rc<Cell<usize>>,
+        result: Result<(), &'static str>,
+    }
+
+    impl FakePlatformPreflight {
+        fn succeeding() -> Self {
+            Self {
+                calls: Rc::new(Cell::new(0)),
+                result: Ok(()),
+            }
+        }
+
+        fn failing() -> Self {
+            Self {
+                calls: Rc::new(Cell::new(0)),
+                result: Err("TV rejected native authentication"),
+            }
+        }
+    }
+
+    impl PlatformPreflight for FakePlatformPreflight {
+        fn preflight(
+            &self,
+            platform: TvPlatform,
+            _config_path: &Path,
+            _tv_ip: std::net::Ipv4Addr,
+            writer: &mut dyn std::io::Write,
+        ) -> Result<(), String> {
+            assert_eq!(platform, TvPlatform::LgWebOs);
+            self.calls.set(self.calls.get() + 1);
+            if self.result.is_ok() {
+                writeln!(writer, "native preflight succeeded")
+                    .map_err(|error| error.to_string())?;
+                Ok(())
+            } else {
+                self.result.map_err(str::to_string)
+            }
+        }
     }
 
     #[derive(Debug, Clone)]

--- a/crates/lg-buddy/src/sources/linux/network_manager.rs
+++ b/crates/lg-buddy/src/sources/linux/network_manager.rs
@@ -523,6 +523,7 @@ mod tests {
                 .parse::<MacAddress>()
                 .expect("parse mac"),
             input: HdmiInput::Hdmi2,
+            tv_platform: crate::config::TvPlatform::Bscpylgtv,
             screen_backend: ScreenBackend::Auto,
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -16,7 +16,7 @@ use crate::auth::{
 };
 use crate::config::{HdmiInput, MacAddress, TvPlatform};
 use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
-use crate::web_os::{WebOsEndpoint, WebOsTvClient};
+use crate::web_os::{WebOsEndpoint, WebOsPairingPolicy, WebOsTvClient};
 use crate::wol::{WakeOnLanError, WakeOnLanSender};
 
 pub const DEFAULT_BSCPYLGTV_COMMAND_PATH: &str = "/usr/bin/LG_Buddy_PIP/bin/bscpylgtvcommand";
@@ -24,6 +24,7 @@ pub const OLED_BRIGHTNESS_MIN: u8 = 0;
 pub const OLED_BRIGHTNESS_MAX: u8 = 100;
 const DEFAULT_WEBOS_CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
 const DEFAULT_WEBOS_RESPONSE_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_WEBOS_UNATTENDED_RESPONSE_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct CommandOutput {
@@ -215,17 +216,24 @@ pub trait TvClient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TvClientBuildOptions {
     command_timeout: Option<Duration>,
+    webos_pairing_policy: WebOsPairingPolicy,
 }
 
 impl TvClientBuildOptions {
     pub(crate) fn production() -> Self {
         Self {
             command_timeout: None,
+            webos_pairing_policy: WebOsPairingPolicy::PairIfNeeded,
         }
     }
 
     pub(crate) fn with_command_timeout(mut self, timeout: Duration) -> Self {
         self.command_timeout = Some(timeout);
+        self
+    }
+
+    pub(crate) fn stored_token_only(mut self) -> Self {
+        self.webos_pairing_policy = WebOsPairingPolicy::StoredTokenOnly;
         self
     }
 }
@@ -310,6 +318,17 @@ impl TvClient for SelectedTvClient {
     }
 }
 
+impl SelectedTvClient {
+    pub(crate) fn can_authenticate_unattended(&self) -> Result<bool, TvClientBuildError> {
+        match self {
+            Self::Bscpylgtv(_) => Ok(true),
+            Self::WebOs(client) => client
+                .has_stored_access_token()
+                .map_err(TvClientBuildError::TokenStore),
+        }
+    }
+}
+
 pub(crate) fn build_tv_client(
     config_path: &Path,
     tv_ip: Ipv4Addr,
@@ -333,14 +352,21 @@ pub(crate) fn build_tv_client(
                 resolve_config_owner(config_path).map_err(TvClientBuildError::AuthContext)?;
             let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
                 .map_err(TvClientBuildError::TokenStore)?;
-            let response_timeout = options
-                .command_timeout
-                .unwrap_or(DEFAULT_WEBOS_RESPONSE_TIMEOUT);
+            let response_timeout =
+                options
+                    .command_timeout
+                    .unwrap_or(match options.webos_pairing_policy {
+                        WebOsPairingPolicy::PairIfNeeded => DEFAULT_WEBOS_RESPONSE_TIMEOUT,
+                        WebOsPairingPolicy::StoredTokenOnly => {
+                            DEFAULT_WEBOS_UNATTENDED_RESPONSE_TIMEOUT
+                        }
+                    });
             Ok(SelectedTvClient::WebOs(Box::new(WebOsTvClient::new(
                 WebOsEndpoint::wss(tv_ip),
                 DEFAULT_WEBOS_CONNECT_TIMEOUT,
                 response_timeout,
                 token_store,
+                options.webos_pairing_policy,
             ))))
         }
     }

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -214,18 +214,18 @@ pub trait TvClient {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TvClientBuildOptions {
-    legacy_command_timeout: Option<Duration>,
+    command_timeout: Option<Duration>,
 }
 
 impl TvClientBuildOptions {
     pub(crate) fn production() -> Self {
         Self {
-            legacy_command_timeout: None,
+            command_timeout: None,
         }
     }
 
-    pub(crate) fn with_legacy_command_timeout(mut self, timeout: Duration) -> Self {
-        self.legacy_command_timeout = Some(timeout);
+    pub(crate) fn with_command_timeout(mut self, timeout: Duration) -> Self {
+        self.command_timeout = Some(timeout);
         self
     }
 }
@@ -323,7 +323,7 @@ pub(crate) fn build_tv_client(
             let mut client = BscpylgtvCommandClient::from_env(tv_ip)
                 .with_auth_context(auth_context)
                 .with_launcher(UserScopedBscpylgtvCommandLauncher);
-            if let Some(timeout) = options.legacy_command_timeout {
+            if let Some(timeout) = options.command_timeout {
                 client = client.with_command_timeout(timeout);
             }
             Ok(SelectedTvClient::Bscpylgtv(client))
@@ -333,10 +333,13 @@ pub(crate) fn build_tv_client(
                 resolve_config_owner(config_path).map_err(TvClientBuildError::AuthContext)?;
             let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
                 .map_err(TvClientBuildError::TokenStore)?;
+            let response_timeout = options
+                .command_timeout
+                .unwrap_or(DEFAULT_WEBOS_RESPONSE_TIMEOUT);
             Ok(SelectedTvClient::WebOs(Box::new(WebOsTvClient::new(
                 WebOsEndpoint::wss(tv_ip),
                 DEFAULT_WEBOS_CONNECT_TIMEOUT,
-                DEFAULT_WEBOS_RESPONSE_TIMEOUT,
+                response_timeout,
                 token_store,
             ))))
         }
@@ -1089,6 +1092,26 @@ mod tests {
     }
 
     #[test]
+    fn centralized_factory_applies_command_timeout_to_native_responses() {
+        let config = TestConfigFile::new("tv-client-native-timeout");
+        config.write_sample("HDMI_2");
+        let command_timeout = Duration::from_secs(3);
+
+        let webos = build_tv_client(
+            config.path(),
+            ip("192.0.2.42"),
+            TvPlatform::LgWebOs,
+            TvClientBuildOptions::production().with_command_timeout(command_timeout),
+        )
+        .expect("build native webOS TV client");
+
+        let SelectedTvClient::WebOs(client) = webos else {
+            panic!("lg_webos should select the native webOS client");
+        };
+        assert_eq!(client.response_timeout(), command_timeout);
+    }
+
+    #[test]
     fn get_input_uses_last_non_empty_stdout_line() {
         let mock = MockBscpylgtv::new("tv-get-input");
         mock.queue_success("get_input", "\nignored\ncom.webos.app.hdmi2\n");
@@ -1349,7 +1372,11 @@ mod tests {
 
         assert_eq!(err.operation(), TvOperation::ReadInput);
         assert_eq!(err.kind(), TvErrorKind::Transport);
-        assert!(err.detail().contains("timed out after"));
+        assert!(
+            err.detail().contains("timed out after"),
+            "unexpected error detail: {}",
+            err.detail()
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -14,7 +14,7 @@ use crate::auth::{
     resolve_bscpylgtv_auth_context_from_env, resolve_config_owner, AuthContextError,
     BscpylgtvAuthContext, SystemUser,
 };
-use crate::config::{HdmiInput, MacAddress};
+use crate::config::{HdmiInput, MacAddress, TvPlatform};
 use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
 use crate::web_os::{WebOsEndpoint, WebOsTvClient};
 use crate::wol::{WakeOnLanError, WakeOnLanSender};
@@ -213,21 +213,13 @@ pub trait TvClient {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum TvClientImplementation {
-    Bscpylgtv,
-    WebOs,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct TvClientBuildOptions {
-    implementation: TvClientImplementation,
     legacy_command_timeout: Option<Duration>,
 }
 
 impl TvClientBuildOptions {
     pub(crate) fn production() -> Self {
         Self {
-            implementation: TvClientImplementation::Bscpylgtv,
             legacy_command_timeout: None,
         }
     }
@@ -235,14 +227,6 @@ impl TvClientBuildOptions {
     pub(crate) fn with_legacy_command_timeout(mut self, timeout: Duration) -> Self {
         self.legacy_command_timeout = Some(timeout);
         self
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn webos() -> Self {
-        Self {
-            implementation: TvClientImplementation::WebOs,
-            legacy_command_timeout: None,
-        }
     }
 }
 
@@ -329,10 +313,11 @@ impl TvClient for SelectedTvClient {
 pub(crate) fn build_tv_client(
     config_path: &Path,
     tv_ip: Ipv4Addr,
+    platform: TvPlatform,
     options: TvClientBuildOptions,
 ) -> Result<SelectedTvClient, TvClientBuildError> {
-    match options.implementation {
-        TvClientImplementation::Bscpylgtv => {
+    match platform {
+        TvPlatform::Bscpylgtv => {
             let auth_context = resolve_bscpylgtv_auth_context_from_env(config_path)
                 .map_err(TvClientBuildError::AuthContext)?;
             let mut client = BscpylgtvCommandClient::from_env(tv_ip)
@@ -343,7 +328,7 @@ pub(crate) fn build_tv_client(
             }
             Ok(SelectedTvClient::Bscpylgtv(client))
         }
-        TvClientImplementation::WebOs => {
+        TvPlatform::LgWebOs => {
             let owner =
                 resolve_config_owner(config_path).map_err(TvClientBuildError::AuthContext)?;
             let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner)
@@ -1027,7 +1012,7 @@ mod tests {
         DEFAULT_BSCPYLGTV_COMMAND_PATH,
     };
     use crate::auth::{BscpylgtvAuthContext, SystemUser};
-    use crate::config::{HdmiInput, MacAddress};
+    use crate::config::{HdmiInput, MacAddress, TvPlatform};
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
     use std::cell::RefCell;
     use std::io;
@@ -1079,17 +1064,27 @@ mod tests {
     }
 
     #[test]
-    fn centralized_factory_can_build_both_internal_implementations() {
+    fn centralized_factory_maps_each_platform_to_its_client() {
         let config = TestConfigFile::new("tv-client-factory");
         config.write_sample("HDMI_2");
         let tv_ip = ip("192.0.2.42");
 
-        let production = build_tv_client(config.path(), tv_ip, TvClientBuildOptions::production())
-            .expect("build production TV client");
-        assert!(matches!(production, SelectedTvClient::Bscpylgtv(_)));
+        let bscpylgtv = build_tv_client(
+            config.path(),
+            tv_ip,
+            TvPlatform::Bscpylgtv,
+            TvClientBuildOptions::production(),
+        )
+        .expect("build bscpylgtv TV client");
+        assert!(matches!(bscpylgtv, SelectedTvClient::Bscpylgtv(_)));
 
-        let webos = build_tv_client(config.path(), tv_ip, TvClientBuildOptions::webos())
-            .expect("build internal webOS TV client");
+        let webos = build_tv_client(
+            config.path(),
+            tv_ip,
+            TvPlatform::LgWebOs,
+            TvClientBuildOptions::production(),
+        )
+        .expect("build native webOS TV client");
         assert!(matches!(webos, SelectedTvClient::WebOs(_)));
     }
 

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -35,6 +35,11 @@ impl WebOsTvClient {
         }
     }
 
+    #[cfg(test)]
+    pub(crate) fn response_timeout(&self) -> Duration {
+        self.response_timeout
+    }
+
     fn with_session<T>(
         &self,
         operation: TvOperation,

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -81,12 +81,11 @@ impl WebOsTvClient {
             return Ok(());
         }
 
-        let client = WebOsClient::connect_authenticated(
+        let client = WebOsClient::connect_authenticated_with_stored_token(
             self.endpoint,
             self.connect_timeout,
             self.response_timeout,
             &self.token_store,
-            |_| {},
         )
         .map_err(|error| authenticated_client_failure(error).into_tv_error(operation))?;
         *session = Some(client);
@@ -243,6 +242,9 @@ fn authenticated_client_failure(error: WebOsAuthenticatedClientError) -> WebOsAd
             client_failure_with_detail(source, detail)
         }
         WebOsAuthenticatedClientError::Authentication { source } => match source {
+            PlatformAccessTokenAcquisitionError::MissingStoredToken => {
+                WebOsAdapterFailure::new(TvErrorKind::Authentication, detail, false)
+            }
             PlatformAccessTokenAcquisitionError::Registration { source } => match source {
                 super::WebOsClientRegistrationError::Transport { source } => {
                     client_failure_with_detail(source, detail)
@@ -465,10 +467,44 @@ mod tests {
         TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
     };
     use crate::web_os::WebOsPowerState;
+    use std::fs;
     use std::time::Duration;
 
     const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
     const RESPONSE_TIMEOUT: Duration = Duration::from_millis(500);
+
+    #[test]
+    fn missing_runtime_token_returns_actionable_authentication_error() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        fs::remove_file(token_fixture.store().token_path()).expect("remove stored token");
+        let client = client_for_server(&server, &token_fixture);
+
+        let error = client
+            .current_input()
+            .expect_err("background authentication must not initiate pairing");
+
+        assert_eq!(error.kind(), TvErrorKind::Authentication);
+        assert!(error
+            .detail()
+            .contains("pair the TV from foreground settings"));
+        server.finish();
+    }
+
+    #[test]
+    fn rejected_runtime_token_returns_actionable_authentication_error() {
+        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server(&server, &token_fixture);
+
+        let error = client
+            .current_input()
+            .expect_err("stale runtime token must not initiate pairing");
+
+        assert_eq!(error.kind(), TvErrorKind::Authentication);
+        assert!(error.detail().contains("foreground pairing"));
+        server.finish();
+    }
 
     #[test]
     fn complete_tv_contract_reuses_one_authenticated_session() {

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -11,28 +11,43 @@ use std::fmt;
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum WebOsPairingPolicy {
+    PairIfNeeded,
+    StoredTokenOnly,
+}
+
 pub struct WebOsTvClient {
     endpoint: WebOsEndpoint,
     connect_timeout: Duration,
     response_timeout: Duration,
     token_store: PlatformAccessTokenStore,
+    pairing_policy: WebOsPairingPolicy,
     session: Mutex<Option<WebOsClient>>,
 }
 
 impl WebOsTvClient {
-    pub fn new(
+    pub(crate) fn new(
         endpoint: WebOsEndpoint,
         connect_timeout: Duration,
         response_timeout: Duration,
         token_store: PlatformAccessTokenStore,
+        pairing_policy: WebOsPairingPolicy,
     ) -> Self {
         Self {
             endpoint,
             connect_timeout,
             response_timeout,
             token_store,
+            pairing_policy,
             session: Mutex::new(None),
         }
+    }
+
+    pub(crate) fn has_stored_access_token(
+        &self,
+    ) -> Result<bool, crate::platform_access_token::PlatformAccessTokenStoreError> {
+        self.token_store.load().map(|token| token.is_some())
     }
 
     #[cfg(test)]
@@ -86,12 +101,23 @@ impl WebOsTvClient {
             return Ok(());
         }
 
-        let client = WebOsClient::connect_authenticated_with_stored_token(
-            self.endpoint,
-            self.connect_timeout,
-            self.response_timeout,
-            &self.token_store,
-        )
+        let client = match self.pairing_policy {
+            WebOsPairingPolicy::PairIfNeeded => WebOsClient::connect_authenticated(
+                self.endpoint,
+                self.connect_timeout,
+                self.response_timeout,
+                &self.token_store,
+                |_| {},
+            ),
+            WebOsPairingPolicy::StoredTokenOnly => {
+                WebOsClient::connect_authenticated_with_stored_token(
+                    self.endpoint,
+                    self.connect_timeout,
+                    self.response_timeout,
+                    &self.token_store,
+                )
+            }
+        }
         .map_err(|error| authenticated_client_failure(error).into_tv_error(operation))?;
         *session = Some(client);
         Ok(())
@@ -458,6 +484,7 @@ impl fmt::Debug for WebOsTvClient {
             .field("connect_timeout", &self.connect_timeout)
             .field("response_timeout", &self.response_timeout)
             .field("token_store", &self.token_store)
+            .field("pairing_policy", &self.pairing_policy)
             .field("session", &"<redacted>")
             .finish()
     }
@@ -465,7 +492,7 @@ impl fmt::Debug for WebOsTvClient {
 
 #[cfg(test)]
 mod tests {
-    use super::WebOsTvClient;
+    use super::{WebOsPairingPolicy, WebOsTvClient};
     use crate::config::HdmiInput;
     use crate::tv::{CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind};
     use crate::web_os::test_support::{
@@ -479,35 +506,90 @@ mod tests {
     const RESPONSE_TIMEOUT: Duration = Duration::from_millis(500);
 
     #[test]
-    fn missing_runtime_token_returns_actionable_authentication_error() {
+    fn ordinary_operation_pairs_and_persists_a_missing_token() {
         let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         fs::remove_file(token_fixture.store().token_path()).expect("remove stored token");
         let client = client_for_server(&server, &token_fixture);
 
-        let error = client
+        let input = client
             .current_input()
-            .expect_err("background authentication must not initiate pairing");
+            .expect("ordinary operation should pair");
 
-        assert_eq!(error.kind(), TvErrorKind::Authentication);
-        assert!(error
-            .detail()
-            .contains("pair the TV from foreground settings"));
+        assert_eq!(input, CurrentInput::Hdmi(HdmiInput::Hdmi3));
+        assert_eq!(
+            token_fixture.store().load().expect("load acquired token"),
+            Some(server.access_token())
+        );
+        assert_eq!(server.snapshot().connection_count, 1);
         server.finish();
     }
 
     #[test]
-    fn rejected_runtime_token_returns_actionable_authentication_error() {
+    fn ordinary_operation_repairs_a_rejected_token() {
         let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 
+        let input = client
+            .current_input()
+            .expect("ordinary operation should repair stale token");
+
+        assert_eq!(input, CurrentInput::Hdmi(HdmiInput::Hdmi3));
+        assert_eq!(
+            token_fixture.store().load().expect("load repaired token"),
+            Some(server.access_token())
+        );
+        assert_eq!(server.snapshot().connection_count, 2);
+        server.finish();
+    }
+
+    #[test]
+    fn stored_token_only_operation_returns_immediately_when_token_is_missing() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        fs::remove_file(token_fixture.store().token_path()).expect("remove stored token");
+        let client = client_for_server_with_policy(
+            &server,
+            &token_fixture,
+            WebOsPairingPolicy::StoredTokenOnly,
+        );
+
         let error = client
             .current_input()
-            .expect_err("stale runtime token must not initiate pairing");
+            .expect_err("stored-token-only operation must not pair");
 
         assert_eq!(error.kind(), TvErrorKind::Authentication);
-        assert!(error.detail().contains("foreground pairing"));
+        assert_eq!(server.snapshot().connection_count, 0);
+        assert!(!token_fixture.store().token_path().exists());
+        server.finish();
+    }
+
+    #[test]
+    fn stored_token_only_operation_does_not_repair_a_rejected_token() {
+        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let token_fixture = TestAccessTokenStore::new();
+        let original = token_fixture
+            .store()
+            .load()
+            .expect("load original token")
+            .expect("original token");
+        let client = client_for_server_with_policy(
+            &server,
+            &token_fixture,
+            WebOsPairingPolicy::StoredTokenOnly,
+        );
+
+        let error = client
+            .current_input()
+            .expect_err("stored-token-only operation must not repair stale token");
+
+        assert_eq!(error.kind(), TvErrorKind::Authentication);
+        assert_eq!(
+            token_fixture.store().load().expect("reload original token"),
+            Some(original)
+        );
+        assert_eq!(server.snapshot().connection_count, 1);
         server.finish();
     }
 
@@ -629,11 +711,20 @@ mod tests {
         server: &WebOsTestServer,
         token_fixture: &TestAccessTokenStore,
     ) -> WebOsTvClient {
+        client_for_server_with_policy(server, token_fixture, WebOsPairingPolicy::PairIfNeeded)
+    }
+
+    fn client_for_server_with_policy(
+        server: &WebOsTestServer,
+        token_fixture: &TestAccessTokenStore,
+        pairing_policy: WebOsPairingPolicy,
+    ) -> WebOsTvClient {
         WebOsTvClient::new(
             server.endpoint(),
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             token_fixture.store().clone(),
+            pairing_policy,
         )
     }
 

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -399,7 +399,7 @@ impl fmt::Display for WebOsClientRegistrationError {
             Self::StoredTokenRequiresPairing => {
                 write!(
                     f,
-                    "webOS rejected the stored access token and requires foreground pairing; run `lg-buddy settings set tv.platform lg_webos` to pair the TV again"
+                    "webOS rejected the stored access token and requires pairing"
                 )
             }
         }

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -47,15 +47,16 @@ impl WebOsEndpoint {
         Self::wss_at(SocketAddr::new(IpAddr::V4(ip), WEBOS_WSS_PORT))
     }
 
-    #[cfg(test)]
-    pub(super) fn ws_at(address: SocketAddr) -> Self {
+    #[doc(hidden)]
+    pub fn ws_at(address: SocketAddr) -> Self {
         Self {
             address,
             transport: WebOsTransport::Ws,
         }
     }
 
-    pub(super) fn wss_at(address: SocketAddr) -> Self {
+    #[doc(hidden)]
+    pub fn wss_at(address: SocketAddr) -> Self {
         Self {
             address,
             transport: WebOsTransport::Wss,
@@ -84,6 +85,32 @@ pub struct WebOsClient {
 }
 
 impl WebOsClient {
+    /// Connects and authenticates using the stored token only.
+    ///
+    /// This is the authentication path for background operations. It loads
+    /// the token before connecting and never attempts pairing when the token
+    /// is missing or stale.
+    pub fn connect_authenticated_with_stored_token(
+        endpoint: WebOsEndpoint,
+        connect_timeout: Duration,
+        response_timeout: Duration,
+        token_store: &PlatformAccessTokenStore,
+    ) -> Result<Self, WebOsAuthenticatedClientError> {
+        let token = token_store
+            .load_stored()
+            .map_err(|source| WebOsAuthenticatedClientError::Authentication { source })?;
+        let mut client = Self::connect(endpoint, connect_timeout, response_timeout)
+            .map_err(|source| WebOsAuthenticatedClientError::Connect { source })?;
+        let mut registration = client.registration();
+        registration
+            .register(Some(&token), &mut |_| {})
+            .map_err(|source| WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::Registration { source },
+            })?;
+
+        Ok(client)
+    }
+
     pub fn connect_authenticated<F>(
         endpoint: WebOsEndpoint,
         connect_timeout: Duration,
@@ -96,12 +123,29 @@ impl WebOsClient {
     {
         let mut client = Self::connect(endpoint, connect_timeout, response_timeout)
             .map_err(|source| WebOsAuthenticatedClientError::Connect { source })?;
-        let mut registration = client.registration();
-        token_store
-            .get_or_acquire(&mut registration, &mut on_auth_event)
-            .map_err(|source| WebOsAuthenticatedClientError::Authentication { source })?;
+        let authentication = {
+            let mut registration = client.registration();
+            token_store.get_or_acquire(&mut registration, &mut on_auth_event)
+        };
 
-        Ok(client)
+        match authentication {
+            Ok(_) => Ok(client),
+            Err(PlatformAccessTokenAcquisitionError::Registration {
+                source: WebOsClientRegistrationError::StoredTokenRequiresPairing,
+            }) => {
+                // Foreground preflight may repair a stale credential, but it
+                // must retire the rejected connection before pairing again.
+                drop(client);
+                let mut client = Self::connect(endpoint, connect_timeout, response_timeout)
+                    .map_err(|source| WebOsAuthenticatedClientError::Connect { source })?;
+                let mut registration = client.registration();
+                token_store
+                    .acquire_and_persist(&mut registration, &mut on_auth_event)
+                    .map_err(|source| WebOsAuthenticatedClientError::Authentication { source })?;
+                Ok(client)
+            }
+            Err(source) => Err(WebOsAuthenticatedClientError::Authentication { source }),
+        }
     }
 
     fn connect(
@@ -355,7 +399,7 @@ impl fmt::Display for WebOsClientRegistrationError {
             Self::StoredTokenRequiresPairing => {
                 write!(
                     f,
-                    "webOS rejected the stored access token and requested pairing"
+                    "webOS rejected the stored access token and requires foreground pairing; run `lg-buddy settings set tv.platform lg_webos` to pair the TV again"
                 )
             }
         }
@@ -791,6 +835,29 @@ mod tests {
         server.finish();
     }
 
+    #[test]
+    fn stored_token_authentication_requires_a_credential_without_pairing() {
+        let dir = TestDir::new("missing-runtime-token");
+        let store = token_store(&dir);
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+
+        let result = WebOsClient::connect_authenticated_with_stored_token(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
+        );
+
+        assert!(matches!(
+            result,
+            Err(WebOsAuthenticatedClientError::Authentication {
+                source: PlatformAccessTokenAcquisitionError::MissingStoredToken,
+            })
+        ));
+        assert!(!store.token_path().exists());
+        server.finish();
+    }
+
     // Real-TV first-pairing acceptance target:
     // https://github.com/Staphylococcus/LG_Buddy/issues/47
     #[test]
@@ -825,7 +892,7 @@ mod tests {
     }
 
     #[test]
-    fn stored_token_pairing_request_is_typed_and_preserves_token() {
+    fn foreground_authentication_repairs_rejected_stored_token() {
         let dir = TestDir::new("rejected-stored-token");
         let store = token_store(&dir);
         let original = token("rejected-client-key");
@@ -833,12 +900,45 @@ mod tests {
         let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
         let mut events = Vec::new();
 
-        let result = WebOsClient::connect_authenticated(
+        let _client = WebOsClient::connect_authenticated(
             server.endpoint(),
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &store,
             |event| events.push(event),
+        )
+        .expect("foreground authentication should repair a stale token");
+
+        assert_eq!(
+            events,
+            vec![
+                WebOsAuthenticationEvent::UsingStoredAccessToken,
+                WebOsAuthenticationEvent::PairingPrompt,
+                WebOsAuthenticationEvent::AccessTokenPersisted,
+            ]
+        );
+        assert_eq!(
+            store.load().expect("reload stored token"),
+            Some(server.access_token())
+        );
+        assert_ne!(store.load().expect("reload stored token"), Some(original));
+        assert_eq!(server.snapshot().connection_count, 2);
+        server.finish();
+    }
+
+    #[test]
+    fn stored_token_runtime_authentication_rejects_pairing_prompt() {
+        let dir = TestDir::new("rejected-runtime-token");
+        let store = token_store(&dir);
+        let original = token("rejected-runtime-client-key");
+        store.persist(&original).expect("persist stored token");
+        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+
+        let result = WebOsClient::connect_authenticated_with_stored_token(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &store,
         );
 
         assert!(matches!(
@@ -849,10 +949,6 @@ mod tests {
                 },
             })
         ));
-        assert_eq!(
-            events,
-            vec![WebOsAuthenticationEvent::UsingStoredAccessToken]
-        );
         assert_eq!(store.load().expect("reload stored token"), Some(original));
         server.finish();
     }

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -14,6 +14,7 @@ mod screen;
 mod test_support;
 mod tls;
 
+pub(crate) use adapter::WebOsPairingPolicy;
 pub use adapter::WebOsTvClient;
 pub(crate) use client::WebOsClientRegistration;
 pub use client::{

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -105,7 +105,10 @@ impl WebOsTestInput {
 pub(in crate::web_os) struct WebOsTestTvSnapshot {
     pub(in crate::web_os) power_state: WebOsPowerState,
     pub(in crate::web_os) input: WebOsTestInput,
+    pub(in crate::web_os) backlight: Value,
     pub(in crate::web_os) connection_count: u64,
+    pub(in crate::web_os) pairing_prompt_count: u64,
+    pub(in crate::web_os) registration_tokens: Vec<Option<String>>,
 }
 
 struct WebOsTestTv {
@@ -287,6 +290,8 @@ struct WebOsTestRuntime {
     tv: WebOsTestTv,
     scenario: WebOsTestScenario,
     connection_count: u64,
+    pairing_prompt_count: u64,
+    registration_tokens: Vec<Option<String>>,
     ambiguous_input_write_injected: bool,
 }
 
@@ -336,13 +341,44 @@ impl WebOsTestServer {
         )
     }
 
+    #[allow(dead_code)]
+    pub(in crate::web_os) fn active_tls_at(
+        input: WebOsTestInput,
+        address: std::net::SocketAddr,
+    ) -> Self {
+        Self::spawn_at(
+            WebOsPowerState::Active,
+            input,
+            WebOsTestScenario::StatefulTv,
+            WebOsTestTransport::Tls,
+            address,
+        )
+    }
+
     fn spawn(
         power_state: WebOsPowerState,
         input: WebOsTestInput,
         scenario: WebOsTestScenario,
         transport: WebOsTestTransport,
     ) -> Self {
-        let listener = TcpListener::bind("127.0.0.1:0").expect("bind webOS test server");
+        Self::spawn_at(
+            power_state,
+            input,
+            scenario,
+            transport,
+            "127.0.0.1:0".parse().expect("webOS test bind address"),
+        )
+    }
+
+    fn spawn_at(
+        power_state: WebOsPowerState,
+        input: WebOsTestInput,
+        scenario: WebOsTestScenario,
+        transport: WebOsTestTransport,
+        bind_address: std::net::SocketAddr,
+    ) -> Self {
+        let listener = TcpListener::bind(bind_address)
+            .unwrap_or_else(|error| panic!("bind webOS test server at {bind_address}: {error}"));
         listener
             .set_nonblocking(true)
             .expect("configure webOS test listener");
@@ -355,6 +391,8 @@ impl WebOsTestServer {
             tv: WebOsTestTv::new(power_state, input),
             scenario,
             connection_count: 0,
+            pairing_prompt_count: 0,
+            registration_tokens: Vec::new(),
             ambiguous_input_write_injected: false,
         }));
         let active_connection = Arc::new(Mutex::new(None));
@@ -420,12 +458,31 @@ impl WebOsTestServer {
         PlatformAccessToken::new(TEST_ACCESS_TOKEN).expect("webOS test access token")
     }
 
+    #[allow(dead_code)]
+    pub(in crate::web_os) fn set_scenario(&self, scenario: WebOsTestScenario) {
+        self.runtime
+            .lock()
+            .expect("webOS test server state")
+            .scenario = scenario;
+    }
+
+    #[allow(dead_code)]
+    pub(in crate::web_os) fn assert_healthy(&self) {
+        assert!(
+            !self.handle.as_ref().is_some_and(JoinHandle::is_finished),
+            "webOS test server stopped unexpectedly"
+        );
+    }
+
     pub(in crate::web_os) fn snapshot(&self) -> WebOsTestTvSnapshot {
         let runtime = self.runtime.lock().expect("webOS test TV state");
         WebOsTestTvSnapshot {
             power_state: runtime.tv.power_state.clone(),
             input: runtime.tv.input,
+            backlight: runtime.tv.backlight.clone(),
             connection_count: runtime.connection_count,
+            pairing_prompt_count: runtime.pairing_prompt_count,
+            registration_tokens: runtime.registration_tokens.clone(),
         }
     }
 
@@ -507,6 +564,7 @@ fn serve_connection<S>(
         let scenario = runtime.lock().expect("webOS test server state").scenario;
         let keep_open = match scenario {
             WebOsTestScenario::StatefulTv
+            | WebOsTestScenario::StoredTokenPairingPrompt
             | WebOsTestScenario::PowerStatePermissionDenied
             | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
             | WebOsTestScenario::CloseAfterFirstInputWrite => {
@@ -600,6 +658,16 @@ where
         top_level,
         write_settings_authorized,
     });
+    let presented_token = match payload.get("client-key") {
+        Some(Value::String(token)) => Some(token.clone()),
+        Some(Value::Null) => None,
+        other => panic!("registration client key is neither a string nor null: {other:?}"),
+    };
+    runtime
+        .lock()
+        .expect("webOS test server state")
+        .registration_tokens
+        .push(presented_token);
 
     match scenario {
         WebOsTestScenario::StatefulTv
@@ -608,6 +676,7 @@ where
         | WebOsTestScenario::CloseAfterFirstInputWrite => match payload["client-key"].as_str() {
             Some(token) => send_json(socket, registration_response(request_id, token)),
             None if payload["client-key"].is_null() => {
+                record_pairing_prompt(runtime);
                 send_json(socket, pairing_prompt_response(request_id));
                 send_json(socket, registration_response(request_id, TEST_ACCESS_TOKEN));
             }
@@ -622,12 +691,18 @@ where
                 registration_response(request_id, TEST_REPLACEMENT_ACCESS_TOKEN),
             );
         }
-        WebOsTestScenario::StoredTokenPairingPrompt => {
-            payload["client-key"]
-                .as_str()
-                .expect("stored-token pairing scenario requires a client key");
-            send_json(socket, pairing_prompt_response(request_id));
-        }
+        WebOsTestScenario::StoredTokenPairingPrompt => match payload["client-key"].as_str() {
+            Some(_) => {
+                record_pairing_prompt(runtime);
+                send_json(socket, pairing_prompt_response(request_id));
+            }
+            None if payload["client-key"].is_null() => {
+                record_pairing_prompt(runtime);
+                send_json(socket, pairing_prompt_response(request_id));
+                send_json(socket, registration_response(request_id, TEST_ACCESS_TOKEN));
+            }
+            None => panic!("registration access token is neither a string nor null"),
+        },
         WebOsTestScenario::PairingRejected => {
             assert!(payload["client-key"].is_null());
             send_json(
@@ -747,6 +822,16 @@ where
             Ok(Message::Close(_)) => return None,
             Ok(other) => panic!("expected webOS text request, got {other:?}"),
             Err(WebSocketError::Io(_)) if stop.load(Ordering::Acquire) => return None,
+            Err(WebSocketError::Io(error))
+                if matches!(
+                    error.kind(),
+                    io::ErrorKind::UnexpectedEof
+                        | io::ErrorKind::ConnectionReset
+                        | io::ErrorKind::BrokenPipe
+                ) =>
+            {
+                return None
+            }
             Err(WebSocketError::ConnectionClosed | WebSocketError::AlreadyClosed) => return None,
             Err(WebSocketError::Protocol(ProtocolError::ResetWithoutClosingHandshake)) => {
                 return None
@@ -814,9 +899,19 @@ fn has_observed_write_settings_envelope(manifest: &serde_json::Map<String, Value
 
 fn write_settings_signed_envelope() -> &'static Value {
     WRITE_SETTINGS_SIGNED_ENVELOPE.get_or_init(|| {
-        serde_json::from_str(include_str!("write_settings_signed_envelope.json"))
-            .expect("parse observed WRITE_SETTINGS registration envelope")
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/src/web_os/test_support/write_settings_signed_envelope.json"
+        )))
+        .expect("parse observed WRITE_SETTINGS registration envelope")
     })
+}
+
+fn record_pairing_prompt(runtime: &Arc<Mutex<WebOsTestRuntime>>) {
+    runtime
+        .lock()
+        .expect("webOS test server state")
+        .pairing_prompt_count += 1;
 }
 
 fn require_top_level_permission(permissions: &WebOsTestPermissions, permission: &str, uri: &str) {
@@ -912,6 +1007,7 @@ impl Drop for TestAccessTokenStore {
 }
 
 #[cfg(test)]
+#[allow(dead_code, unused_imports)]
 mod tests {
     use super::{
         write_settings_signed_envelope, WebOsTestInput, WebOsTestScenario, WebOsTestServer,

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -63,6 +63,7 @@ pub(in crate::web_os) enum WebOsTestScenario {
     PowerStatePermissionDenied,
     BacklightWriteAcknowledgedWithoutChange,
     CloseAfterFirstInputWrite,
+    StallFirstRequest,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -293,6 +294,7 @@ struct WebOsTestRuntime {
     pairing_prompt_count: u64,
     registration_tokens: Vec<Option<String>>,
     ambiguous_input_write_injected: bool,
+    stalled_request_injected: bool,
 }
 
 pub(in crate::web_os) struct WebOsTestServer {
@@ -394,6 +396,7 @@ impl WebOsTestServer {
             pairing_prompt_count: 0,
             registration_tokens: Vec::new(),
             ambiguous_input_write_injected: false,
+            stalled_request_injected: false,
         }));
         let active_connection = Arc::new(Mutex::new(None));
         let stop = Arc::new(AtomicBool::new(false));
@@ -562,12 +565,29 @@ fn serve_connection<S>(
         }
 
         let scenario = runtime.lock().expect("webOS test server state").scenario;
+        if scenario == WebOsTestScenario::StallFirstRequest {
+            let should_stall = {
+                let mut runtime = runtime.lock().expect("webOS test server state");
+                if runtime.stalled_request_injected {
+                    false
+                } else {
+                    runtime.stalled_request_injected = true;
+                    true
+                }
+            };
+            if should_stall {
+                let _ = read_json(&mut socket, stop);
+                return;
+            }
+        }
+
         let keep_open = match scenario {
             WebOsTestScenario::StatefulTv
             | WebOsTestScenario::StoredTokenPairingPrompt
             | WebOsTestScenario::PowerStatePermissionDenied
             | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
-            | WebOsTestScenario::CloseAfterFirstInputWrite => {
+            | WebOsTestScenario::CloseAfterFirstInputWrite
+            | WebOsTestScenario::StallFirstRequest => {
                 let response =
                     {
                         let mut runtime = runtime.lock().expect("webOS test server state");
@@ -673,7 +693,8 @@ where
         WebOsTestScenario::StatefulTv
         | WebOsTestScenario::PowerStatePermissionDenied
         | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
-        | WebOsTestScenario::CloseAfterFirstInputWrite => match payload["client-key"].as_str() {
+        | WebOsTestScenario::CloseAfterFirstInputWrite
+        | WebOsTestScenario::StallFirstRequest => match payload["client-key"].as_str() {
             Some(token) => send_json(socket, registration_response(request_id, token)),
             None if payload["client-key"].is_null() => {
                 record_pairing_prompt(runtime);
@@ -803,7 +824,8 @@ where
         | WebOsTestScenario::RegistrationMissingClientKey
         | WebOsTestScenario::PowerStatePermissionDenied
         | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
-        | WebOsTestScenario::CloseAfterFirstInputWrite => {
+        | WebOsTestScenario::CloseAfterFirstInputWrite
+        | WebOsTestScenario::StallFirstRequest => {
             panic!("scenario `{scenario:?}` requires registered stateful handling")
         }
     }

--- a/crates/lg-buddy/tests/cucumber.rs
+++ b/crates/lg-buddy/tests/cucumber.rs
@@ -1,6 +1,17 @@
 mod cucumber_support;
 mod support;
 
+mod auth {
+    pub use lg_buddy::auth::SystemUser;
+}
+
+mod platform_access_token {
+    pub use lg_buddy::platform_access_token::{PlatformAccessToken, PlatformAccessTokenStore};
+}
+
+#[path = "cucumber_support/webos.rs"]
+mod web_os;
+
 use cucumber::World as _;
 use cucumber_support::world::LgBuddyWorld;
 

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -71,6 +71,16 @@ fn native_webos_tv_rejects_pairing(world: &mut LgBuddyWorld) {
     world.reject_native_pairing();
 }
 
+#[given("the native webOS TV stalls its first TV response")]
+fn native_webos_tv_stalls_first_response(world: &mut LgBuddyWorld) {
+    world.stall_native_tv_response();
+}
+
+#[given(regex = r#"mock system logind reports PreparingForSleep=(true|false)"#)]
+fn mock_system_logind_preparing_for_sleep(world: &mut LgBuddyWorld, value: String) {
+    world.configure_system_logind(value == "true");
+}
+
 #[given(regex = r#"the TV auth key file override is "([^"]+)""#)]
 fn tv_auth_key_file_override(world: &mut LgBuddyWorld, path: String) {
     world.set_auth_key_file_override(&path);
@@ -319,6 +329,15 @@ fn command_fails(world: &mut LgBuddyWorld) {
         "command unexpectedly succeeded\nstdout:\n{}\nstderr:\n{}",
         world.command_result().stdout,
         world.command_result().stderr
+    );
+}
+
+#[then(regex = r#"the command completes within (\d+) seconds"#)]
+fn command_completes_within_seconds(world: &mut LgBuddyWorld, seconds: u64) {
+    assert!(
+        world.command_duration() < std::time::Duration::from_secs(seconds),
+        "command took {:?}, expected less than {seconds}s",
+        world.command_duration()
     );
 }
 

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -6,6 +6,11 @@ fn temporary_config(world: &mut LgBuddyWorld, input: String) {
     world.create_config(&input);
 }
 
+#[given("an empty temporary LG Buddy config path")]
+fn empty_temporary_config_path(world: &mut LgBuddyWorld) {
+    world.create_empty_config_path();
+}
+
 #[given(regex = r#"the screen restore policy is "(marker_only|conservative|aggressive)""#)]
 fn screen_restore_policy(world: &mut LgBuddyWorld, policy: String) {
     world.set_screen_restore_policy(&policy);
@@ -310,6 +315,11 @@ fn journalctl_reports_no_sleep_requested(world: &mut LgBuddyWorld) {
 #[when(regex = r#"I run the command "([^"]+)""#)]
 fn run_command(world: &mut LgBuddyWorld, command: String) {
     world.run_named_command(&command);
+}
+
+#[when("I choose native webOS during initial configuration")]
+fn run_native_initial_configuration(world: &mut LgBuddyWorld) {
+    world.run_native_initial_configuration();
 }
 
 #[then("the command succeeds")]

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -46,6 +46,31 @@ fn mock_tv_client(world: &mut LgBuddyWorld) {
     world.create_mock_tv();
 }
 
+#[given(regex = r#"a native webOS TV on input (HDMI_[23]) with brightness (\d+)"#)]
+fn native_webos_tv(world: &mut LgBuddyWorld, input: String, brightness: u8) {
+    world.create_native_webos_tv(&input, brightness);
+}
+
+#[given(regex = r#"the existing config selects TV platform \"(bscpylgtv|lg_webos)\""#)]
+fn existing_tv_platform(world: &mut LgBuddyWorld, platform: String) {
+    world.select_tv_platform(&platform);
+}
+
+#[given("a valid native TV access token is stored")]
+fn valid_native_access_token(world: &mut LgBuddyWorld) {
+    world.store_valid_native_access_token();
+}
+
+#[given("a stale native TV access token is stored")]
+fn stale_native_access_token(world: &mut LgBuddyWorld) {
+    world.store_native_access_token("stale-cucumber-access-token");
+}
+
+#[given("the native webOS TV rejects pairing")]
+fn native_webos_tv_rejects_pairing(world: &mut LgBuddyWorld) {
+    world.reject_native_pairing();
+}
+
 #[given(regex = r#"the TV auth key file override is "([^"]+)""#)]
 fn tv_auth_key_file_override(world: &mut LgBuddyWorld, path: String) {
     world.set_auth_key_file_override(&path);
@@ -377,70 +402,99 @@ fn system_marker_absent(world: &mut LgBuddyWorld) {
 
 #[then(regex = r#"the TV input is (HDMI_[1-4])"#)]
 fn tv_input_is(world: &mut LgBuddyWorld, input: String) {
-    assert_eq!(world.tv().state_snapshot().input, input);
+    world.assert_tv_input(&input);
 }
 
 #[then(regex = r#"the TV brightness is (\d+)"#)]
 fn tv_brightness_is(world: &mut LgBuddyWorld, value: u8) {
-    assert_eq!(world.tv().state_snapshot().backlight, value);
+    world.assert_tv_brightness(value);
 }
 
 #[then("the TV is powered off")]
 fn tv_is_powered_off(world: &mut LgBuddyWorld) {
-    assert!(!world.tv().state_snapshot().power_on);
+    world.assert_tv_powered_on(false);
 }
 
 #[then("the TV is powered on")]
 fn tv_is_powered_on(world: &mut LgBuddyWorld) {
-    assert!(world.tv().state_snapshot().power_on);
+    world.assert_tv_powered_on(true);
 }
 
 #[then("the TV screen is blanked")]
 fn tv_screen_is_blanked(world: &mut LgBuddyWorld) {
-    assert!(!world.tv().state_snapshot().screen_on);
+    world.assert_tv_screen_on(false);
 }
 
 #[then("the TV screen is visible")]
 fn tv_screen_is_visible(world: &mut LgBuddyWorld) {
-    assert!(world.tv().state_snapshot().screen_on);
+    world.assert_tv_screen_on(true);
 }
 
 #[then(regex = r#"^the TV client received "([^"]+)"$"#)]
 fn tv_client_received(world: &mut LgBuddyWorld, command: String) {
+    let calls = world.tv_call_names();
     assert!(
-        world
-            .tv()
-            .calls()
-            .iter()
-            .any(|call| call.command == command),
-        "calls were: {:?}",
-        world.tv().calls()
+        calls.iter().any(|call| call == &command),
+        "calls were: {calls:?}"
     );
 }
 
 #[then(regex = r#"^the TV client received "([^"]+)" exactly (\d+) times$"#)]
 fn tv_client_received_exactly(world: &mut LgBuddyWorld, command: String, expected: usize) {
-    let actual = world
-        .tv()
-        .calls()
-        .iter()
-        .filter(|call| call.command == command)
-        .count();
+    let calls = world.tv_call_names();
+    let actual = calls.iter().filter(|call| *call == &command).count();
 
-    assert_eq!(actual, expected, "calls were: {:?}", world.tv().calls());
+    assert_eq!(actual, expected, "calls were: {calls:?}");
 }
 
 #[then(regex = r#"^the TV client did not receive "([^"]+)"$"#)]
 fn tv_client_did_not_receive(world: &mut LgBuddyWorld, command: String) {
+    let calls = world.tv_call_names();
     assert!(
-        world
-            .tv()
-            .calls()
-            .iter()
-            .all(|call| call.command != command),
-        "calls were: {:?}",
-        world.tv().calls()
+        calls.iter().all(|call| call != &command),
+        "calls were: {calls:?}"
     );
+}
+
+#[then("a valid native TV access token is stored")]
+fn valid_native_access_token_is_stored(world: &mut LgBuddyWorld) {
+    world.assert_valid_native_access_token();
+}
+
+#[then("no native TV access token is stored")]
+fn no_native_access_token_is_stored(world: &mut LgBuddyWorld) {
+    world.assert_no_native_access_token();
+}
+
+#[then(regex = r#"the native TV access token is \"([^\"]+)\""#)]
+fn native_access_token_is(world: &mut LgBuddyWorld, access_token: String) {
+    world.assert_native_access_token(&access_token);
+}
+
+#[then(regex = r#"the native TV connection count is (\d+)"#)]
+fn native_connection_count_is(world: &mut LgBuddyWorld, expected: u64) {
+    assert_eq!(world.webos_snapshot().connection_count, expected);
+}
+
+#[then(regex = r#"the native TV pairing prompt count is (\d+)"#)]
+fn native_pairing_prompt_count_is(world: &mut LgBuddyWorld, expected: u64) {
+    assert_eq!(world.webos_snapshot().pairing_prompt_count, expected);
+}
+
+#[then(regex = r#"the native TV registration tokens are \"([^\"]*)\""#)]
+fn native_registration_tokens_are(world: &mut LgBuddyWorld, expected: String) {
+    let expected = if expected.is_empty() {
+        Vec::new()
+    } else {
+        expected
+            .split(',')
+            .map(|token| match token.trim() {
+                "none" => None,
+                token => Some(token.to_string()),
+            })
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(world.webos_snapshot().registration_tokens, expected);
 }
 
 #[then("the TV helper uses the expected auth context")]

--- a/crates/lg-buddy/tests/cucumber_support/test_support.rs
+++ b/crates/lg-buddy/tests/cucumber_support/test_support.rs
@@ -1,0 +1,3 @@
+#[allow(dead_code)]
+#[path = "../../src/web_os/test_support/test_server.rs"]
+pub mod test_server;

--- a/crates/lg-buddy/tests/cucumber_support/webos.rs
+++ b/crates/lg-buddy/tests/cucumber_support/webos.rs
@@ -51,6 +51,11 @@ impl MockWebOsTv {
             .set_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
     }
 
+    pub fn stall_first_tv_response(&self) {
+        self.server
+            .set_scenario(WebOsTestScenario::StallFirstRequest);
+    }
+
     pub fn snapshot(&self) -> MockWebOsTvSnapshot {
         self.assert_healthy();
         let snapshot = self.server.snapshot();

--- a/crates/lg-buddy/tests/cucumber_support/webos.rs
+++ b/crates/lg-buddy/tests/cucumber_support/webos.rs
@@ -1,0 +1,86 @@
+pub use lg_buddy::web_os::{
+    WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsEndpoint,
+    WebOsPowerState,
+};
+use serde_json::Value;
+use std::net::{Ipv4Addr, SocketAddr};
+
+mod test_support;
+
+use test_support::test_server::{
+    WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestTvSnapshot,
+};
+
+pub const VALID_WEBOS_ACCESS_TOKEN: &str = "webos-test-access-token";
+const WEBOS_WSS_PORT: u16 = 3001;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MockWebOsTvSnapshot {
+    pub power_on: bool,
+    pub screen_on: bool,
+    pub input: String,
+    pub backlight: u8,
+    pub connection_count: u64,
+    pub pairing_prompt_count: u64,
+    pub registration_tokens: Vec<Option<String>>,
+}
+
+pub struct MockWebOsTv {
+    server: WebOsTestServer,
+}
+
+impl MockWebOsTv {
+    pub fn new(input: &str) -> Self {
+        let input = match input {
+            "HDMI_2" => WebOsTestInput::Hdmi2,
+            "HDMI_3" => WebOsTestInput::Hdmi3,
+            other => panic!("no hardware-backed native WebOS fixture exists for `{other}`"),
+        };
+        let address = SocketAddr::from((Ipv4Addr::LOCALHOST, WEBOS_WSS_PORT));
+        Self {
+            server: WebOsTestServer::active_tls_at(input, address),
+        }
+    }
+
+    pub fn reject_pairing(&self) {
+        self.server.set_scenario(WebOsTestScenario::PairingRejected);
+    }
+
+    pub fn require_stale_token_pairing(&self) {
+        self.server
+            .set_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+    }
+
+    pub fn snapshot(&self) -> MockWebOsTvSnapshot {
+        self.assert_healthy();
+        let snapshot = self.server.snapshot();
+        MockWebOsTvSnapshot {
+            power_on: snapshot.power_state != WebOsPowerState::PowerOff,
+            screen_on: snapshot.power_state == WebOsPowerState::Active,
+            input: input_name(snapshot.input).to_string(),
+            backlight: backlight_value(&snapshot),
+            connection_count: snapshot.connection_count,
+            pairing_prompt_count: snapshot.pairing_prompt_count,
+            registration_tokens: snapshot.registration_tokens,
+        }
+    }
+
+    pub fn assert_healthy(&self) {
+        self.server.assert_healthy();
+    }
+}
+
+fn input_name(input: WebOsTestInput) -> &'static str {
+    match input {
+        WebOsTestInput::Hdmi2 => "HDMI_2",
+        WebOsTestInput::Hdmi3 => "HDMI_3",
+    }
+}
+
+fn backlight_value(snapshot: &WebOsTestTvSnapshot) -> u8 {
+    match &snapshot.backlight {
+        Value::Number(value) => value.as_u64().expect("native backlight integer") as u8,
+        Value::String(value) => value.parse().expect("native backlight numeric string"),
+        other => panic!("unexpected native backlight value: {other}"),
+    }
+}

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -2,6 +2,7 @@ use crate::support::{
     ExecutableScript, MockBscpylgtv, MockNmOnline, MockSessionBusIdleMonitor, MockSwayidle,
     RuntimeStateLayout, TestConfigFile, TestEnv,
 };
+use crate::web_os::{MockWebOsTv, MockWebOsTvSnapshot, VALID_WEBOS_ACCESS_TOKEN};
 use cucumber::World;
 use lg_buddy::auth::resolve_bscpylgtv_auth_context_from_env;
 use std::fmt;
@@ -15,6 +16,7 @@ pub struct LgBuddyWorld {
     config: Option<TestConfigFile>,
     runtime: Option<RuntimeStateLayout>,
     tv: Option<MockBscpylgtv>,
+    webos_tv: Option<MockWebOsTv>,
     session_bus_idle_monitor: Option<MockSessionBusIdleMonitor>,
     nm_online: Option<MockNmOnline>,
     swayidle: Option<MockSwayidle>,
@@ -37,6 +39,7 @@ impl fmt::Debug for LgBuddyWorld {
             .field("config", &self.config.is_some())
             .field("runtime", &self.runtime.is_some())
             .field("tv", &self.tv.is_some())
+            .field("webos_tv", &self.webos_tv.is_some())
             .field(
                 "session_bus_idle_monitor",
                 &self.session_bus_idle_monitor.is_some(),
@@ -177,6 +180,71 @@ exit 1\n",
         self.tv = Some(tv);
     }
 
+    pub fn create_native_webos_tv(&mut self, input: &str, backlight: u8) {
+        self.config().set_value("tvs_primary_ip", "127.0.0.1");
+        let tv = MockWebOsTv::new(input);
+        assert_eq!(
+            tv.snapshot().backlight,
+            backlight,
+            "native WebOS initial brightness must match the hardware-backed TV model"
+        );
+        self.webos_tv = Some(tv);
+    }
+
+    pub fn select_tv_platform(&self, platform: &str) {
+        self.config().set_value("tvs_primary_platform", platform);
+    }
+
+    pub fn store_native_access_token(&self, access_token: &str) {
+        if access_token != VALID_WEBOS_ACCESS_TOKEN {
+            self.webos_tv().require_stale_token_pairing();
+        }
+        let token = lg_buddy::platform_access_token::PlatformAccessToken::new(access_token)
+            .expect("valid native access token fixture");
+        self.native_access_token_store()
+            .persist(&token)
+            .expect("persist native access token fixture");
+    }
+
+    pub fn store_valid_native_access_token(&self) {
+        self.store_native_access_token(VALID_WEBOS_ACCESS_TOKEN);
+    }
+
+    pub fn reject_native_pairing(&self) {
+        self.webos_tv().reject_pairing();
+    }
+
+    pub fn assert_native_access_token(&self, expected: &str) {
+        let stored = self
+            .native_access_token_store()
+            .load()
+            .expect("load native access token")
+            .expect("native access token should exist");
+        assert_eq!(stored.as_secret_str(), expected);
+    }
+
+    pub fn assert_valid_native_access_token(&self) {
+        self.assert_native_access_token(VALID_WEBOS_ACCESS_TOKEN);
+    }
+
+    pub fn assert_no_native_access_token(&self) {
+        assert!(
+            self.native_access_token_store()
+                .load()
+                .expect("load native access token")
+                .is_none(),
+            "native access token unexpectedly exists"
+        );
+    }
+
+    pub fn webos_tv(&self) -> &MockWebOsTv {
+        self.webos_tv.as_ref().expect("native webOS TV configured")
+    }
+
+    pub fn webos_snapshot(&self) -> MockWebOsTvSnapshot {
+        self.webos_tv().snapshot()
+    }
+
     pub fn tv(&self) -> &MockBscpylgtv {
         self.tv.as_ref().expect("mock TV configured")
     }
@@ -194,6 +262,9 @@ exit 1\n",
     }
 
     pub fn command_result(&self) -> &CommandExecution {
+        if let Some(tv) = &self.webos_tv {
+            tv.assert_healthy();
+        }
         self.command_result
             .as_ref()
             .expect("command result should be present")
@@ -468,6 +539,62 @@ exit 1\n",
             stdout: String::from_utf8(output.stdout).expect("utf8 command output"),
             stderr: String::from_utf8(output.stderr).expect("utf8 command stderr"),
         });
+    }
+
+    pub fn assert_tv_input(&self, expected: &str) {
+        if let Some(tv) = &self.webos_tv {
+            assert_eq!(tv.snapshot().input, expected);
+        } else {
+            assert_eq!(self.tv().state_snapshot().input, expected);
+        }
+    }
+
+    pub fn assert_tv_brightness(&self, expected: u8) {
+        if let Some(tv) = &self.webos_tv {
+            assert_eq!(tv.snapshot().backlight, expected);
+        } else {
+            assert_eq!(self.tv().state_snapshot().backlight, expected);
+        }
+    }
+
+    pub fn assert_tv_powered_on(&self, expected: bool) {
+        if let Some(tv) = &self.webos_tv {
+            assert_eq!(tv.snapshot().power_on, expected);
+        } else {
+            assert_eq!(self.tv().state_snapshot().power_on, expected);
+        }
+    }
+
+    pub fn assert_tv_screen_on(&self, expected: bool) {
+        if let Some(tv) = &self.webos_tv {
+            assert_eq!(tv.snapshot().screen_on, expected);
+        } else {
+            assert_eq!(self.tv().state_snapshot().screen_on, expected);
+        }
+    }
+
+    pub fn tv_call_names(&self) -> Vec<String> {
+        assert!(
+            self.webos_tv.is_none(),
+            "native Cucumber scenarios must assert product outcomes, not mock call labels"
+        );
+        self.tv()
+            .calls()
+            .into_iter()
+            .map(|call| call.command)
+            .collect()
+    }
+
+    fn native_access_token_store(
+        &self,
+    ) -> lg_buddy::platform_access_token::PlatformAccessTokenStore {
+        let owner = lg_buddy::auth::resolve_config_owner(self.config().path())
+            .expect("resolve native access token owner");
+        lg_buddy::platform_access_token::PlatformAccessTokenStore::for_primary_profile(
+            self.config().path(),
+            owner,
+        )
+        .expect("construct native access token store")
     }
 
     fn prepend_path_script(&mut self, script: ExecutableScript) {

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -67,6 +67,12 @@ impl LgBuddyWorld {
         self.config = Some(config);
     }
 
+    pub fn create_empty_config_path(&mut self) {
+        let config = TestConfigFile::new("cucumber-initial-config");
+        self.ensure_env().set("LG_BUDDY_CONFIG", config.path());
+        self.config = Some(config);
+    }
+
     pub fn set_screen_restore_policy(&self, policy: &str) {
         self.config
             .as_ref()
@@ -184,7 +190,9 @@ exit 1\n",
     }
 
     pub fn create_native_webos_tv(&mut self, input: &str, backlight: u8) {
-        self.config().set_value("tvs_primary_ip", "127.0.0.1");
+        if self.config().path().exists() {
+            self.config().set_value("tvs_primary_ip", "127.0.0.1");
+        }
         let tv = MockWebOsTv::new(input);
         assert_eq!(
             tv.snapshot().backlight,
@@ -560,6 +568,34 @@ exit 1\n",
             success: output.status.success(),
             stdout: String::from_utf8(output.stdout).expect("utf8 command output"),
             stderr: String::from_utf8(output.stderr).expect("utf8 command stderr"),
+            duration,
+        });
+    }
+
+    pub fn run_native_initial_configuration(&mut self) {
+        self.ensure_env().set("LG_BUDDY_NONINTERACTIVE", "1");
+        self.ensure_env().set("LG_BUDDY_TV_IP", "127.0.0.1");
+        self.ensure_env()
+            .set("LG_BUDDY_TV_MAC", "22:33:44:55:66:77");
+        self.ensure_env().set("LG_BUDDY_INPUT", "HDMI_2");
+        self.ensure_env().set("LG_BUDDY_TV_PLATFORM", "lg_webos");
+        self.ensure_env()
+            .set("LG_BUDDY_RUNTIME_BINARY", env!("CARGO_BIN_EXE_lg-buddy"));
+        self.ensure_env().set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+
+        let configure = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("configure.sh");
+        let started = std::time::Instant::now();
+        let output = ProcessCommand::new(configure)
+            .output()
+            .expect("run initial configuration");
+        let duration = started.elapsed();
+
+        self.command_result = Some(CommandExecution {
+            success: output.status.success(),
+            stdout: String::from_utf8(output.stdout).expect("utf8 configure output"),
+            stderr: String::from_utf8(output.stderr).expect("utf8 configure stderr"),
             duration,
         });
     }

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -1,6 +1,6 @@
 use crate::support::{
     ExecutableScript, MockBscpylgtv, MockNmOnline, MockSessionBusIdleMonitor, MockSwayidle,
-    RuntimeStateLayout, TestConfigFile, TestEnv,
+    MockSystemLogind, RuntimeStateLayout, TestConfigFile, TestEnv,
 };
 use crate::web_os::{MockWebOsTv, MockWebOsTvSnapshot, VALID_WEBOS_ACCESS_TOKEN};
 use cucumber::World;
@@ -17,6 +17,7 @@ pub struct LgBuddyWorld {
     runtime: Option<RuntimeStateLayout>,
     tv: Option<MockBscpylgtv>,
     webos_tv: Option<MockWebOsTv>,
+    system_logind: Option<MockSystemLogind>,
     session_bus_idle_monitor: Option<MockSessionBusIdleMonitor>,
     nm_online: Option<MockNmOnline>,
     swayidle: Option<MockSwayidle>,
@@ -31,6 +32,7 @@ pub struct CommandExecution {
     pub success: bool,
     pub stdout: String,
     pub stderr: String,
+    pub duration: std::time::Duration,
 }
 
 impl fmt::Debug for LgBuddyWorld {
@@ -40,6 +42,7 @@ impl fmt::Debug for LgBuddyWorld {
             .field("runtime", &self.runtime.is_some())
             .field("tv", &self.tv.is_some())
             .field("webos_tv", &self.webos_tv.is_some())
+            .field("system_logind", &self.system_logind.is_some())
             .field(
                 "session_bus_idle_monitor",
                 &self.session_bus_idle_monitor.is_some(),
@@ -214,6 +217,19 @@ exit 1\n",
         self.webos_tv().reject_pairing();
     }
 
+    pub fn stall_native_tv_response(&self) {
+        self.webos_tv().stall_first_tv_response();
+    }
+
+    pub fn configure_system_logind(&mut self, preparing_for_sleep: bool) {
+        let logind = MockSystemLogind::new("cucumber-system-logind");
+        logind.reset();
+        logind.set_preparing_for_sleep(preparing_for_sleep);
+        self.ensure_env()
+            .set("DBUS_SYSTEM_BUS_ADDRESS", logind.address());
+        self.system_logind = Some(logind);
+    }
+
     pub fn assert_native_access_token(&self, expected: &str) {
         let stored = self
             .native_access_token_store()
@@ -268,6 +284,10 @@ exit 1\n",
         self.command_result
             .as_ref()
             .expect("command result should be present")
+    }
+
+    pub fn command_duration(&self) -> std::time::Duration {
+        self.command_result().duration
     }
 
     pub fn create_session_marker(&self) {
@@ -529,15 +549,18 @@ exit 1\n",
             self.ensure_env()
                 .set("LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS", "0.2");
         }
+        let started = std::time::Instant::now();
         let output = ProcessCommand::new(env!("CARGO_BIN_EXE_lg-buddy"))
             .args(args)
             .output()
             .expect("run lg-buddy binary");
+        let duration = started.elapsed();
 
         self.command_result = Some(CommandExecution {
             success: output.status.success(),
             stdout: String::from_utf8(output.stdout).expect("utf8 command output"),
             stderr: String::from_utf8(output.stderr).expect("utf8 command stderr"),
+            duration,
         });
     }
 

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -8,6 +8,7 @@ Feature: Settings CLI
     And stdout contains "tv.ip=192.0.2.42 (config.env, read-write, ops: get,describe,set)"
     And stdout contains "tv.mac=aa:bb:cc:dd:ee:ff (config.env, read-write, ops: get,describe,set)"
     And stdout contains "tv.input=HDMI_2 (config.env, read-write, ops: get,describe,set)"
+    And stdout contains "tv.platform=bscpylgtv (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.backend=auto (config.env, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.idle_blank=enabled (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)"
@@ -23,6 +24,23 @@ Feature: Settings CLI
     And stdout contains "storage key: tvs_primary_input"
     And stdout contains "default: required"
     And stdout contains "supported operations: get, describe, set"
+
+  Scenario: settings describe exposes the sole TV platform selector
+    Given a temporary LG Buddy config using input HDMI_2
+    When I run the command "settings describe tv.platform"
+    Then the command succeeds
+    And stdout contains "storage key: tvs_primary_platform"
+    And stdout contains "default: bscpylgtv"
+    And stdout contains "supported operations: get, describe, set, unset"
+    And stdout contains "allowed values: bscpylgtv, lg_webos"
+
+  Scenario: settings rejects an invalid TV platform without altering config
+    Given a temporary LG Buddy config using input HDMI_2
+    And the current config is remembered
+    When I run the command "settings set tv.platform native"
+    Then the command fails
+    And stderr contains "invalid value for setting `tv.platform`"
+    And config.env is unchanged
 
   Scenario: settings describe shows lifecycle policy operations
     Given a temporary LG Buddy config using input HDMI_2

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -1,6 +1,20 @@
 Feature: Native webOS TV platform
   LG Buddy should expose the same product behavior through its native webOS platform,
-  while pairing only from an explicit foreground settings command.
+  pairing when the user is setting up or actively controlling the TV without delaying
+  shutdown, suspend, or network teardown when no stored credential is available.
+
+  Scenario: Initial configuration selects and pairs the native platform
+    Given an empty temporary LG Buddy config path
+    And a native webOS TV on input HDMI_2 with brightness 90
+    When I choose native webOS during initial configuration
+    Then the command succeeds
+    And stdout contains "TV Platform:         lg_webos"
+    And stdout contains "pairing required; accept the prompt on the TV"
+    And config.env contains "tvs_primary_platform=lg_webos"
+    And a valid native TV access token is stored
+    And the native TV connection count is 1
+    And the native TV registration tokens are "none"
+    And the native TV pairing prompt count is 1
 
   Scenario: Opting in pairs the TV and the stored token authenticates later commands
     Given a temporary LG Buddy config using input HDMI_2
@@ -20,31 +34,30 @@ Feature: Native webOS TV platform
     And the native TV connection count is 2
     And the native TV pairing prompt count is 1
 
-  Scenario: A missing token fails before a background command connects to the TV
+  Scenario: An ordinary command pairs when the token is missing
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"
     And a native webOS TV on input HDMI_2 with brightness 90
     When I run the command "brightness get"
-    Then the command fails
-    And stderr contains "no stored platform access token is available"
-    And stderr contains "settings set tv.platform lg_webos"
-    And no native TV access token is stored
-    And the native TV connection count is 0
-    And the native TV registration tokens are ""
+    Then the command succeeds
+    And stdout is "90"
+    And a valid native TV access token is stored
+    And the native TV connection count is 1
+    And the native TV registration tokens are "none"
+    And the native TV pairing prompt count is 1
 
-  Scenario: A stale token fails without background re-pairing or credential replacement
+  Scenario: An ordinary command repairs a stale token
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"
     And a native webOS TV on input HDMI_2 with brightness 90
     And a stale native TV access token is stored
     When I run the command "brightness get"
-    Then the command fails
-    And stderr contains "requires foreground pairing"
-    And stderr contains "settings set tv.platform lg_webos"
-    And the native TV access token is "stale-cucumber-access-token"
-    And the native TV connection count is 1
-    And the native TV registration tokens are "stale-cucumber-access-token"
-    And the native TV pairing prompt count is 1
+    Then the command succeeds
+    And stdout is "90"
+    And a valid native TV access token is stored
+    And the native TV connection count is 2
+    And the native TV registration tokens are "stale-cucumber-access-token,none"
+    And the native TV pairing prompt count is 2
 
   Scenario: Foreground opt-in repairs a stale token before persisting the platform
     Given a temporary LG Buddy config using input HDMI_2
@@ -154,6 +167,40 @@ Feature: Native webOS TV platform
     And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
     And the native TV pairing prompt count is 0
 
+  Scenario: Native startup does not delay boot when the token is missing
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_3 with brightness 100
+    And the system marker exists
+    When I run the command "startup boot"
+    Then the command succeeds
+    And the command completes within 1 seconds
+    And stdout contains "No stored native TV credential; skipping unattended TV control."
+    And no native TV access token is stored
+    And the system marker is absent
+    And the TV input is HDMI_3
+    And the native TV connection count is 0
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native resume retires ownership when the stored token is stale
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_3 with brightness 100
+    And a stale native TV access token is stored
+    And the system marker exists
+    And nm-online succeeds
+    And startup delays are disabled
+    When I run the command "startup auto"
+    Then the command succeeds
+    And stdout contains "Stored TV authentication is unavailable; skipping unattended TV control."
+    And the system marker is absent
+    And the native TV access token is "stale-cucumber-access-token"
+    And the TV input is HDMI_3
+    And the native TV registration tokens are "stale-cucumber-access-token"
+    And the native TV pairing prompt count is 1
+
   Scenario: Native pre-sleep handling powers off an owned TV without background pairing
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"
@@ -168,6 +215,62 @@ Feature: Native webOS TV platform
     And the TV is powered off
     And the native TV registration tokens are "webos-test-access-token"
     And the native TV pairing prompt count is 0
+
+  Scenario: Native shutdown is immediate and does not pair when the token is missing
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And reboot detection reports no pending reboot
+    When I run the command "shutdown"
+    Then the command succeeds
+    And the command completes within 1 seconds
+    And stdout contains "No stored native TV credential; skipping unattended TV control."
+    And no native TV access token is stored
+    And the TV is powered on
+    And the native TV connection count is 0
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native pre-sleep does not pair or retry when the token is missing
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    When I run the command "sleep-pre"
+    Then the command succeeds
+    And the command completes within 1 seconds
+    And no native TV access token is stored
+    And the system marker is absent
+    And the TV is powered on
+    And the native TV connection count is 0
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native NetworkManager pre-down does not pair or retry when the token is missing
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And mock system logind reports PreparingForSleep=true
+    When I run the command "nm-pre-down"
+    Then the command succeeds
+    And the command completes within 1 seconds
+    And no native TV access token is stored
+    And the system marker is absent
+    And the TV is powered on
+    And the native TV connection count is 0
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native shutdown does not repair a stale token
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a stale native TV access token is stored
+    And reboot detection reports no pending reboot
+    When I run the command "shutdown"
+    Then the command succeeds
+    And the native TV access token is "stale-cucumber-access-token"
+    And the TV is powered on
+    And the native TV registration tokens are "stale-cucumber-access-token"
+    And the native TV pairing prompt count is 1
 
   Scenario: Native pre-sleep bounds a stalled TV response and uses the fallback
     Given a temporary LG Buddy config using input HDMI_2

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -1,0 +1,144 @@
+Feature: Native webOS TV platform
+  LG Buddy should expose the same product behavior through its native webOS platform,
+  while pairing only from an explicit foreground settings command.
+
+  Scenario: Opting in pairs the TV and the stored token authenticates later commands
+    Given a temporary LG Buddy config using input HDMI_2
+    And a native webOS TV on input HDMI_3 with brightness 100
+    When I run the command "settings set tv.platform lg_webos"
+    Then the command succeeds
+    And stdout contains "pairing required; accept the prompt on the TV"
+    And stdout contains "stored access token"
+    And stdout contains "native webOS preflight succeeded: power_state=Active"
+    And config.env contains "tvs_primary_platform=lg_webos"
+    And a valid native TV access token is stored
+    And the native TV registration tokens are "none"
+    When I run the command "brightness get"
+    Then the command succeeds
+    And stdout is "100"
+    And the native TV registration tokens are "none,webos-test-access-token"
+    And the native TV connection count is 2
+    And the native TV pairing prompt count is 1
+
+  Scenario: A missing token fails before a background command connects to the TV
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    When I run the command "brightness get"
+    Then the command fails
+    And stderr contains "no stored platform access token is available"
+    And stderr contains "settings set tv.platform lg_webos"
+    And no native TV access token is stored
+    And the native TV connection count is 0
+    And the native TV registration tokens are ""
+
+  Scenario: A stale token fails without background re-pairing or credential replacement
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a stale native TV access token is stored
+    When I run the command "brightness get"
+    Then the command fails
+    And stderr contains "requires foreground pairing"
+    And stderr contains "settings set tv.platform lg_webos"
+    And the native TV access token is "stale-cucumber-access-token"
+    And the native TV connection count is 1
+    And the native TV registration tokens are "stale-cucumber-access-token"
+    And the native TV pairing prompt count is 1
+
+  Scenario: Foreground opt-in repairs a stale token before persisting the platform
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "bscpylgtv"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a stale native TV access token is stored
+    When I run the command "settings set tv.platform lg_webos"
+    Then the command succeeds
+    And stdout contains "using stored access token"
+    And stdout contains "pairing required; accept the prompt on the TV"
+    And stdout contains "native webOS preflight succeeded: power_state=Active"
+    And config.env contains "tvs_primary_platform=lg_webos"
+    And a valid native TV access token is stored
+    And the native TV connection count is 2
+    And the native TV registration tokens are "stale-cucumber-access-token,none"
+    And the native TV pairing prompt count is 2
+
+  Scenario: Rejected foreground pairing leaves the platform and credentials unchanged
+    Given a temporary LG Buddy config using input HDMI_2
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And the native webOS TV rejects pairing
+    And the current config is remembered
+    When I run the command "settings set tv.platform lg_webos"
+    Then the command fails
+    And stderr contains "webOS pairing was rejected: pairing denied"
+    And config.env is unchanged
+    And no native TV access token is stored
+    And the native TV connection count is 1
+    And the native TV registration tokens are "none"
+
+  Scenario: Native brightness writes use the observed signed protocol and update the TV
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    When I run the command "brightness set 66"
+    Then the command succeeds
+    And stdout contains "Set OLED pixel brightness to 66%."
+    And the TV brightness is 66
+    And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native screen blanking and restoration preserve screen ownership
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    When I run the command "screen-off"
+    Then the command succeeds
+    And the session marker exists
+    And the TV screen is blanked
+    And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0
+    When I run the command "screen-on"
+    Then the command succeeds
+    And the session marker is absent
+    And the TV screen is visible
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native startup input restoration is followed by native shutdown power-off
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_3 with brightness 100
+    And a valid native TV access token is stored
+    And nm-online succeeds
+    And startup delays are disabled
+    When I run the command "startup boot"
+    Then the command succeeds
+    And stdout contains "TV turned on and set to HDMI_2."
+    And the TV input is HDMI_2
+    And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0
+    Given reboot detection reports no pending reboot
+    When I run the command "shutdown"
+    Then the command succeeds
+    And stdout contains "TV is on HDMI_2. Turning off for shutdown."
+    And the TV is powered off
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native pre-sleep handling powers off an owned TV without background pairing
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    And sleep retry delays are disabled
+    When I run the command "sleep-pre"
+    Then the command succeeds
+    And stdout contains "TV is on HDMI_2. Turning off for sleep."
+    And the system marker exists
+    And the TV is powered off
+    And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -62,6 +62,32 @@ Feature: Native webOS TV platform
     And the native TV registration tokens are "stale-cucumber-access-token,none"
     And the native TV pairing prompt count is 2
 
+  Scenario: Foreground opt-in reuses a valid token before persisting the platform
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "bscpylgtv"
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    When I run the command "settings set tv.platform lg_webos"
+    Then the command succeeds
+    And stdout contains "using stored access token"
+    And stdout contains "native webOS preflight succeeded: power_state=Active"
+    And config.env contains "tvs_primary_platform=lg_webos"
+    And a valid native TV access token is stored
+    And the native TV connection count is 1
+    And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Unsetting native platform restores the default without preflight
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    When I run the command "settings unset tv.platform"
+    Then the command succeeds
+    And stdout contains "tv.platform unset"
+    And config.env does not contain "tvs_primary_platform="
+    When I run the command "settings get tv.platform"
+    Then the command succeeds
+    And stdout is "bscpylgtv"
+
   Scenario: Rejected foreground pairing leaves the platform and credentials unchanged
     Given a temporary LG Buddy config using input HDMI_2
     And a native webOS TV on input HDMI_2 with brightness 90
@@ -141,4 +167,40 @@ Feature: Native webOS TV platform
     And the system marker exists
     And the TV is powered off
     And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native pre-sleep bounds a stalled TV response and uses the fallback
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    And the native webOS TV stalls its first TV response
+    And sleep retry delays are disabled
+    When I run the command "sleep-pre"
+    Then the command succeeds
+    And the command completes within 5 seconds
+    And stdout contains "Could not query TV input. Attempting power_off fallback."
+    And the system marker exists
+    And the TV is powered off
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native NetworkManager pre-down enters the suspend rail through system logind
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    And the native webOS TV stalls its first TV response
+    And mock system logind reports PreparingForSleep=true
+    And sleep retry delays are disabled
+    When I run the command "nm-pre-down"
+    Then the command succeeds
+    And the command completes within 5 seconds
+    And stdout contains "logind is preparing for sleep; running pre-sleep TV handling before network teardown."
+    And stdout contains "Could not query TV input. Attempting power_off fallback."
+    And the system marker exists
+    And the TV is powered off
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
     And the native TV pairing prompt count is 0

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -337,6 +337,66 @@ fn run_system_resume_clears_sleep_cycle_state_and_preserves_session_marker() {
 }
 
 #[test]
+fn run_system_resume_without_native_token_retires_all_system_sleep_state() {
+    let config = TestConfigFile::new("entrypoint-native-resume-missing-token-config");
+    config.write_sample("HDMI_4");
+    config.append_line("tvs_primary_platform=lg_webos");
+
+    let runtime = RuntimeStateLayout::new("entrypoint-native-resume-missing-token-runtime");
+    runtime.create_system_marker();
+    runtime.create_system_sleep_attempt_marker();
+    let cycle_state = runtime.system_dir().join("system_sleep_cycle");
+    fs::write(&cycle_state, "outcome=completed\n").expect("create completed cycle state");
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SYSTEM_RUNTIME_DIR", runtime.system_dir());
+
+    let mut output = Vec::new();
+    run_system_resume(&mut output).expect("missing native token should skip resume");
+
+    runtime.assert_system_marker_absent();
+    runtime.assert_system_sleep_attempt_marker_absent();
+    assert!(!cycle_state.exists());
+    assert!(String::from_utf8(output)
+        .expect("utf8 output")
+        .contains("No stored native TV credential; skipping unattended TV control."));
+}
+
+#[test]
+fn run_system_resume_cleans_sleep_state_when_native_token_is_malformed() {
+    let config = TestConfigFile::new("entrypoint-native-resume-malformed-token-config");
+    config.write_sample("HDMI_4");
+    config.append_line("tvs_primary_platform=lg_webos");
+    let token_path = config
+        .path()
+        .parent()
+        .expect("config parent")
+        .join("tvs/primary/access-token.json");
+    fs::create_dir_all(token_path.parent().expect("token parent")).expect("create token directory");
+    fs::write(&token_path, "{ malformed").expect("write malformed token");
+
+    let runtime = RuntimeStateLayout::new("entrypoint-native-resume-malformed-token-runtime");
+    runtime.create_system_marker();
+    runtime.create_system_sleep_attempt_marker();
+    let cycle_state = runtime.system_dir().join("system_sleep_cycle");
+    fs::write(&cycle_state, "outcome=completed\n").expect("create completed cycle state");
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SYSTEM_RUNTIME_DIR", runtime.system_dir());
+
+    let mut output = Vec::new();
+    let error = run_system_resume(&mut output)
+        .expect_err("malformed native token should remain an actionable error");
+
+    assert!(error.to_string().contains("malformed"));
+    runtime.assert_system_marker_absent();
+    runtime.assert_system_sleep_attempt_marker_absent();
+    assert!(!cycle_state.exists());
+}
+
+#[test]
 fn run_system_resume_aggressive_policy_restores_without_system_marker() {
     let mock = MockBscpylgtv::new("entrypoint-system-resume-aggressive-tv");
     let wrapper = mock.command_wrapper("entrypoint-system-resume-aggressive-wrapper");

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -1119,6 +1119,27 @@ impl TestConfigFile {
         self.write_contents(&contents);
     }
 
+    pub fn set_value(&self, key: &str, value: &str) {
+        let contents = fs::read_to_string(&self.path).expect("read temp config");
+        let prefix = format!("{key}=");
+        let mut found = false;
+        let mut updated = contents
+            .lines()
+            .map(|line| {
+                if line.starts_with(&prefix) {
+                    found = true;
+                    format!("{key}={value}")
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>();
+        if !found {
+            updated.push(format!("{key}={value}"));
+        }
+        self.write_contents(&format!("{}\n", updated.join("\n")));
+    }
+
     pub fn write_sample(&self, input: &str) {
         self.write_contents(&sample_config_contents(input));
     }

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -111,10 +111,12 @@ choice.
 
 - `bscpylgtv` remains the default, including for existing profiles where the
   key is absent
-- `lg_webos` is the experimental native Rust platform and must be selected
-  explicitly with `lg-buddy settings set tv.platform lg_webos`
-- native selection is saved only after foreground credential and TV-state
-  preflight succeeds; background services do not initiate pairing
+- `lg_webos` is the experimental native Rust platform and can be selected
+  during initial configuration or with `lg-buddy settings set tv.platform lg_webos`
+- initial native selection pairs before it is saved; ordinary TV operations
+  can also pair or repair credentials when needed
+- shutdown, suspend, resume, startup, and network-teardown handling use stored
+  credentials only and skip promptly when no credential is available
 - this is the only platform selector; there is no separate backend, adapter,
   or migration override
 

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -49,11 +49,12 @@ error. Mutation commands may still overwrite or unset the bad value so users can
 repair the file through the structured interface.
 
 The current public settings interface exposes one TV through `tv.ip`, `tv.mac`,
-and `tv.input`. New writes store those values as `tvs_primary_ip`,
-`tvs_primary_mac`, and `tvs_primary_input`. The profile-shaped storage is only an
-extensibility point; LG Buddy does not currently expose multiple TVs or TV
-profile selection. Existing single-TV keys `tv_ip`, `tv_mac`, and `input` remain
-readable for compatibility.
+`tv.input`, and `tv.platform`. New writes store those values as
+`tvs_primary_ip`, `tvs_primary_mac`, `tvs_primary_input`, and
+`tvs_primary_platform`. The profile-shaped storage is only an extensibility
+point; LG Buddy does not currently expose multiple TVs or TV profile selection.
+Existing single-TV keys `tv_ip`, `tv_mac`, and `input` remain readable for
+compatibility.
 
 New behavior should use a config key when users may reasonably want to keep a
 non-default choice across reinstalls or upgrades. Prefer enum-shaped values over
@@ -76,6 +77,7 @@ Good shapes:
 tvs_primary_ip=192.168.1.100
 tvs_primary_mac=aa:bb:cc:dd:ee:ff
 tvs_primary_input=HDMI_2
+tvs_primary_platform=bscpylgtv
 screen_restore_policy=conservative
 screen_idle_blank=enabled
 system_sleep_wake_policy=enabled
@@ -104,6 +106,17 @@ a user has opted out through config, the installer should honor that persisted
 choice.
 
 ## Current Examples
+
+`tvs_primary_platform` selects the control platform for the active TV profile:
+
+- `bscpylgtv` remains the default, including for existing profiles where the
+  key is absent
+- `lg_webos` is the experimental native Rust platform and must be selected
+  explicitly with `lg-buddy settings set tv.platform lg_webos`
+- native selection is saved only after foreground credential and TV-state
+  preflight succeeds; background services do not initiate pairing
+- this is the only platform selector; there is no separate backend, adapter,
+  or migration override
 
 `screen_restore_policy` follows this model:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -21,7 +21,7 @@ with `v` followed by a digit, such as `v1.0.0` or `v1.0.0-beta.1`.
    - `docs/`
    - `README.md`
    - `LICENSE`
-4. Smoke tests the generated release bundle by unpacking it, running a non-interactive install into a temporary root, checking the lifecycle service plus NetworkManager pre-down hook topology, and then uninstalling from that temporary install.
+4. Smoke tests the generated release bundle by unpacking it, running a non-interactive install into a temporary root, checking both TV platform modes and the lifecycle service plus NetworkManager pre-down hook topology, and then uninstalling from that temporary install.
 5. Generates and verifies `sha256sums.txt` for the release archive.
 6. Publishes the release assets through `scripts/publish-release-assets.sh`.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -139,6 +139,10 @@ It is useful when we want to express scenarios like:
 - when the user returns after LG Buddy blanked the TV, LG Buddy restores the screen
 - when aggressive restore policy is enabled, wake/activity can restore even without a marker
 - when GNOME is available, backend detection resolves to `gnome`
+- when the user opts into `lg_webos`, foreground pairing stores the credential
+  and later TV commands authenticate without pairing again
+- when native credentials are missing or stale, background commands fail with
+  foreground-pairing guidance without creating or replacing credentials
 
 It is not the right place for:
 
@@ -183,10 +187,19 @@ Examples:
 
 ### Native webOS boundary
 
-The native webOS client uses one stateful test server for complete webOS frames,
+The native webOS client tests use one stateful server for complete webOS frames,
 device state, and protocol-fault scenarios. Characterization tests keep its TV
-behavior aligned with observed hardware evidence, while higher-level LG Buddy
-tests consume the same server without duplicating webOS response fixtures.
+behavior aligned with observed hardware evidence.
+
+Cucumber adds the process-level product boundary. It runs the real `lg-buddy`
+binary against the same stateful server over TLS on the standard webOS port.
+The server enforces the observed registration permissions, signed brightness
+write envelope, request payloads, and device state transitions while recording
+authentication history and pairing prompts. The scenarios cover opt-in and
+credential outcomes plus representative brightness, screen, input, and power
+operations; detailed transport faults remain in the native client tests.
+The process-level fixture binds `127.0.0.1:3001`, matching the production TV
+endpoint, so that port must be free while the serial Cucumber suite runs.
 
 The evidence workflow, response ownership rules, and semantic scenario model
 are documented in
@@ -259,7 +272,10 @@ These should not dominate the Rust test suite, but they still matter because ins
 
 The release-bundle smoke test covers the current installed lifecycle topology:
 the logind lifecycle service remains installed, the NetworkManager pre-down hook
-remains installed, and legacy systemd sleep hooks are absent.
+remains installed, and legacy systemd sleep hooks are absent. It also verifies
+that a missing TV platform remains `bscpylgtv`, explicit platform values survive
+reconfiguration, and `lg_webos` routes to the stored-credential-only native path
+and reports a missing credential without initiating background pairing.
 
 ## Current Practical Gaps
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -139,10 +139,12 @@ It is useful when we want to express scenarios like:
 - when the user returns after LG Buddy blanked the TV, LG Buddy restores the screen
 - when aggressive restore policy is enabled, wake/activity can restore even without a marker
 - when GNOME is available, backend detection resolves to `gnome`
-- when the user opts into `lg_webos`, foreground pairing stores the credential
-  and later TV commands authenticate without pairing again
-- when native credentials are missing or stale, background commands fail with
-  foreground-pairing guidance without creating or replacing credentials
+- when the user chooses `lg_webos` during initial configuration, pairing stores
+  the credential before setup completes
+- when native credentials are missing or stale, ordinary TV commands pair or
+  repair them as part of the operation
+- when native credentials are missing, shutdown and suspend-related commands
+  skip immediately without connecting or opening a pairing prompt
 
 It is not the right place for:
 

--- a/install.sh
+++ b/install.sh
@@ -282,7 +282,7 @@ echo "Running configuration script..."
 if [ ! -x "$SCRIPT_DIR/configure.sh" ]; then
     chmod +x "$SCRIPT_DIR/configure.sh"
 fi
-"$SCRIPT_DIR/configure.sh"
+LG_BUDDY_RUNTIME_BINARY="$RUNTIME_BINARY" "$SCRIPT_DIR/configure.sh"
 CONFIG_FILE="$(bash "$SCRIPT_DIR/bin/LG_Buddy_Common" --user-config-path)"
 SCREEN_IDLE_BLANK="$(sed -n 's/^screen_idle_blank=//p' "$CONFIG_FILE" | tail -n1)"
 case "$SCREEN_IDLE_BLANK" in

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -299,7 +299,8 @@ grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
 
 # Configure should read inline-commented platform values with the same value
 # semantics as the Rust config parser, then persist the sanitized choice.
-sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=  lg_webos # experimental/' "$CONFIG_FILE"
+sed -i 's/^tvs_primary_platform=bscpylgtv$/  tvs_primary_platform = bscpylgtv # legacy/' "$CONFIG_FILE"
+printf '%s\n' 'tvs_primary_platform =  lg_webos # experimental' >>"$CONFIG_FILE"
 
 (
     unset LG_BUDDY_SCREEN_BACKEND
@@ -324,6 +325,68 @@ grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
 grep -q '^updates_auto_check=disabled$' "$CONFIG_FILE"
 grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
+
+VALID_PLATFORM_CONFIG="$WORK_DIR/config-valid-platform.snapshot"
+cp "$CONFIG_FILE" "$VALID_PLATFORM_CONFIG"
+for invalid_platform_line in \
+    '  tvs_primary_platform = # explicit empty' \
+    'tvs_primary_platform=not-a-platform'
+do
+    cp "$VALID_PLATFORM_CONFIG" "$CONFIG_FILE"
+    sed -i "s/^tvs_primary_platform=lg_webos$/${invalid_platform_line}/" "$CONFIG_FILE"
+    INVALID_PLATFORM_CONFIG="$WORK_DIR/config-invalid-platform.snapshot"
+    INVALID_PLATFORM_OUTPUT="$WORK_DIR/config-invalid-platform.output"
+    cp "$CONFIG_FILE" "$INVALID_PLATFORM_CONFIG"
+    if (
+        cd "$BUNDLE_DIR"
+        ./configure.sh >"$INVALID_PLATFORM_OUTPUT" 2>&1
+    ); then
+        echo "configure.sh unexpectedly accepted invalid TV platform: $invalid_platform_line"
+        exit 1
+    fi
+    cmp -s "$INVALID_PLATFORM_CONFIG" "$CONFIG_FILE" || {
+        echo "configure.sh rewrote invalid TV platform config: $invalid_platform_line"
+        exit 1
+    }
+    grep -F -q 'invalid TV platform' "$INVALID_PLATFORM_OUTPUT"
+done
+cp "$VALID_PLATFORM_CONFIG" "$CONFIG_FILE"
+rm -f "$VALID_PLATFORM_CONFIG" "$INVALID_PLATFORM_CONFIG" "$INVALID_PLATFORM_OUTPUT"
+
+# A real in-place install must preserve an opted-in platform and its
+# profile-scoped native credential. Do this before the existing uninstall and
+# fresh-install coverage below, without removing the user configuration.
+NATIVE_ACCESS_TOKEN_FILE="$(dirname "$CONFIG_FILE")/tvs/primary/access-token.json"
+NATIVE_ACCESS_TOKEN_SNAPSHOT="$WORK_DIR/native-access-token.snapshot"
+NATIVE_ACCESS_TOKEN_CONTENT='{"access_token":"release-smoke-native-token"}'
+mkdir -p "$(dirname "$NATIVE_ACCESS_TOKEN_FILE")"
+printf '%s\n' "$NATIVE_ACCESS_TOKEN_CONTENT" >"$NATIVE_ACCESS_TOKEN_FILE"
+chmod 600 "$NATIVE_ACCESS_TOKEN_FILE"
+cp "$NATIVE_ACCESS_TOKEN_FILE" "$NATIVE_ACCESS_TOKEN_SNAPSHOT"
+"$INSTALLED_BINARY" settings get tv.platform | grep -q '^lg_webos$'
+
+(
+    unset LG_BUDDY_TV_IP
+    unset LG_BUDDY_TV_MAC
+    unset LG_BUDDY_INPUT
+    unset LG_BUDDY_SCREEN_BACKEND
+    unset LG_BUDDY_SCREEN_IDLE_TIMEOUT
+    unset LG_BUDDY_SCREEN_RESTORE_POLICY
+    unset LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY
+    unset LG_BUDDY_DISABLE_SLEEP_WAKE
+    cd "$BUNDLE_DIR"
+    ./install.sh
+)
+
+assert_file "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+"$INSTALLED_BINARY" settings get tv.platform | grep -q '^lg_webos$'
+assert_file "$NATIVE_ACCESS_TOKEN_FILE"
+cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE" || {
+    echo "In-place install changed the stored native access token."
+    exit 1
+}
+rm -f "$NATIVE_ACCESS_TOKEN_SNAPSHOT"
 
 export LG_BUDDY_REMOVE_CONFIG="1"
 (

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -226,6 +226,7 @@ fi
 grep -q '^tvs_primary_ip=192.168.1.10$' "$CONFIG_FILE"
 grep -q '^tvs_primary_mac=aa:bb:cc:dd:ee:ff$' "$CONFIG_FILE"
 grep -q '^tvs_primary_input=HDMI_2$' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 grep -q '^screen_idle_blank=enabled$' "$CONFIG_FILE"
 grep -q '^screen_backend=auto$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
@@ -251,6 +252,27 @@ printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^version: "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^channel: "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^commit: "
 
+# Existing profiles without the platform key remain on bscpylgtv. Materialize
+# that choice through settings, then use a controlled raw-config fixture to
+# prove lg_webos routes to native stored-credential authentication without
+# requiring a real TV in the release smoke test.
+sed -i '/^tvs_primary_platform=/d' "$CONFIG_FILE"
+"$INSTALLED_BINARY" settings get tv.platform | grep -q '^bscpylgtv$'
+"$INSTALLED_BINARY" settings set tv.platform bscpylgtv
+grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
+
+sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' "$CONFIG_FILE"
+"$INSTALLED_BINARY" settings get tv.platform | grep -q '^lg_webos$'
+if NATIVE_PLATFORM_OUTPUT="$("$INSTALLED_BINARY" brightness get 2>&1)"; then
+    echo "Native platform smoke unexpectedly succeeded without a stored credential."
+    exit 1
+fi
+printf '%s\n' "$NATIVE_PLATFORM_OUTPUT" | grep -F -q 'no stored platform access token is available'
+printf '%s\n' "$NATIVE_PLATFORM_OUTPUT" | grep -F -q 'lg-buddy settings set tv.platform lg_webos'
+
+"$INSTALLED_BINARY" settings set tv.platform bscpylgtv
+grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
+
 "$INSTALLED_BINARY" settings set screen.backend gnome
 "$INSTALLED_BINARY" settings set screen.idle_timeout 900
 "$INSTALLED_BINARY" settings set screen.idle_timeout 90000
@@ -271,6 +293,7 @@ grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
 grep -q '^tvs_primary_ip=192.168.1.12$' "$CONFIG_FILE"
 grep -q '^tvs_primary_mac=22:33:44:55:66:77$' "$CONFIG_FILE"
 grep -q '^tvs_primary_input=HDMI_4$' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 grep -q '^updates_auto_check=disabled$' "$CONFIG_FILE"
 grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
 
@@ -289,6 +312,7 @@ grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
 grep -q '^tvs_primary_ip=192.168.1.11$' "$CONFIG_FILE"
 grep -q '^tvs_primary_mac=11:22:33:44:55:66$' "$CONFIG_FILE"
 grep -q '^tvs_primary_input=HDMI_3$' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
 grep -q '^screen_idle_blank=disabled$' "$CONFIG_FILE"
 grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -297,6 +297,10 @@ grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 grep -q '^updates_auto_check=disabled$' "$CONFIG_FILE"
 grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
 
+# Configure should read inline-commented platform values with the same value
+# semantics as the Rust config parser, then persist the sanitized choice.
+sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=  lg_webos # experimental/' "$CONFIG_FILE"
+
 (
     unset LG_BUDDY_SCREEN_BACKEND
     unset LG_BUDDY_SCREEN_IDLE_TIMEOUT
@@ -312,7 +316,7 @@ grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
 grep -q '^tvs_primary_ip=192.168.1.11$' "$CONFIG_FILE"
 grep -q '^tvs_primary_mac=11:22:33:44:55:66$' "$CONFIG_FILE"
 grep -q '^tvs_primary_input=HDMI_3$' "$CONFIG_FILE"
-grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
 grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
 grep -q '^screen_idle_blank=disabled$' "$CONFIG_FILE"
 grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -357,9 +357,11 @@ rm -f "$VALID_PLATFORM_CONFIG" "$INVALID_PLATFORM_CONFIG" "$INVALID_PLATFORM_OUT
 # profile-scoped native credential. Do this before the existing uninstall and
 # fresh-install coverage below, without removing the user configuration.
 NATIVE_ACCESS_TOKEN_FILE="$(dirname "$CONFIG_FILE")/tvs/primary/access-token.json"
+NATIVE_PROFILE_DIR="$(dirname "$NATIVE_ACCESS_TOKEN_FILE")"
+NATIVE_PROFILES_DIR="$(dirname "$NATIVE_PROFILE_DIR")"
 NATIVE_ACCESS_TOKEN_SNAPSHOT="$WORK_DIR/native-access-token.snapshot"
 NATIVE_ACCESS_TOKEN_CONTENT='{"access_token":"release-smoke-native-token"}'
-mkdir -p "$(dirname "$NATIVE_ACCESS_TOKEN_FILE")"
+mkdir -p "$NATIVE_PROFILE_DIR"
 printf '%s\n' "$NATIVE_ACCESS_TOKEN_CONTENT" >"$NATIVE_ACCESS_TOKEN_FILE"
 chmod 600 "$NATIVE_ACCESS_TOKEN_FILE"
 cp "$NATIVE_ACCESS_TOKEN_FILE" "$NATIVE_ACCESS_TOKEN_SNAPSHOT"
@@ -448,6 +450,18 @@ export LG_BUDDY_REMOVE_CONFIG="1"
 }
 [ ! -e "$CONFIG_FILE" ] || {
     echo "User config still present after uninstall: $CONFIG_FILE"
+    exit 1
+}
+[ ! -e "$NATIVE_ACCESS_TOKEN_FILE" ] || {
+    echo "Native access token still present after uninstall: $NATIVE_ACCESS_TOKEN_FILE"
+    exit 1
+}
+[ ! -e "$NATIVE_PROFILE_DIR" ] || {
+    echo "Native TV profile still present after uninstall: $NATIVE_PROFILE_DIR"
+    exit 1
+}
+[ ! -e "$NATIVE_PROFILES_DIR" ] || {
+    echo "Native TV profiles directory still present after uninstall: $NATIVE_PROFILES_DIR"
     exit 1
 }
 

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -254,8 +254,7 @@ printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^commit: "
 
 # Existing profiles without the platform key remain on bscpylgtv. Materialize
 # that choice through settings, then use a controlled raw-config fixture to
-# prove lg_webos routes to native stored-credential authentication without
-# requiring a real TV in the release smoke test.
+# prove an unpaired native shutdown skips immediately without contacting a TV.
 sed -i '/^tvs_primary_platform=/d' "$CONFIG_FILE"
 "$INSTALLED_BINARY" settings get tv.platform | grep -q '^bscpylgtv$'
 "$INSTALLED_BINARY" settings set tv.platform bscpylgtv
@@ -263,12 +262,8 @@ grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 
 sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' "$CONFIG_FILE"
 "$INSTALLED_BINARY" settings get tv.platform | grep -q '^lg_webos$'
-if NATIVE_PLATFORM_OUTPUT="$("$INSTALLED_BINARY" brightness get 2>&1)"; then
-    echo "Native platform smoke unexpectedly succeeded without a stored credential."
-    exit 1
-fi
-printf '%s\n' "$NATIVE_PLATFORM_OUTPUT" | grep -F -q 'no stored platform access token is available'
-printf '%s\n' "$NATIVE_PLATFORM_OUTPUT" | grep -F -q 'lg-buddy settings set tv.platform lg_webos'
+NATIVE_PLATFORM_OUTPUT="$("$INSTALLED_BINARY" shutdown 2>&1)"
+printf '%s\n' "$NATIVE_PLATFORM_OUTPUT" | grep -F -q 'No stored native TV credential; skipping unattended TV control.'
 
 "$INSTALLED_BINARY" settings set tv.platform bscpylgtv
 grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -67,6 +67,7 @@ fi
 
 CONFIG_FILE="${CONFIG_FILE:-${LG_BUDDY_CONFIG:-${XDG_CONFIG_HOME:-$HOME/.config}/lg-buddy/config.env}}"
 CONFIG_DIR="$(dirname "$CONFIG_FILE")"
+TV_PROFILES_DIR="${CONFIG_DIR}/tvs"
 
 echo "Disabling & removing services..."
 echo "(This might turn off your TV)"
@@ -145,6 +146,7 @@ if [ -f "$CONFIG_FILE" ]; then
     case "$REMOVE_CONFIG" in
         [Yy]*|1|true|TRUE|True|yes|YES|Yes)
             rm -f "$CONFIG_FILE"
+            rm -rf "$TV_PROFILES_DIR"
             rmdir "$CONFIG_DIR" 2>/dev/null || true
             echo "Removed user configuration."
             ;;


### PR DESCRIPTION
## Summary

- add `tv.platform` as the single profile-scoped selector between `bscpylgtv` and experimental `lg_webos`
- preflight native opt-in with stored-token reuse or explicit foreground pairing before persisting the setting
- keep existing and unset profiles on `bscpylgtv`, with actionable native credential failures
- honor bounded native response timeouts during suspend handling and align shell config parsing with the Rust parser
- lock the product surface in with native WebSocket Cucumber scenarios and release-bundle upgrade coverage

## Why

Issue #53 introduces the opt-in migration rail for the native Rust webOS client without changing behavior for existing users. The preflight and credential rules prevent background services from depending on an unusable native configuration, while the lifecycle timeout and parser fixes keep suspend and upgrade behavior bounded and consistent.

## User impact

Users can select `lg_webos` through `settings set tv.platform lg_webos`. A successful opt-in proves native access first; failed or rejected pairing leaves the previous platform and credentials unchanged. In-place upgrades preserve the selected platform and profile-scoped token.

## Validation

- `cargo test -p lg-buddy --all-targets` — 69 Cucumber scenarios / 819 steps passed; hardware-only gamepad smoke ignored
- `cargo clippy -p lg-buddy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- shell syntax checks for installer, configuration, and release scripts
- packaged musl release-bundle smoke test
- `git diff --check`

Closes #53