### PR TITLE
Prepare LG Buddy 1.2.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "base64",
  "cucumber",

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2021"
 publish = false
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,7 +47,7 @@ cargo build --release -p lg-buddy
 Official release builds inject version identity into the binary:
 
 ```bash
-LG_BUDDY_RELEASE_VERSION=1.2.0 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
+LG_BUDDY_RELEASE_VERSION=1.2.1 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
 ```
 
 Without those environment variables, `lg-buddy --version` reports the Cargo

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,15 +33,15 @@ those two checks.
 ## Creating a release
 
 1. Make sure the branch you want to release has passed CI.
-2. Create a tag such as `v1.2.0`.
+2. Create a tag such as `v1.2.1`.
 3. Push the tag.
 4. After the workflow publishes the release, verify the archive against
    `sha256sums.txt` and replace the generated generic description with concise
    release-specific notes.
 
 ```bash
-git tag v1.2.0
-git push origin v1.2.0
+git tag v1.2.1
+git push origin v1.2.1
 ```
 
 ## Installing from a release bundle


### PR DESCRIPTION
## Summary

- bump the Rust package and lockfile metadata to 1.2.1
- advance the official provenance-build and release-tag examples to 1.2.1

## Release notes draft

LG Buddy 1.2.1 fixes cold-boot Wake-on-LAN timing on hosts where generic network readiness can precede the route to the configured TV.

### Fixes

- Wait for a usable route to the configured TV before sending the initial cold-boot Wake-on-LAN packet.
- Reuse the bounded, fail-open route readiness behavior already used after system resume.
- Avoid requiring a user-facing network-interface setting on hosts where Docker or another virtual interface makes generic connectivity appear ready too early.

No configuration changes are required.

## Validation

- `cargo test -p lg-buddy`
  - 597 unit tests passed; 1 hardware-only test ignored
  - 82 Cucumber scenarios / 1,025 steps passed
  - integration and mock-boundary suites passed
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- shell syntax validation
- provenance-bearing `x86_64-unknown-linux-musl` 1.2.1 build
- release-bundle install/upgrade/uninstall smoke test
- archive checksum verification
- release publish dry-run