### PR TITLE
Fix screen inactivity timeout ownership

### DIFF
--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -27,6 +27,7 @@ pub struct InactivityEngine {
     blank_after: Duration,
     blank_at: Instant,
     phase: InactivityPhase,
+    restore_pending: bool,
 }
 
 impl InactivityEngine {
@@ -35,6 +36,16 @@ impl InactivityEngine {
             blank_after,
             blank_at: started_at + blank_after,
             phase: InactivityPhase::Unknown,
+            restore_pending: false,
+        }
+    }
+
+    pub fn new_with_restore_pending(blank_after: Duration, started_at: Instant) -> Self {
+        Self {
+            blank_after,
+            blank_at: started_at + blank_after,
+            phase: InactivityPhase::Unknown,
+            restore_pending: true,
         }
     }
 
@@ -52,14 +63,18 @@ impl InactivityEngine {
         match self.phase {
             InactivityPhase::Idle => {
                 self.phase = InactivityPhase::Active;
+                self.restore_pending = false;
                 InactivityDecision::RestoreNow
             }
             InactivityPhase::Unknown => {
                 self.phase = InactivityPhase::Active;
-                if observation == InactivityObservation::DesktopActivityObserved {
-                    InactivityDecision::NoOp
-                } else {
+                if self.restore_pending
+                    || observation != InactivityObservation::DesktopActivityObserved
+                {
+                    self.restore_pending = false;
                     InactivityDecision::RestoreNow
+                } else {
+                    InactivityDecision::NoOp
                 }
             }
             InactivityPhase::Active => InactivityDecision::NoOp,
@@ -122,6 +137,33 @@ mod tests {
         );
         assert_eq!(
             engine.observe_time(started_at + Duration::from_secs(9)),
+            InactivityDecision::BlankNow
+        );
+    }
+
+    #[test]
+    fn owned_blank_restores_on_first_desktop_activity_after_restart() {
+        let started_at = Instant::now();
+        let mut engine =
+            InactivityEngine::new_with_restore_pending(Duration::from_secs(5), started_at);
+
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                started_at + Duration::from_secs(1),
+            ),
+            InactivityDecision::RestoreNow
+        );
+    }
+
+    #[test]
+    fn pending_restore_does_not_suppress_timeout_reconciliation() {
+        let started_at = Instant::now();
+        let mut engine =
+            InactivityEngine::new_with_restore_pending(Duration::from_secs(5), started_at);
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
             InactivityDecision::BlankNow
         );
     }

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -1,7 +1,8 @@
+use std::time::{Duration, Instant};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InactivityObservation {
-    IdleTimeMs(u64),
-    ProviderIdle,
+    DesktopActivityObserved,
     ProviderActive,
     WakeRequested,
     UserActivityObserved,
@@ -15,12 +16,6 @@ pub enum InactivityDecision {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct InactivityThresholds {
-    pub blank_threshold_ms: u64,
-    pub active_threshold_ms: u64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InactivityPhase {
     Unknown,
     Active,
@@ -29,317 +24,200 @@ enum InactivityPhase {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InactivityEngine {
-    thresholds: InactivityThresholds,
+    blank_after: Duration,
+    blank_at: Instant,
     phase: InactivityPhase,
-    provider_idle: bool,
 }
 
 impl InactivityEngine {
-    pub fn new(thresholds: InactivityThresholds) -> Self {
+    pub fn new(blank_after: Duration, started_at: Instant) -> Self {
         Self {
-            thresholds,
+            blank_after,
+            blank_at: started_at + blank_after,
             phase: InactivityPhase::Unknown,
-            provider_idle: false,
         }
     }
 
-    pub fn thresholds(&self) -> InactivityThresholds {
-        self.thresholds
+    pub fn time_until_blank(&self, now: Instant) -> Option<Duration> {
+        (self.phase != InactivityPhase::Idle).then(|| self.blank_at.saturating_duration_since(now))
     }
 
-    fn activate_from_signal(&mut self) -> InactivityDecision {
-        if self.phase == InactivityPhase::Active {
-            InactivityDecision::NoOp
-        } else {
-            self.phase = InactivityPhase::Active;
-            InactivityDecision::RestoreNow
-        }
-    }
+    pub fn observe_activity(
+        &mut self,
+        observation: InactivityObservation,
+        observed_at: Instant,
+    ) -> InactivityDecision {
+        self.blank_at = self.blank_at.max(observed_at + self.blank_after);
 
-    fn observe_idletime(&mut self, idletime_ms: u64) -> InactivityDecision {
-        if self.provider_idle {
-            if idletime_ms < self.thresholds.active_threshold_ms {
-                self.provider_idle = false;
-                return self.activate_from_signal();
+        match self.phase {
+            InactivityPhase::Idle => {
+                self.phase = InactivityPhase::Active;
+                InactivityDecision::RestoreNow
             }
+            InactivityPhase::Unknown => {
+                self.phase = InactivityPhase::Active;
+                if observation == InactivityObservation::DesktopActivityObserved {
+                    InactivityDecision::NoOp
+                } else {
+                    InactivityDecision::RestoreNow
+                }
+            }
+            InactivityPhase::Active => InactivityDecision::NoOp,
+        }
+    }
 
+    pub fn observe_time(&mut self, observed_at: Instant) -> InactivityDecision {
+        if self.phase == InactivityPhase::Idle || observed_at < self.blank_at {
             return InactivityDecision::NoOp;
         }
 
-        if idletime_ms >= self.thresholds.blank_threshold_ms {
-            match self.phase {
-                InactivityPhase::Unknown | InactivityPhase::Active => {
-                    self.phase = InactivityPhase::Idle;
-                    InactivityDecision::BlankNow
-                }
-                InactivityPhase::Idle => InactivityDecision::NoOp,
-            }
-        } else if idletime_ms < self.thresholds.active_threshold_ms {
-            match self.phase {
-                InactivityPhase::Idle => {
-                    self.phase = InactivityPhase::Active;
-                    InactivityDecision::RestoreNow
-                }
-                InactivityPhase::Unknown => {
-                    self.phase = InactivityPhase::Active;
-                    InactivityDecision::NoOp
-                }
-                InactivityPhase::Active => InactivityDecision::NoOp,
-            }
-        } else {
-            InactivityDecision::NoOp
-        }
-    }
-
-    pub fn observe(&mut self, observation: InactivityObservation) -> InactivityDecision {
-        match observation {
-            InactivityObservation::ProviderIdle => {
-                self.provider_idle = true;
-                if self.phase == InactivityPhase::Idle {
-                    InactivityDecision::NoOp
-                } else {
-                    self.phase = InactivityPhase::Idle;
-                    InactivityDecision::BlankNow
-                }
-            }
-            InactivityObservation::IdleTimeMs(idletime_ms) => self.observe_idletime(idletime_ms),
-            InactivityObservation::ProviderActive => {
-                self.provider_idle = false;
-                self.activate_from_signal()
-            }
-            InactivityObservation::WakeRequested | InactivityObservation::UserActivityObserved => {
-                self.provider_idle = false;
-                self.activate_from_signal()
-            }
-        }
+        self.phase = InactivityPhase::Idle;
+        InactivityDecision::BlankNow
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        InactivityDecision, InactivityEngine, InactivityObservation, InactivityThresholds,
-    };
+    use super::{InactivityDecision, InactivityEngine, InactivityObservation};
+    use std::time::{Duration, Instant};
 
-    fn test_engine() -> InactivityEngine {
-        InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 5_000,
-            active_threshold_ms: 1_000,
-        })
+    fn test_engine(started_at: Instant) -> InactivityEngine {
+        InactivityEngine::new(Duration::from_secs(5), started_at)
     }
 
     #[test]
-    fn idle_threshold_crossing_blanks_once() {
-        let mut engine = test_engine();
+    fn timeout_blanks_once() {
+        let started_at = Instant::now();
+        let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(4_999)),
+            engine.observe_time(started_at + Duration::from_millis(4_999)),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
-            InactivityDecision::BlankNow
-        );
-    }
-
-    #[test]
-    fn remaining_above_idle_threshold_does_not_blank_repeatedly() {
-        let mut engine = test_engine();
-
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
+            engine.observe_time(started_at + Duration::from_secs(5)),
             InactivityDecision::BlankNow
         );
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(6_000)),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(7_500)),
+            engine.observe_time(started_at + Duration::from_secs(6)),
             InactivityDecision::NoOp
         );
     }
 
     #[test]
-    fn fresh_activity_below_active_threshold_restores_after_blank() {
-        let mut engine = test_engine();
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
-            InactivityDecision::BlankNow
-        );
+    fn desktop_activity_resets_the_timeout() {
+        let started_at = Instant::now();
+        let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(1_500)),
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                started_at + Duration::from_secs(4),
+            ),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(999)),
-            InactivityDecision::RestoreNow
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(9)),
+            InactivityDecision::BlankNow
         );
     }
 
     #[test]
-    fn wake_request_restores_after_blank() {
-        let mut engine = test_engine();
+    fn auxiliary_activity_resets_the_timeout_and_restores_after_blank() {
+        let started_at = Instant::now();
+        let mut engine = test_engine(started_at);
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
+            engine.observe_time(started_at + Duration::from_secs(5)),
             InactivityDecision::BlankNow
         );
 
         assert_eq!(
-            engine.observe(InactivityObservation::WakeRequested),
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                started_at + Duration::from_secs(6),
+            ),
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe(InactivityObservation::WakeRequested),
+            engine.observe_time(started_at + Duration::from_secs(10)),
             InactivityDecision::NoOp
         );
-    }
-
-    #[test]
-    fn provider_active_restores_after_blank() {
-        let mut engine = test_engine();
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
-            InactivityDecision::BlankNow
-        );
-
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderActive),
-            InactivityDecision::RestoreNow
-        );
-    }
-
-    #[test]
-    fn observed_user_activity_restores_after_blank() {
-        let mut engine = test_engine();
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
-            InactivityDecision::BlankNow
-        );
-
-        assert_eq!(
-            engine.observe(InactivityObservation::UserActivityObserved),
-            InactivityDecision::RestoreNow
-        );
-    }
-
-    #[test]
-    fn provider_idle_blanks_immediately() {
-        let mut engine = test_engine();
-
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderIdle),
+            engine.observe_time(started_at + Duration::from_secs(11)),
             InactivityDecision::BlankNow
         );
     }
 
     #[test]
-    fn provider_idle_is_a_first_class_blank_source() {
-        let mut engine = test_engine();
+    fn wake_and_provider_activity_reset_the_same_timeout() {
+        let started_at = Instant::now();
 
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderIdle),
-            InactivityDecision::BlankNow
-        );
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderIdle),
-            InactivityDecision::NoOp
-        );
+        for observation in [
+            InactivityObservation::ProviderActive,
+            InactivityObservation::WakeRequested,
+        ] {
+            let mut engine = test_engine(started_at);
+            assert_eq!(
+                engine.observe_activity(observation, started_at + Duration::from_secs(4)),
+                InactivityDecision::RestoreNow
+            );
+            assert_eq!(
+                engine.observe_time(started_at + Duration::from_secs(5)),
+                InactivityDecision::NoOp
+            );
+            assert_eq!(
+                engine.observe_time(started_at + Duration::from_secs(9)),
+                InactivityDecision::BlankNow
+            );
+        }
     }
 
     #[test]
-    fn idletime_activity_restores_while_provider_still_reports_idle() {
-        let mut engine = test_engine();
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderIdle),
-            InactivityDecision::BlankNow
-        );
+    fn stale_activity_cannot_move_the_deadline_back() {
+        let started_at = Instant::now();
+        let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(0)),
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                started_at + Duration::from_secs(4),
+            ),
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe(InactivityObservation::ProviderActive),
-            InactivityDecision::NoOp
-        );
-    }
-
-    #[test]
-    fn idletime_above_active_threshold_does_not_restore_while_provider_reports_idle() {
-        let mut engine = test_engine();
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderIdle),
-            InactivityDecision::BlankNow
-        );
-
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(1_000)),
-            InactivityDecision::NoOp
-        );
-    }
-
-    #[test]
-    fn restore_signals_are_noops_after_engine_is_already_active() {
-        let mut engine = test_engine();
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(250)),
-            InactivityDecision::NoOp
-        );
-
-        assert_eq!(
-            engine.observe(InactivityObservation::ProviderActive),
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                started_at + Duration::from_secs(2),
+            ),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe(InactivityObservation::WakeRequested),
+            engine.observe_time(started_at + Duration::from_secs(7)),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe(InactivityObservation::UserActivityObserved),
-            InactivityDecision::NoOp
-        );
-    }
-
-    #[test]
-    fn low_idletime_seeds_active_state_without_restoring() {
-        let mut engine = test_engine();
-
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(999)),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(
-            engine.observe(InactivityObservation::IdleTimeMs(5_000)),
+            engine.observe_time(started_at + Duration::from_secs(9)),
             InactivityDecision::BlankNow
         );
     }
 
     #[test]
-    fn provider_active_restores_when_engine_starts_unknown() {
-        let mut engine = test_engine();
+    fn idle_phase_has_no_pending_timeout() {
+        let started_at = Instant::now();
+        let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.observe(InactivityObservation::ProviderActive),
-            InactivityDecision::RestoreNow
+            engine.time_until_blank(started_at),
+            Some(Duration::from_secs(5))
         );
         assert_eq!(
-            engine.observe(InactivityObservation::ProviderActive),
-            InactivityDecision::NoOp
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
         );
-    }
-
-    #[test]
-    fn thresholds_are_reported_verbatim() {
-        let engine = test_engine();
-
-        assert_eq!(
-            engine.thresholds(),
-            InactivityThresholds {
-                blank_threshold_ms: 5_000,
-                active_threshold_ms: 1_000,
-            }
-        );
+        assert_eq!(engine.time_until_blank(started_at), None);
     }
 }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -29,9 +29,7 @@ use crate::session::gamepad::{
     open_system_gamepad_activity_source, open_system_gamepad_device_event_monitor,
     SystemGamepadActivitySource, SystemGamepadDeviceEventMonitor,
 };
-use crate::session::inactivity::{
-    InactivityDecision, InactivityEngine, InactivityObservation, InactivityThresholds,
-};
+use crate::session::inactivity::{InactivityDecision, InactivityEngine, InactivityObservation};
 use crate::session::{SessionBackend, SessionBackendError, SessionEvent};
 use crate::session_bus::{
     new_session_bus_client, new_system_bus_client, BusSignal, BusSignalMatch, SessionBusClient,
@@ -49,9 +47,9 @@ use crate::sources::linux::logind::{
 use crate::RunError;
 
 const GNOME_WAIT_TIMEOUT_SECS: u64 = 15;
-const GNOME_ACTIVE_THRESHOLD_MS: u64 = 1000;
 const GNOME_BUS_PROCESS_INTERVAL: Duration = Duration::from_millis(50);
 const GNOME_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const GNOME_DESKTOP_ACTIVITY_WINDOW: Duration = Duration::from_millis(500);
 const GAMEPAD_ACTIVITY_POLL_INTERVAL: Duration = Duration::from_millis(50);
 const GAMEPAD_ACTIVITY_REFRESH_DEBOUNCE: Duration = Duration::from_millis(250);
 const GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL: Duration = Duration::from_secs(2);
@@ -635,85 +633,87 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
 
     writeln!(writer, "LG Buddy Monitor: Using GNOME backend.")?;
 
-    let thresholds = InactivityThresholds {
-        blank_threshold_ms: resolve_idle_timeout_ms(),
-        active_threshold_ms: GNOME_ACTIVE_THRESHOLD_MS,
-    };
-    let mut inactivity = InactivityEngine::new(thresholds);
+    let mut inactivity = InactivityEngine::new(
+        Duration::from_millis(resolve_idle_timeout_ms()),
+        Instant::now(),
+    );
 
     let (sender, receiver) = mpsc::channel();
     let latest_inactivity = Arc::new(LatestInactivityObservation::default());
     let monitor_handle = spawn_gnome_monitor_thread(sender.clone(), Arc::clone(&latest_inactivity));
     let _gamepad_monitor = spawn_gamepad_activity_thread(sender.clone());
-    let mut observation_merger = InactivityObservationMerger::new(thresholds.blank_threshold_ms);
     let mut monitor_result = Ok(());
 
-    while let Ok(message) = receiver.recv() {
-        match message {
-            RunnerMessage::InactivityObservationReady => {
-                if let Some(observation) = latest_inactivity.take() {
-                    let observation =
-                        observation_merger.merge(observation.observation, observation.observed_at);
-                    handle_gnome_inactivity_observation(
+    loop {
+        let message = match inactivity.time_until_blank(Instant::now()) {
+            Some(wait) => match receiver.recv_timeout(wait) {
+                Ok(message) => message,
+                Err(mpsc::RecvTimeoutError::Timeout) => {
+                    handle_gnome_inactivity_timeout(
                         writer,
                         dispatcher,
                         &mut inactivity,
-                        observation,
+                        Instant::now(),
+                    )?;
+                    continue;
+                }
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            },
+            None => match receiver.recv() {
+                Ok(message) => message,
+                Err(_) => break,
+            },
+        };
+
+        match message {
+            RunnerMessage::InactivityObservationReady => {
+                if let Some(observation) = latest_inactivity.take() {
+                    handle_gnome_activity_observation(
+                        writer,
+                        dispatcher,
+                        &mut inactivity,
+                        observation.observation,
+                        observation.observed_at,
                     )?;
                 }
             }
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Idle,
-                observed_at,
+                ..
             } => {
-                let observation =
-                    observation_merger.merge(InactivityObservation::ProviderIdle, observed_at);
-                handle_gnome_inactivity_observation(
-                    writer,
-                    dispatcher,
-                    &mut inactivity,
-                    observation,
-                )?;
+                // GNOME ScreenSaver idle is observational. Only LG Buddy's
+                // inactivity deadline decides when to blank.
             }
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Active,
                 observed_at,
-            } => {
-                let observation =
-                    observation_merger.merge(InactivityObservation::ProviderActive, observed_at);
-                handle_gnome_inactivity_observation(
-                    writer,
-                    dispatcher,
-                    &mut inactivity,
-                    observation,
-                )?
-            }
+            } => handle_gnome_activity_observation(
+                writer,
+                dispatcher,
+                &mut inactivity,
+                InactivityObservation::ProviderActive,
+                observed_at,
+            )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::WakeRequested,
                 observed_at,
-            } => {
-                let observation =
-                    observation_merger.merge(InactivityObservation::WakeRequested, observed_at);
-                handle_gnome_inactivity_observation(
-                    writer,
-                    dispatcher,
-                    &mut inactivity,
-                    observation,
-                )?
-            }
+            } => handle_gnome_activity_observation(
+                writer,
+                dispatcher,
+                &mut inactivity,
+                InactivityObservation::WakeRequested,
+                observed_at,
+            )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::UserActivity,
                 observed_at,
-            } => {
-                let observation = observation_merger
-                    .merge(InactivityObservation::UserActivityObserved, observed_at);
-                handle_gnome_inactivity_observation(
-                    writer,
-                    dispatcher,
-                    &mut inactivity,
-                    observation,
-                )?
-            }
+            } => handle_gnome_activity_observation(
+                writer,
+                dispatcher,
+                &mut inactivity,
+                InactivityObservation::UserActivityObserved,
+                observed_at,
+            )?,
             RunnerMessage::SessionEvent { event, .. } => {
                 dispatcher.dispatch_event(writer, event)?;
             }
@@ -1118,72 +1118,6 @@ impl Drop for GamepadActivityThread {
     }
 }
 
-#[derive(Debug)]
-struct InactivityObservationMerger {
-    blank_threshold_ms: u64,
-    latest_external_activity_at: Option<Instant>,
-}
-
-impl InactivityObservationMerger {
-    fn new(blank_threshold_ms: u64) -> Self {
-        Self {
-            blank_threshold_ms,
-            latest_external_activity_at: None,
-        }
-    }
-
-    fn merge(
-        &mut self,
-        observation: InactivityObservation,
-        observed_at: Instant,
-    ) -> InactivityObservation {
-        match observation {
-            InactivityObservation::IdleTimeMs(idletime_ms) => InactivityObservation::IdleTimeMs(
-                self.effective_idletime_ms(idletime_ms, observed_at),
-            ),
-            InactivityObservation::ProviderIdle => self.effective_provider_idle(observed_at),
-            InactivityObservation::ProviderActive
-            | InactivityObservation::WakeRequested
-            | InactivityObservation::UserActivityObserved => {
-                self.latest_external_activity_at = Some(observed_at);
-                observation
-            }
-        }
-    }
-
-    fn effective_provider_idle(&self, observed_at: Instant) -> InactivityObservation {
-        let Some(external_idletime_ms) = self.external_idletime_ms(observed_at) else {
-            return InactivityObservation::ProviderIdle;
-        };
-
-        if external_idletime_ms < self.blank_threshold_ms {
-            InactivityObservation::IdleTimeMs(external_idletime_ms)
-        } else {
-            InactivityObservation::ProviderIdle
-        }
-    }
-
-    fn effective_idletime_ms(&self, provider_idletime_ms: u64, observed_at: Instant) -> u64 {
-        self.external_idletime_ms(observed_at)
-            .map(|external_idletime_ms| provider_idletime_ms.min(external_idletime_ms))
-            .unwrap_or(provider_idletime_ms)
-    }
-
-    fn external_idletime_ms(&self, observed_at: Instant) -> Option<u64> {
-        self.latest_external_activity_at.map(|activity_at| {
-            duration_millis_u64(
-                observed_at
-                    .checked_duration_since(activity_at)
-                    .unwrap_or_default(),
-            )
-        })
-    }
-}
-
-fn duration_millis_u64(duration: Duration) -> u64 {
-    duration.as_millis().try_into().unwrap_or(u64::MAX)
-}
-
 fn gamepad_activity_send_due(last_sent_at: Option<Instant>, observed_at: Instant) -> bool {
     last_sent_at
         .map(|last_sent_at| {
@@ -1406,23 +1340,32 @@ fn poll_gnome_idle_monitor_once(
         return true;
     };
 
+    let activity_age = Duration::from_millis(idletime_ms);
+    if activity_age > GNOME_DESKTOP_ACTIVITY_WINDOW {
+        return true;
+    }
+
+    let observed_at = Instant::now();
+    let activity_at = observed_at.checked_sub(activity_age).unwrap_or(observed_at);
+
     latest_observation.publish(
         sender,
-        InactivityObservation::IdleTimeMs(idletime_ms),
-        Instant::now(),
+        InactivityObservation::DesktopActivityObserved,
+        activity_at,
     )
 }
 
-fn handle_gnome_inactivity_observation<W: Write, E: SessionActionExecutor>(
+fn handle_gnome_activity_observation<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     inactivity: &mut InactivityEngine,
     observation: InactivityObservation,
+    observed_at: Instant,
 ) -> Result<(), SessionRunnerError> {
-    let decision = inactivity.observe(observation);
+    let decision = inactivity.observe_activity(observation, observed_at);
     let event = match (observation, decision) {
         (_, InactivityDecision::NoOp) => None,
-        (_, InactivityDecision::BlankNow) => Some(SessionEvent::Idle),
+        (_, InactivityDecision::BlankNow) => None,
         (InactivityObservation::ProviderActive, InactivityDecision::RestoreNow) => {
             Some(SessionEvent::Active)
         }
@@ -1430,14 +1373,27 @@ fn handle_gnome_inactivity_observation<W: Write, E: SessionActionExecutor>(
             Some(SessionEvent::WakeRequested)
         }
         (
-            InactivityObservation::IdleTimeMs(_) | InactivityObservation::UserActivityObserved,
+            InactivityObservation::DesktopActivityObserved
+            | InactivityObservation::UserActivityObserved,
             InactivityDecision::RestoreNow,
         ) => Some(SessionEvent::UserActivity),
-        (InactivityObservation::ProviderIdle, InactivityDecision::RestoreNow) => None,
     };
 
     if let Some(event) = event {
         dispatcher.dispatch_event(writer, event)?;
+    }
+
+    Ok(())
+}
+
+fn handle_gnome_inactivity_timeout<W: Write, E: SessionActionExecutor>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    inactivity: &mut InactivityEngine,
+    observed_at: Instant,
+) -> Result<(), SessionRunnerError> {
+    if inactivity.observe_time(observed_at) == InactivityDecision::BlankNow {
+        dispatcher.dispatch_event(writer, SessionEvent::Idle)?;
     }
 
     Ok(())
@@ -1477,18 +1433,16 @@ mod tests {
     use super::{
         complete_gamepad_refresh, gamepad_activity_send_due,
         gamepad_device_event_refresh_requested, gamepad_refresh_due,
-        handle_gnome_inactivity_observation, normalize_idle_timeout_secs,
-        poll_gnome_idle_monitor_once, run_lifecycle_monitor_with_bus, schedule_gamepad_refresh,
-        shell_quote, GamepadDeviceEventMonitor, GamepadDeviceEventRefresh,
-        GamepadDiagnosticEmitter, InactivityObservationMerger, LatestInactivityObservation,
+        handle_gnome_activity_observation, handle_gnome_inactivity_timeout,
+        normalize_idle_timeout_secs, poll_gnome_idle_monitor_once, run_lifecycle_monitor_with_bus,
+        schedule_gamepad_refresh, shell_quote, GamepadDeviceEventMonitor,
+        GamepadDeviceEventRefresh, GamepadDiagnosticEmitter, LatestInactivityObservation,
         RunnerMessage, SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
         TrustedScreenSaverSignals, GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL,
         GAMEPAD_ACTIVITY_SEND_INTERVAL,
     };
     use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
-    use crate::session::inactivity::{
-        InactivityEngine, InactivityObservation, InactivityThresholds,
-    };
+    use crate::session::inactivity::{InactivityEngine, InactivityObservation};
     use crate::session::SessionEvent;
     use crate::session_bus::{
         BusMethodCall, BusReply, BusSignal, BusSignalMatch, BusValue, SessionBusClient,
@@ -2089,12 +2043,12 @@ system_sleep_wake_policy={policy}
 
         assert!(latest.publish(
             &sender,
-            InactivityObservation::IdleTimeMs(1_000),
+            InactivityObservation::DesktopActivityObserved,
             first_observed_at
         ));
         assert!(latest.publish(
             &sender,
-            InactivityObservation::IdleTimeMs(2_000),
+            InactivityObservation::DesktopActivityObserved,
             second_observed_at
         ));
 
@@ -2105,7 +2059,7 @@ system_sleep_wake_policy={policy}
         assert_eq!(
             latest.take(),
             Some(TimedInactivityObservation {
-                observation: InactivityObservation::IdleTimeMs(2_000),
+                observation: InactivityObservation::DesktopActivityObserved,
                 observed_at: second_observed_at,
             })
         );
@@ -2121,7 +2075,7 @@ system_sleep_wake_policy={policy}
 
         assert!(latest.publish(
             &sender,
-            InactivityObservation::IdleTimeMs(1_000),
+            InactivityObservation::DesktopActivityObserved,
             first_observed_at
         ));
         assert!(matches!(
@@ -2131,14 +2085,14 @@ system_sleep_wake_policy={policy}
         assert_eq!(
             latest.take(),
             Some(TimedInactivityObservation {
-                observation: InactivityObservation::IdleTimeMs(1_000),
+                observation: InactivityObservation::DesktopActivityObserved,
                 observed_at: first_observed_at,
             })
         );
 
         assert!(latest.publish(
             &sender,
-            InactivityObservation::IdleTimeMs(3_000),
+            InactivityObservation::DesktopActivityObserved,
             second_observed_at
         ));
         assert!(matches!(
@@ -2148,18 +2102,18 @@ system_sleep_wake_policy={policy}
         assert_eq!(
             latest.take(),
             Some(TimedInactivityObservation {
-                observation: InactivityObservation::IdleTimeMs(3_000),
+                observation: InactivityObservation::DesktopActivityObserved,
                 observed_at: second_observed_at,
             })
         );
     }
 
     #[test]
-    fn gnome_idle_monitor_poller_publishes_idletime_from_session_bus() {
+    fn gnome_idle_monitor_poller_publishes_recent_desktop_activity() {
         let (sender, receiver) = mpsc::channel();
         let latest = LatestInactivityObservation::default();
         let mut bus = FakeSessionBus {
-            method_replies: vec![Ok(BusReply::new(vec![BusValue::U64(1_500)]))],
+            method_replies: vec![Ok(BusReply::new(vec![BusValue::U64(250)]))],
             ..FakeSessionBus::default()
         };
         let before_poll = Instant::now();
@@ -2172,10 +2126,24 @@ system_sleep_wake_policy={policy}
         let observation = latest.take().expect("latest observation");
         assert_eq!(
             observation.observation,
-            InactivityObservation::IdleTimeMs(1_500)
+            InactivityObservation::DesktopActivityObserved
         );
-        assert!(observation.observed_at >= before_poll);
+        assert!(observation.observed_at < before_poll);
         assert!(observation.observed_at <= Instant::now());
+    }
+
+    #[test]
+    fn gnome_idle_monitor_poller_does_not_publish_old_activity() {
+        let (sender, receiver) = mpsc::channel();
+        let latest = LatestInactivityObservation::default();
+        let mut bus = FakeSessionBus {
+            method_replies: vec![Ok(BusReply::new(vec![BusValue::U64(1_500)]))],
+            ..FakeSessionBus::default()
+        };
+
+        assert!(poll_gnome_idle_monitor_once(&mut bus, &sender, &latest));
+        assert!(receiver.try_recv().is_err());
+        assert_eq!(latest.take(), None);
     }
 
     #[test]
@@ -2423,99 +2391,114 @@ system_sleep_wake_policy={policy}
     }
 
     #[test]
-    fn idletime_observation_blanks_when_threshold_is_crossed() {
+    fn inactivity_timeout_blanks_once() {
         let executor = FakeActionExecutor {
             screen_off_output: "screen-off output\n".to_string(),
             ..FakeActionExecutor::default()
         };
         let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            InactivityObservation::IdleTimeMs(1_000),
+            started_at + Duration::from_secs(1),
         )
-        .expect("blank from idletime observation");
+        .expect("blank when the LG Buddy timeout expires");
+        handle_gnome_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(2),
+        )
+        .expect("do not blank repeatedly");
+
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("Session became idle."));
         assert_eq!(dispatcher.executor.screen_off_calls, 1);
     }
 
     #[test]
-    fn idletime_observation_restores_when_activity_returns() {
-        let executor = FakeActionExecutor {
-            screen_on_output: "screen-on output\n".to_string(),
-            ..FakeActionExecutor::default()
-        };
-        let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
-        let mut output = Vec::new();
-
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            InactivityObservation::IdleTimeMs(1_000),
-        )
-        .expect("blank from idletime observation");
-        let mut output = Vec::new();
-
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            InactivityObservation::IdleTimeMs(99),
-        )
-        .expect("restore from idletime observation");
-        let output = String::from_utf8(output).expect("utf8");
-        assert!(output.contains("user-activity"));
-        assert_eq!(dispatcher.executor.screen_on_calls, 1);
-    }
-
-    #[test]
-    fn idletime_activity_restores_while_provider_still_reports_idle() {
+    fn desktop_activity_restores_and_resets_the_timeout() {
         let executor = FakeActionExecutor {
             screen_off_output: "screen-off output\n".to_string(),
             screen_on_output: "screen-on output\n".to_string(),
             ..FakeActionExecutor::default()
         };
         let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            InactivityObservation::ProviderIdle,
+            started_at + Duration::from_secs(1),
         )
-        .expect("blank from provider idle");
-
+        .expect("blank when the timeout expires");
         let mut output = Vec::new();
-        handle_gnome_inactivity_observation(
+
+        handle_gnome_activity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            InactivityObservation::IdleTimeMs(99),
+            InactivityObservation::DesktopActivityObserved,
+            started_at + Duration::from_millis(1_100),
         )
-        .expect("restore from lock-screen user activity");
-        handle_gnome_inactivity_observation(
+        .expect("restore from desktop activity");
+        handle_gnome_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(2),
+        )
+        .expect("activity reset should keep the screen active");
+
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("user-activity"));
+        assert_eq!(dispatcher.executor.screen_on_calls, 1);
+        assert_eq!(dispatcher.executor.screen_off_calls, 1);
+    }
+
+    #[test]
+    fn auxiliary_activity_restores_before_provider_reports_active() {
+        let executor = FakeActionExecutor {
+            screen_off_output: "screen-off output\n".to_string(),
+            screen_on_output: "screen-on output\n".to_string(),
+            ..FakeActionExecutor::default()
+        };
+        let mut dispatcher = SessionEventDispatcher::new(executor);
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
+        let mut output = Vec::new();
+
+        handle_gnome_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(1),
+        )
+        .expect("blank when the timeout expires");
+
+        let mut output = Vec::new();
+        handle_gnome_activity_observation(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            InactivityObservation::UserActivityObserved,
+            started_at + Duration::from_millis(1_100),
+        )
+        .expect("restore from auxiliary activity");
+        handle_gnome_activity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
             InactivityObservation::ProviderActive,
+            started_at + Duration::from_millis(1_200),
         )
         .expect("provider active should not duplicate restore");
 
@@ -2534,210 +2517,82 @@ system_sleep_wake_policy={policy}
     }
 
     #[test]
-    fn external_activity_caps_effective_provider_idletime() {
-        let started = Instant::now();
-        let mut merger = InactivityObservationMerger::new(1_000);
-
-        assert_eq!(
-            merger.merge(
-                InactivityObservation::UserActivityObserved,
-                started + Duration::from_millis(100),
-            ),
-            InactivityObservation::UserActivityObserved
-        );
-        assert_eq!(
-            merger.merge(
-                InactivityObservation::IdleTimeMs(10_000),
-                started + Duration::from_millis(350),
-            ),
-            InactivityObservation::IdleTimeMs(250)
-        );
-    }
-
-    #[test]
-    fn external_activity_delays_provider_idle_until_blank_threshold_passes() {
-        let started = Instant::now();
-        let mut merger = InactivityObservationMerger::new(1_000);
-
-        assert_eq!(
-            merger.merge(InactivityObservation::UserActivityObserved, started),
-            InactivityObservation::UserActivityObserved
-        );
-        assert_eq!(
-            merger.merge(
-                InactivityObservation::ProviderIdle,
-                started + Duration::from_millis(250),
-            ),
-            InactivityObservation::IdleTimeMs(250)
-        );
-        assert_eq!(
-            merger.merge(
-                InactivityObservation::ProviderIdle,
-                started + Duration::from_millis(1_000),
-            ),
-            InactivityObservation::ProviderIdle
-        );
-    }
-
-    #[test]
-    fn gamepad_activity_prevents_next_high_idletime_sample_from_reblanking() {
+    fn activity_resets_timeout_before_reblanking() {
         let executor = FakeActionExecutor {
             screen_off_output: "screen-off output\n".to_string(),
             screen_on_output: "screen-on output\n".to_string(),
             ..FakeActionExecutor::default()
         };
         let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
-        let mut merger = InactivityObservationMerger::new(1_000);
-        let started = Instant::now();
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            merger.merge(InactivityObservation::IdleTimeMs(1_000), started),
+            started_at + Duration::from_secs(1),
         )
-        .expect("blank from provider idletime");
+        .expect("blank when the timeout expires");
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_activity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            merger.merge(
-                InactivityObservation::UserActivityObserved,
-                started + Duration::from_millis(100),
-            ),
+            InactivityObservation::UserActivityObserved,
+            started_at + Duration::from_millis(1_100),
         )
-        .expect("restore from gamepad activity");
+        .expect("restore from auxiliary activity");
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            merger.merge(
-                InactivityObservation::IdleTimeMs(5_000),
-                started + Duration::from_millis(250),
-            ),
+            started_at + Duration::from_secs(2),
         )
-        .expect("recent gamepad activity should suppress stale provider idletime");
+        .expect("the original deadline must stay retired");
+        handle_gnome_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_millis(2_100),
+        )
+        .expect("blank at the reset deadline");
 
-        assert_eq!(dispatcher.executor.screen_off_calls, 1);
+        assert_eq!(dispatcher.executor.screen_off_calls, 2);
         assert_eq!(dispatcher.executor.screen_on_calls, 1);
     }
 
     #[test]
-    fn gamepad_activity_prevents_recent_provider_idle_from_blanking() {
-        let executor = FakeActionExecutor {
-            screen_on_output: "screen-on output\n".to_string(),
-            ..FakeActionExecutor::default()
-        };
-        let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
-        let mut merger = InactivityObservationMerger::new(1_000);
-        let started = Instant::now();
-        let mut output = Vec::new();
-
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            merger.merge(InactivityObservation::UserActivityObserved, started),
-        )
-        .expect("gamepad activity should seed active state");
-
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            merger.merge(
-                InactivityObservation::ProviderIdle,
-                started + Duration::from_millis(250),
-            ),
-        )
-        .expect("recent gamepad activity should suppress stale provider idle");
-
-        assert_eq!(dispatcher.executor.screen_off_calls, 0);
-        assert_eq!(dispatcher.executor.screen_on_calls, 1);
-    }
-
-    #[test]
-    fn failed_blank_from_idletime_is_not_retried_while_session_stays_idle() {
+    fn failed_blank_is_not_retried_without_activity() {
         let executor = FakeActionExecutor {
             screen_off_error: Some("tv did not respond".to_string()),
             ..FakeActionExecutor::default()
         };
         let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            InactivityObservation::IdleTimeMs(1_000),
+            started_at + Duration::from_secs(1),
         )
         .expect("initial blank attempt should be logged");
-        handle_gnome_inactivity_observation(
+        handle_gnome_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
-            InactivityObservation::IdleTimeMs(1_500),
+            started_at + Duration::from_secs(2),
         )
-        .expect("repeated idle sample should not retry blank");
+        .expect("elapsed time should not retry blank");
 
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("screen-off action failed. tv did not respond"));
         assert_eq!(dispatcher.executor.screen_off_calls, 1);
-    }
-
-    #[test]
-    fn failed_restore_from_idletime_is_not_retried_while_session_stays_active() {
-        let executor = FakeActionExecutor {
-            screen_on_error: Some("tv is still waking".to_string()),
-            ..FakeActionExecutor::default()
-        };
-        let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
-        let mut output = Vec::new();
-
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            InactivityObservation::IdleTimeMs(1_000),
-        )
-        .expect("blank should succeed");
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            InactivityObservation::IdleTimeMs(99),
-        )
-        .expect("initial restore attempt should be logged");
-        handle_gnome_inactivity_observation(
-            &mut output,
-            &mut dispatcher,
-            &mut inactivity,
-            InactivityObservation::IdleTimeMs(0),
-        )
-        .expect("repeated active sample should not retry restore");
-
-        let output = String::from_utf8(output).expect("utf8");
-        assert!(output.contains("screen restore action failed. tv is still waking"));
-        assert_eq!(dispatcher.executor.screen_on_calls, 1);
     }
 
     #[test]
@@ -2747,24 +2602,24 @@ system_sleep_wake_policy={policy}
             ..FakeActionExecutor::default()
         };
         let mut dispatcher = SessionEventDispatcher::new(executor);
-        let mut inactivity = InactivityEngine::new(InactivityThresholds {
-            blank_threshold_ms: 1_000,
-            active_threshold_ms: 100,
-        });
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_observation(
+        handle_gnome_activity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
             InactivityObservation::ProviderActive,
+            started_at,
         )
         .expect("initial provider active should restore");
-        handle_gnome_inactivity_observation(
+        handle_gnome_activity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
             InactivityObservation::ProviderActive,
+            started_at + Duration::from_millis(100),
         )
         .expect("repeated provider active should not duplicate restore");
 

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -44,6 +44,7 @@ use crate::sources::desktop::gnome::{
 use crate::sources::linux::logind::{
     acquire_sleep_delay_inhibitor, add_logind_signal_match, map_prepare_for_sleep_signal,
 };
+use crate::state::{ScreenOwnershipMarker, StateScope};
 use crate::RunError;
 
 const GNOME_WAIT_TIMEOUT_SECS: u64 = 15;
@@ -633,10 +634,13 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
 
     writeln!(writer, "LG Buddy Monitor: Using GNOME backend.")?;
 
-    let mut inactivity = InactivityEngine::new(
-        Duration::from_millis(resolve_idle_timeout_ms()),
-        Instant::now(),
-    );
+    let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
+    let started_at = Instant::now();
+    let mut inactivity = if session_screen_ownership_marker_exists()? {
+        InactivityEngine::new_with_restore_pending(blank_after, started_at)
+    } else {
+        InactivityEngine::new(blank_after, started_at)
+    };
 
     let (sender, receiver) = mpsc::channel();
     let latest_inactivity = Arc::new(LatestInactivityObservation::default());
@@ -792,6 +796,15 @@ fn resolve_idle_timeout_secs() -> u64 {
             .map(u128::from)
             .unwrap_or(u128::from(DEFAULT_IDLE_TIMEOUT)),
     )
+}
+
+fn session_screen_ownership_marker_exists() -> Result<bool, SessionRunnerError> {
+    ScreenOwnershipMarker::from_env(StateScope::Session)
+        .map(|marker| marker.exists())
+        .map_err(|err| SessionRunnerError::Failed {
+            backend: ScreenBackend::Gnome,
+            message: format!("failed to inspect session screen ownership: {err}"),
+        })
 }
 
 fn resolve_idle_timeout_ms() -> u64 {

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -15,23 +15,46 @@ Feature: GNOME monitor
     And the TV client did not receive "get_input"
     And the TV client did not receive "turn_screen_off"
 
-  Scenario: GNOME ScreenSaver idle still blanks the configured TV input
+  Scenario: GNOME ScreenSaver idle does not bypass the LG Buddy timeout
     Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 2 seconds
     And LG Buddy session runtime is isolated
     And a mock TV client
     And the TV is on input HDMI_2
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME reports the session idle
+    And GNOME idle monitor will report idletimes "1000"
+    And GNOME monitor stays open for 0.6 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "Using GNOME backend."
-    And the TV client received "get_input"
-    And the TV client received "turn_screen_off"
-    And the session marker exists
-    And the TV screen is blanked
+    And stdout does not contain "Session became idle."
+    And the TV client did not receive "get_input"
+    And the TV client did not receive "turn_screen_off"
+    And the session marker is absent
+    And the TV screen is visible
 
-  Scenario: GNOME inactivity blanks the configured TV input when ScreenSaver idle is inhibited
+  Scenario: Desktop activity resets the LG Buddy timeout
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 1 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000, 1000, 0, 1000"
+    And GNOME monitor stays open for 1.2 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout does not contain "Session became idle."
+    And the TV client did not receive "get_input"
+    And the TV client did not receive "turn_screen_off"
+    And the session marker is absent
+    And the TV screen is visible
+
+  Scenario: LG Buddy blanks after its timeout without activity reports
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 1 seconds
     And LG Buddy session runtime is isolated
@@ -41,7 +64,7 @@ Feature: GNOME monitor
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
     And GNOME idle monitor will report idletimes "1000"
-    And GNOME monitor stays open for 1.0 seconds
+    And GNOME monitor stays open for 1.2 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "Using GNOME backend."
@@ -50,7 +73,7 @@ Feature: GNOME monitor
     And the session marker exists
     And the TV screen is blanked
 
-  Scenario: GNOME inhibited inactivity does not blank repeatedly while idletime stays high
+  Scenario: LG Buddy does not blank repeatedly without intervening activity
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 1 seconds
     And LG Buddy session runtime is isolated
@@ -60,7 +83,7 @@ Feature: GNOME monitor
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
     And GNOME idle monitor will report idletimes "1000, 1500, 2000, 2500"
-    And GNOME monitor stays open for 1.0 seconds
+    And GNOME monitor stays open for 1.2 seconds
     When I run the command "monitor"
     Then the command succeeds
     And the TV client received "turn_screen_off" exactly 1 times
@@ -78,8 +101,8 @@ Feature: GNOME monitor
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
     And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000"
-    And gamepad activity is observed after 0.1 seconds
-    And GNOME monitor stays open for 0.6 seconds
+    And gamepad activity is observed after 1.2 seconds
+    And GNOME monitor stays open for 1.6 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "Session event `user-activity` requests screen restore."
@@ -97,8 +120,8 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME reports the session idle
-    And GNOME idle monitor will report idletimes "500, 0, 0"
-    And GNOME monitor stays open for 0.7 seconds
+    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And GNOME monitor stays open for 1.8 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "Session event `user-activity` requests screen restore."
@@ -118,7 +141,7 @@ Feature: GNOME monitor
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
     And GNOME idle monitor will report idletimes "1000"
-    And GNOME monitor stays open for 1.0 seconds
+    And GNOME monitor stays open for 1.2 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "Skipping idle action."
@@ -195,8 +218,8 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 0, 0, 0"
-    And GNOME monitor stays open for 1.0 seconds
+    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And GNOME monitor stays open for 1.8 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "screen restore action failed"
@@ -238,8 +261,8 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 0, 0, 0"
-    And GNOME monitor stays open for 1.0 seconds
+    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And GNOME monitor stays open for 1.8 seconds
     When I run the command "monitor"
     Then the command succeeds
     And the TV client received "turn_screen_off" exactly 1 times

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -54,6 +54,26 @@ Feature: GNOME monitor
     And the session marker is absent
     And the TV screen is visible
 
+  Scenario: Monitor restart restores an owned blank screen on desktop activity
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 120 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the TV screen is blanked
+    And the session marker exists
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "0"
+    And GNOME monitor stays open for 0.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Session event `user-activity` requests screen restore."
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the session marker is absent
+    And the TV screen is visible
+
   Scenario: LG Buddy blanks after its timeout without activity reports
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 1 seconds

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -145,6 +145,26 @@ Feature: Native webOS TV platform
     And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
     And the native TV pairing prompt count is 0
 
+  Scenario: Native GNOME inactivity follows the LG Buddy timeout
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And the idle timeout is 1 seconds
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And GNOME monitor stays open for 1.8 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Using GNOME backend."
+    And the session marker is absent
+    And the TV screen is visible
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
   Scenario: Native startup input restoration is followed by native shutdown power-off
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -251,8 +251,9 @@ The intended split is:
   - top-level event consumption is mapped separately in
     [runtime-event-handler-map.md](runtime-event-handler-map.md)
 - `session/inactivity.rs`
-  - synthesizes idle and active transitions from native backend observations
-    and configured thresholds
+  - owns the configured inactivity deadline
+  - resets the deadline from normalized activity observations and blanks when
+    it expires
   - keeps blank and restore decisions edge-triggered instead of poll-triggered
 - `session/gamepad/`
   - discovers readable Linux gamepad-like input devices
@@ -300,14 +301,14 @@ The session-facing pieces should be read as one subsystem:
 - `session.rs`
   - defines the homogenized session contract
 - `session/inactivity.rs`
-  - owns session-phase synthesis from native inactivity observations and
-    configured thresholds
+  - owns session-phase synthesis and the configured inactivity deadline
 - `session/gamepad/`
   - supplies auxiliary user-activity observations for controller input
   - owns gamepad device discovery, event-triggered refresh, and reconciliation
   - see [gamepad-subsystem.md](gamepad-subsystem.md) for adapter and lifecycle details
 - `session/runner.rs`
-  - consumes normalized session events and idletime observations and dispatches runtime policy
+  - converts provider input into activity observations, resets the inactivity
+    deadline, and dispatches runtime policy
   - treats `screen_idle_blank=disabled` as a passive user-session mode that
     preserves update notification handoff without TV idle blank/restore actions
   - treats delegated `swayidle` as a CLI/API client for timeout/resume actions
@@ -641,9 +642,9 @@ and state normally, construct canonical CLI/API runtime events, and enter
 The session subsystem is intentionally asymmetric where the providers are
 asymmetric:
 
-- the current GNOME pilot combines ScreenSaver idle/active and wake signals
-  with Mutter idletime observations, then passes them through the inactivity
-  engine
+- the current GNOME pilot treats ScreenSaver active/wake, recent Mutter input,
+  and gamepad input as activity that resets LG Buddy's inactivity deadline;
+  ScreenSaver idle is not a blanking authority
 - the native monitor path also consumes gamepad activity directly from Linux
   input devices; today that is attached to GNOME because GNOME is the only
   native production adapter, but the source is not GNOME-specific

--- a/docs/development.md
+++ b/docs/development.md
@@ -141,7 +141,7 @@ For the tagged GitHub release process, see [release-process.md](release-process.
 | `crates/lg-buddy/src/lifecycle.rs` | Startup, shutdown, system sleep, and system resume policy |
 | `crates/lg-buddy/src/runtime_phase.rs` | Runtime sleep-phase provider abstraction |
 | `crates/lg-buddy/src/session/runner.rs` | Session monitor loop |
-| `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity synthesis and thresholds |
+| `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity deadline and phase synthesis |
 | `crates/lg-buddy/src/session/gamepad/` | Gamepad activity discovery, device-event refresh, adapters, capture, registry, and policy |
 | `crates/lg-buddy/src/session_bus.rs` | Generic D-Bus transport used by session and system event sources |
 | `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle signal and property adapter |

--- a/docs/gamepad-subsystem.md
+++ b/docs/gamepad-subsystem.md
@@ -38,8 +38,8 @@ screen behavior.
    immediate. Axis activity is compared against a moving baseline so arbitrary
    resting positions, such as a wheel left turned, do not continuously count as
    input.
-7. The runner receives throttled `UserActivity` events and merges them into the
-   inactivity engine.
+7. The runner receives throttled `UserActivity` events and resets the same
+   inactivity deadline used by desktop activity.
 
 ## Module Map
 

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -18,15 +18,15 @@ LG Buddy has four related but distinct event/result shapes.
 | Command entrypoint | `lib.rs` / `commands.rs` / `session::runner` | External service, hook, or user command invokes one runtime command. |
 | Runtime event | `events.rs` | Source-classified fact or intent, such as CLI/API, Linux logind, Linux NetworkManager, desktop session, or auxiliary input. |
 | Session event | `session.rs` | Backend-neutral event such as `Idle`, `Active`, `WakeRequested`, `BeforeSleep`, or `AfterResume`. |
-| Inactivity observation | `session/inactivity.rs` | Lower-level inactivity fact such as idletime, provider idle, wake request, or user activity. |
+| Inactivity observation | `session/inactivity.rs` | Lower-level activity fact such as desktop input, wake request, or auxiliary input. |
 | Policy outcome | `policy.rs` | Explicit selected actions, no-action decisions, diagnostics, and state transitions. |
 
 The command entrypoint layer remains the external integration surface. The
 session event layer is active for native monitor behavior and delegated backend
 modeling. System lifecycle handling is normalized through `RuntimeEvent` and
-the lifecycle policy domain. The inactivity observation layer owns
-edge-triggered blank and restore decisions for native idle/activity
-integrations.
+the lifecycle policy domain. The inactivity observation layer owns one
+deadline. Every activity observation resets it; expiry produces an
+edge-triggered blank decision.
 
 GNOME is the production pilot for the native inactivity path today, but the
 model is not GNOME-specific. A future non-GNOME Wayland adapter should feed the
@@ -87,7 +87,7 @@ Examples:
 | Source category | Example source | Runtime representation |
 | --- | --- | --- |
 | system lifecycle | `org.freedesktop.login1`, platform-native lifecycle APIs | `MachinePreparingForSleep`, `MachineResumed`, `NetworkTeardownImminent` |
-| desktop idle/activity | Mutter, native Wayland idle protocols | idletime and activity observations |
+| desktop activity | Mutter, native Wayland idle protocols | activity observations |
 | desktop wake request | GNOME ScreenSaver wake signal, future equivalents | `WakeRequested` |
 | auxiliary activity | Linux gamepad input | `UserActivityObserved` |
 
@@ -104,7 +104,8 @@ instead of delegating blank/restore commands to an external tool.
 native desktop activity facts
 auxiliary activity facts
   -> inactivity observations
-  -> InactivityEngine
+  -> reset the InactivityEngine deadline
+  -> configured timeout expires
   -> Idle / Active / WakeRequested / UserActivity
   -> screen policy
 ```
@@ -113,10 +114,10 @@ Current pilot inputs:
 
 | Provider surface | Runtime representation | Consumed by |
 | --- | --- | --- |
-| `org.gnome.ScreenSaver.ActiveChanged(true)` | `ProviderIdle` | `InactivityEngine` |
+| `org.gnome.ScreenSaver.ActiveChanged(true)` | Non-authoritative idle observation | GNOME runner; does not change the LG Buddy deadline |
 | `org.gnome.ScreenSaver.ActiveChanged(false)` | `ProviderActive` | `InactivityEngine` |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | `InactivityEngine` |
-| `org.gnome.Mutter.IdleMonitor.GetIdletime` | `IdleTimeMs` | `InactivityEngine` |
+| Recent activity reported by `org.gnome.Mutter.IdleMonitor.GetIdletime` | `DesktopActivityObserved` | `InactivityEngine` |
 | Linux gamepad activity | `UserActivityObserved` | `InactivityEngine` |
 
 These are GNOME-specific source surfaces, but the runtime representations are
@@ -130,7 +131,7 @@ The resulting decisions are dispatched as:
 | `BlankNow` | `SessionEvent::Idle` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_off_from_env_for_event` |
 | `RestoreNow` from provider active | `SessionEvent::Active` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from wake request | `SessionEvent::WakeRequested` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
-| `RestoreNow` from idletime or auxiliary activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
+| `RestoreNow` from desktop or auxiliary activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 
 ### Delegated `swayidle` CLI/API Path
 

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -129,17 +129,23 @@ Current mapping:
 
 | Provider surface | Canonical meaning | Current Rust Status |
 | --- | --- | --- |
-| `org.gnome.ScreenSaver.ActiveChanged (true,)` | `Idle` | Implemented |
+| `org.gnome.ScreenSaver.ActiveChanged (true,)` | Idle observation that cannot bypass LG Buddy's timeout | Implemented |
 | `org.gnome.ScreenSaver.ActiveChanged (false,)` | `Active` | Implemented |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | Implemented |
-| `org.gnome.Mutter.IdleMonitor.GetIdletime` | LG Buddy-owned inactivity thresholding and activity synthesis | Implemented |
+| Recent activity from `org.gnome.Mutter.IdleMonitor.GetIdletime` | `UserActivity` | Implemented |
 | Linux gamepad input devices | `UserActivity` | Implemented in the GNOME monitor runtime |
 
 Notes:
 
 - GNOME requires GNOME Shell, `org.gnome.ScreenSaver`, and `org.gnome.Mutter.IdleMonitor`.
 - LG Buddy owns the configured timeout value for this backend.
-- ScreenSaver idle/active signals and Mutter idletime are both observation inputs into LG Buddy policy.
+- LG Buddy owns one inactivity deadline. Desktop, gamepad, active, and wake
+  activity reports reset it; expiry after `screen_idle_timeout` triggers blanking.
+- Mutter idletime is used only to detect recent desktop activity. Its absolute
+  value does not trigger blanking.
+- ScreenSaver idle cannot trigger blanking by itself. ScreenSaver active and
+  wake signals reset the same LG Buddy deadline and remain restore observations
+  evaluated by screen policy.
 - Gamepad activity is not a separate desktop backend. It is an auxiliary
   activity source attached to the current native monitor path because some
   desktop idle APIs may not count controller input as activity.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -79,7 +79,7 @@ This is the place for integration tests and contract tests.
 - GNOME runner behavior against a private session-bus harness
 - logind lifecycle and NetworkManager gate behavior against a private system-bus
   harness
-- GNOME inactivity merging with auxiliary gamepad activity observations
+- GNOME and auxiliary gamepad activity resetting one LG Buddy-owned deadline
 
 ### How to test it
 
@@ -222,7 +222,7 @@ Examples:
 - GNOME capability probing
 - GNOME signal mapping
 - GNOME monitor and idletime integration over the session-bus seam
-- gamepad activity integration with the GNOME inactivity merger
+- gamepad activity integration with the LG Buddy inactivity deadline
 - screen runtime-phase eligibility over the private logind system-bus seam
 
 ### Gamepad activity

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -260,6 +260,9 @@ idle-driven blank/restore behavior:
 `screen_idle_timeout` is the inactivity threshold in seconds used by the session monitor.
 LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
 Values above 86400 seconds are capped at 86400 seconds.
+On GNOME, activity reported by desktop and gamepad sources resets one LG
+Buddy-owned timer. The TV is blanked only when that timer reaches
+`screen_idle_timeout`.
 
 `screen_restore_policy` controls how aggressively LG Buddy reclaims the display on wake and user activity:
 


### PR DESCRIPTION
## Summary

- make the configured LG Buddy timeout the single inactivity deadline
- reset that deadline from desktop, gamepad, active, and wake observations
- preserve pending LG Buddy screen ownership across monitor restarts so later activity restores the screen
- keep restore ownership independent from the inactivity engine phase

## Validation

- `cargo test --workspace --all-targets --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- live native webOS check: blanked after a 10-second timeout, restarted the monitor while blank, then restored immediately on later user input; timeout restored to 120 seconds