### PR TITLE
Prepare LG Buddy 1.2.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "base64",
  "cucumber",

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ The GNOME monitor also observes readable Linux gamepad input devices so
 controller activity can keep the TV output awake even when GNOME does not count
 that input as desktop activity. It refreshes the watched device set when Linux
 reports input-device add, remove, or change events, with a periodic
-reconciliation scan as a fallback.
+reconciliation scan as a fallback. For the Logitech G923 raw HID path, only
+meaningful control changes count as activity; unsolicited status reports do not.
 
 Typical package installs:
 
@@ -118,7 +119,8 @@ LG Buddy is mostly automatic after installation.
   `--notify` to send a desktop notification when an update is available
 - Weekly background update checks are installed by default; opt out with
   `lg-buddy settings set updates.auto_check disabled`
-- To rerun full setup for TV IP, MAC address, or HDMI input, run `./configure.sh`
+- To rerun full setup for TV identity, control platform, or idle behavior, run
+  `./configure.sh`
 - To check the user-session service, run `systemctl --user status LG_Buddy_screen.service`
 - To remove LG Buddy, run `./uninstall.sh`
 
@@ -176,6 +178,14 @@ pairing. Switch back with `lg-buddy settings set tv.platform bscpylgtv`.
 Use the settings command for native opt-in rather than editing
 `tvs_primary_platform` directly, because a direct edit bypasses credential
 preflight.
+
+The native driver keeps the selected TV-control path inside the Rust runtime
+and does not depend on the Python client for those operations. This makes it a
+useful building block for declarative or immutable distributions such as
+NixOS. The current shell installer is not yet a first-class NixOS installation
+path: it still provisions the legacy fallback and writes conventional mutable
+system locations. That packaging work is tracked in
+[issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).
 
 If a direct `config.env` edit leaves a value malformed, `lg-buddy settings list`
 and `describe` show it as invalid instead of silently treating it as default or

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2021"
 publish = false
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -203,8 +203,8 @@ flowchart LR
     SCREEN --> WOL
     LIFECYCLE --> WOL
 
-    TV -->|"production-selected"| BSCPY --> LGTV
-    TV -.->|"internal / test"| WEBOS --> LGTV
+    TV -->|"tv.platform=bscpylgtv"| BSCPY --> LGTV
+    TV -->|"tv.platform=lg_webos"| WEBOS --> LGTV
     WOL -->|"magic packet"| LGTV
 ```
 
@@ -263,6 +263,7 @@ The intended split is:
 - `tv.rs`
   - TV transport abstraction
   - profile-bound `bscpylgtvcommand` adapter
+  - configured selection between the compatibility and native adapters
   - adapter-neutral errors and selected-client construction
   - typed facade for input, screen, power, and brightness operations
 - `web_os/adapter.rs`
@@ -553,9 +554,11 @@ outcomes such as the screen not being visible, but transport and platform state
 remain inside the adapter. Wake-on-LAN keeps the configured network identity at
 `TvDevice`; adapter operations do not accept targeting data.
 
-### Transitional Backend
+### TV Implementations
 
-The current production-side TV backend is still `bscpylgtvcommand`.
+`tv.platform` selects the production TV implementation. `bscpylgtvcommand`
+remains the compatibility default, including when an existing profile has no
+platform value. `lg_webos` explicitly selects the native Rust implementation.
 
 The Rust runtime talks to it through `BscpylgtvCommandClient`, which:
 
@@ -574,6 +577,14 @@ may reconnect for safe read-only verification, but it never replays the
 effectful operation. The legacy adapter performs its equivalent power-state
 readback through `bscpylgtvcommand`; neither implementation exposes webOS power
 states to policy code.
+
+Keeping native TV control within the Rust runtime removes the Python client
+from that selected operation path. This is useful groundwork for declarative or
+immutable distributions such as NixOS, but it is not yet first-class NixOS
+installation support. The shell installer still provisions the compatibility
+fallback and writes conventional mutable system locations; alternative install
+layouts are tracked in
+[issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).
 
 ## State Model
 
@@ -721,17 +732,23 @@ The test strategy has three layers:
 - subprocess-backed integration tests for TV behavior
 - manual hardware probes when exact external behavior is unclear
 
-The important current design choice is that TV-facing tests now run against a stateful subprocess mock rather than an in-memory fake.
+TV-facing tests exercise the production protocol boundaries instead of relying
+only on in-memory fakes. The compatibility adapter uses a stateful subprocess
+mock, while the native adapter uses a centralized stateful webOS test server.
 
 Relevant test assets:
 
 - `tools/mock_bscpylgtvcommand.py`
 - `crates/lg-buddy/tests/support/mod.rs`
 - `crates/lg-buddy/tests/mock_bscpylgtvcommand.rs`
+- `crates/lg-buddy/src/web_os/test_support/test_server.rs`
+- `crates/lg-buddy/src/web_os/observed_behavior.rs`
+- `crates/lg-buddy/tests/features/webos.feature`
 
-That mock preserves the real command/response shapes we have already observed
-from the installed TV client, so TV-policy tests exercise the same subprocess
-boundary the runtime uses in production.
+The legacy mock preserves the command and response shapes observed from the
+installed client. Native behavior claimed as real is linked to hardware
+evidence and modeled by the centralized server; defensive protocol faults are
+identified separately. See [Native webOS testing](webos-testing.md).
 
 ## Current Boundary
 
@@ -761,6 +778,7 @@ What is still not implemented:
 
 - `swayidle` `before-sleep`, `after-resume`, `lock`, and `unlock` handling
 - additional desktop backends
-- native WebOS transport
+- an immutable-distribution install layout that avoids conventional `/usr`
+  writes
 
 So the current architecture should be read as a Rust-owned runtime with a thin shell setup surface.

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,8 +4,14 @@ This document covers building, local installation, validation, release tooling, 
 
 ## Build Prerequisites
 
+Compiling the Rust runtime requires:
+
 - a Rust toolchain with `cargo`
 - a working C toolchain
+
+Running the interactive installer, exercising the legacy TV fallback, and
+testing release bundles also requires:
+
 - `python3-venv`
 - `python3-pip`
 - `zenity`
@@ -41,7 +47,7 @@ cargo build --release -p lg-buddy
 Official release builds inject version identity into the binary:
 
 ```bash
-LG_BUDDY_RELEASE_VERSION=1.1.0 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
+LG_BUDDY_RELEASE_VERSION=1.2.0 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
 ```
 
 Without those environment variables, `lg-buddy --version` reports the Cargo
@@ -119,7 +125,10 @@ Smoke test a generated release bundle with:
 ./scripts/test-release-bundle.sh --archive ./dist/lg-buddy-0.0.0-dev-x86_64-unknown-linux-gnu.tar.gz
 ```
 
-The smoke test unpacks the archive, verifies expected files are present, runs a non-interactive install into a temporary root, and then runs uninstall assertions against that temporary install.
+The smoke test unpacks the archive, verifies expected files, and installs into a
+temporary root. It checks both TV platforms, native credential preservation
+across upgrades, lifecycle and NetworkManager hook topology, and uninstall
+cleanup without mutating the host installation.
 
 Dry-run the GitHub release publish step with:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -5,9 +5,8 @@ with `v` followed by a digit, such as `v1.0.0` or `v1.0.0-beta.1`.
 
 ## What the release workflow does
 
-1. Runs the same validation as CI:
-   - `cargo test -p lg-buddy --lib`
-   - `cargo test -p lg-buddy --test cucumber`
+1. Runs the release validation suite:
+   - `cargo test -p lg-buddy`
    - `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
    - `bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh`
 2. Builds a static Linux binary for `x86_64-unknown-linux-musl`.
@@ -27,15 +26,22 @@ with `v` followed by a digit, such as `v1.0.0` or `v1.0.0-beta.1`.
 
 `install.sh` is only an installer. It does not build the runtime.
 
+The tagged commit should already have passed normal branch CI. Branch CI also
+runs the privileged root-ownership tests; the tag workflow does not repeat
+those two checks.
+
 ## Creating a release
 
 1. Make sure the branch you want to release has passed CI.
-2. Create a tag such as `v0.7.0`.
+2. Create a tag such as `v1.2.0`.
 3. Push the tag.
+4. After the workflow publishes the release, verify the archive against
+   `sha256sums.txt` and replace the generated generic description with concise
+   release-specific notes.
 
 ```bash
-git tag v0.7.0
-git push origin v0.7.0
+git tag v1.2.0
+git push origin v1.2.0
 ```
 
 ## Installing from a release bundle

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -110,7 +110,8 @@ refreshed when Linux reports input-device add, remove, or change events, and
 periodically reconciled so hot-plugged controllers can be picked up without
 restarting the service. Standard controllers are read through evdev. The
 Logitech G923 also has a raw HID fallback for wheel and pedal activity that is
-not exposed as evdev events on some Linux hosts.
+not exposed as evdev events on some Linux hosts. That fallback reports activity
+only for meaningful control changes, not unsolicited vendor or status reports.
 
 Gamepad activity detection requires the user session running
 `LG_Buddy_screen.service` to have read access to the relevant `/dev/input/event*`
@@ -176,6 +177,7 @@ To change supported settings:
 
 ```bash
 lg-buddy settings set tv.input HDMI_2
+lg-buddy settings set tv.platform lg_webos
 lg-buddy settings set screen.idle_blank disabled
 lg-buddy settings set screen.idle_timeout 600
 lg-buddy settings set screen.restore_policy aggressive
@@ -188,12 +190,13 @@ lg-buddy settings unset screen.restore_policy
 runtime apply step is needed. User-session screen settings restart
 `LG_Buddy_screen.service` when the user service is installed and active or
 enabled. `updates.auto_check` enables or disables the installed user timer for
-background update checks. TV identity, system sleep/wake policy, and update
-channel changes are read by later runtime actions and do not require a service
-restart.
+background update checks. Selecting `tv.platform` performs a foreground
+credential preflight before writing the setting. TV identity, system sleep/wake
+policy, and update channel changes are read by later runtime actions and do not
+require a service restart.
 
-To rerun full setup for TV IP, MAC address, HDMI input, or install-time service
-wiring:
+To rerun full setup for TV identity, control platform, idle behavior, or
+install-time service wiring:
 
 ```bash
 ./configure.sh
@@ -211,6 +214,7 @@ Current config keys:
 - `tvs_primary_ip`
 - `tvs_primary_mac`
 - `tvs_primary_input`
+- `tvs_primary_platform`
 - `screen_idle_blank`
 - `screen_backend`
 - `screen_idle_timeout`
@@ -236,6 +240,7 @@ Current structured settings:
 | `tv.ip` | `tvs_primary_ip` | `get`, `describe`, `set` |
 | `tv.mac` | `tvs_primary_mac` | `get`, `describe`, `set` |
 | `tv.input` | `tvs_primary_input` | `get`, `describe`, `set` |
+| `tv.platform` | `tvs_primary_platform` | `get`, `describe`, `set`, `unset` |
 | `screen.backend` | `screen_backend` | `get`, `describe`, `set`, `unset` |
 | `screen.idle_blank` | `screen_idle_blank` | `get`, `describe`, `set`, `unset` |
 | `screen.idle_timeout` | `screen_idle_timeout` | `get`, `describe`, `set`, `unset` |
@@ -246,8 +251,31 @@ Current structured settings:
 
 The `tv.*` settings expose the single supported TV in the public API. Their
 storage keys are profile-shaped only to leave room for future storage growth;
-this version does not expose multiple TVs or TV profile selection. These values
-are required, so `unset` is not supported.
+this version does not expose multiple TVs or TV profile selection. TV identity
+values are required, so `unset` is not supported for them. Unsetting
+`tv.platform` removes its storage key and restores the `bscpylgtv` default.
+
+`tv.platform` selects one of two control implementations:
+
+- `bscpylgtv`: compatibility default, including existing profiles without a
+  platform value
+- `lg_webos`: experimental native Rust webOS driver
+
+Selecting `lg_webos` through `lg-buddy settings set` connects in the foreground,
+reuses or acquires the profile credential, and verifies it with a safe TV state
+read before saving the choice. Accept the pairing prompt on the TV. Ordinary
+foreground TV operations can also pair or repair credentials when needed.
+Unattended startup, shutdown, suspend, resume, and network-teardown commands
+never initiate pairing: they use a stored credential or skip promptly when one
+is unavailable. Editing `tvs_primary_platform` directly bypasses the selection
+preflight.
+
+The native path removes the Python TV client from selected runtime operations,
+which makes it useful groundwork for declarative or immutable distributions
+such as NixOS. The current installer still provisions the legacy fallback and
+writes conventional mutable system locations, so first-class NixOS packaging is
+future work tracked in
+[issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).
 
 `screen_idle_blank` controls whether the user-session service performs automatic
 idle-driven blank/restore behavior:
@@ -305,6 +333,7 @@ Example:
 tvs_primary_ip=192.168.1.100
 tvs_primary_mac=aa:bb:cc:dd:ee:ff
 tvs_primary_input=HDMI_2
+tvs_primary_platform=bscpylgtv
 screen_idle_blank=enabled
 screen_backend=auto
 screen_idle_timeout=300
@@ -325,4 +354,6 @@ chmod +x ./uninstall.sh
 ./uninstall.sh
 ```
 
-This removes the installed services, desktop entry, Rust runtime binary, Python TV-control environment, and optionally the user config file.
+This removes the installed services, desktop entry, Rust runtime binary, and
+Python TV-control environment. If you choose to remove user configuration, it
+also removes the config file and profile-scoped native TV credentials.


### PR DESCRIPTION
## Summary

- bump the Rust package and lockfile to 1.2.0
- document the experimental native Rust webOS platform across the user, development, testing, and architecture surfaces
- frame native TV control as useful groundwork for declarative and immutable distributions such as NixOS without claiming first-class installer support
- bring the documented release workflow and bundle coverage in line with current CI

## Release notes draft

LG Buddy 1.2.0 introduces an experimental native Rust webOS control platform and improves screen-idle reliability.

### Highlights

- Added opt-in native webOS control for input switching, screen blank/restore, power-off, and OLED brightness.
- Added native pairing and profile-scoped credential persistence. Foreground operations can pair or repair credentials; unattended startup, shutdown, suspend, resume, and network teardown never open a pairing flow.
- Added adapter-owned postcondition verification and bounded recovery for ambiguous screen restoration, with complete failure-context snapshots when recovery does not succeed directly.
- Made LG Buddy's configured inactivity timeout authoritative on GNOME and restored owned blank screens after monitor restarts.
- Filtered unsolicited Logitech G923 HID status reports so only meaningful control changes reset inactivity.
- Expanded hardware-grounded native webOS mocks, Cucumber product scenarios, and release-bundle smoke coverage.

### Upgrade notes

Existing and unset profiles continue to use `bscpylgtv`. Native control remains an explicit experimental opt-in:

```bash
lg-buddy settings set tv.platform lg_webos
```

Accept the pairing prompt on the TV during opt-in. The current installer still provisions the Python compatibility platform and uses conventional mutable system locations; first-class immutable-distribution packaging remains tracked in #24.

### Known issue

Native screen restoration can occasionally take roughly 6–9 seconds when it enters the bounded fallback path. Restoration has remained correct in observed testing, so this is considered non-blocking and is tracked in #72.

## Validation

- `cargo test -p lg-buddy`
  - 595 unit tests
  - 82 Cucumber scenarios / 1,025 steps
  - integration and mock-boundary suites
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- shell syntax validation
- provenance-bearing `x86_64-unknown-linux-musl` 1.2.0 build
- archive checksum verification
- release-bundle install/upgrade/uninstall smoke test
- release publish dry-run
