### PR TITLE
Make gamepad activity monitoring desktop-environment agnostic

### DIFF
--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -187,11 +187,19 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
         writer: &mut W,
         event: SessionEvent,
     ) -> Result<(), SessionRunnerError> {
+        self.dispatch_event_from_source(writer, EventSource::DesktopSession, event)
+    }
+
+    fn dispatch_event_from_source<W: Write>(
+        &mut self,
+        writer: &mut W,
+        source: EventSource,
+        event: SessionEvent,
+    ) -> Result<(), SessionRunnerError> {
         match event {
             SessionEvent::Idle => {
                 writeln!(writer, "LG Buddy Monitor: Session became idle.")?;
-                let runtime_event =
-                    RuntimeEvent::from_session_event(EventSource::DesktopSession, event);
+                let runtime_event = RuntimeEvent::from_session_event(source, event);
                 match self.executor.screen_off(runtime_event) {
                     Ok(output) => write_command_output(writer, &output)?,
                     Err(err) => {
@@ -205,8 +213,7 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
                     "LG Buddy Monitor: Session event `{}` requests screen restore.",
                     event.as_str()
                 )?;
-                let runtime_event =
-                    RuntimeEvent::from_session_event(EventSource::DesktopSession, event);
+                let runtime_event = RuntimeEvent::from_session_event(source, event);
                 match self.executor.screen_on(runtime_event) {
                     Ok(output) => write_command_output(writer, &output)?,
                     Err(err) => writeln!(
@@ -220,8 +227,7 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
                     writer,
                     "LG Buddy Monitor: Session event `before-sleep` requests pre-sleep handling."
                 )?;
-                let runtime_event =
-                    RuntimeEvent::from_session_event(EventSource::DesktopSession, event);
+                let runtime_event = RuntimeEvent::from_session_event(source, event);
                 match self.executor.before_sleep(runtime_event) {
                     Ok(output) => write_command_output(writer, &output)?,
                     Err(err) => {
@@ -235,8 +241,7 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
                     "LG Buddy Monitor: Session event `after-resume` requests wake restore."
                 )?;
                 writer.flush()?;
-                let runtime_event =
-                    RuntimeEvent::from_session_event(EventSource::DesktopSession, event);
+                let runtime_event = RuntimeEvent::from_session_event(source, event);
                 match self.executor.after_resume_streaming(writer, runtime_event) {
                     Ok(()) => {}
                     Err(err) => writeln!(
@@ -634,9 +639,28 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
 
     writeln!(writer, "LG Buddy Monitor: Using GNOME backend.")?;
 
+    run_native_session_monitor(
+        writer,
+        dispatcher,
+        ScreenBackend::Gnome,
+        spawn_gnome_monitor_thread,
+    )
+}
+
+fn run_native_session_monitor<W, E, S>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    backend: ScreenBackend,
+    spawn_monitor: S,
+) -> Result<(), SessionRunnerError>
+where
+    W: Write,
+    E: SessionActionExecutor,
+    S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
+{
     let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
     let started_at = Instant::now();
-    let mut inactivity = if session_screen_ownership_marker_exists()? {
+    let mut inactivity = if session_screen_ownership_marker_exists(backend)? {
         InactivityEngine::new_with_restore_pending(blank_after, started_at)
     } else {
         InactivityEngine::new(blank_after, started_at)
@@ -644,7 +668,7 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
 
     let (sender, receiver) = mpsc::channel();
     let latest_inactivity = Arc::new(LatestInactivityObservation::default());
-    let monitor_handle = spawn_gnome_monitor_thread(sender.clone(), Arc::clone(&latest_inactivity));
+    let monitor_handle = spawn_monitor(sender.clone(), Arc::clone(&latest_inactivity));
     let _gamepad_monitor = spawn_gamepad_activity_thread(sender.clone());
     let mut monitor_result = Ok(());
 
@@ -653,12 +677,7 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
             Some(wait) => match receiver.recv_timeout(wait) {
                 Ok(message) => message,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
-                    handle_gnome_inactivity_timeout(
-                        writer,
-                        dispatcher,
-                        &mut inactivity,
-                        Instant::now(),
-                    )?;
+                    handle_inactivity_timeout(writer, dispatcher, &mut inactivity, Instant::now())?;
                     continue;
                 }
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
@@ -672,49 +691,65 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
         match message {
             RunnerMessage::InactivityObservationReady => {
                 if let Some(observation) = latest_inactivity.take() {
-                    handle_gnome_activity_observation(
+                    handle_inactivity_observation(
                         writer,
                         dispatcher,
                         &mut inactivity,
+                        EventSource::DesktopSession,
                         observation.observation,
                         observation.observed_at,
                     )?;
                 }
             }
+            RunnerMessage::ActivityObservation {
+                source,
+                observation,
+                observed_at,
+            } => handle_inactivity_observation(
+                writer,
+                dispatcher,
+                &mut inactivity,
+                source,
+                observation,
+                observed_at,
+            )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Idle,
                 ..
             } => {
-                // GNOME ScreenSaver idle is observational. Only LG Buddy's
-                // inactivity deadline decides when to blank.
+                // Provider idle is observational. Only LG Buddy's inactivity
+                // deadline decides when to blank.
             }
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Active,
                 observed_at,
-            } => handle_gnome_activity_observation(
+            } => handle_inactivity_observation(
                 writer,
                 dispatcher,
                 &mut inactivity,
+                EventSource::DesktopSession,
                 InactivityObservation::ProviderActive,
                 observed_at,
             )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::WakeRequested,
                 observed_at,
-            } => handle_gnome_activity_observation(
+            } => handle_inactivity_observation(
                 writer,
                 dispatcher,
                 &mut inactivity,
+                EventSource::DesktopSession,
                 InactivityObservation::WakeRequested,
                 observed_at,
             )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::UserActivity,
                 observed_at,
-            } => handle_gnome_activity_observation(
+            } => handle_inactivity_observation(
                 writer,
                 dispatcher,
                 &mut inactivity,
+                EventSource::DesktopSession,
                 InactivityObservation::UserActivityObserved,
                 observed_at,
             )?,
@@ -798,11 +833,13 @@ fn resolve_idle_timeout_secs() -> u64 {
     )
 }
 
-fn session_screen_ownership_marker_exists() -> Result<bool, SessionRunnerError> {
+fn session_screen_ownership_marker_exists(
+    backend: ScreenBackend,
+) -> Result<bool, SessionRunnerError> {
     ScreenOwnershipMarker::from_env(StateScope::Session)
         .map(|marker| marker.exists())
         .map_err(|err| SessionRunnerError::Failed {
-            backend: ScreenBackend::Gnome,
+            backend,
             message: format!("failed to inspect session screen ownership: {err}"),
         })
 }
@@ -912,8 +949,9 @@ fn run_synthetic_gamepad_activity_process(
     }
 
     if !stop.load(Ordering::SeqCst) {
-        let _ = sender.send(RunnerMessage::SessionEvent {
-            event: SessionEvent::UserActivity,
+        let _ = sender.send(RunnerMessage::ActivityObservation {
+            source: EventSource::AuxiliaryInput,
+            observation: InactivityObservation::UserActivityObserved,
             observed_at: Instant::now(),
         });
     }
@@ -1003,8 +1041,9 @@ fn run_gamepad_activity_process(sender: mpsc::Sender<RunnerMessage>, stop: Arc<A
 
         if poll.activity && gamepad_activity_send_due(last_activity_sent_at, observed_at) {
             if sender
-                .send(RunnerMessage::SessionEvent {
-                    event: SessionEvent::UserActivity,
+                .send(RunnerMessage::ActivityObservation {
+                    source: EventSource::AuxiliaryInput,
+                    observation: InactivityObservation::UserActivityObserved,
                     observed_at,
                 })
                 .is_err()
@@ -1109,6 +1148,11 @@ fn run_gnome_monitor_process(
 enum RunnerMessage {
     SessionEvent {
         event: SessionEvent,
+        observed_at: Instant,
+    },
+    ActivityObservation {
+        source: EventSource,
+        observation: InactivityObservation,
         observed_at: Instant,
     },
     InactivityObservationReady,
@@ -1368,10 +1412,11 @@ fn poll_gnome_idle_monitor_once(
     )
 }
 
-fn handle_gnome_activity_observation<W: Write, E: SessionActionExecutor>(
+fn handle_inactivity_observation<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     inactivity: &mut InactivityEngine,
+    source: EventSource,
     observation: InactivityObservation,
     observed_at: Instant,
 ) -> Result<(), SessionRunnerError> {
@@ -1393,13 +1438,13 @@ fn handle_gnome_activity_observation<W: Write, E: SessionActionExecutor>(
     };
 
     if let Some(event) = event {
-        dispatcher.dispatch_event(writer, event)?;
+        dispatcher.dispatch_event_from_source(writer, source, event)?;
     }
 
     Ok(())
 }
 
-fn handle_gnome_inactivity_timeout<W: Write, E: SessionActionExecutor>(
+fn handle_inactivity_timeout<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     inactivity: &mut InactivityEngine,
@@ -1445,15 +1490,16 @@ fn write_command_output<W: Write>(writer: &mut W, output: &str) -> io::Result<()
 mod tests {
     use super::{
         complete_gamepad_refresh, gamepad_activity_send_due,
-        gamepad_device_event_refresh_requested, gamepad_refresh_due,
-        handle_gnome_activity_observation, handle_gnome_inactivity_timeout,
-        normalize_idle_timeout_secs, poll_gnome_idle_monitor_once, run_lifecycle_monitor_with_bus,
-        schedule_gamepad_refresh, shell_quote, GamepadDeviceEventMonitor,
-        GamepadDeviceEventRefresh, GamepadDiagnosticEmitter, LatestInactivityObservation,
-        RunnerMessage, SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
+        gamepad_device_event_refresh_requested, gamepad_refresh_due, handle_inactivity_observation,
+        handle_inactivity_timeout, normalize_idle_timeout_secs, poll_gnome_idle_monitor_once,
+        run_lifecycle_monitor_with_bus, run_native_session_monitor, schedule_gamepad_refresh,
+        shell_quote, GamepadDeviceEventMonitor, GamepadDeviceEventRefresh,
+        GamepadDiagnosticEmitter, LatestInactivityObservation, RunnerMessage,
+        SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
         TrustedScreenSaverSignals, GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL,
         GAMEPAD_ACTIVITY_SEND_INTERVAL,
     };
+    use crate::config::ScreenBackend;
     use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
     use crate::session::inactivity::{InactivityEngine, InactivityObservation};
     use crate::session::SessionEvent;
@@ -1473,6 +1519,7 @@ mod tests {
     use std::io;
     use std::path::{Path, PathBuf};
     use std::sync::{mpsc, Mutex, OnceLock};
+    use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     fn env_lock() -> &'static Mutex<()> {
@@ -1496,6 +1543,7 @@ mod tests {
         after_resume_output: String,
         screen_off_error: Option<String>,
         screen_on_error: Option<String>,
+        screen_on_signal: Option<mpsc::Sender<()>>,
         before_sleep_error: Option<String>,
         after_resume_error: Option<String>,
     }
@@ -1524,6 +1572,9 @@ mod tests {
         fn screen_on(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
             self.screen_on_calls += 1;
             self.screen_on_events.push(event);
+            if let Some(sender) = &self.screen_on_signal {
+                let _ = sender.send(());
+            }
             if let Some(message) = &self.screen_on_error {
                 return Err(RunError::Policy(message.clone()));
             }
@@ -2414,14 +2465,14 @@ system_sleep_wake_policy={policy}
         let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
         )
         .expect("blank when the LG Buddy timeout expires");
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2446,7 +2497,7 @@ system_sleep_wake_policy={policy}
         let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2455,15 +2506,16 @@ system_sleep_wake_policy={policy}
         .expect("blank when the timeout expires");
         let mut output = Vec::new();
 
-        handle_gnome_activity_observation(
+        handle_inactivity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
+            EventSource::DesktopSession,
             InactivityObservation::DesktopActivityObserved,
             started_at + Duration::from_millis(1_100),
         )
         .expect("restore from desktop activity");
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2489,7 +2541,7 @@ system_sleep_wake_policy={policy}
         let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2498,18 +2550,20 @@ system_sleep_wake_policy={policy}
         .expect("blank when the timeout expires");
 
         let mut output = Vec::new();
-        handle_gnome_activity_observation(
+        handle_inactivity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
+            EventSource::AuxiliaryInput,
             InactivityObservation::UserActivityObserved,
             started_at + Duration::from_millis(1_100),
         )
         .expect("restore from auxiliary activity");
-        handle_gnome_activity_observation(
+        handle_inactivity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
+            EventSource::DesktopSession,
             InactivityObservation::ProviderActive,
             started_at + Duration::from_millis(1_200),
         )
@@ -2523,7 +2577,64 @@ system_sleep_wake_policy={policy}
         assert_eq!(
             dispatcher.executor.screen_on_events,
             vec![RuntimeEvent::new(
-                EventSource::DesktopSession,
+                EventSource::AuxiliaryInput,
+                RuntimeEventKind::UserActivityObserved,
+            )]
+        );
+    }
+
+    #[test]
+    fn native_session_runtime_starts_gamepad_without_a_desktop_provider() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let runtime_dir = unique_config_path("native-session-runtime");
+        std::env::set_var("LG_BUDDY_SESSION_RUNTIME_DIR", &runtime_dir);
+        std::env::set_var("LG_BUDDY_IDLE_TIMEOUT", "300");
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "synthetic");
+        std::env::set_var(super::GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV, "0");
+
+        let (activity_sender, activity_receiver) = mpsc::channel();
+        let executor = FakeActionExecutor {
+            screen_on_output: "screen-on output\n".to_string(),
+            screen_on_signal: Some(activity_sender),
+            ..FakeActionExecutor::default()
+        };
+        let mut dispatcher = SessionEventDispatcher::new(executor);
+        let mut output = Vec::new();
+
+        let result = run_native_session_monitor(
+            &mut output,
+            &mut dispatcher,
+            ScreenBackend::Auto,
+            |sender, _latest_inactivity| {
+                thread::spawn(move || {
+                    let result = activity_receiver
+                        .recv_timeout(Duration::from_secs(1))
+                        .map(|()| ())
+                        .map_err(|err| super::SessionRunnerError::Failed {
+                            backend: ScreenBackend::Auto,
+                            message: format!(
+                                "synthetic gamepad activity was not dispatched: {err}"
+                            ),
+                        });
+                    let _ = sender.send(RunnerMessage::MonitorExited(result));
+                })
+            },
+        );
+
+        std::env::remove_var("LG_BUDDY_SESSION_RUNTIME_DIR");
+        std::env::remove_var("LG_BUDDY_IDLE_TIMEOUT");
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV);
+
+        result.expect("shared native session runtime should start and process gamepad activity");
+
+        assert_eq!(dispatcher.executor.screen_on_calls, 1);
+        assert_eq!(
+            dispatcher.executor.screen_on_events,
+            vec![RuntimeEvent::new(
+                EventSource::AuxiliaryInput,
                 RuntimeEventKind::UserActivityObserved,
             )]
         );
@@ -2541,7 +2652,7 @@ system_sleep_wake_policy={policy}
         let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2549,23 +2660,24 @@ system_sleep_wake_policy={policy}
         )
         .expect("blank when the timeout expires");
 
-        handle_gnome_activity_observation(
+        handle_inactivity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
+            EventSource::AuxiliaryInput,
             InactivityObservation::UserActivityObserved,
             started_at + Duration::from_millis(1_100),
         )
         .expect("restore from auxiliary activity");
 
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
         )
         .expect("the original deadline must stay retired");
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2588,14 +2700,14 @@ system_sleep_wake_policy={policy}
         let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
         )
         .expect("initial blank attempt should be logged");
-        handle_gnome_inactivity_timeout(
+        handle_inactivity_timeout(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
@@ -2619,18 +2731,20 @@ system_sleep_wake_policy={policy}
         let mut inactivity = InactivityEngine::new(Duration::from_secs(1), started_at);
         let mut output = Vec::new();
 
-        handle_gnome_activity_observation(
+        handle_inactivity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
+            EventSource::DesktopSession,
             InactivityObservation::ProviderActive,
             started_at,
         )
         .expect("initial provider active should restore");
-        handle_gnome_activity_observation(
+        handle_inactivity_observation(
             &mut output,
             &mut dispatcher,
             &mut inactivity,
+            EventSource::DesktopSession,
             InactivityObservation::ProviderActive,
             started_at + Duration::from_millis(100),
         )

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -2611,7 +2611,6 @@ system_sleep_wake_policy={policy}
                 thread::spawn(move || {
                     let result = activity_receiver
                         .recv_timeout(Duration::from_secs(1))
-                        .map(|()| ())
                         .map_err(|err| super::SessionRunnerError::Failed {
                             backend: ScreenBackend::Auto,
                             message: format!(

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -8,12 +8,14 @@ Feature: GNOME monitor
     And a mock TV client
     And the TV is on input HDMI_2
     And the executable PATH is isolated
+    And gamepad activity is observed after 0 seconds
     And GNOME monitor stays open for 0.1 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "screen idle blanking is disabled by config"
     And the TV client did not receive "get_input"
     And the TV client did not receive "turn_screen_off"
+    And the TV client did not receive "turn_screen_on"
 
   Scenario: GNOME ScreenSaver idle does not bypass the LG Buddy timeout
     Given a temporary LG Buddy config using input HDMI_2
@@ -111,7 +113,7 @@ Feature: GNOME monitor
     And the session marker exists
     And the TV screen is blanked
 
-  Scenario: GNOME gamepad activity restores a blanked TV while idletime remains stale
+  Scenario: Gamepad activity restores a blanked TV while GNOME idletime remains stale
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 1 seconds
     And LG Buddy session runtime is isolated

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -336,8 +336,10 @@ The session-facing pieces should be read as one subsystem:
   - owns gamepad device discovery, event-triggered refresh, and reconciliation
   - see [gamepad-subsystem.md](gamepad-subsystem.md) for adapter and lifecycle details
 - `session/runner.rs`
-  - converts provider input into activity observations, resets the inactivity
-    deadline, and dispatches runtime policy
+  - owns the shared native-session runtime, including the gamepad source
+    lifecycle independently of the selected desktop provider
+  - converts provider and auxiliary input into activity observations, resets
+    the inactivity deadline, and dispatches source-classified runtime policy
   - treats `screen_idle_blank=disabled` as a passive user-session mode that
     preserves update notification handoff without TV idle blank/restore actions
   - treats delegated `swayidle` as a CLI/API client for timeout/resume actions
@@ -711,12 +713,12 @@ and state normally, construct canonical CLI/API runtime events, and enter
 The session subsystem is intentionally asymmetric where the providers are
 asymmetric:
 
-- the current GNOME pilot treats ScreenSaver active/wake, recent Mutter input,
-  and gamepad input as activity that resets LG Buddy's inactivity deadline;
-  ScreenSaver idle is not a blanking authority
-- the native monitor path also consumes gamepad activity directly from Linux
-  input devices; today that is attached to GNOME because GNOME is the only
-  native production adapter, but the source is not GNOME-specific
+- the current GNOME provider treats ScreenSaver active/wake and recent Mutter
+  input as activity that resets LG Buddy's inactivity deadline; ScreenSaver
+  idle is not a blanking authority
+- the shared native-session runtime consumes gamepad activity directly from
+  Linux input devices as `AuxiliaryInput`, independently of desktop providers;
+  GNOME is currently the only production provider using this runtime
 - the gamepad source refreshes its device set from Linux device add, remove, and
   change events, with periodic reconciliation for missed events
 - delegated `swayidle` monitor execution is implemented as CLI/API delegation

--- a/docs/gamepad-subsystem.md
+++ b/docs/gamepad-subsystem.md
@@ -10,11 +10,10 @@ modes or device-specific configuration.
 ## Purpose
 
 The subsystem watches readable Linux input devices and reports controller input
-as `UserActivity` to the session runner. The current runtime starts it from the
-native GNOME monitor path because GNOME is the only production adapter on the
-native inactivity path today. The source itself is not GNOME-specific; future
-native desktop adapters can consume the same auxiliary activity signal when
-their idle APIs miss controller input.
+as auxiliary user activity to the session runner. The shared native-session
+runtime starts it independently of the selected desktop provider. GNOME is the
+only production provider using that runtime today, but neither the gamepad
+source nor its lifecycle belongs to GNOME or any other desktop environment.
 
 The subsystem does not decide whether to blank or restore the TV. It only
 reports activity. The session runner and screen policy remain responsible for
@@ -22,8 +21,8 @@ screen behavior.
 
 ## Runtime Flow
 
-1. `session/runner.rs` starts a background gamepad activity thread for the
-   current native monitor path.
+1. The shared native-session runtime in `session/runner.rs` starts a background
+   gamepad activity thread alongside the selected desktop provider.
 2. `session/gamepad/devices.rs` scans `/dev/input/event*`, opens each event
    node, checks whether its capabilities look gamepad-like, records
    vendor/product IDs, and maps related `/dev/hidraw*` paths through sysfs.
@@ -38,7 +37,8 @@ screen behavior.
    immediate. Axis activity is compared against a moving baseline so arbitrary
    resting positions, such as a wheel left turned, do not continuously count as
    input.
-7. The runner receives throttled `UserActivity` events and resets the same
+7. The runner receives throttled `AuxiliaryInput` activity observations,
+   preserves that source on the resulting runtime event, and resets the same
    inactivity deadline used by desktop activity.
 
 ## Module Map
@@ -127,7 +127,8 @@ Default tests should cover the behavior without requiring real hardware:
 - adapter support matching and reader spec keys
 - registry cleanup and retention rules
 - button, axis, baseline, and cooldown policy
-- runner integration of gamepad activity into inactivity observations
+- backend-neutral native-session integration of gamepad activity into
+  inactivity observations
 
 Use the hardware smoke test when changing behavior that depends on real input
 devices:

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -112,7 +112,7 @@ auxiliary activity facts
   -> screen policy
 ```
 
-Current pilot inputs:
+Current native-runtime inputs:
 
 | Provider surface | Runtime representation | Consumed by |
 | --- | --- | --- |
@@ -120,11 +120,12 @@ Current pilot inputs:
 | `org.gnome.ScreenSaver.ActiveChanged(false)` | `ProviderActive` | `InactivityEngine` |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | `InactivityEngine` |
 | Recent activity reported by `org.gnome.Mutter.IdleMonitor.GetIdletime` | `DesktopActivityObserved` | `InactivityEngine` |
-| Linux gamepad activity | `UserActivityObserved` | `InactivityEngine` |
+| Linux gamepad activity | `UserActivityObserved` from `AuxiliaryInput` | Shared native-session runtime -> `InactivityEngine` |
 
-These are GNOME-specific source surfaces, but the runtime representations are
-backend-neutral. The key architectural point is that blank/restore decisions are
-made after normalization, not inside the GNOME adapter.
+The desktop rows are GNOME-specific source surfaces. Gamepad activity is an
+independent auxiliary source owned by the shared native-session runtime. The
+key architectural point is that blank/restore decisions are made after
+normalization, not inside a desktop adapter.
 
 The resulting decisions are dispatched as:
 
@@ -133,7 +134,8 @@ The resulting decisions are dispatched as:
 | `BlankNow` | `SessionEvent::Idle` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_off_from_env_for_event` |
 | `RestoreNow` from provider active | `SessionEvent::Active` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from wake request | `SessionEvent::WakeRequested` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
-| `RestoreNow` from desktop or auxiliary activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
+| `RestoreNow` from desktop activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
+| `RestoreNow` from auxiliary activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `AuxiliaryInput` | `screen::run_screen_on_from_env_for_event` |
 
 ### Delegated `swayidle` CLI/API Path
 

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -26,6 +26,8 @@ contract.
 3. Missing backend capabilities stay missing.
 4. LG Buddy does not invent synthetic provider behavior just to fill gaps in the
    interface.
+5. Auxiliary input sources belong to the session runtime, not desktop backend
+   modules.
 
 That means a backend can say "I do not emit `WakeRequested`" or "idle timeout is
 desktop-managed" without being treated as incomplete.
@@ -54,7 +56,7 @@ These are the semantic events the runtime should reason about.
   - It exists for native desktop adapters that can expose fresh activity before
     the desktop emits its normal active/wake signal. GNOME + Mutter is the
     current production example.
-  - It can also come from backend-adjacent activity sources owned by the session
+  - It can also come from auxiliary activity sources owned by the session
     runtime, such as gamepad input that the desktop does not classify as
     activity.
 - `WakeRequested` is optional.
@@ -133,28 +135,35 @@ Current mapping:
 | `org.gnome.ScreenSaver.ActiveChanged (false,)` | `Active` | Implemented |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | Implemented |
 | Recent activity from `org.gnome.Mutter.IdleMonitor.GetIdletime` | `UserActivity` | Implemented |
-| Linux gamepad input devices | `UserActivity` | Implemented in the GNOME monitor runtime |
 
 Notes:
 
 - GNOME requires GNOME Shell, `org.gnome.ScreenSaver`, and `org.gnome.Mutter.IdleMonitor`.
 - LG Buddy owns the configured timeout value for this backend.
-- LG Buddy owns one inactivity deadline. Desktop, gamepad, active, and wake
+- LG Buddy owns one inactivity deadline. Desktop, auxiliary, active, and wake
   activity reports reset it; expiry after `screen_idle_timeout` triggers blanking.
 - Mutter idletime is used only to detect recent desktop activity. Its absolute
   value does not trigger blanking.
 - ScreenSaver idle cannot trigger blanking by itself. ScreenSaver active and
   wake signals reset the same LG Buddy deadline and remain restore observations
   evaluated by screen policy.
-- Gamepad activity is not a separate desktop backend. It is an auxiliary
-  activity source attached to the current native monitor path because some
-  desktop idle APIs may not count controller input as activity.
-- The gamepad source owns its device set internally. It performs an initial
-  scan, refreshes on Linux input-device add, remove, and change events, and
-  periodically reconciles in case an event is missed.
-- Standard controller input is read from evdev. Logitech G923 wheel and pedal
-  activity has a narrow raw HID fallback for hosts where those reports do not
-  appear on the evdev node.
+
+### Auxiliary Activity Sources
+
+Linux gamepad input is a desktop-independent auxiliary activity source. The
+shared native-session runtime owns its lifecycle and feeds
+`UserActivityObserved` into the same inactivity engine as the selected desktop
+provider. Resulting runtime events retain the `AuxiliaryInput` source.
+
+The gamepad source owns its device set internally. It performs an initial scan,
+refreshes on Linux input-device add, remove, and change events, and periodically
+reconciles in case an event is missed. Standard controller input is read from
+evdev. Logitech G923 wheel and pedal activity has a narrow raw HID fallback for
+hosts where those reports do not appear on the evdev node.
+
+GNOME is currently the only production desktop provider using the shared
+native-session runtime. A future native Wayland provider should plug into that
+runtime without acquiring any gamepad responsibility.
 
 ### `swayidle`
 
@@ -183,6 +192,10 @@ The code split is:
   - canonical events
   - capability model
   - backend-neutral traits and errors
+- `crates/lg-buddy/src/session/runner.rs`
+  - shared native-session orchestration and inactivity policy dispatch
+- `crates/lg-buddy/src/session/gamepad/`
+  - desktop-independent auxiliary input discovery and activity observations
 - `crates/lg-buddy/src/sources/desktop/gnome.rs`
   - GNOME-specific probing and event mapping
 - `crates/lg-buddy/src/sources/desktop/swayidle.rs`

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -79,7 +79,7 @@ This is the place for integration tests and contract tests.
 - GNOME runner behavior against a private session-bus harness
 - logind lifecycle and NetworkManager gate behavior against a private system-bus
   harness
-- GNOME and auxiliary gamepad activity resetting one LG Buddy-owned deadline
+- desktop and auxiliary gamepad activity resetting one LG Buddy-owned deadline
 
 ### How to test it
 
@@ -243,7 +243,7 @@ Primary concern:
 
 Secondary concern:
 
-- module interoperability in the GNOME runner path
+- module interoperability in the shared native-session runner path
 - runner refresh scheduling when device events arrive or reconciliation is due
 
 Discovery coverage should include event-node filtering, readable-device


### PR DESCRIPTION
## Summary

- move gamepad monitor lifecycle ownership into the shared native-session runtime
- preserve gamepad activity as `AuxiliaryInput` through inactivity and screen-policy dispatch
- add backend-independent synthetic-source coverage and align the architecture documentation

This establishes the auxiliary-activity prerequisite for the native Wayland work in #21 without implementing that backend.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

No new configuration or desktop-specific behavior. Meaningful controller activity continues to reset the shared inactivity deadline and restore an LG Buddy-owned blank, but the gamepad source is no longer owned by the GNOME monitor path.

## Validation

- `cargo test -p lg-buddy --lib` — 610 passed, 1 hardware test ignored
- `cargo test -p lg-buddy --test cucumber` — 109 of 110 scenarios passed in the full local Nix sandbox run; the remaining unrelated initial-configuration scenario passed separately after exposing `/bin/bash` in that sandbox
- focused gamepad/GNOME scenarios — 2 scenarios and 32 steps passed
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- shell syntax validation for installer and release scripts

Hardware smoke was not run because device discovery and activity filtering are unchanged.

## Related Issue

Closes #82.

Prerequisite for #21; native Wayland implementation remains out of scope.