### PR TITLE
Make webOS screen restoration observable and idempotent

### DIFF
--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -869,7 +869,9 @@ mod tests {
         let temp_dir = TestDir::new("screen-on-aggressive-no-marker");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         let mock = MockBscpylgtv::new("screen-on-aggressive-no-marker-tv");
+        mock.set_screen_on(false);
         mock.queue_error("turn_screen_on", 1, "offline\n");
+        mock.queue_error("turn_screen_on", 1, "still offline\n");
         mock.queue_error("set_input", 1, "not ready\n");
         let client = client_for_mock(&mock);
         let wol = RecordingWakeOnLanSender::default();
@@ -887,7 +889,20 @@ mod tests {
         .expect("aggressive mode should restore without a marker");
 
         assert!(!marker.exists());
-        assert_call_commands(&mock, &["turn_screen_on", "set_input", "set_input"]);
+        assert_call_commands(
+            &mock,
+            &[
+                "get_power_state",
+                "turn_screen_on",
+                "get_power_state",
+                "set_input",
+                "get_power_state",
+                "turn_screen_on",
+                "get_power_state",
+                "set_input",
+                "get_power_state",
+            ],
+        );
         assert_eq!(wol.calls().len(), 2);
         assert_eq!(
             sleeper.durations(),
@@ -929,7 +944,10 @@ mod tests {
             !marker.exists(),
             "successful restore should clear the marker"
         );
-        assert_call_commands(&mock, &["turn_screen_on"]);
+        assert_call_commands(
+            &mock,
+            &["get_power_state", "turn_screen_on", "get_power_state"],
+        );
         assert!(wol.calls().is_empty());
         assert!(sleeper.durations().is_empty());
         assert!(rendered(&output).contains("Screen unblank succeeded."));
@@ -958,13 +976,16 @@ mod tests {
         .expect("turn_screen_on should succeed");
 
         assert!(!marker.exists());
-        assert_call_commands(&mock, &["turn_screen_on"]);
+        assert_call_commands(
+            &mock,
+            &["get_power_state", "turn_screen_on", "get_power_state"],
+        );
         assert!(wol.calls().is_empty());
         assert!(rendered(&output).contains("Screen unblank succeeded."));
     }
 
     #[test]
-    fn screen_on_uses_full_wake_when_unblank_is_rejected_by_substate() {
+    fn screen_on_reconciles_a_substate_rejection_when_the_tv_is_already_active() {
         let temp_dir = TestDir::new("screen-on-substate-mismatch");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         marker.create().expect("create marker");
@@ -982,16 +1003,15 @@ mod tests {
             &wol,
             &sleeper,
         )
-        .expect("substate mismatch should use full wake recovery");
+        .expect("active readback should reconcile the substate rejection");
 
         assert!(!marker.exists());
-        assert_call_commands(&mock, &["turn_screen_on", "set_input"]);
-        assert_eq!(wol.calls().len(), 1);
-        assert_eq!(sleeper.durations(), vec![Duration::from_secs(6)]);
+        assert_call_commands(&mock, &["get_power_state"]);
+        assert!(wol.calls().is_empty());
+        assert!(sleeper.durations().is_empty());
         let rendered = rendered(&output);
-        assert!(rendered.contains("TV rejected screen unblank"));
-        assert!(rendered.contains("Falling back to full wake."));
-        assert!(rendered.contains("Wake attempt 1 succeeded."));
+        assert!(rendered.contains("Verified TV power state Active."));
+        assert!(!rendered.contains("Falling back to full wake."));
     }
 
     #[test]
@@ -1000,7 +1020,9 @@ mod tests {
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         marker.create().expect("create marker");
         let mock = MockBscpylgtv::new("screen-on-wake-retry-success-tv");
+        mock.set_screen_on(false);
         mock.queue_error("turn_screen_on", 1, "offline\n");
+        mock.queue_error("turn_screen_on", 1, "still offline\n");
         mock.queue_error("set_input", 1, "not ready\n");
         let client = client_for_mock(&mock);
         let wol = RecordingWakeOnLanSender::default();
@@ -1018,7 +1040,20 @@ mod tests {
         .expect("wake retry should succeed");
 
         assert!(!marker.exists());
-        assert_call_commands(&mock, &["turn_screen_on", "set_input", "set_input"]);
+        assert_call_commands(
+            &mock,
+            &[
+                "get_power_state",
+                "turn_screen_on",
+                "get_power_state",
+                "set_input",
+                "get_power_state",
+                "turn_screen_on",
+                "get_power_state",
+                "set_input",
+                "get_power_state",
+            ],
+        );
         assert_eq!(wol.calls().len(), 2);
         assert_eq!(
             sleeper.durations(),
@@ -1036,7 +1071,10 @@ mod tests {
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         marker.create().expect("create marker");
         let mock = MockBscpylgtv::new("screen-on-wake-retry-failure-tv");
-        mock.queue_error("turn_screen_on", 1, "offline\n");
+        mock.set_screen_on(false);
+        for _ in 0..7 {
+            mock.queue_error("turn_screen_on", 1, "offline\n");
+        }
         for _ in 0..6 {
             mock.queue_error("set_input", 1, "not ready\n");
         }
@@ -1056,7 +1094,7 @@ mod tests {
         .expect_err("exhausted retries should fail");
 
         assert!(marker.exists());
-        assert_eq!(mock.calls().len(), 7);
+        assert_eq!(mock.calls().len(), 27);
         assert_eq!(wol.calls().len(), 7);
         assert_eq!(sleeper.durations().len(), 7);
         assert!(matches!(err, crate::RunError::Policy(_)));
@@ -1068,7 +1106,10 @@ mod tests {
         let temp_dir = TestDir::new("screen-on-aggressive-wake-retry-failure");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         let mock = MockBscpylgtv::new("screen-on-aggressive-wake-retry-failure-tv");
-        mock.queue_error("turn_screen_on", 1, "offline\n");
+        mock.set_screen_on(false);
+        for _ in 0..7 {
+            mock.queue_error("turn_screen_on", 1, "offline\n");
+        }
         for _ in 0..6 {
             mock.queue_error("set_input", 1, "not ready\n");
         }
@@ -1088,7 +1129,7 @@ mod tests {
         .expect_err("aggressive mode should still fail after exhausting retries");
 
         assert!(!marker.exists());
-        assert_eq!(mock.calls().len(), 7);
+        assert_eq!(mock.calls().len(), 27);
         assert_eq!(wol.calls().len(), 7);
         assert_eq!(sleeper.durations().len(), 7);
         assert!(matches!(err, crate::RunError::Policy(_)));

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -871,7 +871,6 @@ mod tests {
         let mock = MockBscpylgtv::new("screen-on-aggressive-no-marker-tv");
         mock.set_screen_on(false);
         mock.queue_error("turn_screen_on", 1, "offline\n");
-        mock.queue_error("turn_screen_on", 1, "still offline\n");
         mock.queue_error("set_input", 1, "not ready\n");
         let client = client_for_mock(&mock);
         let wol = RecordingWakeOnLanSender::default();
@@ -892,13 +891,9 @@ mod tests {
         assert_call_commands(
             &mock,
             &[
-                "get_power_state",
                 "turn_screen_on",
                 "get_power_state",
                 "set_input",
-                "get_power_state",
-                "turn_screen_on",
-                "get_power_state",
                 "set_input",
                 "get_power_state",
             ],
@@ -944,10 +939,7 @@ mod tests {
             !marker.exists(),
             "successful restore should clear the marker"
         );
-        assert_call_commands(
-            &mock,
-            &["get_power_state", "turn_screen_on", "get_power_state"],
-        );
+        assert_call_commands(&mock, &["turn_screen_on", "get_power_state"]);
         assert!(wol.calls().is_empty());
         assert!(sleeper.durations().is_empty());
         assert!(rendered(&output).contains("Screen unblank succeeded."));
@@ -976,16 +968,13 @@ mod tests {
         .expect("turn_screen_on should succeed");
 
         assert!(!marker.exists());
-        assert_call_commands(
-            &mock,
-            &["get_power_state", "turn_screen_on", "get_power_state"],
-        );
+        assert_call_commands(&mock, &["turn_screen_on", "get_power_state"]);
         assert!(wol.calls().is_empty());
         assert!(rendered(&output).contains("Screen unblank succeeded."));
     }
 
     #[test]
-    fn screen_on_reconciles_a_substate_rejection_when_the_tv_is_already_active() {
+    fn screen_on_treats_already_active_unblank_as_success() {
         let temp_dir = TestDir::new("screen-on-substate-mismatch");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         marker.create().expect("create marker");
@@ -1003,14 +992,14 @@ mod tests {
             &wol,
             &sleeper,
         )
-        .expect("active readback should reconcile the substate rejection");
+        .expect("active power-state readback should satisfy unblank");
 
         assert!(!marker.exists());
-        assert_call_commands(&mock, &["get_power_state"]);
+        assert_call_commands(&mock, &["turn_screen_on", "get_power_state"]);
         assert!(wol.calls().is_empty());
         assert!(sleeper.durations().is_empty());
         let rendered = rendered(&output);
-        assert!(rendered.contains("Verified TV power state Active."));
+        assert!(rendered.contains("Screen unblank succeeded."));
         assert!(!rendered.contains("Falling back to full wake."));
     }
 
@@ -1022,7 +1011,6 @@ mod tests {
         let mock = MockBscpylgtv::new("screen-on-wake-retry-success-tv");
         mock.set_screen_on(false);
         mock.queue_error("turn_screen_on", 1, "offline\n");
-        mock.queue_error("turn_screen_on", 1, "still offline\n");
         mock.queue_error("set_input", 1, "not ready\n");
         let client = client_for_mock(&mock);
         let wol = RecordingWakeOnLanSender::default();
@@ -1043,13 +1031,9 @@ mod tests {
         assert_call_commands(
             &mock,
             &[
-                "get_power_state",
                 "turn_screen_on",
                 "get_power_state",
                 "set_input",
-                "get_power_state",
-                "turn_screen_on",
-                "get_power_state",
                 "set_input",
                 "get_power_state",
             ],
@@ -1072,9 +1056,7 @@ mod tests {
         marker.create().expect("create marker");
         let mock = MockBscpylgtv::new("screen-on-wake-retry-failure-tv");
         mock.set_screen_on(false);
-        for _ in 0..7 {
-            mock.queue_error("turn_screen_on", 1, "offline\n");
-        }
+        mock.queue_error("turn_screen_on", 1, "offline\n");
         for _ in 0..6 {
             mock.queue_error("set_input", 1, "not ready\n");
         }
@@ -1094,7 +1076,7 @@ mod tests {
         .expect_err("exhausted retries should fail");
 
         assert!(marker.exists());
-        assert_eq!(mock.calls().len(), 27);
+        assert_eq!(mock.calls().len(), 8);
         assert_eq!(wol.calls().len(), 7);
         assert_eq!(sleeper.durations().len(), 7);
         assert!(matches!(err, crate::RunError::Policy(_)));
@@ -1107,9 +1089,7 @@ mod tests {
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         let mock = MockBscpylgtv::new("screen-on-aggressive-wake-retry-failure-tv");
         mock.set_screen_on(false);
-        for _ in 0..7 {
-            mock.queue_error("turn_screen_on", 1, "offline\n");
-        }
+        mock.queue_error("turn_screen_on", 1, "offline\n");
         for _ in 0..6 {
             mock.queue_error("set_input", 1, "not ready\n");
         }
@@ -1129,7 +1109,7 @@ mod tests {
         .expect_err("aggressive mode should still fail after exhausting retries");
 
         assert!(!marker.exists());
-        assert_eq!(mock.calls().len(), 27);
+        assert_eq!(mock.calls().len(), 8);
         assert_eq!(wol.calls().len(), 7);
         assert_eq!(sleeper.durations().len(), 7);
         assert!(matches!(err, crate::RunError::Policy(_)));
@@ -1201,7 +1181,7 @@ mod tests {
         assert_eq!(network.calls(), 1);
         assert_eq!(wol.calls().len(), 1);
         assert_eq!(sleeper.durations(), vec![Duration::from_secs(6)]);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
         let rendered = rendered(&output);
         assert!(rendered.contains("Aggressive restore policy is enabled"));
         assert!(rendered.contains("Wake from sleep: Restoring display state."));
@@ -1238,7 +1218,7 @@ mod tests {
         assert_eq!(network.calls(), 1);
         assert_eq!(wol.calls().len(), 1);
         assert_eq!(sleeper.durations(), vec![Duration::from_secs(6)]);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
         let rendered = rendered(&output);
         assert!(rendered.contains("Cold boot: Turning TV on and switching to HDMI_4."));
         assert!(rendered.contains("TV turned on and set to HDMI_4."));
@@ -1274,7 +1254,7 @@ mod tests {
         assert!(!marker.exists());
         assert_eq!(network.calls(), 1);
         assert_eq!(wol.calls().len(), 1);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
         assert!(rendered(&output).contains("Wake from sleep: LG Buddy turned TV off. Restoring."));
     }
 
@@ -1307,7 +1287,7 @@ mod tests {
 
         assert!(!marker.exists());
         assert_eq!(network.calls(), 1);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
         assert!(rendered(&output).contains("Cold boot: Turning TV on and switching to HDMI_3."));
     }
 
@@ -1339,7 +1319,7 @@ mod tests {
 
         assert_eq!(network.calls(), 1);
         assert_eq!(wol.calls().len(), 1);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
         assert!(rendered(&output).contains("TV turned on and set to HDMI_2."));
     }
 
@@ -1371,7 +1351,7 @@ mod tests {
         .expect("startup retry should succeed");
 
         assert_eq!(network.calls(), 1);
-        assert_call_commands(&mock, &["set_input", "set_input"]);
+        assert_call_commands(&mock, &["set_input", "set_input", "get_power_state"]);
         assert_eq!(wol.calls().len(), 2);
         assert_eq!(
             sleeper.durations(),

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -2759,7 +2759,7 @@ mod tests {
         assert_eq!(sleeper.durations(), vec![Duration::from_secs(6)]);
         assert_eq!(network.calls(), 1);
         assert_eq!(network.route_targets(), vec![ip("192.0.2.42")]);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
     }
 
     #[test]
@@ -2789,7 +2789,7 @@ mod tests {
         assert_eq!(network.calls(), 1);
         assert_eq!(network.route_targets(), vec![ip("192.0.2.42")]);
         assert_eq!(wol.calls().len(), 1);
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
         let rendered = rendered(&output);
         assert!(rendered.contains("Waiting for NetworkManager connectivity"));
         assert!(rendered.contains("Waiting for route to TV at 192.0.2.42"));
@@ -2845,7 +2845,7 @@ mod tests {
         assert!(!marker.exists());
         assert_eq!(network.calls(), 1);
         assert!(network.route_targets().is_empty());
-        assert_call_commands(&mock, &["set_input"]);
+        assert_call_commands(&mock, &["set_input", "get_power_state"]);
     }
 
     #[test]

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -5,7 +5,6 @@ use std::time::{Duration, Instant};
 
 use crate::config::{
     load_config, resolve_config_path_from_env, Config, HdmiInput, MacAddress, ScreenRestorePolicy,
-    TvPlatform,
 };
 use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
 use crate::policy::{
@@ -16,10 +15,7 @@ use crate::policy::{
 use crate::runtime_phase::NoopRuntimePhaseProvider;
 use crate::runtime_phase::{LogindRuntimePhaseProvider, RuntimePhaseProvider, RuntimePhaseRead};
 use crate::state::{ScreenOwnershipMarker, StateScope};
-use crate::tv::{
-    build_tv_client, CurrentInput, TvClient, TvClientBuildOptions, TvDevice, TvError, TvErrorKind,
-    TvPowerState,
-};
+use crate::tv::{build_tv_client, CurrentInput, TvClient, TvClientBuildOptions, TvDevice, TvError};
 use crate::wol::{UdpWakeOnLanSender, WakeOnLanSender};
 use crate::RunError;
 
@@ -161,146 +157,70 @@ enum ScreenOnNext {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ScreenOnUnblankObservation {
-    VerifiedActive,
-    SubstateMismatch(String),
+    Succeeded,
     Failed(String),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TvFailureSnapshot {
-    kind: TvErrorKind,
-    detail: String,
-}
-
-impl TvFailureSnapshot {
-    fn from_error(error: &TvError) -> Self {
-        Self {
-            kind: error.kind(),
-            detail: compact_failure_detail(error.detail()),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum TvStepOutcome {
-    Succeeded,
-    Failed(TvFailureSnapshot),
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TimedTvStep {
-    elapsed: Duration,
-    outcome: TvStepOutcome,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TimedPowerStateObservation {
-    stage: String,
-    elapsed: Duration,
-    result: Result<TvPowerState, TvFailureSnapshot>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct WakePacketSnapshot {
-    elapsed: Duration,
-    error: Option<String>,
-}
-
 #[derive(Debug)]
-struct ScreenRestoreAnomaly {
-    source: EventSource,
-    platform: TvPlatform,
-    configured_input: HdmiInput,
-    marker_before: bool,
+struct ScreenRestoreTrace {
     started_at: Instant,
-    direct_unblank: Option<TimedTvStep>,
-    wake_packets: Vec<WakePacketSnapshot>,
-    input_attempts: Vec<TimedTvStep>,
-    recovery_unblank_attempts: Vec<TimedTvStep>,
-    power_state_observations: Vec<TimedPowerStateObservation>,
+    entries: Vec<String>,
+    failed: bool,
 }
 
-impl ScreenRestoreAnomaly {
-    fn new(event: RuntimeEvent, config: &Config, marker_before: bool) -> Self {
+impl ScreenRestoreTrace {
+    fn new() -> Self {
         Self {
-            source: event.source,
-            platform: config.tv_platform,
-            configured_input: config.input,
-            marker_before,
             started_at: Instant::now(),
-            direct_unblank: None,
-            wake_packets: Vec::new(),
-            input_attempts: Vec::new(),
-            recovery_unblank_attempts: Vec::new(),
-            power_state_observations: Vec::new(),
+            entries: Vec::new(),
+            failed: false,
         }
     }
 
-    fn command_failed(&self) -> bool {
-        self.direct_unblank
-            .as_ref()
-            .is_some_and(|step| matches!(&step.outcome, TvStepOutcome::Failed(_)))
-            || self
-                .input_attempts
-                .iter()
-                .chain(&self.recovery_unblank_attempts)
-                .any(|step| matches!(&step.outcome, TvStepOutcome::Failed(_)))
+    fn record(&mut self, operation: impl AsRef<str>, result: &Result<(), TvError>) {
+        let elapsed_ms = self.started_at.elapsed().as_millis();
+        match result {
+            Ok(()) => self.entries.push(format!(
+                "{}=succeeded elapsed_ms={elapsed_ms}",
+                operation.as_ref()
+            )),
+            Err(error) => {
+                self.failed = true;
+                self.entries.push(format!(
+                    "{}=failed kind={} elapsed_ms={elapsed_ms} detail={:?}",
+                    operation.as_ref(),
+                    error.kind().as_str(),
+                    compact_failure_detail(error.detail())
+                ));
+            }
+        }
     }
 
-    fn render<W: Write>(
+    fn render_if_failed<W: Write>(
         &self,
         writer: &mut W,
-        reconciliation_result: &Result<(), RunError>,
+        event: RuntimeEvent,
+        config: &Config,
+        marker_before: bool,
         marker_after: bool,
     ) -> io::Result<()> {
-        writeln!(writer, "LG Buddy Screen Restore Anomaly:")?;
+        if !self.failed {
+            return Ok(());
+        }
+
+        writeln!(writer, "LG Buddy Screen Restore Failure Context:")?;
         writeln!(
             writer,
             "  context: source={} platform={} configured_input={} marker_before={}",
-            event_source_label(self.source),
-            self.platform,
-            self.configured_input.as_str(),
-            marker_state(self.marker_before),
+            event_source_label(event.source),
+            config.tv_platform,
+            config.input.as_str(),
+            marker_state(marker_before),
         )?;
+        writeln!(writer, "  operations: {}", self.entries.join(" | "))?;
         writeln!(
             writer,
-            "  direct_unblank: {}",
-            self.direct_unblank
-                .as_ref()
-                .map(render_tv_step)
-                .unwrap_or_else(|| "not_attempted".to_string())
-        )?;
-        writeln!(
-            writer,
-            "  wake_packets: {}",
-            render_wake_packets(&self.wake_packets)
-        )?;
-        writeln!(
-            writer,
-            "  input_attempts: {}",
-            render_tv_steps(&self.input_attempts)
-        )?;
-        writeln!(
-            writer,
-            "  recovery_unblank_attempts: {}",
-            render_tv_steps(&self.recovery_unblank_attempts)
-        )?;
-        writeln!(
-            writer,
-            "  power_state_observations: {}",
-            render_power_state_observations(&self.power_state_observations)
-        )?;
-        let reconciliation_result = match reconciliation_result {
-            Ok(()) => "verified_active".to_string(),
-            Err(error) => format!(
-                "failed detail={:?}",
-                compact_failure_detail(&error.to_string())
-            ),
-        };
-        writeln!(
-            writer,
-            "  internal_outcome: reconciliation={} marker_after={} total_elapsed_ms={}",
-            reconciliation_result,
+            "  marker_after={} total_elapsed_ms={}",
             marker_state(marker_after),
             self.started_at.elapsed().as_millis(),
         )
@@ -627,7 +547,6 @@ pub(crate) fn run_screen_on_with_outcome_for_event<
     }
 
     let marker_exists = marker.exists();
-    let mut anomaly = ScreenRestoreAnomaly::new(event, config, marker_exists);
     let start_decision = decide_screen_on_start(config.screen_restore_policy, marker_exists);
     render_screen_on_start_decision(writer, config, marker_exists, &start_decision)?;
     let next = start_decision.next;
@@ -637,12 +556,11 @@ pub(crate) fn run_screen_on_with_outcome_for_event<
     }
 
     let tv = TvDevice::new(deps.tv_client, config.tv_ip);
+    let mut trace = ScreenRestoreTrace::new();
     if next == ScreenOnNext::Unblank
-        && execute_screen_on_unblank(writer, marker, &tv, &mut outcome, &mut anomaly)?
+        && execute_screen_on_unblank(writer, marker, &tv, &mut outcome, &mut trace)?
     {
-        if anomaly.command_failed() {
-            anomaly.render(writer, &Ok(()), marker.exists())?;
-        }
+        trace.render_if_failed(writer, event, config, marker_exists, marker.exists())?;
         return Ok(outcome);
     }
 
@@ -657,9 +575,9 @@ pub(crate) fn run_screen_on_with_outcome_for_event<
             sleeper: deps.sleeper,
         },
         &mut outcome,
-        &mut anomaly,
+        &mut trace,
     );
-    anomaly.render(writer, &fallback_result, marker.exists())?;
+    trace.render_if_failed(writer, event, config, marker_exists, marker.exists())?;
     fallback_result?;
     Ok(outcome)
 }
@@ -823,17 +741,11 @@ fn decide_screen_on_after_unblank(
     observation: ScreenOnUnblankObservation,
 ) -> ScreenPolicyDecision<ScreenOnNext> {
     match observation {
-        ScreenOnUnblankObservation::VerifiedActive => ScreenPolicyDecision::with_outcome(
+        ScreenOnUnblankObservation::Succeeded => ScreenPolicyDecision::with_outcome(
             ScreenOnNext::Stop,
             PolicyOutcome::new().with_state_transition(clear_session_marker(
                 TransitionReasonCode::RestoreCompleted,
             )),
-        ),
-        ScreenOnUnblankObservation::SubstateMismatch(detail) => ScreenPolicyDecision::with_outcome(
-            ScreenOnNext::FullWake,
-            PolicyOutcome::new().with_diagnostic(Diagnostic::warning(format!(
-                "screen unblank rejected because the TV is not in the screen-off substate: {detail}"
-            ))),
         ),
         ScreenOnUnblankObservation::Failed(detail) => ScreenPolicyDecision::with_outcome(
             ScreenOnNext::FullWake,
@@ -1051,87 +963,22 @@ fn execute_screen_on_unblank<W: Write, C: TvClient>(
     marker: &ScreenOwnershipMarker,
     tv: &TvDevice<'_, C>,
     outcome: &mut PolicyOutcome,
-    anomaly: &mut ScreenRestoreAnomaly,
+    trace: &mut ScreenRestoreTrace,
 ) -> Result<bool, RunError> {
-    let initial_power_state = observe_screen_power_state(tv, anomaly, "initial");
-    let (unblank_result, observation) = match initial_power_state {
-        Ok(TvPowerState::Active) => (None, ScreenOnUnblankObservation::VerifiedActive),
-        Ok(TvPowerState::ScreenOff) => {
-            let started_at = Instant::now();
-            let unblank_result = tv.screen().unblank();
-            anomaly.direct_unblank = Some(TimedTvStep {
-                elapsed: started_at.elapsed(),
-                outcome: match &unblank_result {
-                    Ok(()) => TvStepOutcome::Succeeded,
-                    Err(error) => TvStepOutcome::Failed(TvFailureSnapshot::from_error(error)),
-                },
-            });
-            let power_state = observe_screen_power_state(tv, anomaly, "after_direct_unblank");
-            let observation = match &power_state {
-                Ok(TvPowerState::Active) => ScreenOnUnblankObservation::VerifiedActive,
-                Ok(state) => match &unblank_result {
-                    Err(error) if error.indicates_screen_unblank_substate_mismatch() => {
-                        ScreenOnUnblankObservation::SubstateMismatch(format!(
-                            "{error}; TV verification reported `{state}`"
-                        ))
-                    }
-                    Err(error) => ScreenOnUnblankObservation::Failed(format!(
-                        "{error}; TV verification reported `{state}`"
-                    )),
-                    Ok(()) => ScreenOnUnblankObservation::Failed(format!(
-                        "screen unblank was acknowledged but TV verification reported `{state}`"
-                    )),
-                },
-                Err(verification_error) => match &unblank_result {
-                    Err(error) if error.indicates_screen_unblank_substate_mismatch() => {
-                        ScreenOnUnblankObservation::SubstateMismatch(format!(
-                            "{error}; TV verification failed: {verification_error}"
-                        ))
-                    }
-                    Err(error) => ScreenOnUnblankObservation::Failed(format!(
-                        "{error}; TV verification failed: {verification_error}"
-                    )),
-                    Ok(()) => ScreenOnUnblankObservation::Failed(format!(
-                        "screen unblank was acknowledged but TV verification failed: {verification_error}"
-                    )),
-                },
-            };
-            (Some(unblank_result), observation)
-        }
-        Ok(state) => (
-            None,
-            ScreenOnUnblankObservation::Failed(format!(
-                "TV verification reported `{state}` before screen unblank"
-            )),
-        ),
-        Err(error) => (
-            None,
-            ScreenOnUnblankObservation::Failed(format!(
-                "could not observe TV power state before screen unblank: {error}"
-            )),
-        ),
+    let result = tv.screen().unblank();
+    trace.record("direct_unblank", &result);
+    let observation = match result {
+        Ok(()) => ScreenOnUnblankObservation::Succeeded,
+        Err(error) => ScreenOnUnblankObservation::Failed(error.to_string()),
     };
     let decision = decide_screen_on_after_unblank(observation.clone());
     apply_screen_state_transitions(marker, &decision.outcome)?;
 
     match observation {
-        ScreenOnUnblankObservation::VerifiedActive => {
-            if matches!(unblank_result, Some(Ok(()))) {
-                writeln!(
-                    writer,
-                    "LG Buddy Screen On: Screen unblank succeeded. Verified TV power state Active. Clearing wake state."
-                )?;
-            } else {
-                writeln!(
-                    writer,
-                    "LG Buddy Screen On: Verified TV power state Active. Clearing wake state."
-                )?;
-            }
-        }
-        ScreenOnUnblankObservation::SubstateMismatch(_) => {
+        ScreenOnUnblankObservation::Succeeded => {
             writeln!(
                 writer,
-                "LG Buddy Screen On: TV rejected screen unblank because it is not in the screen-off substate. Falling back to full wake."
+                "LG Buddy Screen On: Screen unblank succeeded. Clearing wake state."
             )?;
         }
         ScreenOnUnblankObservation::Failed(_) => {}
@@ -1151,7 +998,7 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
     config: &Config,
     deps: ScreenOnWakeDeps<'_, C, S, Sl>,
     outcome: &mut PolicyOutcome,
-    anomaly: &mut ScreenRestoreAnomaly,
+    trace: &mut ScreenRestoreTrace,
 ) -> Result<(), RunError> {
     writeln!(
         writer,
@@ -1162,14 +1009,14 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
         "LG Buddy Screen On: Sending initial Wake-on-LAN packet..."
     )?;
     outcome.merge(select_screen_on_wake_packet());
-    anomaly.wake_packets.push(send_wake_packet(
+    send_wake_packet(
         writer,
         "LG Buddy Screen On",
         deps.tv,
         deps.wol_sender,
         &config.tv_mac,
         outcome,
-    )?);
+    )?;
     deps.sleeper.sleep(screen_on_initial_wake_delay());
 
     for attempt in 1..=SCREEN_ON_WAKE_ATTEMPTS {
@@ -1180,65 +1027,15 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
         )?;
 
         outcome.merge(select_screen_on_input_restore_attempt());
-        let input_started_at = Instant::now();
-        let input_result = deps.tv.input().set(config.input);
-        anomaly.input_attempts.push(TimedTvStep {
-            elapsed: input_started_at.elapsed(),
-            outcome: match &input_result {
-                Ok(()) => TvStepOutcome::Succeeded,
-                Err(error) => TvStepOutcome::Failed(TvFailureSnapshot::from_error(error)),
-            },
-        });
-
-        let power_state =
-            observe_screen_power_state(deps.tv, anomaly, format!("after_input_attempt_{attempt}"));
-        if matches!(power_state, Ok(TvPowerState::Active)) {
+        if attempt_input_restore(deps.tv, config.input, attempt, trace).is_ok() {
             let success_outcome = decide_screen_on_wake_attempt_succeeded();
             apply_screen_state_transitions(deps.marker, &success_outcome)?;
             writeln!(
                 writer,
-                "LG Buddy Screen On: Wake attempt {attempt} succeeded. Verified TV power state Active. Clearing wake state."
+                "LG Buddy Screen On: Wake attempt {attempt} succeeded. Clearing wake state."
             )?;
             outcome.merge(success_outcome);
             return Ok(());
-        }
-
-        if matches!(power_state, Ok(TvPowerState::ScreenOff)) {
-            if input_result.is_ok() {
-                writeln!(
-                    writer,
-                    "LG Buddy Screen On: Fallback input acknowledgement left the TV in Screen Off; reconciling screen visibility."
-                )?;
-            } else {
-                writeln!(
-                    writer,
-                    "LG Buddy Screen On: Fallback input attempt failed and the TV remains in Screen Off; reconciling screen visibility."
-                )?;
-            }
-            let unblank_started_at = Instant::now();
-            let unblank_result = deps.tv.screen().unblank();
-            anomaly.recovery_unblank_attempts.push(TimedTvStep {
-                elapsed: unblank_started_at.elapsed(),
-                outcome: match &unblank_result {
-                    Ok(()) => TvStepOutcome::Succeeded,
-                    Err(error) => TvStepOutcome::Failed(TvFailureSnapshot::from_error(error)),
-                },
-            });
-            let reconciled_power_state = observe_screen_power_state(
-                deps.tv,
-                anomaly,
-                format!("after_recovery_unblank_attempt_{attempt}"),
-            );
-            if matches!(reconciled_power_state, Ok(TvPowerState::Active)) {
-                let success_outcome = decide_screen_on_wake_attempt_succeeded();
-                apply_screen_state_transitions(deps.marker, &success_outcome)?;
-                writeln!(
-                    writer,
-                    "LG Buddy Screen On: Wake attempt {attempt} succeeded. Verified TV power state Active. Clearing wake state."
-                )?;
-                outcome.merge(success_outcome);
-                return Ok(());
-            }
         }
 
         let retry_delay = screen_on_retry_delay(attempt);
@@ -1248,14 +1045,14 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
             retry_delay.as_secs()
         )?;
         outcome.merge(select_screen_on_wake_packet());
-        anomaly.wake_packets.push(send_wake_packet(
+        send_wake_packet(
             writer,
             "LG Buddy Screen On",
             deps.tv,
             deps.wol_sender,
             &config.tv_mac,
             outcome,
-        )?);
+        )?;
         deps.sleeper.sleep(retry_delay);
     }
 
@@ -1269,6 +1066,31 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
     Err(RunError::Policy(format!(
         "screen-on wake sequence failed after {SCREEN_ON_WAKE_ATTEMPTS} attempts"
     )))
+}
+
+fn attempt_input_restore<C: TvClient>(
+    tv: &TvDevice<'_, C>,
+    input: HdmiInput,
+    attempt: u32,
+    trace: &mut ScreenRestoreTrace,
+) -> Result<(), TvError> {
+    let result = tv.input().set(input);
+    trace.record(format!("input_attempt_{attempt}"), &result);
+
+    let Err(error) = result else {
+        return Ok(());
+    };
+    if !error.indicates_screen_not_visible() {
+        return Err(error);
+    }
+
+    let unblank_result = tv.screen().unblank();
+    trace.record(format!("recovery_unblank_{attempt}"), &unblank_result);
+    unblank_result?;
+
+    let retry_result = tv.input().set(input);
+    trace.record(format!("input_retry_{attempt}"), &retry_result);
+    retry_result
 }
 
 fn log_markerless_restore_notice<W: Write>(writer: &mut W, prefix: &str) -> io::Result<()> {
@@ -1285,133 +1107,18 @@ fn send_wake_packet<W: Write, C: TvClient, S: WakeOnLanSender>(
     wol_sender: &S,
     tv_mac: &MacAddress,
     outcome: &mut PolicyOutcome,
-) -> Result<WakePacketSnapshot, RunError> {
-    let started_at = Instant::now();
-    let error = match tv.power().wake(wol_sender, tv_mac) {
-        Ok(()) => None,
-        Err(err) => {
-            let detail = compact_failure_detail(&err.to_string());
-            outcome.diagnostics.push(Diagnostic::warning(format!(
-                "Wake-on-LAN send failed: {err}"
-            )));
-            writeln!(
-                writer,
-                "{prefix}: Wake-on-LAN send failed. Continuing anyway. {err}"
-            )?;
-            Some(detail)
-        }
-    };
-
-    Ok(WakePacketSnapshot {
-        elapsed: started_at.elapsed(),
-        error,
-    })
-}
-
-fn observe_screen_power_state<C: TvClient>(
-    tv: &TvDevice<'_, C>,
-    anomaly: &mut ScreenRestoreAnomaly,
-    stage: impl Into<String>,
-) -> Result<TvPowerState, TvError> {
-    let started_at = Instant::now();
-    let result = tv.power().state();
-    let snapshot_result = match &result {
-        Ok(state) => Ok(state.clone()),
-        Err(error) => Err(TvFailureSnapshot::from_error(error)),
-    };
-    anomaly
-        .power_state_observations
-        .push(TimedPowerStateObservation {
-            stage: stage.into(),
-            elapsed: started_at.elapsed(),
-            result: snapshot_result,
-        });
-    result
-}
-
-fn render_tv_step(step: &TimedTvStep) -> String {
-    match &step.outcome {
-        TvStepOutcome::Succeeded => {
-            format!("succeeded elapsed_ms={}", step.elapsed.as_millis())
-        }
-        TvStepOutcome::Failed(failure) => format!(
-            "failed kind={} elapsed_ms={} detail={:?}",
-            failure.kind.as_str(),
-            step.elapsed.as_millis(),
-            failure.detail,
-        ),
-    }
-}
-
-fn render_tv_steps(steps: &[TimedTvStep]) -> String {
-    if steps.is_empty() {
-        return "none".to_string();
+) -> Result<(), RunError> {
+    if let Err(err) = tv.power().wake(wol_sender, tv_mac) {
+        outcome.diagnostics.push(Diagnostic::warning(format!(
+            "Wake-on-LAN send failed: {err}"
+        )));
+        writeln!(
+            writer,
+            "{prefix}: Wake-on-LAN send failed. Continuing anyway. {err}"
+        )?;
     }
 
-    steps
-        .iter()
-        .enumerate()
-        .map(|(index, step)| format!("attempt_{}=[{}]", index + 1, render_tv_step(step)))
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn render_wake_packets(packets: &[WakePacketSnapshot]) -> String {
-    if packets.is_empty() {
-        return "none".to_string();
-    }
-
-    packets
-        .iter()
-        .enumerate()
-        .map(|(index, packet)| match &packet.error {
-            None => format!(
-                "attempt_{}=[sent elapsed_ms={}]",
-                index + 1,
-                packet.elapsed.as_millis()
-            ),
-            Some(error) => format!(
-                "attempt_{}=[failed elapsed_ms={} detail={error:?}]",
-                index + 1,
-                packet.elapsed.as_millis()
-            ),
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
-}
-
-fn render_power_state_observation(observation: &TimedPowerStateObservation) -> String {
-    match &observation.result {
-        Ok(state) => format!(
-            "state={:?} elapsed_ms={}",
-            state.to_string(),
-            observation.elapsed.as_millis()
-        ),
-        Err(failure) => format!(
-            "failed kind={} elapsed_ms={} detail={:?}",
-            failure.kind.as_str(),
-            observation.elapsed.as_millis(),
-            failure.detail,
-        ),
-    }
-}
-
-fn render_power_state_observations(observations: &[TimedPowerStateObservation]) -> String {
-    if observations.is_empty() {
-        return "none".to_string();
-    }
-
-    observations
-        .iter()
-        .map(|observation| {
-            format!(
-                "{}=[{}]",
-                observation.stage,
-                render_power_state_observation(observation)
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+    Ok(())
 }
 
 fn compact_failure_detail(detail: &str) -> String {
@@ -1525,13 +1232,12 @@ mod tests {
     }
 
     use super::{
-        decide_screen_action_eligibility, decide_screen_off_after_input,
-        decide_screen_on_after_unblank, decide_screen_on_start, run_screen_off_with_outcome,
-        run_screen_off_with_outcome_for_event, run_screen_on_with_outcome,
-        run_screen_on_with_outcome_for_event, NoopSystemLifecycleStatusProvider,
-        ScreenActionBlockReason, ScreenActionEligibilityInput, ScreenEligibilityNext,
-        ScreenOffInputObservation, ScreenOffNext, ScreenOnDeps, ScreenOnNext,
-        ScreenOnUnblankObservation, Sleeper, SystemLifecycleStatusProvider,
+        decide_screen_action_eligibility, decide_screen_off_after_input, decide_screen_on_start,
+        run_screen_off_with_outcome, run_screen_off_with_outcome_for_event,
+        run_screen_on_with_outcome, run_screen_on_with_outcome_for_event,
+        NoopSystemLifecycleStatusProvider, ScreenActionBlockReason, ScreenActionEligibilityInput,
+        ScreenEligibilityNext, ScreenOffInputObservation, ScreenOffNext, ScreenOnDeps,
+        ScreenOnNext, Sleeper, SystemLifecycleStatusProvider,
     };
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenIdleBlankPolicy, ScreenRestorePolicy,
@@ -1693,19 +1399,6 @@ mod tests {
     }
 
     #[test]
-    fn pure_screen_on_policy_does_not_claim_an_unattempted_unblank_failed() {
-        let decision = decide_screen_on_after_unblank(ScreenOnUnblankObservation::Failed(
-            "could not observe the initial TV power state".to_string(),
-        ));
-
-        assert_eq!(decision.next, ScreenOnNext::FullWake);
-        assert_eq!(
-            decision.outcome.diagnostics[0].message,
-            "screen visibility could not be verified: could not observe the initial TV power state"
-        );
-    }
-
-    #[test]
     fn screen_off_outcome_records_blank_action_and_marker_creation() {
         let temp_dir = TestDir::new("screen-outcome-off-success");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
@@ -1815,21 +1508,17 @@ mod tests {
         );
         assert!(outcome.no_actions.is_empty());
         assert!(!marker.exists());
-        assert!(!rendered(&output).contains("LG Buddy Screen Restore Anomaly:"));
+        assert!(!rendered(&output).contains("LG Buddy Screen Restore Failure Context:"));
     }
 
     #[test]
-    fn screen_on_fallback_reconciles_false_success_and_records_the_full_state_sequence() {
-        let temp_dir = TestDir::new("screen-on-false-success-snapshot");
+    fn legacy_screen_on_reconciles_input_acknowledged_while_screen_off() {
+        let temp_dir = TestDir::new("legacy-screen-on-false-success");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         marker.create().expect("create marker");
-        let mock = MockBscpylgtv::new("screen-on-false-success-snapshot-tv");
+        let mock = MockBscpylgtv::new("legacy-screen-on-false-success-tv");
         mock.set_screen_on(false);
-        mock.queue_error(
-            "turn_screen_on",
-            7,
-            "native-like unblank transport failure\n",
-        );
+        mock.queue_error("turn_screen_on", 1, "unblank transport failure\n");
         mock.queue_set_input_ack_without_screen_on();
         let client = client_for_mock(&mock);
         let wol = RecordingWakeOnLanSender::default();
@@ -1838,45 +1527,36 @@ mod tests {
         let mut output = Vec::new();
         run_screen_on_with_outcome(
             &mut output,
-            &sample_config(HdmiInput::Hdmi2),
+            &sample_config(HdmiInput::Hdmi3),
             &marker,
             &client,
             &wol,
             &sleeper,
         )
-        .expect("reconciler should continue after the false acknowledgement");
+        .expect("legacy adapter should reconcile screen visibility");
 
-        let output = rendered(&output);
-        assert!(output.contains("LG Buddy Screen Restore Anomaly:"));
-        assert!(output.contains(
-            "context: source=cli-api platform=bscpylgtv configured_input=HDMI_2 marker_before=present"
-        ));
-        assert!(output.contains("direct_unblank: failed kind=rejected"));
-        assert!(output.contains("native-like unblank transport failure"));
-        assert!(output.contains("wake_packets: attempt_1=[sent"));
-        assert!(output.contains("input_attempts: attempt_1=[succeeded"));
-        assert!(output.contains("recovery_unblank_attempts: attempt_1=[succeeded"));
-        assert!(output.contains("initial=[state=\"Screen Off\""));
-        assert!(output.contains("after_direct_unblank=[state=\"Screen Off\""));
-        assert!(output.contains("after_input_attempt_1=[state=\"Screen Off\""));
-        assert!(output.contains("after_recovery_unblank_attempt_1=[state=\"Active\""));
-        assert!(
-            output.contains("internal_outcome: reconciliation=verified_active marker_after=absent")
-        );
         assert!(!marker.exists());
         assert!(mock.state_snapshot().screen_on);
         assert_call_commands(
             &mock,
             &[
-                "get_power_state",
                 "turn_screen_on",
                 "get_power_state",
                 "set_input",
                 "get_power_state",
                 "turn_screen_on",
                 "get_power_state",
+                "set_input",
+                "get_power_state",
             ],
         );
+        let output = rendered(&output);
+        assert!(output.contains("LG Buddy Screen Restore Failure Context:"));
+        assert!(output.contains("direct_unblank=failed kind=screen_not_visible"));
+        assert!(output.contains("input_attempt_1=failed kind=screen_not_visible"));
+        assert!(output.contains("recovery_unblank_1=succeeded"));
+        assert!(output.contains("input_retry_1=succeeded"));
+        assert!(output.contains("marker_after=absent"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -1,10 +1,11 @@
 use std::env;
 use std::io::{self, Write};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::config::{
     load_config, resolve_config_path_from_env, Config, HdmiInput, MacAddress, ScreenRestorePolicy,
+    TvPlatform,
 };
 use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
 use crate::policy::{
@@ -15,7 +16,10 @@ use crate::policy::{
 use crate::runtime_phase::NoopRuntimePhaseProvider;
 use crate::runtime_phase::{LogindRuntimePhaseProvider, RuntimePhaseProvider, RuntimePhaseRead};
 use crate::state::{ScreenOwnershipMarker, StateScope};
-use crate::tv::{build_tv_client, CurrentInput, TvClient, TvClientBuildOptions, TvDevice};
+use crate::tv::{
+    build_tv_client, CurrentInput, TvClient, TvClientBuildOptions, TvDevice, TvError, TvErrorKind,
+    TvPowerState,
+};
 use crate::wol::{UdpWakeOnLanSender, WakeOnLanSender};
 use crate::RunError;
 
@@ -157,9 +161,150 @@ enum ScreenOnNext {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ScreenOnUnblankObservation {
-    Succeeded,
+    VerifiedActive,
     SubstateMismatch(String),
     Failed(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TvFailureSnapshot {
+    kind: TvErrorKind,
+    detail: String,
+}
+
+impl TvFailureSnapshot {
+    fn from_error(error: &TvError) -> Self {
+        Self {
+            kind: error.kind(),
+            detail: compact_failure_detail(error.detail()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum TvStepOutcome {
+    Succeeded,
+    Failed(TvFailureSnapshot),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TimedTvStep {
+    elapsed: Duration,
+    outcome: TvStepOutcome,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TimedPowerStateObservation {
+    stage: String,
+    elapsed: Duration,
+    result: Result<TvPowerState, TvFailureSnapshot>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WakePacketSnapshot {
+    elapsed: Duration,
+    error: Option<String>,
+}
+
+#[derive(Debug)]
+struct ScreenRestoreAnomaly {
+    source: EventSource,
+    platform: TvPlatform,
+    configured_input: HdmiInput,
+    marker_before: bool,
+    started_at: Instant,
+    direct_unblank: Option<TimedTvStep>,
+    wake_packets: Vec<WakePacketSnapshot>,
+    input_attempts: Vec<TimedTvStep>,
+    recovery_unblank_attempts: Vec<TimedTvStep>,
+    power_state_observations: Vec<TimedPowerStateObservation>,
+}
+
+impl ScreenRestoreAnomaly {
+    fn new(event: RuntimeEvent, config: &Config, marker_before: bool) -> Self {
+        Self {
+            source: event.source,
+            platform: config.tv_platform,
+            configured_input: config.input,
+            marker_before,
+            started_at: Instant::now(),
+            direct_unblank: None,
+            wake_packets: Vec::new(),
+            input_attempts: Vec::new(),
+            recovery_unblank_attempts: Vec::new(),
+            power_state_observations: Vec::new(),
+        }
+    }
+
+    fn command_failed(&self) -> bool {
+        self.direct_unblank
+            .as_ref()
+            .is_some_and(|step| matches!(&step.outcome, TvStepOutcome::Failed(_)))
+            || self
+                .input_attempts
+                .iter()
+                .chain(&self.recovery_unblank_attempts)
+                .any(|step| matches!(&step.outcome, TvStepOutcome::Failed(_)))
+    }
+
+    fn render<W: Write>(
+        &self,
+        writer: &mut W,
+        reconciliation_result: &Result<(), RunError>,
+        marker_after: bool,
+    ) -> io::Result<()> {
+        writeln!(writer, "LG Buddy Screen Restore Anomaly:")?;
+        writeln!(
+            writer,
+            "  context: source={} platform={} configured_input={} marker_before={}",
+            event_source_label(self.source),
+            self.platform,
+            self.configured_input.as_str(),
+            marker_state(self.marker_before),
+        )?;
+        writeln!(
+            writer,
+            "  direct_unblank: {}",
+            self.direct_unblank
+                .as_ref()
+                .map(render_tv_step)
+                .unwrap_or_else(|| "not_attempted".to_string())
+        )?;
+        writeln!(
+            writer,
+            "  wake_packets: {}",
+            render_wake_packets(&self.wake_packets)
+        )?;
+        writeln!(
+            writer,
+            "  input_attempts: {}",
+            render_tv_steps(&self.input_attempts)
+        )?;
+        writeln!(
+            writer,
+            "  recovery_unblank_attempts: {}",
+            render_tv_steps(&self.recovery_unblank_attempts)
+        )?;
+        writeln!(
+            writer,
+            "  power_state_observations: {}",
+            render_power_state_observations(&self.power_state_observations)
+        )?;
+        let reconciliation_result = match reconciliation_result {
+            Ok(()) => "verified_active".to_string(),
+            Err(error) => format!(
+                "failed detail={:?}",
+                compact_failure_detail(&error.to_string())
+            ),
+        };
+        writeln!(
+            writer,
+            "  internal_outcome: reconciliation={} marker_after={} total_elapsed_ms={}",
+            reconciliation_result,
+            marker_state(marker_after),
+            self.started_at.elapsed().as_millis(),
+        )
+    }
 }
 
 pub(crate) fn run_screen_off_from_env<W: Write>(writer: &mut W) -> Result<(), RunError> {
@@ -482,6 +627,7 @@ pub(crate) fn run_screen_on_with_outcome_for_event<
     }
 
     let marker_exists = marker.exists();
+    let mut anomaly = ScreenRestoreAnomaly::new(event, config, marker_exists);
     let start_decision = decide_screen_on_start(config.screen_restore_policy, marker_exists);
     render_screen_on_start_decision(writer, config, marker_exists, &start_decision)?;
     let next = start_decision.next;
@@ -492,12 +638,15 @@ pub(crate) fn run_screen_on_with_outcome_for_event<
 
     let tv = TvDevice::new(deps.tv_client, config.tv_ip);
     if next == ScreenOnNext::Unblank
-        && execute_screen_on_unblank(writer, marker, &tv, &mut outcome)?
+        && execute_screen_on_unblank(writer, marker, &tv, &mut outcome, &mut anomaly)?
     {
+        if anomaly.command_failed() {
+            anomaly.render(writer, &Ok(()), marker.exists())?;
+        }
         return Ok(outcome);
     }
 
-    execute_screen_on_full_wake(
+    let fallback_result = execute_screen_on_full_wake(
         writer,
         config,
         ScreenOnWakeDeps {
@@ -508,7 +657,10 @@ pub(crate) fn run_screen_on_with_outcome_for_event<
             sleeper: deps.sleeper,
         },
         &mut outcome,
-    )?;
+        &mut anomaly,
+    );
+    anomaly.render(writer, &fallback_result, marker.exists())?;
+    fallback_result?;
     Ok(outcome)
 }
 
@@ -671,7 +823,7 @@ fn decide_screen_on_after_unblank(
     observation: ScreenOnUnblankObservation,
 ) -> ScreenPolicyDecision<ScreenOnNext> {
     match observation {
-        ScreenOnUnblankObservation::Succeeded => ScreenPolicyDecision::with_outcome(
+        ScreenOnUnblankObservation::VerifiedActive => ScreenPolicyDecision::with_outcome(
             ScreenOnNext::Stop,
             PolicyOutcome::new().with_state_transition(clear_session_marker(
                 TransitionReasonCode::RestoreCompleted,
@@ -686,7 +838,7 @@ fn decide_screen_on_after_unblank(
         ScreenOnUnblankObservation::Failed(detail) => ScreenPolicyDecision::with_outcome(
             ScreenOnNext::FullWake,
             PolicyOutcome::new().with_diagnostic(Diagnostic::warning(format!(
-                "screen unblank failed: {detail}"
+                "screen visibility could not be verified: {detail}"
             ))),
         ),
     }
@@ -899,23 +1051,82 @@ fn execute_screen_on_unblank<W: Write, C: TvClient>(
     marker: &ScreenOwnershipMarker,
     tv: &TvDevice<'_, C>,
     outcome: &mut PolicyOutcome,
+    anomaly: &mut ScreenRestoreAnomaly,
 ) -> Result<bool, RunError> {
-    let observation = match tv.screen().unblank() {
-        Ok(_) => ScreenOnUnblankObservation::Succeeded,
-        Err(err) if err.indicates_screen_unblank_substate_mismatch() => {
-            ScreenOnUnblankObservation::SubstateMismatch(err.to_string())
+    let initial_power_state = observe_screen_power_state(tv, anomaly, "initial");
+    let (unblank_result, observation) = match initial_power_state {
+        Ok(TvPowerState::Active) => (None, ScreenOnUnblankObservation::VerifiedActive),
+        Ok(TvPowerState::ScreenOff) => {
+            let started_at = Instant::now();
+            let unblank_result = tv.screen().unblank();
+            anomaly.direct_unblank = Some(TimedTvStep {
+                elapsed: started_at.elapsed(),
+                outcome: match &unblank_result {
+                    Ok(()) => TvStepOutcome::Succeeded,
+                    Err(error) => TvStepOutcome::Failed(TvFailureSnapshot::from_error(error)),
+                },
+            });
+            let power_state = observe_screen_power_state(tv, anomaly, "after_direct_unblank");
+            let observation = match &power_state {
+                Ok(TvPowerState::Active) => ScreenOnUnblankObservation::VerifiedActive,
+                Ok(state) => match &unblank_result {
+                    Err(error) if error.indicates_screen_unblank_substate_mismatch() => {
+                        ScreenOnUnblankObservation::SubstateMismatch(format!(
+                            "{error}; TV verification reported `{state}`"
+                        ))
+                    }
+                    Err(error) => ScreenOnUnblankObservation::Failed(format!(
+                        "{error}; TV verification reported `{state}`"
+                    )),
+                    Ok(()) => ScreenOnUnblankObservation::Failed(format!(
+                        "screen unblank was acknowledged but TV verification reported `{state}`"
+                    )),
+                },
+                Err(verification_error) => match &unblank_result {
+                    Err(error) if error.indicates_screen_unblank_substate_mismatch() => {
+                        ScreenOnUnblankObservation::SubstateMismatch(format!(
+                            "{error}; TV verification failed: {verification_error}"
+                        ))
+                    }
+                    Err(error) => ScreenOnUnblankObservation::Failed(format!(
+                        "{error}; TV verification failed: {verification_error}"
+                    )),
+                    Ok(()) => ScreenOnUnblankObservation::Failed(format!(
+                        "screen unblank was acknowledged but TV verification failed: {verification_error}"
+                    )),
+                },
+            };
+            (Some(unblank_result), observation)
         }
-        Err(err) => ScreenOnUnblankObservation::Failed(err.to_string()),
+        Ok(state) => (
+            None,
+            ScreenOnUnblankObservation::Failed(format!(
+                "TV verification reported `{state}` before screen unblank"
+            )),
+        ),
+        Err(error) => (
+            None,
+            ScreenOnUnblankObservation::Failed(format!(
+                "could not observe TV power state before screen unblank: {error}"
+            )),
+        ),
     };
     let decision = decide_screen_on_after_unblank(observation.clone());
     apply_screen_state_transitions(marker, &decision.outcome)?;
 
     match observation {
-        ScreenOnUnblankObservation::Succeeded => {
-            writeln!(
-                writer,
-                "LG Buddy Screen On: Screen unblank succeeded. Clearing wake state."
-            )?;
+        ScreenOnUnblankObservation::VerifiedActive => {
+            if matches!(unblank_result, Some(Ok(()))) {
+                writeln!(
+                    writer,
+                    "LG Buddy Screen On: Screen unblank succeeded. Verified TV power state Active. Clearing wake state."
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    "LG Buddy Screen On: Verified TV power state Active. Clearing wake state."
+                )?;
+            }
         }
         ScreenOnUnblankObservation::SubstateMismatch(_) => {
             writeln!(
@@ -940,24 +1151,25 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
     config: &Config,
     deps: ScreenOnWakeDeps<'_, C, S, Sl>,
     outcome: &mut PolicyOutcome,
+    anomaly: &mut ScreenRestoreAnomaly,
 ) -> Result<(), RunError> {
     writeln!(
         writer,
-        "LG Buddy Screen On: Screen unblank failed. Falling back to full wake."
+        "LG Buddy Screen On: Screen visibility could not be verified. Falling back to full wake."
     )?;
     writeln!(
         writer,
         "LG Buddy Screen On: Sending initial Wake-on-LAN packet..."
     )?;
     outcome.merge(select_screen_on_wake_packet());
-    send_wake_packet(
+    anomaly.wake_packets.push(send_wake_packet(
         writer,
         "LG Buddy Screen On",
         deps.tv,
         deps.wol_sender,
         &config.tv_mac,
         outcome,
-    )?;
+    )?);
     deps.sleeper.sleep(screen_on_initial_wake_delay());
 
     for attempt in 1..=SCREEN_ON_WAKE_ATTEMPTS {
@@ -968,15 +1180,65 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
         )?;
 
         outcome.merge(select_screen_on_input_restore_attempt());
-        if deps.tv.input().set(config.input).is_ok() {
+        let input_started_at = Instant::now();
+        let input_result = deps.tv.input().set(config.input);
+        anomaly.input_attempts.push(TimedTvStep {
+            elapsed: input_started_at.elapsed(),
+            outcome: match &input_result {
+                Ok(()) => TvStepOutcome::Succeeded,
+                Err(error) => TvStepOutcome::Failed(TvFailureSnapshot::from_error(error)),
+            },
+        });
+
+        let power_state =
+            observe_screen_power_state(deps.tv, anomaly, format!("after_input_attempt_{attempt}"));
+        if matches!(power_state, Ok(TvPowerState::Active)) {
             let success_outcome = decide_screen_on_wake_attempt_succeeded();
             apply_screen_state_transitions(deps.marker, &success_outcome)?;
             writeln!(
                 writer,
-                "LG Buddy Screen On: Wake attempt {attempt} succeeded. Clearing wake state."
+                "LG Buddy Screen On: Wake attempt {attempt} succeeded. Verified TV power state Active. Clearing wake state."
             )?;
             outcome.merge(success_outcome);
             return Ok(());
+        }
+
+        if matches!(power_state, Ok(TvPowerState::ScreenOff)) {
+            if input_result.is_ok() {
+                writeln!(
+                    writer,
+                    "LG Buddy Screen On: Fallback input acknowledgement left the TV in Screen Off; reconciling screen visibility."
+                )?;
+            } else {
+                writeln!(
+                    writer,
+                    "LG Buddy Screen On: Fallback input attempt failed and the TV remains in Screen Off; reconciling screen visibility."
+                )?;
+            }
+            let unblank_started_at = Instant::now();
+            let unblank_result = deps.tv.screen().unblank();
+            anomaly.recovery_unblank_attempts.push(TimedTvStep {
+                elapsed: unblank_started_at.elapsed(),
+                outcome: match &unblank_result {
+                    Ok(()) => TvStepOutcome::Succeeded,
+                    Err(error) => TvStepOutcome::Failed(TvFailureSnapshot::from_error(error)),
+                },
+            });
+            let reconciled_power_state = observe_screen_power_state(
+                deps.tv,
+                anomaly,
+                format!("after_recovery_unblank_attempt_{attempt}"),
+            );
+            if matches!(reconciled_power_state, Ok(TvPowerState::Active)) {
+                let success_outcome = decide_screen_on_wake_attempt_succeeded();
+                apply_screen_state_transitions(deps.marker, &success_outcome)?;
+                writeln!(
+                    writer,
+                    "LG Buddy Screen On: Wake attempt {attempt} succeeded. Verified TV power state Active. Clearing wake state."
+                )?;
+                outcome.merge(success_outcome);
+                return Ok(());
+            }
         }
 
         let retry_delay = screen_on_retry_delay(attempt);
@@ -986,14 +1248,14 @@ fn execute_screen_on_full_wake<W: Write, C: TvClient, S: WakeOnLanSender, Sl: Sl
             retry_delay.as_secs()
         )?;
         outcome.merge(select_screen_on_wake_packet());
-        send_wake_packet(
+        anomaly.wake_packets.push(send_wake_packet(
             writer,
             "LG Buddy Screen On",
             deps.tv,
             deps.wol_sender,
             &config.tv_mac,
             outcome,
-        )?;
+        )?);
         deps.sleeper.sleep(retry_delay);
     }
 
@@ -1023,18 +1285,163 @@ fn send_wake_packet<W: Write, C: TvClient, S: WakeOnLanSender>(
     wol_sender: &S,
     tv_mac: &MacAddress,
     outcome: &mut PolicyOutcome,
-) -> Result<(), RunError> {
-    if let Err(err) = tv.power().wake(wol_sender, tv_mac) {
-        outcome.diagnostics.push(Diagnostic::warning(format!(
-            "Wake-on-LAN send failed: {err}"
-        )));
-        writeln!(
-            writer,
-            "{prefix}: Wake-on-LAN send failed. Continuing anyway. {err}"
-        )?;
+) -> Result<WakePacketSnapshot, RunError> {
+    let started_at = Instant::now();
+    let error = match tv.power().wake(wol_sender, tv_mac) {
+        Ok(()) => None,
+        Err(err) => {
+            let detail = compact_failure_detail(&err.to_string());
+            outcome.diagnostics.push(Diagnostic::warning(format!(
+                "Wake-on-LAN send failed: {err}"
+            )));
+            writeln!(
+                writer,
+                "{prefix}: Wake-on-LAN send failed. Continuing anyway. {err}"
+            )?;
+            Some(detail)
+        }
+    };
+
+    Ok(WakePacketSnapshot {
+        elapsed: started_at.elapsed(),
+        error,
+    })
+}
+
+fn observe_screen_power_state<C: TvClient>(
+    tv: &TvDevice<'_, C>,
+    anomaly: &mut ScreenRestoreAnomaly,
+    stage: impl Into<String>,
+) -> Result<TvPowerState, TvError> {
+    let started_at = Instant::now();
+    let result = tv.power().state();
+    let snapshot_result = match &result {
+        Ok(state) => Ok(state.clone()),
+        Err(error) => Err(TvFailureSnapshot::from_error(error)),
+    };
+    anomaly
+        .power_state_observations
+        .push(TimedPowerStateObservation {
+            stage: stage.into(),
+            elapsed: started_at.elapsed(),
+            result: snapshot_result,
+        });
+    result
+}
+
+fn render_tv_step(step: &TimedTvStep) -> String {
+    match &step.outcome {
+        TvStepOutcome::Succeeded => {
+            format!("succeeded elapsed_ms={}", step.elapsed.as_millis())
+        }
+        TvStepOutcome::Failed(failure) => format!(
+            "failed kind={} elapsed_ms={} detail={:?}",
+            failure.kind.as_str(),
+            step.elapsed.as_millis(),
+            failure.detail,
+        ),
+    }
+}
+
+fn render_tv_steps(steps: &[TimedTvStep]) -> String {
+    if steps.is_empty() {
+        return "none".to_string();
     }
 
-    Ok(())
+    steps
+        .iter()
+        .enumerate()
+        .map(|(index, step)| format!("attempt_{}=[{}]", index + 1, render_tv_step(step)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn render_wake_packets(packets: &[WakePacketSnapshot]) -> String {
+    if packets.is_empty() {
+        return "none".to_string();
+    }
+
+    packets
+        .iter()
+        .enumerate()
+        .map(|(index, packet)| match &packet.error {
+            None => format!(
+                "attempt_{}=[sent elapsed_ms={}]",
+                index + 1,
+                packet.elapsed.as_millis()
+            ),
+            Some(error) => format!(
+                "attempt_{}=[failed elapsed_ms={} detail={error:?}]",
+                index + 1,
+                packet.elapsed.as_millis()
+            ),
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn render_power_state_observation(observation: &TimedPowerStateObservation) -> String {
+    match &observation.result {
+        Ok(state) => format!(
+            "state={:?} elapsed_ms={}",
+            state.to_string(),
+            observation.elapsed.as_millis()
+        ),
+        Err(failure) => format!(
+            "failed kind={} elapsed_ms={} detail={:?}",
+            failure.kind.as_str(),
+            observation.elapsed.as_millis(),
+            failure.detail,
+        ),
+    }
+}
+
+fn render_power_state_observations(observations: &[TimedPowerStateObservation]) -> String {
+    if observations.is_empty() {
+        return "none".to_string();
+    }
+
+    observations
+        .iter()
+        .map(|observation| {
+            format!(
+                "{}=[{}]",
+                observation.stage,
+                render_power_state_observation(observation)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn compact_failure_detail(detail: &str) -> String {
+    detail
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(str::trim)
+        .unwrap_or("no detail")
+        .to_string()
+}
+
+fn event_source_label(source: EventSource) -> &'static str {
+    match source {
+        EventSource::CliApi => "cli-api",
+        EventSource::LinuxLogind => "linux-logind",
+        EventSource::LinuxNetworkManager => "linux-network-manager",
+        EventSource::LinuxSystemd => "linux-systemd",
+        EventSource::DesktopSession => "desktop-session",
+        EventSource::AuxiliaryInput => "auxiliary-input",
+        EventSource::FuturePlatform => "future-platform",
+    }
+}
+
+fn marker_state(exists: bool) -> &'static str {
+    if exists {
+        "present"
+    } else {
+        "absent"
+    }
 }
 
 fn is_session_screen_source(source: EventSource) -> bool {
@@ -1118,12 +1525,13 @@ mod tests {
     }
 
     use super::{
-        decide_screen_action_eligibility, decide_screen_off_after_input, decide_screen_on_start,
-        run_screen_off_with_outcome, run_screen_off_with_outcome_for_event,
-        run_screen_on_with_outcome, run_screen_on_with_outcome_for_event,
-        NoopSystemLifecycleStatusProvider, ScreenActionBlockReason, ScreenActionEligibilityInput,
-        ScreenEligibilityNext, ScreenOffInputObservation, ScreenOffNext, ScreenOnDeps,
-        ScreenOnNext, Sleeper, SystemLifecycleStatusProvider,
+        decide_screen_action_eligibility, decide_screen_off_after_input,
+        decide_screen_on_after_unblank, decide_screen_on_start, run_screen_off_with_outcome,
+        run_screen_off_with_outcome_for_event, run_screen_on_with_outcome,
+        run_screen_on_with_outcome_for_event, NoopSystemLifecycleStatusProvider,
+        ScreenActionBlockReason, ScreenActionEligibilityInput, ScreenEligibilityNext,
+        ScreenOffInputObservation, ScreenOffNext, ScreenOnDeps, ScreenOnNext,
+        ScreenOnUnblankObservation, Sleeper, SystemLifecycleStatusProvider,
     };
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenIdleBlankPolicy, ScreenRestorePolicy,
@@ -1285,6 +1693,19 @@ mod tests {
     }
 
     #[test]
+    fn pure_screen_on_policy_does_not_claim_an_unattempted_unblank_failed() {
+        let decision = decide_screen_on_after_unblank(ScreenOnUnblankObservation::Failed(
+            "could not observe the initial TV power state".to_string(),
+        ));
+
+        assert_eq!(decision.next, ScreenOnNext::FullWake);
+        assert_eq!(
+            decision.outcome.diagnostics[0].message,
+            "screen visibility could not be verified: could not observe the initial TV power state"
+        );
+    }
+
+    #[test]
     fn screen_off_outcome_records_blank_action_and_marker_creation() {
         let temp_dir = TestDir::new("screen-outcome-off-success");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
@@ -1394,6 +1815,68 @@ mod tests {
         );
         assert!(outcome.no_actions.is_empty());
         assert!(!marker.exists());
+        assert!(!rendered(&output).contains("LG Buddy Screen Restore Anomaly:"));
+    }
+
+    #[test]
+    fn screen_on_fallback_reconciles_false_success_and_records_the_full_state_sequence() {
+        let temp_dir = TestDir::new("screen-on-false-success-snapshot");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create marker");
+        let mock = MockBscpylgtv::new("screen-on-false-success-snapshot-tv");
+        mock.set_screen_on(false);
+        mock.queue_error(
+            "turn_screen_on",
+            7,
+            "native-like unblank transport failure\n",
+        );
+        mock.queue_set_input_ack_without_screen_on();
+        let client = client_for_mock(&mock);
+        let wol = RecordingWakeOnLanSender::default();
+        let sleeper = RecordingSleeper::default();
+
+        let mut output = Vec::new();
+        run_screen_on_with_outcome(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+            &wol,
+            &sleeper,
+        )
+        .expect("reconciler should continue after the false acknowledgement");
+
+        let output = rendered(&output);
+        assert!(output.contains("LG Buddy Screen Restore Anomaly:"));
+        assert!(output.contains(
+            "context: source=cli-api platform=bscpylgtv configured_input=HDMI_2 marker_before=present"
+        ));
+        assert!(output.contains("direct_unblank: failed kind=rejected"));
+        assert!(output.contains("native-like unblank transport failure"));
+        assert!(output.contains("wake_packets: attempt_1=[sent"));
+        assert!(output.contains("input_attempts: attempt_1=[succeeded"));
+        assert!(output.contains("recovery_unblank_attempts: attempt_1=[succeeded"));
+        assert!(output.contains("initial=[state=\"Screen Off\""));
+        assert!(output.contains("after_direct_unblank=[state=\"Screen Off\""));
+        assert!(output.contains("after_input_attempt_1=[state=\"Screen Off\""));
+        assert!(output.contains("after_recovery_unblank_attempt_1=[state=\"Active\""));
+        assert!(
+            output.contains("internal_outcome: reconciliation=verified_active marker_after=absent")
+        );
+        assert!(!marker.exists());
+        assert!(mock.state_snapshot().screen_on);
+        assert_call_commands(
+            &mock,
+            &[
+                "get_power_state",
+                "turn_screen_on",
+                "get_power_state",
+                "set_input",
+                "get_power_state",
+                "turn_screen_on",
+                "get_power_state",
+            ],
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -41,10 +41,6 @@ impl CommandOutput {
         &self.stdout
     }
 
-    fn stderr(&self) -> &str {
-        &self.stderr
-    }
-
     fn combined_output(&self) -> String {
         match (self.stdout.is_empty(), self.stderr.is_empty()) {
             (false, false) => format!("{}{}", self.stdout, self.stderr),
@@ -58,7 +54,6 @@ impl CommandOutput {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TvOperation {
     ReadInput,
-    ReadPowerState,
     SetInput,
     ReadOledBrightness,
     SetOledBrightness,
@@ -71,7 +66,6 @@ impl TvOperation {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ReadInput => "read input",
-            Self::ReadPowerState => "read power state",
             Self::SetInput => "set input",
             Self::ReadOledBrightness => "read OLED brightness",
             Self::SetOledBrightness => "set OLED brightness",
@@ -94,7 +88,7 @@ pub enum TvErrorKind {
     Authentication,
     Rejected,
     InvalidResponse,
-    ScreenUnblankSubstateMismatch,
+    ScreenNotVisible,
     Internal,
 }
 
@@ -105,7 +99,7 @@ impl TvErrorKind {
             Self::Authentication => "authentication",
             Self::Rejected => "rejected",
             Self::InvalidResponse => "invalid_response",
-            Self::ScreenUnblankSubstateMismatch => "screen_unblank_substate_mismatch",
+            Self::ScreenNotVisible => "screen_not_visible",
             Self::Internal => "internal",
         }
     }
@@ -151,8 +145,8 @@ impl TvError {
         }
     }
 
-    pub fn indicates_screen_unblank_substate_mismatch(&self) -> bool {
-        self.kind == TvErrorKind::ScreenUnblankSubstateMismatch
+    pub fn indicates_screen_not_visible(&self) -> bool {
+        self.kind == TvErrorKind::ScreenNotVisible
     }
 }
 
@@ -218,49 +212,8 @@ impl fmt::Display for OledBrightness {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TvPowerState {
-    Active,
-    ActiveStandby,
-    ScreenOff,
-    Suspend,
-    PowerOff,
-    Unknown,
-    Other(String),
-}
-
-impl TvPowerState {
-    fn from_wire_value(value: impl Into<String>) -> Self {
-        let value = value.into();
-        match value.as_str() {
-            "Active" => Self::Active,
-            "Active Standby" => Self::ActiveStandby,
-            "Screen Off" => Self::ScreenOff,
-            "Suspend" => Self::Suspend,
-            "Power Off" => Self::PowerOff,
-            "Unknown" => Self::Unknown,
-            _ => Self::Other(value),
-        }
-    }
-}
-
-impl fmt::Display for TvPowerState {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Active => f.write_str("Active"),
-            Self::ActiveStandby => f.write_str("Active Standby"),
-            Self::ScreenOff => f.write_str("Screen Off"),
-            Self::Suspend => f.write_str("Suspend"),
-            Self::PowerOff => f.write_str("Power Off"),
-            Self::Unknown => f.write_str("Unknown"),
-            Self::Other(value) => f.write_str(value),
-        }
-    }
-}
-
 pub trait TvClient {
     fn current_input(&self) -> Result<CurrentInput, TvError>;
-    fn power_state(&self) -> Result<TvPowerState, TvError>;
     fn oled_brightness(&self) -> Result<OledBrightness, TvError>;
     fn set_input(&self, input: HdmiInput) -> Result<(), TvError>;
     fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError>;
@@ -328,13 +281,6 @@ impl TvClient for SelectedTvClient {
         match self {
             Self::Bscpylgtv(client) => client.current_input(),
             Self::WebOs(client) => client.current_input(),
-        }
-    }
-
-    fn power_state(&self) -> Result<TvPowerState, TvError> {
-        match self {
-            Self::Bscpylgtv(client) => client.power_state(),
-            Self::WebOs(client) => client.power_state(),
         }
     }
 
@@ -554,10 +500,6 @@ pub struct TvPower<'a, C> {
 }
 
 impl<'a, C: TvClient> TvPower<'a, C> {
-    pub fn state(&self) -> Result<TvPowerState, TvError> {
-        self.client.power_state()
-    }
-
     pub fn wake<W: WakeOnLanSender>(
         &self,
         sender: &W,
@@ -974,15 +916,72 @@ impl<L: BscpylgtvCommandLauncher> BscpylgtvCommandClient<L> {
                 detail.push_str(": ");
                 detail.push_str(combined.trim_end());
             }
-            let kind = if tv_operation == TvOperation::UnblankScreen
-                && (rendered.stderr().contains("errorCode': '-102'")
-                    || rendered.stdout().contains("errorCode': '-102'"))
-            {
-                TvErrorKind::ScreenUnblankSubstateMismatch
-            } else {
-                TvErrorKind::Rejected
-            };
-            Err(TvError::new(tv_operation, kind, detail))
+            Err(TvError::new(tv_operation, TvErrorKind::Rejected, detail))
+        }
+    }
+
+    fn power_state_for(&self, operation: TvOperation) -> Result<String, TvError> {
+        let output = self.run_command(operation, "get_power_state", &[])?;
+        parse_power_state(output.stdout()).ok_or_else(|| {
+            TvError::new(
+                operation,
+                TvErrorKind::InvalidResponse,
+                invalid_command_output_detail(
+                    "get_power_state",
+                    &output,
+                    "expected a string state field",
+                ),
+            )
+        })
+    }
+
+    fn verify_visible_after_ack(&self, operation: TvOperation) -> Result<(), TvError> {
+        let power_state = self.power_state_for(operation)?;
+        if power_state == "Active" {
+            return Ok(());
+        }
+
+        Err(TvError::new(
+            operation,
+            TvErrorKind::ScreenNotVisible,
+            format!(
+                "bscpylgtv acknowledged the command, but the TV reported power state `{power_state}`"
+            ),
+        ))
+    }
+
+    fn verify_unblank_result(&self, command_result: Result<(), TvError>) -> Result<(), TvError> {
+        let operation = TvOperation::UnblankScreen;
+        match self.power_state_for(operation) {
+            Ok(power_state) if power_state == "Active" => Ok(()),
+            Ok(power_state) => {
+                let detail = match command_result {
+                    Ok(()) => format!(
+                        "bscpylgtv acknowledged screen unblank, but the TV reported power state `{power_state}`"
+                    ),
+                    Err(error) => format!(
+                        "bscpylgtv screen unblank failed: {}; verification found power state `{power_state}`",
+                        error.detail()
+                    ),
+                };
+                Err(TvError::new(
+                    operation,
+                    TvErrorKind::ScreenNotVisible,
+                    detail,
+                ))
+            }
+            Err(verification_error) => match command_result {
+                Ok(()) => Err(verification_error),
+                Err(command_error) => Err(TvError::new(
+                    operation,
+                    command_error.kind(),
+                    format!(
+                        "bscpylgtv screen unblank failed: {}; postcondition verification also failed: {}",
+                        command_error.detail(),
+                        verification_error.detail()
+                    ),
+                )),
+            },
         }
     }
 }
@@ -1005,21 +1004,6 @@ impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
             })
     }
 
-    fn power_state(&self) -> Result<TvPowerState, TvError> {
-        let output = self.run_command(TvOperation::ReadPowerState, "get_power_state", &[])?;
-        parse_power_state(output.stdout()).ok_or_else(|| {
-            TvError::new(
-                TvOperation::ReadPowerState,
-                TvErrorKind::InvalidResponse,
-                invalid_command_output_detail(
-                    "get_power_state",
-                    &output,
-                    "expected a string state field",
-                ),
-            )
-        })
-    }
-
     fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
         let output =
             self.run_command(TvOperation::ReadOledBrightness, "get_picture_settings", &[])?;
@@ -1037,8 +1021,8 @@ impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
     }
 
     fn set_input(&self, input: HdmiInput) -> Result<(), TvError> {
-        self.run_command(TvOperation::SetInput, "set_input", &[input.as_str()])
-            .map(|_| ())
+        self.run_command(TvOperation::SetInput, "set_input", &[input.as_str()])?;
+        self.verify_visible_after_ack(TvOperation::SetInput)
     }
 
     fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError> {
@@ -1062,8 +1046,10 @@ impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
     }
 
     fn unblank_screen(&self) -> Result<(), TvError> {
-        self.run_command(TvOperation::UnblankScreen, "turn_screen_on", &[])
-            .map(|_| ())
+        let command_result = self
+            .run_command(TvOperation::UnblankScreen, "turn_screen_on", &[])
+            .map(|_| ());
+        self.verify_unblank_result(command_result)
     }
 }
 
@@ -1089,7 +1075,7 @@ fn last_non_empty_line(output: &str) -> Option<String> {
         .map(str::to_string)
 }
 
-fn parse_power_state(output: &str) -> Option<TvPowerState> {
+fn parse_power_state(output: &str) -> Option<String> {
     [('\'', "'state'"), ('"', "\"state\"")]
         .into_iter()
         .find_map(|(quote, key)| {
@@ -1097,7 +1083,7 @@ fn parse_power_state(output: &str) -> Option<TvPowerState> {
             let value = suffix.trim_start().strip_prefix(':')?.trim_start();
             let value = value.strip_prefix(quote)?;
             let (value, _) = value.split_once(quote)?;
-            Some(TvPowerState::from_wire_value(value))
+            Some(value.to_string())
         })
 }
 
@@ -1281,11 +1267,18 @@ mod tests {
                 .into_iter()
                 .map(|call| (call.tv_ip, call.command, call.args))
                 .collect::<Vec<_>>(),
-            vec![(
-                "10.0.0.5".to_string(),
-                "set_input".to_string(),
-                vec!["HDMI_3".to_string()],
-            )]
+            vec![
+                (
+                    "10.0.0.5".to_string(),
+                    "set_input".to_string(),
+                    vec!["HDMI_3".to_string()],
+                ),
+                (
+                    "10.0.0.5".to_string(),
+                    "get_power_state".to_string(),
+                    Vec::new(),
+                ),
+            ]
         );
     }
 
@@ -1464,6 +1457,7 @@ mod tests {
     #[test]
     fn command_failures_preserve_diagnostics_without_exposing_command_output() {
         let mock = MockBscpylgtv::new("tv-command-failure");
+        mock.set_screen_on(false);
         mock.queue_error("turn_screen_on", 7, "failure stderr\n");
         let client = client_for_mock(&mock, ip("10.0.0.8"));
         let err = client
@@ -1471,7 +1465,7 @@ mod tests {
             .expect_err("turn_screen_on should fail");
 
         assert_eq!(err.operation(), TvOperation::UnblankScreen);
-        assert_eq!(err.kind(), TvErrorKind::Rejected);
+        assert_eq!(err.kind(), TvErrorKind::ScreenNotVisible);
         assert!(err.detail().contains("failed with status 7"));
         assert!(err.detail().contains("failure stderr"));
     }
@@ -1543,16 +1537,28 @@ mod tests {
 
         assert_eq!(
             launcher.calls(),
-            vec![BscpylgtvInvocation::new(
-                "/usr/bin/mock-bscpylgtv",
-                vec![
-                    "-p".to_string(),
-                    "/home/vas/.local/state/lg-buddy/.aiopylgtv.sqlite".to_string(),
-                    "10.0.0.8".to_string(),
-                    "turn_screen_on".to_string(),
-                ],
-                Some(SystemUser::new("vas", 1000, 1000, "/home/vas")),
-            )]
+            vec![
+                BscpylgtvInvocation::new(
+                    "/usr/bin/mock-bscpylgtv",
+                    vec![
+                        "-p".to_string(),
+                        "/home/vas/.local/state/lg-buddy/.aiopylgtv.sqlite".to_string(),
+                        "10.0.0.8".to_string(),
+                        "turn_screen_on".to_string(),
+                    ],
+                    Some(SystemUser::new("vas", 1000, 1000, "/home/vas")),
+                ),
+                BscpylgtvInvocation::new(
+                    "/usr/bin/mock-bscpylgtv",
+                    vec![
+                        "-p".to_string(),
+                        "/home/vas/.local/state/lg-buddy/.aiopylgtv.sqlite".to_string(),
+                        "10.0.0.8".to_string(),
+                        "get_power_state".to_string(),
+                    ],
+                    Some(SystemUser::new("vas", 1000, 1000, "/home/vas")),
+                ),
+            ]
         );
     }
 
@@ -1820,9 +1826,18 @@ mod tests {
     impl BscpylgtvCommandLauncher for RecordingLauncher {
         fn run(&self, invocation: &BscpylgtvInvocation) -> io::Result<BscpylgtvLaunchResult> {
             self.calls.borrow_mut().push(invocation.clone());
+            let stdout = if invocation
+                .args()
+                .last()
+                .is_some_and(|argument| argument == "get_power_state")
+            {
+                "{'returnValue': True, 'state': 'Active'}\n"
+            } else {
+                "{'returnValue': True}\n"
+            };
             Ok(BscpylgtvLaunchResult::new(
                 Some(0),
-                "{'returnValue': True}\n".to_string(),
+                stdout.to_string(),
                 String::new(),
             ))
         }

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -58,6 +58,7 @@ impl CommandOutput {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TvOperation {
     ReadInput,
+    ReadPowerState,
     SetInput,
     ReadOledBrightness,
     SetOledBrightness,
@@ -70,6 +71,7 @@ impl TvOperation {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::ReadInput => "read input",
+            Self::ReadPowerState => "read power state",
             Self::SetInput => "set input",
             Self::ReadOledBrightness => "read OLED brightness",
             Self::SetOledBrightness => "set OLED brightness",
@@ -94,6 +96,19 @@ pub enum TvErrorKind {
     InvalidResponse,
     ScreenUnblankSubstateMismatch,
     Internal,
+}
+
+impl TvErrorKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Transport => "transport",
+            Self::Authentication => "authentication",
+            Self::Rejected => "rejected",
+            Self::InvalidResponse => "invalid_response",
+            Self::ScreenUnblankSubstateMismatch => "screen_unblank_substate_mismatch",
+            Self::Internal => "internal",
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -203,8 +218,49 @@ impl fmt::Display for OledBrightness {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TvPowerState {
+    Active,
+    ActiveStandby,
+    ScreenOff,
+    Suspend,
+    PowerOff,
+    Unknown,
+    Other(String),
+}
+
+impl TvPowerState {
+    fn from_wire_value(value: impl Into<String>) -> Self {
+        let value = value.into();
+        match value.as_str() {
+            "Active" => Self::Active,
+            "Active Standby" => Self::ActiveStandby,
+            "Screen Off" => Self::ScreenOff,
+            "Suspend" => Self::Suspend,
+            "Power Off" => Self::PowerOff,
+            "Unknown" => Self::Unknown,
+            _ => Self::Other(value),
+        }
+    }
+}
+
+impl fmt::Display for TvPowerState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Active => f.write_str("Active"),
+            Self::ActiveStandby => f.write_str("Active Standby"),
+            Self::ScreenOff => f.write_str("Screen Off"),
+            Self::Suspend => f.write_str("Suspend"),
+            Self::PowerOff => f.write_str("Power Off"),
+            Self::Unknown => f.write_str("Unknown"),
+            Self::Other(value) => f.write_str(value),
+        }
+    }
+}
+
 pub trait TvClient {
     fn current_input(&self) -> Result<CurrentInput, TvError>;
+    fn power_state(&self) -> Result<TvPowerState, TvError>;
     fn oled_brightness(&self) -> Result<OledBrightness, TvError>;
     fn set_input(&self, input: HdmiInput) -> Result<(), TvError>;
     fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError>;
@@ -272,6 +328,13 @@ impl TvClient for SelectedTvClient {
         match self {
             Self::Bscpylgtv(client) => client.current_input(),
             Self::WebOs(client) => client.current_input(),
+        }
+    }
+
+    fn power_state(&self) -> Result<TvPowerState, TvError> {
+        match self {
+            Self::Bscpylgtv(client) => client.power_state(),
+            Self::WebOs(client) => client.power_state(),
         }
     }
 
@@ -491,6 +554,10 @@ pub struct TvPower<'a, C> {
 }
 
 impl<'a, C: TvClient> TvPower<'a, C> {
+    pub fn state(&self) -> Result<TvPowerState, TvError> {
+        self.client.power_state()
+    }
+
     pub fn wake<W: WakeOnLanSender>(
         &self,
         sender: &W,
@@ -938,6 +1005,21 @@ impl<L: BscpylgtvCommandLauncher> TvClient for BscpylgtvCommandClient<L> {
             })
     }
 
+    fn power_state(&self) -> Result<TvPowerState, TvError> {
+        let output = self.run_command(TvOperation::ReadPowerState, "get_power_state", &[])?;
+        parse_power_state(output.stdout()).ok_or_else(|| {
+            TvError::new(
+                TvOperation::ReadPowerState,
+                TvErrorKind::InvalidResponse,
+                invalid_command_output_detail(
+                    "get_power_state",
+                    &output,
+                    "expected a string state field",
+                ),
+            )
+        })
+    }
+
     fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
         let output =
             self.run_command(TvOperation::ReadOledBrightness, "get_picture_settings", &[])?;
@@ -1005,6 +1087,18 @@ fn last_non_empty_line(output: &str) -> Option<String> {
         .rev()
         .find(|line| !line.trim().is_empty())
         .map(str::to_string)
+}
+
+fn parse_power_state(output: &str) -> Option<TvPowerState> {
+    [('\'', "'state'"), ('"', "\"state\"")]
+        .into_iter()
+        .find_map(|(quote, key)| {
+            let (_, suffix) = output.rsplit_once(key)?;
+            let value = suffix.trim_start().strip_prefix(':')?.trim_start();
+            let value = value.strip_prefix(quote)?;
+            let (value, _) = value.split_once(quote)?;
+            Some(TvPowerState::from_wire_value(value))
+        })
 }
 
 fn parse_backlight(output: &str) -> Option<OledBrightness> {

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -5,10 +5,7 @@ use super::{
     WebOsSetBacklightBrightnessError,
 };
 use crate::platform_access_token::{PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore};
-use crate::tv::{
-    CurrentInput, OledBrightness, TvClient, TvError, TvErrorKind, TvOperation, TvPowerState,
-};
-use serde_json::Value;
+use crate::tv::{CurrentInput, OledBrightness, TvClient, TvError, TvErrorKind, TvOperation};
 use std::fmt;
 use std::sync::{Mutex, MutexGuard};
 use std::time::Duration;
@@ -162,6 +159,96 @@ impl WebOsTvClient {
             .power_off()
             .map_err(|error| control_failure(error).into_tv_error(operation))
     }
+
+    fn observe_power_state(&self, operation: TvOperation) -> Result<WebOsPowerState, TvError> {
+        self.with_session(operation, |client| {
+            client.power_state().map_err(power_state_failure)
+        })
+    }
+
+    fn verify_power_state(
+        &self,
+        operation: TvOperation,
+        expected: WebOsPowerState,
+        command_result: Result<(), TvError>,
+    ) -> Result<(), TvError> {
+        if command_result.as_ref().is_err_and(verification_cannot_help) {
+            return command_result;
+        }
+
+        match self.observe_power_state(operation) {
+            Ok(actual) if actual == expected => Ok(()),
+            Ok(actual) => {
+                let kind = if expected == WebOsPowerState::Active {
+                    TvErrorKind::ScreenNotVisible
+                } else {
+                    TvErrorKind::Rejected
+                };
+                Err(postcondition_failure(
+                    operation,
+                    kind,
+                    &command_result,
+                    format!("expected power state `{expected}`, but the TV reported `{actual}`"),
+                ))
+            }
+            Err(verification_error) => match command_result {
+                Ok(()) => Err(verification_error),
+                Err(command_error) => Err(combined_failure(command_error, verification_error)),
+            },
+        }
+    }
+
+    fn verify_input(
+        &self,
+        input: crate::config::HdmiInput,
+        command_result: Result<(), TvError>,
+    ) -> Result<(), TvError> {
+        let operation = TvOperation::SetInput;
+        if command_result.as_ref().is_err_and(verification_cannot_help) {
+            return command_result;
+        }
+
+        match self.observe_power_state(operation) {
+            Ok(WebOsPowerState::Active) => {}
+            Ok(actual) => {
+                return Err(postcondition_failure(
+                    operation,
+                    TvErrorKind::ScreenNotVisible,
+                    &command_result,
+                    format!("cannot verify input while the TV reports power state `{actual}`"),
+                ));
+            }
+            Err(verification_error) => {
+                return match command_result {
+                    Ok(()) => Err(verification_error),
+                    Err(command_error) => Err(combined_failure(command_error, verification_error)),
+                };
+            }
+        }
+
+        let observed_input = self.with_session(operation, |client| {
+            client
+                .foreground_app()
+                .map(|app| CurrentInput::from_raw(app.app_id().to_string()))
+                .map_err(foreground_app_failure)
+        });
+        match observed_input {
+            Ok(actual) if actual.is_hdmi(input) => Ok(()),
+            Ok(actual) => Err(postcondition_failure(
+                operation,
+                TvErrorKind::Rejected,
+                &command_result,
+                format!(
+                    "expected input `{}`, but the TV reported `{actual}`",
+                    input.as_str()
+                ),
+            )),
+            Err(verification_error) => match command_result {
+                Ok(()) => Err(verification_error),
+                Err(command_error) => Err(combined_failure(command_error, verification_error)),
+            },
+        }
+    }
 }
 
 impl TvClient for WebOsTvClient {
@@ -171,15 +258,6 @@ impl TvClient for WebOsTvClient {
                 .foreground_app()
                 .map(|app| CurrentInput::from_raw(app.app_id().to_string()))
                 .map_err(foreground_app_failure)
-        })
-    }
-
-    fn power_state(&self) -> Result<TvPowerState, TvError> {
-        self.with_session(TvOperation::ReadPowerState, |client| {
-            client
-                .power_state()
-                .map(tv_power_state)
-                .map_err(power_state_failure)
         })
     }
 
@@ -206,9 +284,10 @@ impl TvClient for WebOsTvClient {
                 format!("could not map configured input to webOS: {error}"),
             )
         })?;
-        self.with_session(TvOperation::SetInput, |client| {
+        let command_result = self.with_session(TvOperation::SetInput, |client| {
             client.switch_input(&input_id).map_err(control_failure)
-        })
+        });
+        self.verify_input(input, command_result)
     }
 
     fn set_oled_brightness(&self, brightness: OledBrightness) -> Result<(), TvError> {
@@ -232,41 +311,71 @@ impl TvClient for WebOsTvClient {
     }
 
     fn blank_screen(&self) -> Result<(), TvError> {
-        self.with_session(TvOperation::BlankScreen, |client| {
+        let command_result = self.with_session(TvOperation::BlankScreen, |client| {
             client
                 .turn_screen_off()
                 .map(|_| ())
                 .map_err(screen_control_failure)
-        })
+        });
+        self.verify_power_state(
+            TvOperation::BlankScreen,
+            WebOsPowerState::ScreenOff,
+            command_result,
+        )
     }
 
     fn unblank_screen(&self) -> Result<(), TvError> {
-        self.with_session(TvOperation::UnblankScreen, |client| {
-            client.turn_screen_on().map(|_| ()).map_err(|error| {
-                if screen_unblank_substate_mismatch(&error) {
-                    WebOsAdapterFailure::new(
-                        TvErrorKind::ScreenUnblankSubstateMismatch,
-                        error.to_string(),
-                        false,
-                    )
-                } else {
-                    screen_control_failure(error)
-                }
-            })
-        })
+        let command_result = self.with_session(TvOperation::UnblankScreen, |client| {
+            client
+                .turn_screen_on()
+                .map(|_| ())
+                .map_err(screen_control_failure)
+        });
+        self.verify_power_state(
+            TvOperation::UnblankScreen,
+            WebOsPowerState::Active,
+            command_result,
+        )
     }
 }
 
-fn tv_power_state(state: WebOsPowerState) -> TvPowerState {
-    match state {
-        WebOsPowerState::Active => TvPowerState::Active,
-        WebOsPowerState::ActiveStandby => TvPowerState::ActiveStandby,
-        WebOsPowerState::ScreenOff => TvPowerState::ScreenOff,
-        WebOsPowerState::Suspend => TvPowerState::Suspend,
-        WebOsPowerState::PowerOff => TvPowerState::PowerOff,
-        WebOsPowerState::Unknown => TvPowerState::Unknown,
-        WebOsPowerState::Other(value) => TvPowerState::Other(value),
-    }
+fn postcondition_failure(
+    operation: TvOperation,
+    kind: TvErrorKind,
+    command_result: &Result<(), TvError>,
+    observation: impl AsRef<str>,
+) -> TvError {
+    let detail = match command_result {
+        Ok(()) => format!(
+            "native webOS acknowledged the command, but {}",
+            observation.as_ref()
+        ),
+        Err(error) => format!(
+            "native webOS command failed: {}; verification found that {}",
+            error.detail(),
+            observation.as_ref()
+        ),
+    };
+    TvError::new(operation, kind, detail)
+}
+
+fn combined_failure(command_error: TvError, verification_error: TvError) -> TvError {
+    TvError::new(
+        command_error.operation(),
+        command_error.kind(),
+        format!(
+            "native webOS command failed: {}; postcondition verification also failed: {}",
+            command_error.detail(),
+            verification_error.detail()
+        ),
+    )
+}
+
+fn verification_cannot_help(error: &TvError) -> bool {
+    matches!(
+        error.kind(),
+        TvErrorKind::Authentication | TvErrorKind::Internal
+    )
 }
 
 struct WebOsAdapterFailure {
@@ -472,34 +581,6 @@ fn set_backlight_brightness_failure(
     }
 }
 
-fn screen_unblank_substate_mismatch(error: &WebOsScreenControlError) -> bool {
-    let WebOsScreenControlError::Control { source } = error else {
-        return false;
-    };
-    match source {
-        WebOsControlError::Request {
-            source:
-                WebOsClientError::WebOs {
-                    payload: Some(payload),
-                    ..
-                },
-        }
-        | WebOsControlError::RequestRejected { payload, .. } => payload_error_code(payload) == -102,
-        _ => false,
-    }
-}
-
-fn payload_error_code(payload: &Value) -> i64 {
-    payload
-        .get("errorCode")
-        .and_then(|value| match value {
-            Value::Number(number) => number.as_i64(),
-            Value::String(value) => value.parse::<i64>().ok(),
-            _ => None,
-        })
-        .unwrap_or_default()
-}
-
 impl fmt::Debug for WebOsTvClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WebOsTvClient")
@@ -517,9 +598,7 @@ impl fmt::Debug for WebOsTvClient {
 mod tests {
     use super::{WebOsPairingPolicy, WebOsTvClient};
     use crate::config::HdmiInput;
-    use crate::tv::{
-        CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind, TvPowerState,
-    };
+    use crate::tv::{CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind};
     use crate::web_os::test_support::{
         TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
     };
@@ -619,6 +698,25 @@ mod tests {
     }
 
     #[test]
+    fn effectful_operation_does_not_retry_a_definitive_authentication_failure() {
+        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server_with_policy(
+            &server,
+            &token_fixture,
+            WebOsPairingPolicy::StoredTokenOnly,
+        );
+
+        let error = client
+            .set_input(HdmiInput::Hdmi2)
+            .expect_err("stored-token-only operation must not retry authentication");
+
+        assert_eq!(error.kind(), TvErrorKind::Authentication);
+        assert_eq!(server.snapshot().connection_count, 1);
+        server.finish();
+    }
+
+    #[test]
     fn complete_tv_contract_reuses_one_authenticated_session() {
         let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
@@ -652,20 +750,10 @@ mod tests {
                 .as_percent(),
             42
         );
-        assert_eq!(
-            client.power_state().expect("read active power state"),
-            TvPowerState::Active
-        );
         client.blank_screen().expect("blank screen");
-        assert_eq!(
-            client.power_state().expect("read blanked power state"),
-            TvPowerState::ScreenOff
-        );
+        assert_eq!(server.snapshot().power_state, WebOsPowerState::ScreenOff);
         client.unblank_screen().expect("unblank screen");
-        assert_eq!(
-            client.power_state().expect("read restored power state"),
-            TvPowerState::Active
-        );
+        assert_eq!(server.snapshot().power_state, WebOsPowerState::Active);
 
         assert_eq!(server.snapshot().connection_count, 1);
         client.power_off().expect("power off active TV");
@@ -678,7 +766,7 @@ mod tests {
     }
 
     #[test]
-    fn ambiguous_write_is_not_replayed_and_later_operation_reconnects() {
+    fn ambiguous_write_is_not_replayed_and_safe_readback_resolves_success() {
         let server = WebOsTestServer::for_scenario(WebOsTestScenario::CloseAfterFirstInputWrite);
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
@@ -687,20 +775,20 @@ mod tests {
             client.current_input().expect("establish initial session"),
             CurrentInput::Hdmi(HdmiInput::Hdmi3)
         );
-        let error = client
+        client
             .set_input(HdmiInput::Hdmi2)
-            .expect_err("lost write response must be reported");
-
-        assert_eq!(error.kind(), TvErrorKind::Transport);
-        let after_failure = server.snapshot();
-        assert_eq!(after_failure.input, WebOsTestInput::Hdmi2);
+            .expect("safe readback should prove the write succeeded");
+        let after_write = server.snapshot();
+        assert_eq!(after_write.input, WebOsTestInput::Hdmi2);
         assert_eq!(
-            after_failure.connection_count, 1,
-            "the failed effectful operation must not reconnect and replay"
+            after_write.connection_count, 2,
+            "verification reconnects without replaying the effectful operation"
         );
 
         assert_eq!(
-            client.current_input().expect("later operation reconnects"),
+            client
+                .current_input()
+                .expect("verified session remains reusable"),
             CurrentInput::Hdmi(HdmiInput::Hdmi2)
         );
         assert_eq!(server.snapshot().connection_count, 2);
@@ -708,15 +796,14 @@ mod tests {
     }
 
     #[test]
-    fn screen_unblank_substate_mismatch_is_typed_without_discarding_session() {
+    fn unblank_is_idempotent_when_the_screen_is_already_active() {
         let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 
-        let error = client
+        client
             .unblank_screen()
-            .expect_err("active screen cannot be unblanked");
-        assert_eq!(error.kind(), TvErrorKind::ScreenUnblankSubstateMismatch);
+            .expect("verified active state should satisfy unblank");
         assert_eq!(
             client
                 .current_input()
@@ -724,6 +811,24 @@ mod tests {
             CurrentInput::Hdmi(HdmiInput::Hdmi3)
         );
         assert_eq!(server.snapshot().connection_count, 1);
+        server.finish();
+    }
+
+    #[test]
+    fn set_input_reports_screen_not_visible_when_screen_off_ack_changes_nothing() {
+        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server(&server, &token_fixture);
+        client.blank_screen().expect("blank screen");
+        server.set_scenario(WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff);
+
+        let error = client
+            .set_input(HdmiInput::Hdmi3)
+            .expect_err("an acknowledgement without a visible screen is not success");
+
+        assert_eq!(error.kind(), TvErrorKind::ScreenNotVisible);
+        assert!(error.detail().contains("power state `Screen Off`"));
+        assert_eq!(server.snapshot().power_state, WebOsPowerState::ScreenOff);
         server.finish();
     }
 

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -5,7 +5,9 @@ use super::{
     WebOsSetBacklightBrightnessError,
 };
 use crate::platform_access_token::{PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore};
-use crate::tv::{CurrentInput, OledBrightness, TvClient, TvError, TvErrorKind, TvOperation};
+use crate::tv::{
+    CurrentInput, OledBrightness, TvClient, TvError, TvErrorKind, TvOperation, TvPowerState,
+};
 use serde_json::Value;
 use std::fmt;
 use std::sync::{Mutex, MutexGuard};
@@ -172,6 +174,15 @@ impl TvClient for WebOsTvClient {
         })
     }
 
+    fn power_state(&self) -> Result<TvPowerState, TvError> {
+        self.with_session(TvOperation::ReadPowerState, |client| {
+            client
+                .power_state()
+                .map(tv_power_state)
+                .map_err(power_state_failure)
+        })
+    }
+
     fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
         self.with_session(TvOperation::ReadOledBrightness, |client| {
             let brightness = client
@@ -243,6 +254,18 @@ impl TvClient for WebOsTvClient {
                 }
             })
         })
+    }
+}
+
+fn tv_power_state(state: WebOsPowerState) -> TvPowerState {
+    match state {
+        WebOsPowerState::Active => TvPowerState::Active,
+        WebOsPowerState::ActiveStandby => TvPowerState::ActiveStandby,
+        WebOsPowerState::ScreenOff => TvPowerState::ScreenOff,
+        WebOsPowerState::Suspend => TvPowerState::Suspend,
+        WebOsPowerState::PowerOff => TvPowerState::PowerOff,
+        WebOsPowerState::Unknown => TvPowerState::Unknown,
+        WebOsPowerState::Other(value) => TvPowerState::Other(value),
     }
 }
 
@@ -494,7 +517,9 @@ impl fmt::Debug for WebOsTvClient {
 mod tests {
     use super::{WebOsPairingPolicy, WebOsTvClient};
     use crate::config::HdmiInput;
-    use crate::tv::{CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind};
+    use crate::tv::{
+        CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind, TvPowerState,
+    };
     use crate::web_os::test_support::{
         TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
     };
@@ -627,8 +652,20 @@ mod tests {
                 .as_percent(),
             42
         );
+        assert_eq!(
+            client.power_state().expect("read active power state"),
+            TvPowerState::Active
+        );
         client.blank_screen().expect("blank screen");
+        assert_eq!(
+            client.power_state().expect("read blanked power state"),
+            TvPowerState::ScreenOff
+        );
         client.unblank_screen().expect("unblank screen");
+        assert_eq!(
+            client.power_state().expect("read restored power state"),
+            TvPowerState::Active
+        );
 
         assert_eq!(server.snapshot().connection_count, 1);
         client.power_off().expect("power off active TV");

--- a/crates/lg-buddy/src/web_os/observed_behavior.rs
+++ b/crates/lg-buddy/src/web_os/observed_behavior.rs
@@ -84,6 +84,35 @@ fn input_switch_changes_the_observed_foreground_app_and_picture_state() {
 }
 
 // Real-TV wire observation:
+// https://github.com/Staphylococcus/LG_Buddy/issues/70
+#[test]
+fn same_input_switch_is_acknowledged_without_waking_screen_off_tv() {
+    let server = WebOsTestServer::screen_off(WebOsTestInput::Hdmi3);
+    server.set_scenario(WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff);
+    let mut client = server
+        .connect_authenticated()
+        .expect("connect to observed Screen Off webOS TV");
+
+    assert_eq!(
+        client.power_state().expect("read initial power state"),
+        WebOsPowerState::ScreenOff
+    );
+    client
+        .switch_input(&WebOsInputId::new("HDMI_3").expect("input ID"))
+        .expect("switch to the current input while Screen Off");
+    assert_eq!(
+        client.power_state().expect("read resulting power state"),
+        WebOsPowerState::ScreenOff
+    );
+    let snapshot = server.snapshot();
+    assert_eq!(snapshot.power_state, WebOsPowerState::ScreenOff);
+    assert_eq!(snapshot.input, WebOsTestInput::Hdmi3);
+
+    drop(client);
+    server.finish();
+}
+
+// Real-TV wire observation:
 // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
 #[test]
 fn backlight_write_is_acknowledged_and_verified_through_independent_readback() {

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -64,6 +64,7 @@ pub(in crate::web_os) enum WebOsTestScenario {
     BacklightWriteAcknowledgedWithoutChange,
     CloseAfterFirstInputWrite,
     StallFirstRequest,
+    RestoreSessionInterruptedAndInputAckLeavesScreenOff,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -138,6 +139,7 @@ impl WebOsTestTv {
         request: &Value,
         permissions: &WebOsTestPermissions,
         apply_backlight_write: bool,
+        allow_input_while_screen_off: bool,
     ) -> Value {
         assert_eq!(request["type"], "request", "expected webOS request frame");
         let request_id = request["id"].as_str().expect("webOS request ID");
@@ -225,7 +227,14 @@ impl WebOsTestTv {
                 if !permissions.top_level.contains("LAUNCH") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
-                assert_eq!(self.power_state, WebOsPowerState::Active);
+                if allow_input_while_screen_off {
+                    assert!(matches!(
+                        self.power_state,
+                        WebOsPowerState::Active | WebOsPowerState::ScreenOff
+                    ));
+                } else {
+                    assert_eq!(self.power_state, WebOsPowerState::Active);
+                }
                 let input_id = payload["inputId"]
                     .as_str()
                     .expect("switch-input request input ID");
@@ -295,6 +304,7 @@ struct WebOsTestRuntime {
     registration_tokens: Vec<Option<String>>,
     ambiguous_input_write_injected: bool,
     stalled_request_injected: bool,
+    restore_session_interruption_injected: bool,
 }
 
 pub(in crate::web_os) struct WebOsTestServer {
@@ -397,6 +407,7 @@ impl WebOsTestServer {
             registration_tokens: Vec::new(),
             ambiguous_input_write_injected: false,
             stalled_request_injected: false,
+            restore_session_interruption_injected: false,
         }));
         let active_connection = Arc::new(Mutex::new(None));
         let stop = Arc::new(AtomicBool::new(false));
@@ -565,6 +576,23 @@ fn serve_connection<S>(
         }
 
         let scenario = runtime.lock().expect("webOS test server state").scenario;
+        if scenario == WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff {
+            let should_interrupt = {
+                let mut runtime = runtime.lock().expect("webOS test server state");
+                if runtime.restore_session_interruption_injected {
+                    false
+                } else {
+                    runtime.restore_session_interruption_injected = true;
+                    true
+                }
+            };
+            if should_interrupt {
+                socket
+                    .send(Message::Close(None))
+                    .expect("interrupt first webOS restore session");
+                return;
+            }
+        }
         if scenario == WebOsTestScenario::StallFirstRequest {
             let should_stall = {
                 let mut runtime = runtime.lock().expect("webOS test server state");
@@ -587,40 +615,44 @@ fn serve_connection<S>(
             | WebOsTestScenario::PowerStatePermissionDenied
             | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
             | WebOsTestScenario::CloseAfterFirstInputWrite
-            | WebOsTestScenario::StallFirstRequest => {
-                let response =
+            | WebOsTestScenario::StallFirstRequest
+            | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
+                let response = {
+                    let mut runtime = runtime.lock().expect("webOS test server state");
+                    if scenario == WebOsTestScenario::PowerStatePermissionDenied
+                        && request["uri"] == GET_POWER_STATE_URI
                     {
-                        let mut runtime = runtime.lock().expect("webOS test server state");
-                        if scenario == WebOsTestScenario::PowerStatePermissionDenied
-                            && request["uri"] == GET_POWER_STATE_URI
-                        {
-                            Some(webos_error_without_payload(
-                                request["id"].as_str().expect("webOS request ID"),
-                                "-401 not permitted",
-                            ))
-                        } else if scenario == WebOsTestScenario::CloseAfterFirstInputWrite
-                            && request["uri"] == SET_INPUT_URI
-                            && !runtime.ambiguous_input_write_injected
-                        {
-                            runtime.tv.handle_request(
-                                &request,
-                                permissions
-                                    .as_ref()
-                                    .expect("webOS request sent before registration"),
-                                true,
-                            );
-                            runtime.ambiguous_input_write_injected = true;
-                            None
-                        } else {
-                            Some(runtime.tv.handle_request(
+                        Some(webos_error_without_payload(
+                            request["id"].as_str().expect("webOS request ID"),
+                            "-401 not permitted",
+                        ))
+                    } else if scenario == WebOsTestScenario::CloseAfterFirstInputWrite
+                        && request["uri"] == SET_INPUT_URI
+                        && !runtime.ambiguous_input_write_injected
+                    {
+                        runtime.tv.handle_request(
                             &request,
                             permissions
                                 .as_ref()
                                 .expect("webOS request sent before registration"),
-                            scenario != WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
-                        ))
-                        }
-                    };
+                            true,
+                            false,
+                        );
+                        runtime.ambiguous_input_write_injected = true;
+                        None
+                    } else {
+                        Some(runtime.tv.handle_request(
+                                &request,
+                                permissions
+                                    .as_ref()
+                                    .expect("webOS request sent before registration"),
+                                scenario
+                                    != WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
+                                scenario
+                                    == WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff,
+                            ))
+                    }
+                };
                 match response {
                     Some(response) => {
                         send_json(&mut socket, response);
@@ -694,15 +726,18 @@ where
         | WebOsTestScenario::PowerStatePermissionDenied
         | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
         | WebOsTestScenario::CloseAfterFirstInputWrite
-        | WebOsTestScenario::StallFirstRequest => match payload["client-key"].as_str() {
-            Some(token) => send_json(socket, registration_response(request_id, token)),
-            None if payload["client-key"].is_null() => {
-                record_pairing_prompt(runtime);
-                send_json(socket, pairing_prompt_response(request_id));
-                send_json(socket, registration_response(request_id, TEST_ACCESS_TOKEN));
+        | WebOsTestScenario::StallFirstRequest
+        | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
+            match payload["client-key"].as_str() {
+                Some(token) => send_json(socket, registration_response(request_id, token)),
+                None if payload["client-key"].is_null() => {
+                    record_pairing_prompt(runtime);
+                    send_json(socket, pairing_prompt_response(request_id));
+                    send_json(socket, registration_response(request_id, TEST_ACCESS_TOKEN));
+                }
+                None => panic!("registration access token is neither a string nor null"),
             }
-            None => panic!("registration access token is neither a string nor null"),
-        },
+        }
         WebOsTestScenario::StoredTokenReplacement => {
             payload["client-key"]
                 .as_str()
@@ -825,7 +860,8 @@ where
         | WebOsTestScenario::PowerStatePermissionDenied
         | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
         | WebOsTestScenario::CloseAfterFirstInputWrite
-        | WebOsTestScenario::StallFirstRequest => {
+        | WebOsTestScenario::StallFirstRequest
+        | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
             panic!("scenario `{scenario:?}` requires registered stateful handling")
         }
     }

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -64,6 +64,7 @@ pub(in crate::web_os) enum WebOsTestScenario {
     BacklightWriteAcknowledgedWithoutChange,
     CloseAfterFirstInputWrite,
     StallFirstRequest,
+    SameInputWriteAcknowledgedWhileScreenOff,
     RestoreSessionInterruptedAndInputAckLeavesScreenOff,
 }
 
@@ -139,7 +140,7 @@ impl WebOsTestTv {
         request: &Value,
         permissions: &WebOsTestPermissions,
         apply_backlight_write: bool,
-        allow_input_while_screen_off: bool,
+        acknowledge_same_input_while_screen_off: bool,
     ) -> Value {
         assert_eq!(request["type"], "request", "expected webOS request frame");
         let request_id = request["id"].as_str().expect("webOS request ID");
@@ -227,19 +228,24 @@ impl WebOsTestTv {
                 if !permissions.top_level.contains("LAUNCH") {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
-                if allow_input_while_screen_off {
-                    assert!(matches!(
-                        self.power_state,
-                        WebOsPowerState::Active | WebOsPowerState::ScreenOff
-                    ));
-                } else {
-                    assert_eq!(self.power_state, WebOsPowerState::Active);
-                }
                 let input_id = payload["inputId"]
                     .as_str()
                     .expect("switch-input request input ID");
                 assert_eq!(payload, &json!({"inputId": input_id}));
-                self.input = WebOsTestInput::from_input_id(input_id);
+                let requested_input = WebOsTestInput::from_input_id(input_id);
+                if self.power_state == WebOsPowerState::ScreenOff {
+                    assert!(
+                        acknowledge_same_input_while_screen_off,
+                        "no real-TV observation exists for switching input while Screen Off"
+                    );
+                    assert_eq!(
+                        requested_input, self.input,
+                        "the real-TV Screen Off observation only covers acknowledging the current input"
+                    );
+                    return response(request_id, json!({"returnValue": true}));
+                }
+                assert_eq!(self.power_state, WebOsPowerState::Active);
+                self.input = requested_input;
                 self.backlight = self.input.backlight();
                 response(request_id, json!({"returnValue": true}))
             }
@@ -616,6 +622,7 @@ fn serve_connection<S>(
             | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
             | WebOsTestScenario::CloseAfterFirstInputWrite
             | WebOsTestScenario::StallFirstRequest
+            | WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff
             | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
                 let response = {
                     let mut runtime = runtime.lock().expect("webOS test server state");
@@ -648,8 +655,11 @@ fn serve_connection<S>(
                                     .expect("webOS request sent before registration"),
                                 scenario
                                     != WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
-                                scenario
-                                    == WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff,
+                                matches!(
+                                    scenario,
+                                    WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff
+                                        | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff
+                                ),
                             ))
                     }
                 };
@@ -727,6 +737,7 @@ where
         | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
         | WebOsTestScenario::CloseAfterFirstInputWrite
         | WebOsTestScenario::StallFirstRequest
+        | WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff
         | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
             match payload["client-key"].as_str() {
                 Some(token) => send_json(socket, registration_response(request_id, token)),
@@ -861,6 +872,7 @@ where
         | WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange
         | WebOsTestScenario::CloseAfterFirstInputWrite
         | WebOsTestScenario::StallFirstRequest
+        | WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff
         | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
             panic!("scenario `{scenario:?}` requires registered stateful handling")
         }

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -81,6 +81,11 @@ fn native_webos_tv_stalls_first_response(world: &mut LgBuddyWorld) {
     world.stall_native_tv_response();
 }
 
+#[given("the native webOS TV interrupts the first restore session and acknowledges input without unblanking")]
+fn native_webos_tv_has_ambiguous_restore(world: &mut LgBuddyWorld) {
+    world.make_native_restore_ambiguous();
+}
+
 #[given(regex = r#"mock system logind reports PreparingForSleep=(true|false)"#)]
 fn mock_system_logind_preparing_for_sleep(world: &mut LgBuddyWorld, value: String) {
     world.configure_system_logind(value == "true");

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -267,6 +267,11 @@ fn next_input_restore_attempt_powers_tv_on(world: &mut LgBuddyWorld) {
     world.tv_mut().queue_set_input_wake_success();
 }
 
+#[given("the next input restore attempt is acknowledged without unblanking")]
+fn next_input_restore_attempt_is_acknowledged_without_unblanking(world: &mut LgBuddyWorld) {
+    world.tv_mut().queue_set_input_ack_without_screen_on();
+}
+
 #[given(regex = r#"the backend override is "([^"]+)""#)]
 fn backend_override(world: &mut LgBuddyWorld, backend: String) {
     world.set_backend_override(&backend);

--- a/crates/lg-buddy/tests/cucumber_support/webos.rs
+++ b/crates/lg-buddy/tests/cucumber_support/webos.rs
@@ -56,6 +56,11 @@ impl MockWebOsTv {
             .set_scenario(WebOsTestScenario::StallFirstRequest);
     }
 
+    pub fn interrupt_restore_and_ack_input_without_unblanking(&self) {
+        self.server
+            .set_scenario(WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff);
+    }
+
     pub fn snapshot(&self) -> MockWebOsTvSnapshot {
         self.assert_healthy();
         let snapshot = self.server.snapshot();

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -229,6 +229,11 @@ exit 1\n",
         self.webos_tv().stall_first_tv_response();
     }
 
+    pub fn make_native_restore_ambiguous(&self) {
+        self.webos_tv()
+            .interrupt_restore_and_ack_input_without_unblanking();
+    }
+
     pub fn configure_system_logind(&mut self, preparing_for_sleep: bool) {
         let logind = MockSystemLogind::new("cucumber-system-logind");
         logind.reset();

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -220,10 +220,34 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "Aggressive restore policy is enabled"
     And stdout contains "Wake attempt 1 succeeded."
-    And the TV client did not receive "turn_screen_on"
+    And the TV client received "turn_screen_on"
     And the TV client received "set_input"
     And the session marker is absent
     And the TV is powered on
+    And the TV screen is visible
+
+  Scenario: GNOME activity verifies legacy screen visibility after an input acknowledgement
+    Given a temporary LG Buddy config using input HDMI_3
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_3
+    And the TV screen is blanked
+    And the session marker exists
+    And the TV will fail "turn_screen_on" with status 1 and stderr "unblank failed"
+    And the next input restore attempt is acknowledged without unblanking
+    And screen wake delays are disabled
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME reports the session active
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "operations: direct_unblank=failed kind=screen_not_visible"
+    And stdout contains "input_attempt_1=failed kind=screen_not_visible"
+    And stdout contains "recovery_unblank_1=succeeded"
+    And stdout contains "input_retry_1=succeeded"
+    And the TV client received "turn_screen_on" exactly 2 times
+    And the TV client received "set_input" exactly 2 times
+    And the session marker is absent
     And the TV screen is visible
 
   Scenario: GNOME restore failure does not retry continuously while activity stays active
@@ -232,7 +256,7 @@ Feature: GNOME monitor
     And LG Buddy session runtime is isolated
     And a mock TV client
     And the TV is on input HDMI_2
-    And the TV will fail "turn_screen_on" 7 times with status 1 and stderr "offline"
+    And the TV will fail "turn_screen_on" with status 1 and stderr "offline"
     And the TV will fail "set_input" 6 times with status 1 and stderr "not ready"
     And screen wake delays are disabled
     And the executable PATH is isolated
@@ -244,7 +268,7 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "screen restore action failed"
     And the TV client received "turn_screen_off" exactly 1 times
-    And the TV client received "turn_screen_on" exactly 7 times
+    And the TV client received "turn_screen_on" exactly 1 times
     And the TV client received "set_input" exactly 6 times
     And the session marker exists
     And the TV screen is blanked
@@ -266,7 +290,7 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "Sending initial Wake-on-LAN packet"
     And stdout contains "Wake attempt 1 succeeded."
-    And the TV client did not receive "turn_screen_on"
+    And the TV client received "turn_screen_on"
     And the TV client received "set_input"
     And the session marker is absent
     And the TV is powered on

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -220,7 +220,7 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "Aggressive restore policy is enabled"
     And stdout contains "Wake attempt 1 succeeded."
-    And the TV client received "turn_screen_on"
+    And the TV client did not receive "turn_screen_on"
     And the TV client received "set_input"
     And the session marker is absent
     And the TV is powered on
@@ -232,7 +232,7 @@ Feature: GNOME monitor
     And LG Buddy session runtime is isolated
     And a mock TV client
     And the TV is on input HDMI_2
-    And the TV will fail "turn_screen_on" with status 1 and stderr "offline"
+    And the TV will fail "turn_screen_on" 7 times with status 1 and stderr "offline"
     And the TV will fail "set_input" 6 times with status 1 and stderr "not ready"
     And screen wake delays are disabled
     And the executable PATH is isolated
@@ -244,7 +244,7 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "screen restore action failed"
     And the TV client received "turn_screen_off" exactly 1 times
-    And the TV client received "turn_screen_on" exactly 1 times
+    And the TV client received "turn_screen_on" exactly 7 times
     And the TV client received "set_input" exactly 6 times
     And the session marker exists
     And the TV screen is blanked
@@ -266,7 +266,7 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "Sending initial Wake-on-LAN packet"
     And stdout contains "Wake attempt 1 succeeded."
-    And the TV client received "turn_screen_on"
+    And the TV client did not receive "turn_screen_on"
     And the TV client received "set_input"
     And the session marker is absent
     And the TV is powered on

--- a/crates/lg-buddy/tests/features/monitor_swayidle.feature
+++ b/crates/lg-buddy/tests/features/monitor_swayidle.feature
@@ -52,7 +52,7 @@ Feature: swayidle monitor
     Then the command succeeds
     And stdout contains "Sending initial Wake-on-LAN packet"
     And stdout contains "Wake attempt 1 succeeded."
-    And the TV client received "turn_screen_on"
+    And the TV client did not receive "turn_screen_on"
     And the TV client received "set_input"
     And the session marker is absent
     And the TV is powered on

--- a/crates/lg-buddy/tests/features/monitor_swayidle.feature
+++ b/crates/lg-buddy/tests/features/monitor_swayidle.feature
@@ -52,7 +52,7 @@ Feature: swayidle monitor
     Then the command succeeds
     And stdout contains "Sending initial Wake-on-LAN packet"
     And stdout contains "Wake attempt 1 succeeded."
-    And the TV client did not receive "turn_screen_on"
+    And the TV client received "turn_screen_on"
     And the TV client received "set_input"
     And the session marker is absent
     And the TV is powered on

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -161,8 +161,12 @@ Feature: Native webOS TV platform
     Then the command succeeds
     And stdout contains "Screen visibility could not be verified. Falling back to full wake."
     And stdout does not contain "Screen unblank failed."
-    And stdout contains "Fallback input acknowledgement left the TV in Screen Off; reconciling screen visibility."
-    And stdout contains "Verified TV power state Active. Clearing wake state."
+    And stdout contains "LG Buddy Screen Restore Failure Context:"
+    And stdout contains "operations: direct_unblank=failed kind=screen_not_visible"
+    And stdout contains "input_attempt_1=failed kind=screen_not_visible"
+    And stdout contains "recovery_unblank_1=succeeded"
+    And stdout contains "input_retry_1=succeeded"
+    And stdout contains "marker_after=absent"
     And the session marker is absent
     And the TV screen is visible
     And the native TV registration tokens are "webos-test-access-token,webos-test-access-token,webos-test-access-token"
@@ -177,7 +181,7 @@ Feature: Native webOS TV platform
     And the session marker exists
     When I run the command "screen-on"
     Then the command succeeds
-    And stdout contains "Verified TV power state Active. Clearing wake state."
+    And stdout contains "Screen unblank succeeded. Clearing wake state."
     And stdout does not contain "Sending initial Wake-on-LAN packet"
     And the session marker is absent
     And the TV screen is visible

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -145,6 +145,45 @@ Feature: Native webOS TV platform
     And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
     And the native TV pairing prompt count is 0
 
+  Scenario: Native restoration verifies visibility after an ambiguous fallback acknowledgement
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    When I run the command "screen-off"
+    Then the command succeeds
+    And the session marker exists
+    And the TV screen is blanked
+    Given the native webOS TV interrupts the first restore session and acknowledges input without unblanking
+    And screen wake delays are disabled
+    When I run the command "screen-on"
+    Then the command succeeds
+    And stdout contains "Screen visibility could not be verified. Falling back to full wake."
+    And stdout does not contain "Screen unblank failed."
+    And stdout contains "Fallback input acknowledgement left the TV in Screen Off; reconciling screen visibility."
+    And stdout contains "Verified TV power state Active. Clearing wake state."
+    And the session marker is absent
+    And the TV screen is visible
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token,webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native restoration retires a stale marker when the TV is already visible
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    And the session marker exists
+    When I run the command "screen-on"
+    Then the command succeeds
+    And stdout contains "Verified TV power state Active. Clearing wake state."
+    And stdout does not contain "Sending initial Wake-on-LAN packet"
+    And the session marker is absent
+    And the TV screen is visible
+    And the native TV connection count is 1
+    And the native TV pairing prompt count is 0
+
   Scenario: Native GNOME inactivity follows the LG Buddy timeout
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"

--- a/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
+++ b/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
@@ -1,7 +1,9 @@
 mod support;
 
 use lg_buddy::config::HdmiInput;
-use lg_buddy::tv::{BscpylgtvCommandClient, CurrentInput, OledBrightness, TvClient, TvErrorKind};
+use lg_buddy::tv::{
+    BscpylgtvCommandClient, CurrentInput, OledBrightness, TvClient, TvErrorKind, TvPowerState,
+};
 use std::net::Ipv4Addr;
 use support::MockBscpylgtv;
 
@@ -101,15 +103,28 @@ fn mock_tracks_screen_and_power_state_transitions() {
     let mock = MockBscpylgtv::new("mock-state-transitions");
     let client = mock_client(&mock);
 
+    assert_eq!(
+        client.power_state().expect("read active power state"),
+        TvPowerState::Active
+    );
+
     client
         .blank_screen()
         .expect("turn_screen_off should succeed");
     assert!(!mock.state_snapshot().screen_on);
+    assert_eq!(
+        client.power_state().expect("read blanked power state"),
+        TvPowerState::ScreenOff
+    );
 
     client
         .unblank_screen()
         .expect("turn_screen_on should succeed from blank state");
     assert!(mock.state_snapshot().screen_on);
+    assert_eq!(
+        client.power_state().expect("read restored power state"),
+        TvPowerState::Active
+    );
 
     client.power_off().expect("power_off should succeed");
     let state = mock.state_snapshot();

--- a/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
+++ b/crates/lg-buddy/tests/mock_bscpylgtvcommand.rs
@@ -1,9 +1,7 @@
 mod support;
 
 use lg_buddy::config::HdmiInput;
-use lg_buddy::tv::{
-    BscpylgtvCommandClient, CurrentInput, OledBrightness, TvClient, TvErrorKind, TvPowerState,
-};
+use lg_buddy::tv::{BscpylgtvCommandClient, CurrentInput, OledBrightness, TvClient, TvErrorKind};
 use std::net::Ipv4Addr;
 use support::MockBscpylgtv;
 
@@ -30,6 +28,22 @@ fn mock_set_input_succeeds_and_updates_state() {
 
     assert_eq!(mock.state_snapshot().input, "HDMI_2");
     assert!(mock.state_snapshot().screen_on);
+}
+
+#[test]
+fn set_input_acknowledgement_does_not_claim_success_while_screen_off() {
+    let mock = MockBscpylgtv::new("mock-set-input-screen-off-ack");
+    mock.set_screen_on(false);
+    mock.queue_set_input_ack_without_screen_on();
+    let client = mock_client(&mock);
+
+    let error = client
+        .set_input(HdmiInput::Hdmi3)
+        .expect_err("screen-off acknowledgement must not satisfy input restore");
+
+    assert_eq!(error.kind(), TvErrorKind::ScreenNotVisible);
+    assert!(error.detail().contains("power state `Screen Off`"));
+    assert!(!mock.state_snapshot().screen_on);
 }
 
 #[test]
@@ -77,24 +91,21 @@ fn mock_get_picture_settings_includes_backlight() {
 }
 
 #[test]
-fn mock_turn_screen_on_substate_error_matches_real_traceback_shape() {
+fn mock_turn_screen_on_is_idempotent_when_already_active() {
     let mock = MockBscpylgtv::new("mock-turn-screen-on-substate");
     let client = mock_client(&mock);
 
-    let err = client
+    client
         .unblank_screen()
-        .expect_err("substate mismatch should fail");
+        .expect("active power-state readback should satisfy unblank");
 
-    assert_eq!(err.kind(), TvErrorKind::ScreenUnblankSubstateMismatch);
-    assert!(
-        err.detail().contains("bscpylgtv.exceptions.PyLGTVCmdError"),
-        "detail was: {}",
-        err.detail()
-    );
-    assert!(
-        err.detail().contains("errorCode': '-102'"),
-        "detail was: {}",
-        err.detail()
+    assert!(mock.state_snapshot().screen_on);
+    assert_eq!(
+        mock.calls()
+            .into_iter()
+            .map(|call| call.command)
+            .collect::<Vec<_>>(),
+        vec!["turn_screen_on", "get_power_state"]
     );
 }
 
@@ -103,28 +114,15 @@ fn mock_tracks_screen_and_power_state_transitions() {
     let mock = MockBscpylgtv::new("mock-state-transitions");
     let client = mock_client(&mock);
 
-    assert_eq!(
-        client.power_state().expect("read active power state"),
-        TvPowerState::Active
-    );
-
     client
         .blank_screen()
         .expect("turn_screen_off should succeed");
     assert!(!mock.state_snapshot().screen_on);
-    assert_eq!(
-        client.power_state().expect("read blanked power state"),
-        TvPowerState::ScreenOff
-    );
 
     client
         .unblank_screen()
         .expect("turn_screen_on should succeed from blank state");
     assert!(mock.state_snapshot().screen_on);
-    assert_eq!(
-        client.power_state().expect("read restored power state"),
-        TvPowerState::Active
-    );
 
     client.power_off().expect("power_off should succeed");
     let state = mock.state_snapshot();

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -83,7 +83,11 @@ fn run_screen_on_loads_config_and_clears_session_marker() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec!["turn_screen_on".to_string()]
+        vec![
+            "get_power_state".to_string(),
+            "turn_screen_on".to_string(),
+            "get_power_state".to_string(),
+        ]
     );
     assert!(String::from_utf8(output)
         .expect("utf8 output")
@@ -117,7 +121,11 @@ fn run_screen_on_loads_aggressive_config_and_restores_without_session_marker() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec!["turn_screen_on".to_string()]
+        vec![
+            "get_power_state".to_string(),
+            "turn_screen_on".to_string(),
+            "get_power_state".to_string(),
+        ]
     );
     let output = String::from_utf8(output).expect("utf8 output");
     assert!(output.contains("Aggressive restore policy is enabled"));
@@ -167,7 +175,11 @@ fn settings_set_restore_policy_is_loaded_by_screen_runtime() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec!["turn_screen_on".to_string()]
+        vec![
+            "get_power_state".to_string(),
+            "turn_screen_on".to_string(),
+            "get_power_state".to_string(),
+        ]
     );
     assert!(String::from_utf8(output)
         .expect("screen output utf8")

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -83,11 +83,7 @@ fn run_screen_on_loads_config_and_clears_session_marker() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec![
-            "get_power_state".to_string(),
-            "turn_screen_on".to_string(),
-            "get_power_state".to_string(),
-        ]
+        vec!["turn_screen_on".to_string(), "get_power_state".to_string(),]
     );
     assert!(String::from_utf8(output)
         .expect("utf8 output")
@@ -121,11 +117,7 @@ fn run_screen_on_loads_aggressive_config_and_restores_without_session_marker() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec![
-            "get_power_state".to_string(),
-            "turn_screen_on".to_string(),
-            "get_power_state".to_string(),
-        ]
+        vec!["turn_screen_on".to_string(), "get_power_state".to_string(),]
     );
     let output = String::from_utf8(output).expect("utf8 output");
     assert!(output.contains("Aggressive restore policy is enabled"));
@@ -175,11 +167,7 @@ fn settings_set_restore_policy_is_loaded_by_screen_runtime() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec![
-            "get_power_state".to_string(),
-            "turn_screen_on".to_string(),
-            "get_power_state".to_string(),
-        ]
+        vec!["turn_screen_on".to_string(), "get_power_state".to_string(),]
     );
     assert!(String::from_utf8(output)
         .expect("screen output utf8")
@@ -340,7 +328,7 @@ fn run_system_resume_clears_sleep_cycle_state_and_preserves_session_marker() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec!["set_input".to_string()]
+        vec!["set_input".to_string(), "get_power_state".to_string()]
     );
     assert_eq!(nm_online.invocations().len(), 1);
     assert!(String::from_utf8(output)
@@ -444,7 +432,7 @@ fn run_system_resume_aggressive_policy_restores_without_system_marker() {
             .into_iter()
             .map(|call| call.command)
             .collect::<Vec<_>>(),
-        vec!["set_input".to_string()]
+        vec!["set_input".to_string(), "get_power_state".to_string()]
     );
     assert_eq!(nm_online.invocations().len(), 1);
     let output = String::from_utf8(output).expect("utf8 output");

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -127,6 +127,20 @@ impl MockBscpylgtv {
         );
     }
 
+    pub fn queue_set_input_ack_without_screen_on(&self) {
+        self.queue_step(
+            "set_input",
+            json!({
+                "result": "success",
+                "stdout": "{'returnValue': True}\n",
+                "state_update": {
+                    "power_on": true,
+                    "screen_on": false
+                }
+            }),
+        );
+    }
+
     pub fn calls(&self) -> Vec<MockInvocation> {
         self.load_state()
             .get("calls")

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -405,9 +405,10 @@ Flow:
 5. Apply `screen_restore_policy`:
    - `conservative`: skip if the marker is missing
    - `aggressive`: continue even without the marker
-6. Try `turn_screen_on`.
-7. If the TV reports the known active-screen error (`-102`), try immediate input restore.
-8. Otherwise fall back to Wake-on-LAN plus repeated `set_input` attempts.
+6. Try the adapter-neutral screen-unblank operation.
+7. On failure, fall back to Wake-on-LAN plus repeated input-restore attempts.
+8. If input restore reports that the screen is not visible, unblank it and retry
+   the input so the complete restore is verified.
 9. Clear the marker on success.
 10. Leave the marker in place if wake recovery fails.
 
@@ -519,10 +520,10 @@ The current contract covers:
 - `tv.picture().set_oled_brightness(...)`
 
 Successful effectful operations return no transport-specific output. Failures
-are normalized into typed TV errors, including the screen-unblank substate
-mismatch that policy uses to select its full-wake fallback. Wake-on-LAN keeps
-the configured network identity at `TvDevice`; adapter operations do not accept
-targeting data.
+are normalized into typed TV errors. Policy may react to adapter-neutral
+outcomes such as the screen not being visible, but transport and platform state
+remain inside the adapter. Wake-on-LAN keeps the configured network identity at
+`TvDevice`; adapter operations do not accept targeting data.
 
 ### Transitional Backend
 
@@ -534,16 +535,17 @@ The Rust runtime talks to it through `BscpylgtvCommandClient`, which:
 - shells out to the configured command path
 - keeps subprocess output and exit status inside the legacy adapter
 - maps reads and failures into the shared domain contract
+- privately verifies screen visibility after input restore and screen unblank
 
-`SelectedTvClient` is the internal delegation point for the legacy and native
-implementations. `WebOsTvClient` owns one lazily authenticated websocket
-session behind a mutex, reuses it while healthy, and discards it after transport
-or framing failure. It never replays an effectful operation after an ambiguous
-failure; a later policy operation may establish a new session.
-
-Production construction deliberately selects the legacy variant. The native
-variant is available for internal and scripted-server validation, but there is
-no end-user selection or configuration change at this stage.
+`SelectedTvClient` is the internal delegation point for the configured legacy
+or native implementation. `WebOsTvClient` owns one lazily authenticated
+websocket session behind a mutex, reuses it while healthy, and discards it after
+transport or framing failure. Native effectful operations verify their own
+postconditions before reporting success. After an ambiguous failure the adapter
+may reconnect for safe read-only verification, but it never replays the
+effectful operation. The legacy adapter performs its equivalent power-state
+readback through `bscpylgtvcommand`; neither implementation exposes webOS power
+states to policy code.
 
 ## State Model
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -47,6 +47,34 @@ main.rs
            -> tv.rs / wol.rs / state.rs
 ```
 
+## Semantic Abstraction Ladder
+
+LG Buddy is organized as a semantic abstraction ladder. Each rung translates
+implementation-specific observations and outcomes into a smaller, stable
+semantic contract for the rung above. For example:
+
+- G923 HID reports become gamepad control observations, then `UserActivity`,
+  then inactivity decisions and screen actions.
+- webOS messages and power states become TV operation outcomes, which screen
+  and lifecycle policy use without knowing the underlying protocol.
+
+Each rung owns the interpretation, validation, postcondition verification, and
+recovery that are fully scoped to its abstraction. It exports stable semantics,
+not its internal representation. Decisions that require broader product context
+remain with the higher-level policy layer.
+
+This confines complexity rather than bubbling it upward. If every low-level
+detail reaches the top, policy must understand every device, provider,
+transport, and platform quirk, making the core progressively harder to reason
+about and change. Allowing each layer to operate at its own altitude limits how
+much of the system any one component must understand, localizes changes and
+tests, and lets new implementations satisfy existing contracts without teaching
+policy their mechanics.
+
+This is the project-wide application of information hiding, Design by Contract,
+and separation of policy from mechanism. The session rule to unify providers
+semantically rather than mechanically is one instance of this principle.
+
 ## System Diagram
 
 The current runtime can be visualized as several consumer paths into the Rust

--- a/tools/mock_bscpylgtvcommand.py
+++ b/tools/mock_bscpylgtvcommand.py
@@ -251,6 +251,15 @@ def main() -> int:
         save_state(state_path, state)
         return 0
 
+    if command == "get_power_state":
+        if not state["power_on"]:
+            save_state(state_path, state)
+            return powered_off_error()
+        power_state = "Active" if state["screen_on"] else "Screen Off"
+        print({"returnValue": True, "state": power_state})
+        save_state(state_path, state)
+        return 0
+
     if command == "get_picture_settings":
         if not state["power_on"]:
             save_state(state_path, state)


### PR DESCRIPTION
Closes #70

## Summary

- capture complete screen-restore failure context without log streaming
- make native and legacy TV adapters verify their own postconditions and normalize screen visibility failures
- keep webOS power states and transport quirks behind the TV adapter boundary
- reconcile ambiguous input acknowledgements through adapter-neutral screen policy
- extend the webOS and bscpylgtv mocks with behavior characterized from real hardware
- document the semantic abstraction ladder that governs subsystem boundaries

## Validation

- cargo test --workspace
- 82 Cucumber scenarios and 1,025 steps passed
- cargo clippy -p lg-buddy --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check