### PR TITLE
Fix native webOS pairing on affected firmware

### DIFF
--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -560,7 +560,8 @@ fn set_backlight_brightness_failure(
 ) -> WebOsAdapterFailure {
     let detail = error.to_string();
     match error {
-        WebOsSetBacklightBrightnessError::Control { source } => {
+        WebOsSetBacklightBrightnessError::CreateLunaBridge { source }
+        | WebOsSetBacklightBrightnessError::CloseLunaBridge { source } => {
             let mut failure = control_failure(source);
             failure.detail = detail;
             failure
@@ -573,9 +574,9 @@ fn set_backlight_brightness_failure(
         WebOsSetBacklightBrightnessError::NotApplied { .. } => {
             WebOsAdapterFailure::new(TvErrorKind::Rejected, detail, false)
         }
-        WebOsSetBacklightBrightnessError::MissingMethod
-        | WebOsSetBacklightBrightnessError::InvalidMethod
-        | WebOsSetBacklightBrightnessError::UnexpectedMethod { .. } => {
+        WebOsSetBacklightBrightnessError::MissingAlertId
+        | WebOsSetBacklightBrightnessError::InvalidAlertId { .. }
+        | WebOsSetBacklightBrightnessError::UnexpectedAlertId { .. } => {
             WebOsAdapterFailure::new(TvErrorKind::InvalidResponse, detail, false)
         }
     }
@@ -600,7 +601,7 @@ mod tests {
     use crate::config::HdmiInput;
     use crate::tv::{CurrentInput, OledBrightness, SelectedTvClient, TvClient, TvErrorKind};
     use crate::web_os::test_support::{
-        TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
+        TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
     };
     use crate::web_os::WebOsPowerState;
     use std::fs;
@@ -611,7 +612,8 @@ mod tests {
 
     #[test]
     fn ordinary_operation_pairs_and_persists_a_missing_token() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         fs::remove_file(token_fixture.store().token_path()).expect("remove stored token");
         let client = client_for_server(&server, &token_fixture);
@@ -631,7 +633,10 @@ mod tests {
 
     #[test]
     fn ordinary_operation_repairs_a_rejected_token() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StoredTokenPairingPrompt,
+        );
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 
@@ -650,7 +655,8 @@ mod tests {
 
     #[test]
     fn stored_token_only_operation_returns_immediately_when_token_is_missing() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         fs::remove_file(token_fixture.store().token_path()).expect("remove stored token");
         let client = client_for_server_with_policy(
@@ -671,7 +677,10 @@ mod tests {
 
     #[test]
     fn stored_token_only_operation_does_not_repair_a_rejected_token() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StoredTokenPairingPrompt,
+        );
         let token_fixture = TestAccessTokenStore::new();
         let original = token_fixture
             .store()
@@ -699,7 +708,10 @@ mod tests {
 
     #[test]
     fn effectful_operation_does_not_retry_a_definitive_authentication_failure() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StoredTokenPairingPrompt,
+        );
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server_with_policy(
             &server,
@@ -718,7 +730,8 @@ mod tests {
 
     #[test]
     fn complete_tv_contract_reuses_one_authenticated_session() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         let client = SelectedTvClient::WebOs(Box::new(client_for_server(&server, &token_fixture)));
 
@@ -767,7 +780,10 @@ mod tests {
 
     #[test]
     fn ambiguous_write_is_not_replayed_and_safe_readback_resolves_success() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::CloseAfterFirstInputWrite);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::CloseAfterFirstInputWrite,
+        );
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 
@@ -797,7 +813,8 @@ mod tests {
 
     #[test]
     fn unblank_is_idempotent_when_the_screen_is_already_active() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 
@@ -816,7 +833,8 @@ mod tests {
 
     #[test]
     fn set_input_reports_screen_not_visible_when_screen_off_ack_changes_nothing() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
         client.blank_screen().expect("blank screen");
@@ -834,7 +852,10 @@ mod tests {
 
     #[test]
     fn power_off_requires_active_state_and_keeps_rejected_session_usable() {
-        let server = WebOsTestServer::screen_off(WebOsTestInput::Hdmi3);
+        let server = WebOsTestServer::screen_off(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestInput::Hdmi3,
+        );
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -635,7 +635,9 @@ mod tests {
         PlatformAccessToken, PlatformAccessTokenAcquisitionError, PlatformAccessTokenStore,
         PlatformAccessTokenStoreError, PlatformAccessTokenStoreOperation,
     };
-    use crate::web_os::test_support::{WebOsTestInput, WebOsTestScenario, WebOsTestServer};
+    use crate::web_os::test_support::{
+        WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
+    };
     use crate::web_os::{WebOsPowerStateError, WebOsRegistrationError};
     use serde_json::json;
     use std::fs;
@@ -693,7 +695,10 @@ mod tests {
 
     #[test]
     fn requests_use_stable_ids_and_return_the_matching_response() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::ProtocolEcho);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::ProtocolEcho,
+        );
         let mut client = WebOsClient::connect(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
             .expect("connect client");
 
@@ -708,7 +713,10 @@ mod tests {
 
     #[test]
     fn unrelated_frame_is_ignored_before_matching_response() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::UnrelatedFrameBeforeResponse);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::UnrelatedFrameBeforeResponse,
+        );
         let mut client = WebOsClient::connect(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
             .expect("connect client");
 
@@ -721,7 +729,10 @@ mod tests {
 
     #[test]
     fn wrong_response_id_is_not_accepted_and_deadline_is_absolute() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::WrongResponseId);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::WrongResponseId,
+        );
         let mut client = WebOsClient::connect(
             server.endpoint(),
             CONNECT_TIMEOUT,
@@ -738,7 +749,10 @@ mod tests {
 
     #[test]
     fn close_before_matching_response_is_typed() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::CloseBeforeResponse);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::CloseBeforeResponse,
+        );
         let mut client = WebOsClient::connect(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
             .expect("connect client");
 
@@ -752,7 +766,10 @@ mod tests {
 
     #[test]
     fn malformed_text_frame_is_typed() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::MalformedTextFrame);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::MalformedTextFrame,
+        );
         let mut client = WebOsClient::connect(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
             .expect("connect client");
 
@@ -765,7 +782,10 @@ mod tests {
 
     #[test]
     fn webos_error_preserves_code_and_message() {
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::WebOsError);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::WebOsError,
+        );
         let mut client = WebOsClient::connect(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
             .expect("connect client");
 
@@ -797,7 +817,10 @@ mod tests {
 
     #[test]
     fn wss_accepts_self_signed_tv_certificate() {
-        let server = WebOsTestServer::for_tls_scenario(WebOsTestScenario::ProtocolEcho);
+        let server = WebOsTestServer::for_tls_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::ProtocolEcho,
+        );
         let mut client = WebOsClient::connect(server.endpoint(), CONNECT_TIMEOUT, RESPONSE_TIMEOUT)
             .expect("connect secure client");
 
@@ -815,7 +838,10 @@ mod tests {
         let store = token_store(&dir);
         let original = token("stored-client-key");
         store.persist(&original).expect("persist stored token");
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenReplacement);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StoredTokenReplacement,
+        );
         let mut events = Vec::new();
 
         let _client = WebOsClient::connect_authenticated(
@@ -839,7 +865,8 @@ mod tests {
     fn stored_token_authentication_requires_a_credential_without_pairing() {
         let dir = TestDir::new("missing-runtime-token");
         let store = token_store(&dir);
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
 
         let result = WebOsClient::connect_authenticated_with_stored_token(
             server.endpoint(),
@@ -864,7 +891,8 @@ mod tests {
     fn authenticated_client_pairs_and_persists_new_token() {
         let dir = TestDir::new("new-token");
         let store = token_store(&dir);
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
         let mut events = Vec::new();
 
         let client = WebOsClient::connect_authenticated(
@@ -897,7 +925,10 @@ mod tests {
         let store = token_store(&dir);
         let original = token("rejected-client-key");
         store.persist(&original).expect("persist stored token");
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StoredTokenPairingPrompt,
+        );
         let mut events = Vec::new();
 
         let _client = WebOsClient::connect_authenticated(
@@ -932,7 +963,10 @@ mod tests {
         let store = token_store(&dir);
         let original = token("rejected-runtime-client-key");
         store.persist(&original).expect("persist stored token");
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::StoredTokenPairingPrompt);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StoredTokenPairingPrompt,
+        );
 
         let result = WebOsClient::connect_authenticated_with_stored_token(
             server.endpoint(),
@@ -957,7 +991,10 @@ mod tests {
     fn pairing_rejection_does_not_create_token() {
         let dir = TestDir::new("pairing-rejected");
         let store = token_store(&dir);
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::PairingRejected);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PairingRejected,
+        );
 
         let result = WebOsClient::connect_authenticated(
             server.endpoint(),
@@ -987,7 +1024,10 @@ mod tests {
     fn registration_timeout_does_not_create_token() {
         let dir = TestDir::new("registration-timeout");
         let store = token_store(&dir);
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::RegistrationTimeout);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::RegistrationTimeout,
+        );
 
         let result = WebOsClient::connect_authenticated(
             server.endpoint(),
@@ -1015,7 +1055,10 @@ mod tests {
     fn malformed_registration_does_not_create_token() {
         let dir = TestDir::new("malformed-registration");
         let store = token_store(&dir);
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::RegistrationMissingClientKey);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::RegistrationMissingClientKey,
+        );
 
         let result = WebOsClient::connect_authenticated(
             server.endpoint(),
@@ -1044,7 +1087,8 @@ mod tests {
         let dir = TestDir::new("persistence-failure");
         let store = token_store(&dir);
         let token_path = store.token_path().to_path_buf();
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
 
         let result = WebOsClient::connect_authenticated(
             server.endpoint(),
@@ -1080,7 +1124,10 @@ mod tests {
         store
             .persist(&token("power-state-error-key"))
             .expect("persist stored token");
-        let server = WebOsTestServer::for_scenario(WebOsTestScenario::PowerStatePermissionDenied);
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PowerStatePermissionDenied,
+        );
         let mut client = WebOsClient::connect_authenticated(
             server.endpoint(),
             CONNECT_TIMEOUT,

--- a/crates/lg-buddy/src/web_os/observed_behavior.rs
+++ b/crates/lg-buddy/src/web_os/observed_behavior.rs
@@ -1,4 +1,4 @@
-use super::test_support::{WebOsTestInput, WebOsTestScenario, WebOsTestServer};
+use super::test_support::{WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion};
 use super::{
     WebOsAuthenticatedClientError, WebOsBacklightBrightness, WebOsClientError,
     WebOsClientRegistrationError, WebOsControlError, WebOsInputId, WebOsPowerState,
@@ -15,7 +15,8 @@ const TURN_ON_SCREEN_LEGACY_URI: &str = "ssap://com.webos.service.tv.power/turnO
 // https://github.com/Staphylococcus/LG_Buddy/issues/50#issuecomment-5102531370
 #[test]
 fn read_operations_return_the_observed_active_tv_state() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");
@@ -48,7 +49,8 @@ fn read_operations_return_the_observed_active_tv_state() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/50#issuecomment-5179994257
 #[test]
 fn input_switch_changes_the_observed_foreground_app_and_picture_state() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");
@@ -87,7 +89,8 @@ fn input_switch_changes_the_observed_foreground_app_and_picture_state() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/70
 #[test]
 fn same_input_switch_is_acknowledged_without_waking_screen_off_tv() {
-    let server = WebOsTestServer::screen_off(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::screen_off(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     server.set_scenario(WebOsTestScenario::SameInputWriteAcknowledgedWhileScreenOff);
     let mut client = server
         .connect_authenticated()
@@ -112,43 +115,53 @@ fn same_input_switch_is_acknowledged_without_waking_screen_off_tv() {
     server.finish();
 }
 
-// Real-TV wire observation:
-// https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
+// Local webOS24 observation:
+// https://github.com/Staphylococcus/LG_Buddy/issues/76#issuecomment-5420796570
+// External webOS26 wire observation and hardware confirmation:
+// https://github.com/JPersson77/LGTVCompanion/issues/351#issuecomment-5308314909
+// https://github.com/JPersson77/LGTVCompanion/issues/351#issuecomment-5309740894
 #[test]
-fn backlight_write_is_acknowledged_and_verified_through_independent_readback() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
-    let mut client = server
-        .connect_authenticated()
-        .expect("connect to observed webOS TV");
-    let requested = WebOsBacklightBrightness::new(75).expect("backlight brightness");
+fn luna_backlight_write_is_verified_on_each_observed_firmware_profile() {
+    for version in [
+        WebOsTestVersion::WebOs24Version92261,
+        WebOsTestVersion::WebOs26Firmware432160,
+    ] {
+        let server = WebOsTestServer::active(version, WebOsTestInput::Hdmi2);
+        let mut client = server
+            .connect_authenticated()
+            .expect("connect to observed webOS TV profile");
+        let requested = WebOsBacklightBrightness::new(75).expect("backlight brightness");
 
-    assert_eq!(
+        assert_eq!(
+            client
+                .backlight_brightness()
+                .expect("read initial backlight brightness")
+                .as_percent(),
+            90
+        );
         client
-            .backlight_brightness()
-            .expect("read initial backlight brightness")
-            .as_percent(),
-        90
-    );
-    client
-        .set_backlight_brightness(requested)
-        .expect("set and verify backlight brightness");
-    assert_eq!(
-        client
-            .backlight_brightness()
-            .expect("read resulting backlight brightness"),
-        requested
-    );
+            .set_backlight_brightness(requested)
+            .expect("set and verify backlight brightness through Luna bridge");
+        assert_eq!(
+            client
+                .backlight_brightness()
+                .expect("read resulting backlight brightness"),
+            requested
+        );
 
-    drop(client);
-    server.finish();
+        drop(client);
+        server.finish();
+    }
 }
 
 // Synthetic fault injection: the real TV applied the observed acknowledged write,
 // but callers must still detect a device that acknowledges without changing state.
 #[test]
 fn acknowledged_backlight_write_with_unchanged_state_is_typed_failure() {
-    let server =
-        WebOsTestServer::for_scenario(WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange);
+    let server = WebOsTestServer::for_scenario(
+        WebOsTestVersion::WebOs24Version92261,
+        WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
+    );
     let mut client = server
         .connect_authenticated()
         .expect("connect to synthetic unchanged-state TV");
@@ -168,7 +181,8 @@ fn acknowledged_backlight_write_with_unchanged_state_is_typed_failure() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/51#issuecomment-5176461983
 #[test]
 fn screen_off_transitions_active_tv_to_screen_off() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");
@@ -195,7 +209,8 @@ fn screen_off_transitions_active_tv_to_screen_off() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/51#issuecomment-5176461983
 #[test]
 fn screen_on_transitions_screen_off_tv_to_active() {
-    let server = WebOsTestServer::screen_off(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::screen_off(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");
@@ -222,7 +237,8 @@ fn screen_on_transitions_screen_off_tv_to_active() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/51#issuecomment-5176461983
 #[test]
 fn screen_on_while_active_preserves_the_observed_substate_error() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");
@@ -254,7 +270,8 @@ fn screen_on_while_active_preserves_the_observed_substate_error() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/51#issuecomment-5176461983
 #[test]
 fn legacy_screen_endpoints_are_unavailable_and_do_not_change_state() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");
@@ -282,7 +299,8 @@ fn legacy_screen_endpoints_are_unavailable_and_do_not_change_state() {
 // https://github.com/Staphylococcus/LG_Buddy/issues/51#issuecomment-5176463406
 #[test]
 fn power_off_transitions_active_tv_and_rejects_immediate_registration() {
-    let server = WebOsTestServer::active(WebOsTestInput::Hdmi3);
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
     let mut client = server
         .connect_authenticated()
         .expect("connect to observed webOS TV");

--- a/crates/lg-buddy/src/web_os/picture.rs
+++ b/crates/lg-buddy/src/web_os/picture.rs
@@ -7,8 +7,11 @@ use std::thread;
 use std::time::Duration;
 
 const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
-const SET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/setSystemSettings";
-const SET_SYSTEM_SETTINGS_METHOD: &str = "setSystemSettings";
+const CREATE_ALERT_URI: &str = "ssap://system.notifications/createAlert";
+const CLOSE_ALERT_URI: &str = "ssap://system.notifications/closeAlert";
+const SET_SYSTEM_SETTINGS_LUNA_URI: &str = "luna://com.webos.settingsservice/setSystemSettings";
+const ALERT_ID_RESPONSE_PREFIX: &str = "com.webos.service.apiadapter.pub-";
+const ALERT_ID_CLOSE_PREFIX: &str = "com.webos.service.apiadapter-";
 const MAX_BACKLIGHT_BRIGHTNESS: u8 = 100;
 const BACKLIGHT_WRITE_READBACK_DELAY: Duration = Duration::from_secs(1);
 
@@ -149,13 +152,18 @@ impl Error for WebOsBacklightBrightnessError {
 
 #[derive(Debug)]
 pub enum WebOsSetBacklightBrightnessError {
-    Control {
+    CreateLunaBridge {
         source: WebOsControlError,
     },
-    MissingMethod,
-    InvalidMethod,
-    UnexpectedMethod {
-        method: String,
+    MissingAlertId,
+    InvalidAlertId {
+        value: Value,
+    },
+    UnexpectedAlertId {
+        alert_id: String,
+    },
+    CloseLunaBridge {
+        source: WebOsControlError,
     },
     Readback {
         expected: WebOsBacklightBrightness,
@@ -170,19 +178,22 @@ pub enum WebOsSetBacklightBrightnessError {
 impl fmt::Display for WebOsSetBacklightBrightnessError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Control { source } => {
-                write!(f, "could not set webOS backlight brightness: {source}")
+            Self::CreateLunaBridge { source } => {
+                write!(f, "could not create webOS Luna bridge alert: {source}")
             }
-            Self::MissingMethod => {
-                write!(f, "webOS backlight-write response has no method")
+            Self::MissingAlertId => {
+                write!(f, "webOS Luna bridge response has no alert ID")
             }
-            Self::InvalidMethod => {
-                write!(f, "webOS backlight-write response method is not a string")
+            Self::InvalidAlertId { value } => {
+                write!(f, "webOS Luna bridge response alert ID `{value}` is not a string")
             }
-            Self::UnexpectedMethod { method } => write!(
+            Self::UnexpectedAlertId { alert_id } => write!(
                 f,
-                "webOS backlight-write response method `{method}` is not `{SET_SYSTEM_SETTINGS_METHOD}`"
+                "webOS Luna bridge returned unexpected alert ID `{alert_id}`"
             ),
+            Self::CloseLunaBridge { source } => {
+                write!(f, "could not close webOS Luna bridge alert: {source}")
+            }
             Self::Readback { expected, source } => write!(
                 f,
                 "webOS acknowledged backlight brightness {expected}, but verification failed: {source}"
@@ -198,11 +209,11 @@ impl fmt::Display for WebOsSetBacklightBrightnessError {
 impl Error for WebOsSetBacklightBrightnessError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
-            Self::Control { source } => Some(source),
+            Self::CreateLunaBridge { source } | Self::CloseLunaBridge { source } => Some(source),
             Self::Readback { source, .. } => Some(source),
-            Self::MissingMethod
-            | Self::InvalidMethod
-            | Self::UnexpectedMethod { .. }
+            Self::MissingAlertId
+            | Self::InvalidAlertId { .. }
+            | Self::UnexpectedAlertId { .. }
             | Self::NotApplied { .. } => None,
         }
     }
@@ -228,16 +239,13 @@ impl WebOsClient {
         &mut self,
         brightness: WebOsBacklightBrightness,
     ) -> Result<(), WebOsSetBacklightBrightnessError> {
-        let payload = send_control_request(
+        set_system_settings_via_luna_bridge(
             self,
-            SET_SYSTEM_SETTINGS_URI,
             json!({
                 "category": "picture",
-                "settings": {"backlight": brightness.as_percent()},
+                "settings": {"backlight": brightness.as_percent().to_string()},
             }),
-        )
-        .map_err(|source| WebOsSetBacklightBrightnessError::Control { source })?;
-        validate_backlight_write_acknowledgement(&payload)?;
+        )?;
 
         thread::sleep(BACKLIGHT_WRITE_READBACK_DELAY);
         let actual = self.backlight_brightness().map_err(|source| {
@@ -257,17 +265,55 @@ impl WebOsClient {
     }
 }
 
-fn validate_backlight_write_acknowledgement(
-    payload: &Map<String, Value>,
+fn set_system_settings_via_luna_bridge(
+    client: &mut WebOsClient,
+    params: Value,
 ) -> Result<(), WebOsSetBacklightBrightnessError> {
-    match payload.get("method") {
-        Some(Value::String(method)) if method == SET_SYSTEM_SETTINGS_METHOD => Ok(()),
-        Some(Value::String(method)) => Err(WebOsSetBacklightBrightnessError::UnexpectedMethod {
-            method: method.clone(),
+    let callback = json!({
+        "params": params.clone(),
+        "uri": SET_SYSTEM_SETTINGS_LUNA_URI,
+    });
+    let payload = send_control_request(
+        client,
+        CREATE_ALERT_URI,
+        json!({
+            "buttons": [{
+                "label": "",
+                "onClick": SET_SYSTEM_SETTINGS_LUNA_URI,
+                "params": params,
+            }],
+            "message": " ",
+            "onclose": callback.clone(),
+            "onfail": callback,
         }),
-        Some(_) => Err(WebOsSetBacklightBrightnessError::InvalidMethod),
-        None => Err(WebOsSetBacklightBrightnessError::MissingMethod),
-    }
+    )
+    .map_err(|source| WebOsSetBacklightBrightnessError::CreateLunaBridge { source })?;
+    let close_alert_id = close_alert_id(&payload)?;
+
+    send_control_request(client, CLOSE_ALERT_URI, json!({"alertId": close_alert_id}))
+        .map_err(|source| WebOsSetBacklightBrightnessError::CloseLunaBridge { source })?;
+    Ok(())
+}
+
+fn close_alert_id(
+    payload: &Map<String, Value>,
+) -> Result<String, WebOsSetBacklightBrightnessError> {
+    let alert_id = match payload.get("alertId") {
+        Some(Value::String(alert_id)) => alert_id,
+        Some(value) => {
+            return Err(WebOsSetBacklightBrightnessError::InvalidAlertId {
+                value: value.clone(),
+            })
+        }
+        None => return Err(WebOsSetBacklightBrightnessError::MissingAlertId),
+    };
+    let sequence = alert_id
+        .strip_prefix(ALERT_ID_RESPONSE_PREFIX)
+        .filter(|sequence| !sequence.is_empty())
+        .ok_or_else(|| WebOsSetBacklightBrightnessError::UnexpectedAlertId {
+            alert_id: alert_id.clone(),
+        })?;
+    Ok(format!("{ALERT_ID_CLOSE_PREFIX}{sequence}"))
 }
 
 fn parse_backlight_brightness_response(
@@ -347,9 +393,8 @@ fn normalize_backlight_brightness(value: &Value) -> Result<u8, WebOsBacklightBri
 #[cfg(test)]
 mod tests {
     use super::{
-        normalize_backlight_brightness, parse_backlight_brightness_response,
-        validate_backlight_write_acknowledgement, WebOsBacklightBrightness,
-        WebOsBacklightBrightnessError, WebOsSetBacklightBrightnessError,
+        close_alert_id, normalize_backlight_brightness, parse_backlight_brightness_response,
+        WebOsBacklightBrightness, WebOsBacklightBrightnessError, WebOsSetBacklightBrightnessError,
     };
     use serde_json::{json, Value};
 
@@ -371,31 +416,41 @@ mod tests {
     }
 
     #[test]
-    fn observed_backlight_write_acknowledgement_is_accepted() {
-        let payload = json!({"method": "setSystemSettings", "returnValue": true});
-        validate_backlight_write_acknowledgement(payload.as_object().expect("object payload"))
-            .expect("observed acknowledgement");
+    fn observed_luna_bridge_alert_id_maps_to_close_request_id() {
+        let payload = json!({
+            "returnValue": true,
+            "alertId": "com.webos.service.apiadapter.pub-1786895965205",
+        });
+        assert_eq!(
+            close_alert_id(payload.as_object().expect("object payload"))
+                .expect("observed alert ID"),
+            "com.webos.service.apiadapter-1786895965205"
+        );
     }
 
     #[test]
-    fn malformed_backlight_write_acknowledgements_are_typed_errors() {
+    fn malformed_luna_bridge_alert_ids_are_typed_errors() {
         for (payload, expected) in [
-            (json!({}), WebOsSetBacklightBrightnessError::MissingMethod),
+            (json!({}), WebOsSetBacklightBrightnessError::MissingAlertId),
             (
-                json!({"method": 7}),
-                WebOsSetBacklightBrightnessError::InvalidMethod,
+                json!({"alertId": 7}),
+                WebOsSetBacklightBrightnessError::InvalidAlertId { value: json!(7) },
             ),
             (
-                json!({"method": "other"}),
-                WebOsSetBacklightBrightnessError::UnexpectedMethod {
-                    method: "other".to_string(),
+                json!({"alertId": "other"}),
+                WebOsSetBacklightBrightnessError::UnexpectedAlertId {
+                    alert_id: "other".to_string(),
+                },
+            ),
+            (
+                json!({"alertId": "com.webos.service.apiadapter.pub-"}),
+                WebOsSetBacklightBrightnessError::UnexpectedAlertId {
+                    alert_id: "com.webos.service.apiadapter.pub-".to_string(),
                 },
             ),
         ] {
-            let actual = validate_backlight_write_acknowledgement(
-                payload.as_object().expect("object payload"),
-            )
-            .expect_err("acknowledgement should be rejected");
+            let actual = close_alert_id(payload.as_object().expect("object payload"))
+                .expect_err("alert ID should be rejected");
             assert_eq!(
                 std::mem::discriminant(&actual),
                 std::mem::discriminant(&expected)

--- a/crates/lg-buddy/src/web_os/registration.rs
+++ b/crates/lg-buddy/src/web_os/registration.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 
 const REGISTRATION_MESSAGE_TYPE: &str = "register";
 const PAIRING_PROMPT_TYPE: &str = "PROMPT";
-// Keep grants limited to envelopes confirmed by hardware characterization.
+// Keep grants limited to permissions exercised by LG Buddy.
 // Changing this manifest may invalidate stored client keys and require re-pairing.
 const REGISTRATION_MANIFEST_JSON: &str = include_str!("registration_manifest.json");
 
@@ -349,7 +349,7 @@ mod tests {
     }
 
     #[test]
-    fn registration_request_without_token_uses_observed_write_capable_manifest() {
+    fn registration_request_without_token_uses_unsigned_minimal_manifest() {
         let request =
             WebOsRegistrationRequest::new(REQUEST_ID, None).expect("registration request");
         let value = request.to_json_value();
@@ -360,7 +360,6 @@ mod tests {
         assert_eq!(value["payload"]["client-key"], Value::Null);
         assert_eq!(value["payload"]["forcePairing"], false);
         assert_eq!(value["payload"]["pairingType"], "PROMPT");
-        assert_eq!(manifest["appVersion"], "1.1");
         assert_eq!(manifest["manifestVersion"], 1);
         assert_eq!(
             manifest["permissions"],
@@ -370,36 +369,14 @@ mod tests {
                 "LAUNCH",
                 "READ_POWER_STATE",
                 "READ_RUNNING_APPS",
-                "READ_SETTINGS"
-            ])
-        );
-        assert_eq!(manifest["signatures"][0]["signatureVersion"], 1);
-        assert!(manifest["signatures"][0]["signature"]
-            .as_str()
-            .is_some_and(|signature| !signature.is_empty()));
-        assert_eq!(manifest["signed"]["appId"], "com.lge.test");
-        assert_eq!(manifest["signed"]["vendorId"], "com.lge");
-        assert_eq!(
-            manifest["signed"]["permissions"],
-            json!([
-                "TEST_SECURE",
-                "CONTROL_INPUT_TEXT",
-                "CONTROL_MOUSE_AND_KEYBOARD",
-                "READ_INSTALLED_APPS",
-                "READ_LGE_SDX",
-                "READ_NOTIFICATIONS",
-                "SEARCH",
-                "WRITE_SETTINGS",
+                "READ_SETTINGS",
                 "WRITE_NOTIFICATION_ALERT",
-                "CONTROL_POWER",
-                "READ_CURRENT_CHANNEL",
-                "READ_RUNNING_APPS",
-                "READ_UPDATE_INFO",
-                "UPDATE_FROM_REMOTE_APP",
-                "READ_LGE_TV_INPUT_EVENTS",
-                "READ_TV_CURRENT_TIME"
+                "WRITE_NOTIFICATION_TOAST",
+                "WRITE_SETTINGS"
             ])
         );
+        assert!(manifest.get("signed").is_none());
+        assert!(manifest.get("signatures").is_none());
         assert_eq!(value["payload"]["manifest"], *manifest);
         assert_eq!(
             serde_json::from_str::<Value>(&request.to_json_string())

--- a/crates/lg-buddy/src/web_os/registration_manifest.json
+++ b/crates/lg-buddy/src/web_os/registration_manifest.json
@@ -1,5 +1,4 @@
 {
-  "appVersion": "1.1",
   "manifestVersion": 1,
   "permissions": [
     "CONTROL_POWER",
@@ -7,44 +6,9 @@
     "LAUNCH",
     "READ_POWER_STATE",
     "READ_RUNNING_APPS",
-    "READ_SETTINGS"
-  ],
-  "signatures": [
-    {
-      "signature": "eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbmctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRyaMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQojoa7NQnAtw==",
-      "signatureVersion": 1
-    }
-  ],
-  "signed": {
-    "appId": "com.lge.test",
-    "created": "20140509",
-    "localizedAppNames": {
-      "": "LG Remote App",
-      "ko-KR": "\ub9ac\ubaa8\ucee8 \uc571",
-      "zxx-XX": "\u041b\u0413 R\u044d\u043cot\u044d A\u041f\u041f"
-    },
-    "localizedVendorNames": {
-      "": "LG Electronics"
-    },
-    "permissions": [
-      "TEST_SECURE",
-      "CONTROL_INPUT_TEXT",
-      "CONTROL_MOUSE_AND_KEYBOARD",
-      "READ_INSTALLED_APPS",
-      "READ_LGE_SDX",
-      "READ_NOTIFICATIONS",
-      "SEARCH",
-      "WRITE_SETTINGS",
-      "WRITE_NOTIFICATION_ALERT",
-      "CONTROL_POWER",
-      "READ_CURRENT_CHANNEL",
-      "READ_RUNNING_APPS",
-      "READ_UPDATE_INFO",
-      "UPDATE_FROM_REMOTE_APP",
-      "READ_LGE_TV_INPUT_EVENTS",
-      "READ_TV_CURRENT_TIME"
-    ],
-    "serial": "2f930e2d2cfe083771f68e4fe7bb07",
-    "vendorId": "com.lge"
-  }
+    "READ_SETTINGS",
+    "WRITE_NOTIFICATION_ALERT",
+    "WRITE_NOTIFICATION_TOAST",
+    "WRITE_SETTINGS"
+  ]
 }

--- a/crates/lg-buddy/src/web_os/test_support.rs
+++ b/crates/lg-buddy/src/web_os/test_support.rs
@@ -1,5 +1,5 @@
 mod test_server;
 
 pub(super) use test_server::{
-    TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
+    TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
 };

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -36,6 +36,11 @@ const GET_FOREGROUND_APP_URI: &str = "ssap://com.webos.applicationManager/getFor
 const GET_POWER_STATE_URI: &str = "ssap://com.webos.service.tvpower/power/getPowerState";
 const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
 const SET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/setSystemSettings";
+const CREATE_ALERT_URI: &str = "ssap://system.notifications/createAlert";
+const CLOSE_ALERT_URI: &str = "ssap://system.notifications/closeAlert";
+const SET_SYSTEM_SETTINGS_LUNA_URI: &str = "luna://com.webos.settingsservice/setSystemSettings";
+const TEST_ALERT_ID_RESPONSE: &str = "com.webos.service.apiadapter.pub-1786895965205";
+const TEST_ALERT_ID_CLOSE: &str = "com.webos.service.apiadapter-1786895965205";
 const SET_INPUT_URI: &str = "ssap://tv/switchInput";
 const TURN_OFF_SCREEN_URI: &str = "ssap://com.webos.service.tvpower/power/turnOffScreen";
 const TURN_ON_SCREEN_URI: &str = "ssap://com.webos.service.tvpower/power/turnOnScreen";
@@ -66,6 +71,14 @@ pub(in crate::web_os) enum WebOsTestScenario {
     StallFirstRequest,
     SameInputWriteAcknowledgedWhileScreenOff,
     RestoreSessionInterruptedAndInputAckLeavesScreenOff,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::web_os) enum WebOsTestVersion {
+    // Local hardware baseline: webOS24 / 9.2.2-61.
+    WebOs24Version92261,
+    // External hardware observation: webOS26 firmware 43.21.60.
+    WebOs26Firmware432160,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,9 +128,11 @@ pub(in crate::web_os) struct WebOsTestTvSnapshot {
 }
 
 struct WebOsTestTv {
+    version: WebOsTestVersion,
     power_state: WebOsPowerState,
     input: WebOsTestInput,
     backlight: Value,
+    pending_luna_backlight: Option<(u64, bool)>,
 }
 
 #[derive(Default)]
@@ -127,11 +142,13 @@ struct WebOsTestPermissions {
 }
 
 impl WebOsTestTv {
-    fn new(power_state: WebOsPowerState, input: WebOsTestInput) -> Self {
+    fn new(version: WebOsTestVersion, power_state: WebOsPowerState, input: WebOsTestInput) -> Self {
         Self {
+            version,
             power_state,
             input,
             backlight: input.backlight(),
+            pending_luna_backlight: None,
         }
     }
 
@@ -201,6 +218,9 @@ impl WebOsTestTv {
                 )
             }
             SET_SYSTEM_SETTINGS_URI => {
+                if self.version == WebOsTestVersion::WebOs26Firmware432160 {
+                    return webos_error(request_id, "401 insufficient permissions", json!({}));
+                }
                 if !permissions.write_settings_authorized {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
@@ -223,6 +243,68 @@ impl WebOsTestTv {
                     request_id,
                     json!({"method": "setSystemSettings", "returnValue": true}),
                 )
+            }
+            CREATE_ALERT_URI => {
+                require_top_level_permission(permissions, "WRITE_NOTIFICATION_ALERT", uri);
+                require_top_level_permission(permissions, "WRITE_SETTINGS", uri);
+                if self.version == WebOsTestVersion::WebOs24Version92261
+                    && !permissions.top_level.contains("WRITE_NOTIFICATION_TOAST")
+                {
+                    return webos_error(request_id, "401 insufficient permissions", json!({}));
+                }
+                assert_eq!(self.power_state, WebOsPowerState::Active);
+                let backlight_value = payload["onclose"]["params"]["settings"]["backlight"]
+                    .as_str()
+                    .expect("Luna bridge backlight string");
+                let backlight = backlight_value
+                    .parse::<u64>()
+                    .expect("Luna bridge numeric backlight string");
+                assert!(backlight <= 100, "backlight must be between 0 and 100");
+                let params = json!({
+                    "category": "picture",
+                    "settings": {"backlight": backlight_value},
+                });
+                let callback = json!({
+                    "params": params.clone(),
+                    "uri": SET_SYSTEM_SETTINGS_LUNA_URI,
+                });
+                assert_eq!(
+                    payload,
+                    &json!({
+                        "buttons": [{
+                            "label": "",
+                            "onClick": SET_SYSTEM_SETTINGS_LUNA_URI,
+                            "params": params,
+                        }],
+                        "message": " ",
+                        "onclose": callback.clone(),
+                        "onfail": callback,
+                    })
+                );
+                assert!(
+                    self.pending_luna_backlight.is_none(),
+                    "only one Luna bridge alert may be pending"
+                );
+                self.pending_luna_backlight = Some((backlight, apply_backlight_write));
+                response(
+                    request_id,
+                    json!({
+                        "returnValue": true,
+                        "alertId": TEST_ALERT_ID_RESPONSE,
+                    }),
+                )
+            }
+            CLOSE_ALERT_URI => {
+                require_top_level_permission(permissions, "WRITE_NOTIFICATION_ALERT", uri);
+                assert_eq!(payload, &json!({"alertId": TEST_ALERT_ID_CLOSE}));
+                let (backlight, apply_backlight_write) = self
+                    .pending_luna_backlight
+                    .take()
+                    .expect("Luna bridge alert must be created before it is closed");
+                if apply_backlight_write {
+                    self.backlight = json!(backlight);
+                }
+                response(request_id, json!({"returnValue": true}))
             }
             SET_INPUT_URI => {
                 if !permissions.top_level.contains("LAUNCH") {
@@ -323,8 +405,9 @@ pub(in crate::web_os) struct WebOsTestServer {
 }
 
 impl WebOsTestServer {
-    pub(in crate::web_os) fn active(input: WebOsTestInput) -> Self {
+    pub(in crate::web_os) fn active(version: WebOsTestVersion, input: WebOsTestInput) -> Self {
         Self::spawn(
+            version,
             WebOsPowerState::Active,
             input,
             WebOsTestScenario::StatefulTv,
@@ -332,8 +415,9 @@ impl WebOsTestServer {
         )
     }
 
-    pub(in crate::web_os) fn screen_off(input: WebOsTestInput) -> Self {
+    pub(in crate::web_os) fn screen_off(version: WebOsTestVersion, input: WebOsTestInput) -> Self {
         Self::spawn(
+            version,
             WebOsPowerState::ScreenOff,
             input,
             WebOsTestScenario::StatefulTv,
@@ -341,8 +425,12 @@ impl WebOsTestServer {
         )
     }
 
-    pub(in crate::web_os) fn for_scenario(scenario: WebOsTestScenario) -> Self {
+    pub(in crate::web_os) fn for_scenario(
+        version: WebOsTestVersion,
+        scenario: WebOsTestScenario,
+    ) -> Self {
         Self::spawn(
+            version,
             WebOsPowerState::Active,
             WebOsTestInput::Hdmi3,
             scenario,
@@ -350,8 +438,12 @@ impl WebOsTestServer {
         )
     }
 
-    pub(in crate::web_os) fn for_tls_scenario(scenario: WebOsTestScenario) -> Self {
+    pub(in crate::web_os) fn for_tls_scenario(
+        version: WebOsTestVersion,
+        scenario: WebOsTestScenario,
+    ) -> Self {
         Self::spawn(
+            version,
             WebOsPowerState::Active,
             WebOsTestInput::Hdmi3,
             scenario,
@@ -361,10 +453,12 @@ impl WebOsTestServer {
 
     #[allow(dead_code)]
     pub(in crate::web_os) fn active_tls_at(
+        version: WebOsTestVersion,
         input: WebOsTestInput,
         address: std::net::SocketAddr,
     ) -> Self {
         Self::spawn_at(
+            version,
             WebOsPowerState::Active,
             input,
             WebOsTestScenario::StatefulTv,
@@ -374,12 +468,14 @@ impl WebOsTestServer {
     }
 
     fn spawn(
+        version: WebOsTestVersion,
         power_state: WebOsPowerState,
         input: WebOsTestInput,
         scenario: WebOsTestScenario,
         transport: WebOsTestTransport,
     ) -> Self {
         Self::spawn_at(
+            version,
             power_state,
             input,
             scenario,
@@ -389,6 +485,7 @@ impl WebOsTestServer {
     }
 
     fn spawn_at(
+        version: WebOsTestVersion,
         power_state: WebOsPowerState,
         input: WebOsTestInput,
         scenario: WebOsTestScenario,
@@ -406,7 +503,7 @@ impl WebOsTestServer {
             WebOsTestTransport::Tls => WebOsEndpoint::wss_at(address),
         };
         let runtime = Arc::new(Mutex::new(WebOsTestRuntime {
-            tv: WebOsTestTv::new(power_state, input),
+            tv: WebOsTestTv::new(version, power_state, input),
             scenario,
             connection_count: 0,
             pairing_prompt_count: 0,
@@ -688,9 +785,13 @@ fn handle_registration<S>(
 where
     S: Read + Write,
 {
-    let (scenario, power_state) = {
+    let (scenario, power_state, version) = {
         let runtime = runtime.lock().expect("webOS test server state");
-        (runtime.scenario, runtime.tv.power_state.clone())
+        (
+            runtime.scenario,
+            runtime.tv.power_state.clone(),
+            runtime.tv.version,
+        )
     };
     if power_state == WebOsPowerState::PowerOff {
         socket
@@ -716,10 +817,6 @@ where
         "registration permission",
     );
     let write_settings_authorized = has_observed_write_settings_envelope(manifest);
-    *permissions = Some(WebOsTestPermissions {
-        top_level,
-        write_settings_authorized,
-    });
     let presented_token = match payload.get("client-key") {
         Some(Value::String(token)) => Some(token.clone()),
         Some(Value::Null) => None,
@@ -730,6 +827,23 @@ where
         .expect("webOS test server state")
         .registration_tokens
         .push(presented_token);
+
+    if version == WebOsTestVersion::WebOs26Firmware432160 && write_settings_authorized {
+        send_json(
+            socket,
+            webos_error(
+                request_id,
+                "403 Pairing rejected: blacklisted certificate detected",
+                json!({}),
+            ),
+        );
+        return true;
+    }
+
+    *permissions = Some(WebOsTestPermissions {
+        top_level,
+        write_settings_authorized,
+    });
 
     match scenario {
         WebOsTestScenario::StatefulTv
@@ -1081,7 +1195,9 @@ impl Drop for TestAccessTokenStore {
 mod tests {
     use super::{
         write_settings_signed_envelope, WebOsTestInput, WebOsTestScenario, WebOsTestServer,
-        GET_SYSTEM_SETTINGS_URI, SET_SYSTEM_SETTINGS_URI,
+        WebOsTestVersion, CLOSE_ALERT_URI, CREATE_ALERT_URI, GET_SYSTEM_SETTINGS_URI,
+        SET_SYSTEM_SETTINGS_LUNA_URI, SET_SYSTEM_SETTINGS_URI, TEST_ALERT_ID_CLOSE,
+        TEST_ALERT_ID_RESPONSE,
     };
     use serde_json::{json, Value};
     use std::net::TcpStream;
@@ -1095,6 +1211,24 @@ mod tests {
         top_level_permissions: &[&str],
         signed_envelope: Option<Value>,
     ) -> TestClient {
+        let (socket, registration) =
+            connect_and_register(server, top_level_permissions, signed_envelope);
+        assert_eq!(
+            registration,
+            json!({
+                "id": "register_0",
+                "type": "registered",
+                "payload": {"client-key": "test-client-key"},
+            })
+        );
+        socket
+    }
+
+    fn connect_and_register(
+        server: &WebOsTestServer,
+        top_level_permissions: &[&str],
+        signed_envelope: Option<Value>,
+    ) -> (TestClient, Value) {
         let (mut socket, _) = connect(server.endpoint().to_string()).expect("connect test client");
         let mut manifest = json!({
             "manifestVersion": 1,
@@ -1121,15 +1255,8 @@ mod tests {
                 .to_string(),
             ))
             .expect("send test registration");
-        assert_eq!(
-            read_json(&mut socket),
-            json!({
-                "id": "register_0",
-                "type": "registered",
-                "payload": {"client-key": "test-client-key"},
-            })
-        );
-        socket
+        let registration = read_json(&mut socket);
+        (socket, registration)
     }
 
     fn exchange(socket: &mut TestClient, request_id: &str, uri: &str, payload: Value) -> Value {
@@ -1164,11 +1291,188 @@ mod tests {
             .clone()
     }
 
+    fn luna_bridge_payload(backlight: u8) -> Value {
+        let backlight = backlight.to_string();
+        let params = json!({
+            "category": "picture",
+            "settings": {"backlight": backlight},
+        });
+        let callback = json!({
+            "params": params.clone(),
+            "uri": SET_SYSTEM_SETTINGS_LUNA_URI,
+        });
+        json!({
+            "buttons": [{
+                "label": "",
+                "onClick": SET_SYSTEM_SETTINGS_LUNA_URI,
+                "params": params,
+            }],
+            "message": " ",
+            "onclose": callback.clone(),
+            "onfail": callback,
+        })
+    }
+
+    // External real-TV observation:
+    // https://github.com/Staphylococcus/LG_Buddy/issues/76
+    // https://github.com/JPersson77/LGTVCompanion/issues/351
+    #[test]
+    fn affected_firmware_rejects_the_legacy_blacklisted_certificate() {
+        let server = WebOsTestServer::active(
+            WebOsTestVersion::WebOs26Firmware432160,
+            WebOsTestInput::Hdmi2,
+        );
+        let (socket, registration) = connect_and_register(
+            &server,
+            &["READ_SETTINGS"],
+            Some(write_settings_signed_envelope().clone()),
+        );
+
+        assert_eq!(
+            registration,
+            json!({
+                "id": "register_0",
+                "type": "error",
+                "error": "403 Pairing rejected: blacklisted certificate detected",
+                "payload": {},
+            })
+        );
+
+        drop(socket);
+        server.finish();
+    }
+
+    // External real-TV observation:
+    // https://github.com/Staphylococcus/LG_Buddy/issues/76
+    // https://github.com/JPersson77/LGTVCompanion/issues/351
+    #[test]
+    fn affected_firmware_rejects_direct_ssap_brightness_writes() {
+        let server = WebOsTestServer::active(
+            WebOsTestVersion::WebOs26Firmware432160,
+            WebOsTestInput::Hdmi2,
+        );
+        let mut socket = connect_registered(&server, &["READ_SETTINGS", "WRITE_SETTINGS"], None);
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                SET_SYSTEM_SETTINGS_URI,
+                json!({"category": "picture", "settings": {"backlight": 75}}),
+            ),
+            json!({
+                "id": "request_0",
+                "type": "error",
+                "error": "401 insufficient permissions",
+                "payload": {},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!("90"));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // Available-TV observation on webOS24 / 9.2.2-61: createAlert returned 401
+    // until WRITE_NOTIFICATION_TOAST was added to this otherwise identical manifest.
+    // https://github.com/Staphylococcus/LG_Buddy/issues/76#issuecomment-5420796570
+    #[test]
+    fn webos24_luna_bridge_requires_write_notification_toast() {
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
+        let mut socket = connect_registered(
+            &server,
+            &[
+                "READ_SETTINGS",
+                "WRITE_SETTINGS",
+                "WRITE_NOTIFICATION_ALERT",
+            ],
+            None,
+        );
+
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_0",
+                CREATE_ALERT_URI,
+                luna_bridge_payload(75),
+            ),
+            json!({
+                "id": "request_0",
+                "type": "error",
+                "error": "401 insufficient permissions",
+                "payload": {},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_1"), json!("90"));
+
+        drop(socket);
+        server.finish();
+    }
+
+    // External real-TV observation:
+    // https://github.com/Staphylococcus/LG_Buddy/issues/76
+    // https://github.com/JPersson77/LGTVCompanion/issues/351
+    #[test]
+    fn affected_firmware_applies_the_luna_callback_when_the_alert_closes() {
+        let server = WebOsTestServer::active(
+            WebOsTestVersion::WebOs26Firmware432160,
+            WebOsTestInput::Hdmi2,
+        );
+        let mut socket = connect_registered(
+            &server,
+            &[
+                "READ_SETTINGS",
+                "WRITE_SETTINGS",
+                "WRITE_NOTIFICATION_ALERT",
+                "WRITE_NOTIFICATION_TOAST",
+            ],
+            None,
+        );
+
+        assert_eq!(read_backlight(&mut socket, "request_0"), json!("90"));
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_1",
+                CREATE_ALERT_URI,
+                luna_bridge_payload(75),
+            ),
+            json!({
+                "id": "request_1",
+                "type": "response",
+                "payload": {
+                    "returnValue": true,
+                    "alertId": TEST_ALERT_ID_RESPONSE,
+                },
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_2"), json!("90"));
+        assert_eq!(
+            exchange(
+                &mut socket,
+                "request_3",
+                CLOSE_ALERT_URI,
+                json!({"alertId": TEST_ALERT_ID_CLOSE}),
+            ),
+            json!({
+                "id": "request_3",
+                "type": "response",
+                "payload": {"returnValue": true},
+            })
+        );
+        assert_eq!(read_backlight(&mut socket, "request_4"), json!(75));
+
+        drop(socket);
+        server.finish();
+    }
+
     // Real-TV wire observation:
     // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
     #[test]
     fn observed_write_settings_envelope_changes_backlight_to_numeric_state() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
         let mut socket = connect_registered(
             &server,
             &["READ_SETTINGS"],
@@ -1199,7 +1503,8 @@ mod tests {
     // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
     #[test]
     fn tampered_observed_signature_does_not_authorize_backlight_write() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
         let mut envelope = write_settings_signed_envelope().clone();
         let signature = envelope["signatures"][0]["signature"]
             .as_str()
@@ -1242,7 +1547,8 @@ mod tests {
     // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
     #[test]
     fn reduced_observed_signed_permissions_do_not_authorize_backlight_write() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
         let mut envelope = write_settings_signed_envelope().clone();
         envelope["signed"]["permissions"] = json!(["WRITE_SETTINGS"]);
         let mut socket = connect_registered(&server, &["READ_SETTINGS"], Some(envelope));
@@ -1271,7 +1577,8 @@ mod tests {
     // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181831148
     #[test]
     fn top_level_write_settings_permission_does_not_authorize_backlight_write() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
         let mut socket = connect_registered(&server, &["READ_SETTINGS", "WRITE_SETTINGS"], None);
 
         assert_eq!(
@@ -1298,7 +1605,8 @@ mod tests {
     // https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5181933079
     #[test]
     fn minimal_signed_write_settings_permission_does_not_authorize_backlight_write() {
-        let server = WebOsTestServer::active(WebOsTestInput::Hdmi2);
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
         let mut socket = connect_registered(
             &server,
             &["READ_SETTINGS"],
@@ -1329,6 +1637,7 @@ mod tests {
     #[test]
     fn acknowledged_backlight_write_can_leave_state_unchanged() {
         let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
             WebOsTestScenario::BacklightWriteAcknowledgedWithoutChange,
         );
         let mut socket = connect_registered(

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -56,6 +56,13 @@ fn native_webos_tv(world: &mut LgBuddyWorld, input: String, brightness: u8) {
     world.create_native_webos_tv(&input, brightness);
 }
 
+#[given(
+    regex = r#"a native webOS26 TV on firmware 43\.21\.60 on input (HDMI_[23]) with brightness (\d+)"#
+)]
+fn webos26_firmware_43_21_60_tv(world: &mut LgBuddyWorld, input: String, brightness: u8) {
+    world.create_webos26_firmware_43_21_60_tv(&input, brightness);
+}
+
 #[given(regex = r#"the existing config selects TV platform \"(bscpylgtv|lg_webos)\""#)]
 fn existing_tv_platform(world: &mut LgBuddyWorld, platform: String) {
     world.select_tv_platform(&platform);

--- a/crates/lg-buddy/tests/cucumber_support/webos.rs
+++ b/crates/lg-buddy/tests/cucumber_support/webos.rs
@@ -8,11 +8,26 @@ use std::net::{Ipv4Addr, SocketAddr};
 mod test_support;
 
 use test_support::test_server::{
-    WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestTvSnapshot,
+    WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestTvSnapshot, WebOsTestVersion,
 };
 
 pub const VALID_WEBOS_ACCESS_TOKEN: &str = "webos-test-access-token";
 const WEBOS_WSS_PORT: u16 = 3001;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MockWebOsVersion {
+    WebOs24Version92261,
+    WebOs26Firmware432160,
+}
+
+impl MockWebOsVersion {
+    fn test_version(self) -> WebOsTestVersion {
+        match self {
+            Self::WebOs24Version92261 => WebOsTestVersion::WebOs24Version92261,
+            Self::WebOs26Firmware432160 => WebOsTestVersion::WebOs26Firmware432160,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MockWebOsTvSnapshot {
@@ -30,7 +45,7 @@ pub struct MockWebOsTv {
 }
 
 impl MockWebOsTv {
-    pub fn new(input: &str) -> Self {
+    pub fn with_version(version: MockWebOsVersion, input: &str) -> Self {
         let input = match input {
             "HDMI_2" => WebOsTestInput::Hdmi2,
             "HDMI_3" => WebOsTestInput::Hdmi3,
@@ -38,7 +53,7 @@ impl MockWebOsTv {
         };
         let address = SocketAddr::from((Ipv4Addr::LOCALHOST, WEBOS_WSS_PORT));
         Self {
-            server: WebOsTestServer::active_tls_at(input, address),
+            server: WebOsTestServer::active_tls_at(version.test_version(), input, address),
         }
     }
 

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -2,7 +2,7 @@ use crate::support::{
     ExecutableScript, MockBscpylgtv, MockNmOnline, MockSessionBusIdleMonitor, MockSwayidle,
     MockSystemLogind, RuntimeStateLayout, TestConfigFile, TestEnv,
 };
-use crate::web_os::{MockWebOsTv, MockWebOsTvSnapshot, VALID_WEBOS_ACCESS_TOKEN};
+use crate::web_os::{MockWebOsTv, MockWebOsTvSnapshot, MockWebOsVersion, VALID_WEBOS_ACCESS_TOKEN};
 use cucumber::World;
 use lg_buddy::auth::resolve_bscpylgtv_auth_context_from_env;
 use std::fmt;
@@ -190,10 +190,31 @@ exit 1\n",
     }
 
     pub fn create_native_webos_tv(&mut self, input: &str, backlight: u8) {
+        self.create_native_webos_tv_with_version(
+            MockWebOsVersion::WebOs24Version92261,
+            input,
+            backlight,
+        );
+    }
+
+    pub fn create_webos26_firmware_43_21_60_tv(&mut self, input: &str, backlight: u8) {
+        self.create_native_webos_tv_with_version(
+            MockWebOsVersion::WebOs26Firmware432160,
+            input,
+            backlight,
+        );
+    }
+
+    fn create_native_webos_tv_with_version(
+        &mut self,
+        version: MockWebOsVersion,
+        input: &str,
+        backlight: u8,
+    ) {
         if self.config().path().exists() {
             self.config().set_value("tvs_primary_ip", "127.0.0.1");
         }
-        let tv = MockWebOsTv::new(input);
+        let tv = MockWebOsTv::with_version(version, input);
         assert_eq!(
             tv.snapshot().backlight,
             backlight,

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -5,7 +5,7 @@ Feature: Native webOS TV platform
 
   Scenario: Initial configuration selects and pairs the native platform
     Given an empty temporary LG Buddy config path
-    And a native webOS TV on input HDMI_2 with brightness 90
+    And a native webOS26 TV on firmware 43.21.60 on input HDMI_2 with brightness 90
     When I choose native webOS during initial configuration
     Then the command succeeds
     And stdout contains "TV Platform:         lg_webos"
@@ -114,10 +114,22 @@ Feature: Native webOS TV platform
     And the native TV connection count is 1
     And the native TV registration tokens are "none"
 
-  Scenario: Native brightness writes use the observed signed protocol and update the TV
+  Scenario: Native brightness writes use the Luna bridge on available webOS24
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"
     And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    When I run the command "brightness set 66"
+    Then the command succeeds
+    And stdout contains "Set OLED pixel brightness to 66%."
+    And the TV brightness is 66
+    And the native TV registration tokens are "webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
+  Scenario: Native brightness writes use the Luna bridge on affected webOS26 firmware
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And a native webOS26 TV on firmware 43.21.60 on input HDMI_2 with brightness 90
     And a valid native TV access token is stored
     When I run the command "brightness set 66"
     Then the command succeeds

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -578,6 +578,20 @@ effectful operation. The legacy adapter performs its equivalent power-state
 readback through `bscpylgtvcommand`; neither implementation exposes webOS power
 states to policy code.
 
+Native picture settings have two known service-invocation paths. A direct SSAP
+write sends `ssap://settings/setSystemSettings` on the websocket. The Luna path
+uses that same websocket to create and close a temporary notification alert;
+the alert callback invokes
+`luna://com.webos.settingsservice/setSystemSettings` inside the TV. Luna is
+therefore not a second network transport.
+
+LG Buddy uses only the alert-backed Luna path for brightness writes. It does not
+try direct SSAP first, select a path from detected firmware, or fall back between
+the two. Direct SSAP is rejected on affected firmware, while the Luna path is
+the one supported by both evidence-backed firmware profiles. The direct path
+remains represented in tests only so the mock can preserve the observed
+firmware difference.
+
 Keeping native TV control within the Rust runtime removes the Python client
 from that selected operation path. This is useful groundwork for declarative or
 immutable distributions such as NixOS, but it is not yet first-class NixOS

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -195,11 +195,16 @@ behavior aligned with observed hardware evidence.
 
 Cucumber adds the process-level product boundary. It runs the real `lg-buddy`
 binary against the same stateful server over TLS on the standard webOS port.
-The server enforces the observed registration permissions, signed brightness
-write envelope, request payloads, and device state transitions while recording
-authentication history and pairing prompts. The scenarios cover opt-in and
-credential outcomes plus representative brightness, screen, input, and power
-operations; detailed transport faults remain in the native client tests.
+The scenarios exercise the production unsigned registration manifest and
+alert-backed Luna brightness payload while the server enforces exact
+firmware-profile behavior and device state transitions. The server also retains
+the legacy direct SSAP brightness path as an observed webOS24 behavior; its
+webOS26 profile rejects the blacklisted legacy certificate and direct SSAP
+write. These are two service-invocation paths over one websocket transport, not
+two production routes. Authentication history and pairing prompts are recorded
+for assertions. The scenarios cover opt-in and credential outcomes plus
+representative brightness, screen, input, and power operations; detailed
+transport faults remain in the native client tests.
 The process-level fixture binds `127.0.0.1:3001`, matching the production TV
 endpoint, so that port must be free while the serial Cucumber suite runs.
 

--- a/docs/webos-testing.md
+++ b/docs/webos-testing.md
@@ -44,20 +44,52 @@ scenarios.
 Its stateful TV behavior includes:
 
 - changing the foreground application after an input switch
-- changing picture backlight after an authorized write and exposing the numeric
-  result through a later read
+- applying a picture-backlight Luna callback when its temporary alert closes,
+  then exposing the numeric result through a later SSAP read
 - moving between `Active` and `Screen Off`
 - moving to `Power Off` and rejecting an immediate new registration
+
+The server has exact firmware profiles for observed device behavior:
+
+- `WebOs24Version92261` is the local webOS24 / 9.2.2-61 baseline. It accepts the
+  legacy signed envelope and its direct SSAP brightness write, and it also
+  accepts the unsigned manifest plus alert-backed Luna route. With the unsigned
+  manifest, omitting `WRITE_NOTIFICATION_TOAST` makes `createAlert` return 401.
+  See the earlier [direct-SSAP observation][webos24-direct-ssap] and the current
+  [unsigned/Luna characterization][webos24-luna].
+- `WebOs26Firmware432160` represents external webOS26 / 43.21.60 reports. It
+  rejects the legacy signed registration certificate and direct SSAP brightness
+  writes, while accepting unsigned registration and the alert-backed Luna
+  route. See the external [registration and direct-SSAP report][webos26-direct]
+  and [working Luna-route confirmation][webos26-luna].
+
+Picture writes therefore have two modeled service-invocation paths, but not two
+network transports:
+
+- direct SSAP sends `ssap://settings/setSystemSettings` over the TV websocket
+- alert-backed Luna sends `createAlert` and `closeAlert` over that same
+  websocket, with
+  `luna://com.webos.settingsservice/setSystemSettings` as the on-TV callback
+
+Production always uses the alert-backed Luna path. It does not probe direct
+SSAP, detect firmware, or fall back between paths. The mock retains direct SSAP
+only to preserve the observed version difference and to prove that production
+does not depend on the path rejected by affected firmware.
+
+Profiles represent observations, not a guessed version range. Production does
+not infer behavior for neighboring versions. Named scenarios remain transient
+fault injection layered on top of a selected profile.
 
 The server validates the request URI and payload sent by the client before it
 responds. Controls mutate server state, and later reads expose that state. This
 lets tests verify an operation through an independent observation instead of
 only accepting its immediate acknowledgement.
 
-Tests select semantic scenarios such as registration rejection, response
-timeout, malformed frame, or permission denial. They cannot author raw server
-frames. Successful responses, rejected operations, accepted operations with no
-state change, and transport failures therefore have the same response owner.
+Tests select a firmware profile plus semantic scenarios such as registration
+rejection, response timeout, malformed frame, or permission denial. They cannot
+author raw server frames. Successful responses, rejected operations, accepted
+operations with no state change, and transport failures therefore have the same
+response owner.
 
 Whether a behavior was observed on hardware or introduced as defensive fault
 injection is documented by the test and its evidence link. Provenance does not
@@ -137,8 +169,10 @@ about a device quirk:
 2. Record the initial state, request, response, and resulting state in the
    relevant GitHub issue. Remove access tokens and other secrets.
 3. Add or update an evidence-linked characterization test.
-4. Extend the centralized stateful server with the observed response and state
-   transition. Preserve exact quirks when LG Buddy behavior depends on them.
+4. Extend the matching exact firmware profile in the centralized stateful
+   server with the observed response and state transition. Preserve exact quirks
+   when LG Buddy behavior depends on them; do not infer a version range from one
+   observation.
 5. Add named server scenarios or parser tests for defensive behavior that
    cannot be claimed as an observation.
 6. Use the refined server in the LG Buddy functionality tests for the new
@@ -163,6 +197,11 @@ use the same server and response construction.
 Keeping transport assertions and device-semantics assertions in distinct tests
 makes failures diagnostic: a characterization failure points to device
 semantics, while a WSS test failure points to transport setup.
+
+[webos24-direct-ssap]: https://github.com/Staphylococcus/LG_Buddy/issues/52#issuecomment-5183221492
+[webos24-luna]: https://github.com/Staphylococcus/LG_Buddy/issues/76#issuecomment-5420796570
+[webos26-direct]: https://github.com/JPersson77/LGTVCompanion/issues/351#issuecomment-5277399395
+[webos26-luna]: https://github.com/JPersson77/LGTVCompanion/issues/351#issuecomment-5309740894
 
 ## Review Checklist
 


### PR DESCRIPTION
## Summary

- replace the legacy signed registration envelope rejected by affected firmware with a minimal unsigned outer manifest
- send brightness writes exclusively through the alert-backed Luna callback, including the required notification permissions
- model the local webOS24 and externally observed webOS26 behavior separately, with regression and acceptance coverage for the single production route
- document direct SSAP versus Luna as two service-invocation paths over one websocket transport, not two production routes

## Evidence

- Issue #76 reports `403 Pairing rejected: blacklisted certificate detected` on firmware 43.21.60-43.21.62. That firmware is not locally available.
- Local webOS24 / 9.2.2-61 characterization isolated `WRITE_NOTIFICATION_TOAST` as required for `createAlert` and verified the tracked LG Buddy implementation with a `100 -> 10 -> 100` brightness cycle.
- webOS26 registration, direct-SSAP rejection, and Luna-route behavior are modeled from the external hardware reports linked in the issue evidence comment and tests, without inferring a broader version range.

## Validation

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- real webOS24 / 9.2.2-61 read, fresh-pairing permission isolation, and final stored-token `100 -> 10 -> 100` control/readback

Closes #76
