### PR TITLE
Fix Rust 1.98 Clippy compatibility

### DIFF
--- a/crates/lg-buddy/src/wol.rs
+++ b/crates/lg-buddy/src/wol.rs
@@ -297,7 +297,7 @@ mod tests {
         assert_eq!(packet.len(), MAGIC_PACKET_LEN);
         assert_eq!(&packet[..6], &[0xFF; 6]);
 
-        for chunk in packet[6..].chunks_exact(6) {
+        for chunk in packet[6..].as_chunks::<6>().0 {
             assert_eq!(chunk, &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff]);
         }
     }


### PR DESCRIPTION
## Summary

- replace the fixed-size `chunks_exact(6)` test loop with `as_chunks::<6>()`
- satisfy the new `chunks_exact_to_as_chunks` lint enabled by CI Rust 1.98
- keep the WOL packet assertion behavior unchanged

## Validation

- `cargo test --workspace --all-targets --quiet`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`