### PR TITLE
Filter unsolicited Logitech G923 HID reports

### DIFF
--- a/crates/lg-buddy/src/session/gamepad/adapters/logitech_g923.rs
+++ b/crates/lg-buddy/src/session/gamepad/adapters/logitech_g923.rs
@@ -1,9 +1,37 @@
-use super::{ActivityReaderSpec, GamepadActivityAdapter};
+use std::io;
+use std::path::PathBuf;
+
+use super::{
+    ActivityReader, ActivityReaderKey, ActivityReaderSpec, ActivityReaderSurface,
+    GamepadActivityAdapter,
+};
 use crate::session::gamepad::devices::GamepadDevice;
-use crate::session::gamepad::hidraw::RawHidActivityReaderSpec;
+use crate::session::gamepad::hidraw::RawHidReportReader;
+use crate::session::gamepad::{AxisRange, DeviceId, RawGamepadEvent, RawGamepadEventKind};
 
 const LOGITECH_VENDOR_ID: u16 = 0x046d;
 const LOGITECH_G923_PRODUCT_ID: u16 = 0xc267;
+const INPUT_REPORT_ID: u8 = 0x01;
+const INPUT_REPORT_MINIMUM_SIZE: usize = 10;
+const BUTTON_COUNT: u16 = 14;
+const ANALOG_BYTE_OFFSETS: [usize; 6] = [1, 2, 3, 4, 8, 9];
+// Adapter axes must not share registry keys with the evdev reader: the two
+// surfaces can expose the same physical control with different scales.
+const ADAPTER_AXIS_BASE: u16 = 0x100;
+const HAT_X_AXIS: u16 = ADAPTER_AXIS_BASE + ANALOG_BYTE_OFFSETS.len() as u16;
+const HAT_Y_AXIS: u16 = HAT_X_AXIS + 1;
+const AXIS_RANGE: AxisRange = AxisRange {
+    minimum: 0,
+    maximum: 255,
+    flat: 15,
+    fuzz: 0,
+};
+const HAT_RANGE: AxisRange = AxisRange {
+    minimum: -1,
+    maximum: 1,
+    flat: 0,
+    fuzz: 0,
+};
 
 #[derive(Debug)]
 pub(super) struct LogitechG923Adapter;
@@ -24,7 +52,7 @@ impl GamepadActivityAdapter for LogitechG923Adapter {
             .hidraw_paths
             .iter()
             .map(|path| {
-                Box::new(RawHidActivityReaderSpec::new(
+                Box::new(LogitechG923ActivityReaderSpec::new(
                     self.name(),
                     device.id.clone(),
                     path.clone(),
@@ -34,12 +62,156 @@ impl GamepadActivityAdapter for LogitechG923Adapter {
     }
 }
 
+#[derive(Debug, Clone)]
+struct LogitechG923ActivityReaderSpec {
+    key: ActivityReaderKey,
+    device_id: DeviceId,
+    path: PathBuf,
+}
+
+impl LogitechG923ActivityReaderSpec {
+    fn new(adapter: &'static str, device_id: DeviceId, path: PathBuf) -> Self {
+        let key = ActivityReaderKey::Adapter {
+            adapter,
+            device_id: device_id.clone(),
+            surface: ActivityReaderSurface::Hidraw(path.clone()),
+        };
+
+        Self {
+            key,
+            device_id,
+            path,
+        }
+    }
+}
+
+impl ActivityReaderSpec for LogitechG923ActivityReaderSpec {
+    fn key(&self) -> ActivityReaderKey {
+        self.key.clone()
+    }
+
+    fn open(&self) -> io::Result<Box<dyn ActivityReader>> {
+        Ok(Box::new(LogitechG923ActivityReader {
+            key: self.key.clone(),
+            device_id: self.device_id.clone(),
+            reports: RawHidReportReader::open(&self.path)?,
+            previous_buttons: None,
+        }))
+    }
+}
+
+#[derive(Debug)]
+struct LogitechG923ActivityReader {
+    key: ActivityReaderKey,
+    device_id: DeviceId,
+    reports: RawHidReportReader,
+    previous_buttons: Option<u16>,
+}
+
+impl ActivityReader for LogitechG923ActivityReader {
+    fn key(&self) -> &ActivityReaderKey {
+        &self.key
+    }
+
+    fn device_id(&self) -> &DeviceId {
+        &self.device_id
+    }
+
+    fn read_available(&mut self) -> io::Result<Vec<RawGamepadEvent>> {
+        let mut events = Vec::new();
+        for report in self.reports.read_available()? {
+            events.extend(events_from_report(
+                &self.device_id,
+                &mut self.previous_buttons,
+                &report,
+            ));
+        }
+        Ok(events)
+    }
+}
+
+fn events_from_report(
+    device_id: &DeviceId,
+    previous_buttons: &mut Option<u16>,
+    report: &[u8],
+) -> Vec<RawGamepadEvent> {
+    if report.len() < INPUT_REPORT_MINIMUM_SIZE || report[0] != INPUT_REPORT_ID {
+        return Vec::new();
+    }
+
+    let mut observations = Vec::with_capacity(8 + usize::from(BUTTON_COUNT));
+    for (index, byte_offset) in ANALOG_BYTE_OFFSETS.iter().copied().enumerate() {
+        observations.push(axis_observation(
+            device_id,
+            ADAPTER_AXIS_BASE + index as u16,
+            i32::from(report[byte_offset]),
+            AXIS_RANGE,
+        ));
+    }
+
+    let (hat_x, hat_y) = hat_coordinates(report[5] & 0x0f);
+    observations.push(axis_observation(device_id, HAT_X_AXIS, hat_x, HAT_RANGE));
+    observations.push(axis_observation(device_id, HAT_Y_AXIS, hat_y, HAT_RANGE));
+
+    let buttons =
+        (u32::from(report[5]) | (u32::from(report[6]) << 8) | (u32::from(report[7]) << 16)) >> 4;
+    let buttons = (buttons & ((1 << BUTTON_COUNT) - 1)) as u16;
+    if let Some(previous) = previous_buttons.replace(buttons) {
+        let changed = previous ^ buttons;
+        for bit in 0..BUTTON_COUNT {
+            let mask = 1_u16 << bit;
+            if changed & mask != 0 {
+                observations.push(RawGamepadEvent {
+                    device_id: device_id.clone(),
+                    kind: RawGamepadEventKind::Button {
+                        code: bit,
+                        pressed: buttons & mask != 0,
+                    },
+                });
+            }
+        }
+    }
+
+    observations
+}
+
+fn axis_observation(
+    device_id: &DeviceId,
+    code: u16,
+    value: i32,
+    range: AxisRange,
+) -> RawGamepadEvent {
+    RawGamepadEvent {
+        device_id: device_id.clone(),
+        kind: RawGamepadEventKind::Axis { code, value, range },
+    }
+}
+
+fn hat_coordinates(value: u8) -> (i32, i32) {
+    match value {
+        0 => (0, -1),
+        1 => (1, -1),
+        2 => (1, 0),
+        3 => (1, 1),
+        4 => (0, 1),
+        5 => (-1, 1),
+        6 => (-1, 0),
+        7 => (-1, -1),
+        _ => (0, 0),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{GamepadActivityAdapter, LogitechG923Adapter};
+    use super::{
+        events_from_report, GamepadActivityAdapter, LogitechG923Adapter, ANALOG_BYTE_OFFSETS,
+    };
+    use crate::session::gamepad::activity::ActivityPolicy;
     use crate::session::gamepad::devices::GamepadDevice;
-    use crate::session::gamepad::DeviceId;
+    use crate::session::gamepad::registry::ActivityRegistry;
+    use crate::session::gamepad::{DeviceId, RawGamepadEvent};
     use std::path::PathBuf;
+    use std::time::{Duration, Instant};
 
     fn device(vendor_id: u16, product_id: u16, hidraw_paths: Vec<PathBuf>) -> GamepadDevice {
         GamepadDevice {
@@ -78,5 +250,123 @@ mod tests {
             specs[1].key().to_string(),
             "logitech-g923 hidraw /dev/hidraw8 for event-controller"
         );
+    }
+
+    fn report() -> [u8; 64] {
+        let mut report = [0_u8; 64];
+        report[..10].copy_from_slice(&[0x01, 128, 128, 128, 128, 0x08, 0, 0, 0, 0]);
+        report
+    }
+
+    fn observe(
+        registry: &mut ActivityRegistry,
+        events: Vec<RawGamepadEvent>,
+        now: Instant,
+    ) -> bool {
+        events.into_iter().any(|event| registry.observe(event, now))
+    }
+
+    #[test]
+    fn first_report_seeds_controls_without_activity() {
+        let device_id = DeviceId::new("event-controller");
+        let mut previous_buttons = None;
+        let events = events_from_report(&device_id, &mut previous_buttons, &report());
+        let mut registry = ActivityRegistry::new(ActivityPolicy::default());
+
+        assert!(!observe(&mut registry, events, Instant::now()));
+        assert_eq!(previous_buttons, Some(0));
+    }
+
+    #[test]
+    fn changing_only_vendor_status_bytes_is_not_activity() {
+        let device_id = DeviceId::new("event-controller");
+        let mut previous_buttons = None;
+        let mut registry = ActivityRegistry::new(ActivityPolicy::default());
+        let started = Instant::now();
+        assert!(!observe(
+            &mut registry,
+            events_from_report(&device_id, &mut previous_buttons, &report()),
+            started,
+        ));
+
+        let mut status_report = report();
+        status_report[10..].fill(0xff);
+
+        assert!(!observe(
+            &mut registry,
+            events_from_report(&device_id, &mut previous_buttons, &status_report),
+            started + Duration::from_secs(20),
+        ));
+    }
+
+    #[test]
+    fn meaningful_movement_on_each_analog_field_is_activity() {
+        for byte_offset in ANALOG_BYTE_OFFSETS {
+            let device_id = DeviceId::new("event-controller");
+            let mut previous_buttons = None;
+            let mut registry = ActivityRegistry::new(ActivityPolicy::default());
+            let started = Instant::now();
+            assert!(!observe(
+                &mut registry,
+                events_from_report(&device_id, &mut previous_buttons, &report()),
+                started,
+            ));
+
+            let mut moved_report = report();
+            moved_report[byte_offset] = 144;
+
+            assert!(
+                observe(
+                    &mut registry,
+                    events_from_report(&device_id, &mut previous_buttons, &moved_report),
+                    started + Duration::from_millis(100),
+                ),
+                "movement in report byte {byte_offset} should be activity"
+            );
+        }
+    }
+
+    #[test]
+    fn small_axis_jitter_is_not_activity() {
+        let device_id = DeviceId::new("event-controller");
+        let mut previous_buttons = None;
+        let mut registry = ActivityRegistry::new(ActivityPolicy::default());
+        let started = Instant::now();
+        assert!(!observe(
+            &mut registry,
+            events_from_report(&device_id, &mut previous_buttons, &report()),
+            started,
+        ));
+
+        let mut jittered_report = report();
+        jittered_report[1] = 129;
+
+        assert!(!observe(
+            &mut registry,
+            events_from_report(&device_id, &mut previous_buttons, &jittered_report),
+            started + Duration::from_millis(100),
+        ));
+    }
+
+    #[test]
+    fn button_transition_is_activity() {
+        let device_id = DeviceId::new("event-controller");
+        let mut previous_buttons = None;
+        let mut registry = ActivityRegistry::new(ActivityPolicy::default());
+        let started = Instant::now();
+        assert!(!observe(
+            &mut registry,
+            events_from_report(&device_id, &mut previous_buttons, &report()),
+            started,
+        ));
+
+        let mut pressed_report = report();
+        pressed_report[5] |= 0x10;
+
+        assert!(observe(
+            &mut registry,
+            events_from_report(&device_id, &mut previous_buttons, &pressed_report),
+            started + Duration::from_millis(100),
+        ));
     }
 }

--- a/crates/lg-buddy/src/session/gamepad/adapters/mod.rs
+++ b/crates/lg-buddy/src/session/gamepad/adapters/mod.rs
@@ -21,7 +21,7 @@ pub(crate) trait ActivityReaderSpec: fmt::Debug {
 pub(crate) trait ActivityReader: fmt::Debug {
     fn key(&self) -> &ActivityReaderKey;
     fn device_id(&self) -> &DeviceId;
-    fn read_available(&mut self) -> io::Result<Vec<ActivityObservation>>;
+    fn read_available(&mut self) -> io::Result<Vec<RawGamepadEvent>>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -56,15 +56,6 @@ impl fmt::Display for ActivityReaderSurface {
             Self::Hidraw(path) => write!(f, "hidraw {}", path.display()),
         }
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum ActivityObservation {
-    #[allow(dead_code)]
-    RawEvent(RawGamepadEvent),
-    ActivityPulse {
-        device_id: DeviceId,
-    },
 }
 
 static REGISTERED_ADAPTERS: &[&dyn GamepadActivityAdapter] = &[&logitech_g923::ADAPTER];

--- a/crates/lg-buddy/src/session/gamepad/hidraw.rs
+++ b/crates/lg-buddy/src/session/gamepad/hidraw.rs
@@ -1,127 +1,36 @@
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
 use std::os::unix::fs::OpenOptionsExt;
-use std::path::PathBuf;
-
-use super::adapters::{
-    ActivityObservation, ActivityReader, ActivityReaderKey, ActivityReaderSpec,
-    ActivityReaderSurface,
-};
-use super::DeviceId;
+use std::path::Path;
 
 const HID_REPORT_BUFFER_SIZE: usize = 64;
 
-#[derive(Debug, Clone)]
-pub(crate) struct RawHidActivityReaderSpec {
-    key: ActivityReaderKey,
-    device_id: DeviceId,
-    path: PathBuf,
-}
-
-impl RawHidActivityReaderSpec {
-    pub(crate) fn new(adapter: &'static str, device_id: DeviceId, path: PathBuf) -> Self {
-        let key = ActivityReaderKey::Adapter {
-            adapter,
-            device_id: device_id.clone(),
-            surface: ActivityReaderSurface::Hidraw(path.clone()),
-        };
-
-        Self {
-            key,
-            device_id,
-            path,
-        }
-    }
-}
-
-impl ActivityReaderSpec for RawHidActivityReaderSpec {
-    fn key(&self) -> ActivityReaderKey {
-        self.key.clone()
-    }
-
-    fn open(&self) -> io::Result<Box<dyn ActivityReader>> {
-        Ok(Box::new(RawHidActivityReader::open(
-            self.key.clone(),
-            self.device_id.clone(),
-            self.path.clone(),
-        )?))
-    }
-}
-
 #[derive(Debug)]
-pub(crate) struct RawHidActivityReader {
-    key: ActivityReaderKey,
-    device_id: DeviceId,
+pub(crate) struct RawHidReportReader {
     file: File,
 }
 
-impl RawHidActivityReader {
-    fn open(key: ActivityReaderKey, device_id: DeviceId, path: PathBuf) -> io::Result<Self> {
+impl RawHidReportReader {
+    pub(crate) fn open(path: &Path) -> io::Result<Self> {
         let file = OpenOptions::new()
             .read(true)
             .custom_flags(libc::O_NONBLOCK)
-            .open(&path)?;
+            .open(path)?;
 
-        Ok(Self {
-            key,
-            device_id,
-            file,
-        })
+        Ok(Self { file })
     }
 
-    fn read_report_available(&mut self) -> io::Result<bool> {
-        let mut saw_report = false;
+    pub(crate) fn read_available(&mut self) -> io::Result<Vec<Vec<u8>>> {
+        let mut reports = Vec::new();
         let mut buffer = [0_u8; HID_REPORT_BUFFER_SIZE];
 
         loop {
             match self.file.read(&mut buffer) {
-                Ok(0) => return Ok(saw_report),
-                Ok(_) => saw_report = true,
-                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(saw_report),
+                Ok(0) => return Ok(reports),
+                Ok(length) => reports.push(buffer[..length].to_vec()),
+                Err(err) if err.kind() == io::ErrorKind::WouldBlock => return Ok(reports),
                 Err(err) => return Err(err),
             }
         }
-    }
-}
-
-impl ActivityReader for RawHidActivityReader {
-    fn key(&self) -> &ActivityReaderKey {
-        &self.key
-    }
-
-    fn device_id(&self) -> &DeviceId {
-        &self.device_id
-    }
-
-    fn read_available(&mut self) -> io::Result<Vec<ActivityObservation>> {
-        if self.read_report_available()? {
-            Ok(vec![ActivityObservation::ActivityPulse {
-                device_id: self.device_id.clone(),
-            }])
-        } else {
-            Ok(Vec::new())
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::RawHidActivityReaderSpec;
-    use crate::session::gamepad::adapters::ActivityReaderSpec;
-    use crate::session::gamepad::DeviceId;
-    use std::path::PathBuf;
-
-    #[test]
-    fn raw_hid_reader_spec_uses_adapter_device_and_path_as_key() {
-        let spec = RawHidActivityReaderSpec::new(
-            "test-adapter",
-            DeviceId::new("event-controller"),
-            PathBuf::from("/dev/hidraw8"),
-        );
-
-        assert_eq!(
-            spec.key().to_string(),
-            "test-adapter hidraw /dev/hidraw8 for event-controller"
-        );
     }
 }

--- a/crates/lg-buddy/src/session/gamepad/mod.rs
+++ b/crates/lg-buddy/src/session/gamepad/mod.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use std::time::Instant;
 
 pub(crate) use activity::ActivityPolicy;
-use adapters::{reader_specs_for_device, ActivityObservation, ActivityReader};
+use adapters::{reader_specs_for_device, ActivityReader};
 pub(crate) use device_events::{
     open_system_gamepad_device_event_monitor, SystemGamepadDeviceEventMonitor,
 };
@@ -163,28 +163,15 @@ impl SystemGamepadActivitySource {
             self.adapter_readers.retain_mut(|reader| {
                 let key = reader.key().clone();
                 match reader.read_available() {
-                    Ok(observations) => {
-                        for observation in observations {
-                            match observation {
-                                ActivityObservation::RawEvent(event) => {
-                                    #[cfg(test)]
-                                    let event_device_id = event.device_id.clone();
-                                    if registry.observe(event, now) {
-                                        activity = true;
-                                        #[cfg(test)]
-                                        if !activity_devices.contains(&event_device_id) {
-                                            activity_devices.push(event_device_id);
-                                        }
-                                    }
-                                }
-                                ActivityObservation::ActivityPulse {
-                                    device_id: _activity_device_id,
-                                } => {
-                                    activity = true;
-                                    #[cfg(test)]
-                                    if !activity_devices.contains(&_activity_device_id) {
-                                        activity_devices.push(_activity_device_id);
-                                    }
+                    Ok(events) => {
+                        for event in events {
+                            #[cfg(test)]
+                            let event_device_id = event.device_id.clone();
+                            if registry.observe(event, now) {
+                                activity = true;
+                                #[cfg(test)]
+                                if !activity_devices.contains(&event_device_id) {
+                                    activity_devices.push(event_device_id);
                                 }
                             }
                         }

--- a/docs/gamepad-subsystem.md
+++ b/docs/gamepad-subsystem.md
@@ -107,7 +107,7 @@ Use this shape for a new device adapter:
 2. Match devices narrowly, preferably by vendor/product ID. If a whole device
    family is supported, document the reason in the adapter tests or comments.
 3. Reuse `RawHidReportReader` to read reports from a hidraw surface.
-4. Add a custom reader that extracts meaningful controls as `RawEvent` values;
+4. Add a custom reader that extracts meaningful controls as `RawGamepadEvent` values;
    ignore sequence, timestamp, status, and other non-input fields.
 5. Register the adapter in `adapters/mod.rs`.
 6. Add tests for support matching and reader specs. If the adapter parses

--- a/docs/gamepad-subsystem.md
+++ b/docs/gamepad-subsystem.md
@@ -52,7 +52,7 @@ screen behavior.
 | `session/gamepad/activity.rs` | Pure activity policy for buttons and axes |
 | `session/gamepad/registry.rs` | Per-device state registry that applies activity policy |
 | `session/gamepad/adapters/` | Device-specific supplemental activity adapters |
-| `session/gamepad/hidraw.rs` | Reusable raw HID activity reader for adapters |
+| `session/gamepad/hidraw.rs` | Reusable nonblocking raw HID report reader for adapters |
 
 ## Refresh And Lifecycle
 
@@ -86,13 +86,11 @@ Adapters live under `session/gamepad/adapters/` and implement
 
 An adapter decides whether it supports a discovered `GamepadDevice` and returns
 zero or more `ActivityReaderSpec`s. A reader spec has a stable
-`ActivityReaderKey` and opens an `ActivityReader`. Readers emit
-`ActivityObservation` values:
-
-- `RawEvent` is for readers that can map device data into the normal button or
-  axis model.
-- `ActivityPulse` is for opaque device surfaces where the presence of a report
-  is enough to prove user activity.
+`ActivityReaderKey` and opens an `ActivityReader`. Adapter readers map device
+data into normal button or axis observations. Those
+observations pass through the shared movement and noise policy before they can
+count as activity. Receiving an opaque report is not itself proof of user
+activity because devices may emit unsolicited status reports while untouched.
 
 Adapters should stay narrow. They should not own refresh scheduling, retries,
 registry cleanup, idle policy, screen behavior, or user configuration.
@@ -108,10 +106,9 @@ Use this shape for a new device adapter:
 1. Add a file under `crates/lg-buddy/src/session/gamepad/adapters/`.
 2. Match devices narrowly, preferably by vendor/product ID. If a whole device
    family is supported, document the reason in the adapter tests or comments.
-3. Reuse `RawHidActivityReaderSpec` when any report on a hidraw surface should
-   count as activity.
-4. Add a custom reader only when the raw data needs parsing before it can become
-   a `RawEvent` or `ActivityPulse`.
+3. Reuse `RawHidReportReader` to read reports from a hidraw surface.
+4. Add a custom reader that extracts meaningful controls as `RawEvent` values;
+   ignore sequence, timestamp, status, and other non-input fields.
 5. Register the adapter in `adapters/mod.rs`.
 6. Add tests for support matching and reader specs. If the adapter parses
    reports, add parser tests with captured representative payloads.


### PR DESCRIPTION
## Summary

- parse the G923 input report instead of treating every raw HID report as user activity
- ignore unsolicited vendor and status payload bytes
- route meaningful analog, hat, and button changes through the shared gamepad activity filter
- identify raw analog fields by stable HID slot rather than invented Linux axis semantics
- preserve the existing narrow G923 raw HID fallback

## Validation

- `cargo test --workspace --all-targets --quiet`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- live G923 check: the TV blanked after a 10-second timeout and remained blank for another 30 seconds while the wheel was untouched, with no false activity or restore