### PR TITLE
Prepare LG Buddy 1.2.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,7 +826,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "base64",
  "cucumber",

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.2.1"
+version = "1.2.2"
 edition = "2021"
 publish = false
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,7 +47,7 @@ cargo build --release -p lg-buddy
 Official release builds inject version identity into the binary:
 
 ```bash
-LG_BUDDY_RELEASE_VERSION=1.2.1 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
+LG_BUDDY_RELEASE_VERSION=1.2.2 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
 ```
 
 Without those environment variables, `lg-buddy --version` reports the Cargo

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,15 +33,15 @@ those two checks.
 ## Creating a release
 
 1. Make sure the branch you want to release has passed CI.
-2. Create a tag such as `v1.2.1`.
+2. Create a tag such as `v1.2.2`.
 3. Push the tag.
 4. After the workflow publishes the release, verify the archive against
    `sha256sums.txt` and replace the generated generic description with concise
    release-specific notes.
 
 ```bash
-git tag v1.2.1
-git push origin v1.2.1
+git tag v1.2.2
+git push origin v1.2.2
 ```
 
 ## Installing from a release bundle


### PR DESCRIPTION
## Summary

- bump LG Buddy package and release documentation to 1.2.2
- prepare the release containing the webOS certificate-blacklist pairing fix and explicit SSAP/Luna routing from #78

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- shell syntax validation for install, configure, bundle, and publish scripts
- `git diff --check`

Release context: #76