### PR TITLE
Add opt-in native Wayland idle backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,6 +847,8 @@ dependencies = [
  "tokio",
  "tungstenite",
  "ureq",
+ "wayland-client",
+ "wayland-protocols",
 ]
 
 [[package]]
@@ -1024,6 +1032,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1598,6 +1615,63 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38a91b4eaddff87b1cd1074985e3713da4af2c49742d1b356b2c01670a67a078"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c36a0f861ad76d0901f2800b46321410d9f73f2ea88aac0650d86c32688073"
+dependencies = [
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/README.md
+++ b/README.md
@@ -1,264 +1,156 @@
 # LG Buddy
 
-Inspired by [LGTV Companion for Windows](https://github.com/JPersson77/LGTVCompanion), LG Buddy makes an LG WebOS TV behave more like a monitor for a Linux PC.
+LG Buddy makes an LG webOS TV behave more like a monitor for a Linux PC.
+It is inspired by
+[LGTV Companion for Windows](https://github.com/JPersson77/LGTVCompanion).
 
-It can:
+LG Buddy can:
 
 - turn the TV on at boot and wake
 - turn the TV off at shutdown and before system sleep
 - blank and restore the panel on supported desktop idle backends
-- keep the panel awake from gamepad activity on GNOME
-- adjust OLED pixel brightness with a small desktop dialog or CLI command
+- keep the panel awake when supported gamepads are active
+- adjust OLED pixel brightness from a desktop dialog or the command line
+- manage settings and check for updates from the command line
 
 GNOME is not required. Official release bundles include a prebuilt `lg-buddy`
 binary, so normal installation does not require a Rust toolchain.
 
-If you build `lg-buddy` from source instead of using a release bundle, `cargo`
-now also needs a working C toolchain because the vendored `libdbus` runtime is
-compiled as part of the build.
-
 ## Desktop Compatibility
 
-| Functionality | GNOME | Native Wayland | Wayland with `swayidle` | Other Linux sessions | Notes |
-| --- | --- | --- | --- | --- | --- |
-| Turn TV on at boot and wake | ✅ | ✅ | ✅ | ✅ | Desktop-independent Linux lifecycle integration |
-| Turn TV off at shutdown and before system sleep | ✅ | ✅ | ✅ | ✅ | Desktop-independent Linux lifecycle integration |
-| Blank and restore on desktop idle/activity | ✅ | ✅ | ✅ | ❌ | Native Wayland is currently explicit opt-in; `auto` remains GNOME then `swayidle` |
-| Keep the panel awake from gamepad activity | ✅ | ✅ | ❌ | ❌ | Available through the shared native-session runtime |
-| OLED brightness CLI | ✅ | ✅ | ✅ | ✅ | Desktop-independent runtime command |
-| OLED brightness desktop dialog | ✅ | ✅ | ✅ | ✅ | Requires `zenity` |
-| Settings CLI | ✅ | ✅ | ✅ | ✅ | Desktop-independent runtime command |
-| Manual and background update checks | ✅ | ✅ | ✅ | ✅ | Desktop notifications depend on the session notification service and desktop notification support |
+| Functionality | GNOME | Compatible native Wayland | Wayland with `swayidle` | Other Linux sessions |
+| --- | --- | --- | --- | --- |
+| TV control at boot, shutdown, sleep, and wake | ✅ | ✅ | ✅ | ✅ |
+| Idle blank and activity restore | ✅ | ✅ | ✅ | ❌ |
+| Gamepad activity keeps the panel awake | ✅ | ✅ | ❌ | ❌ |
+| Brightness, settings, and update commands | ✅ | ✅ | ✅ | ✅ |
+| Brightness desktop dialog | ✅ | ✅ | ✅ | ✅ |
 
-## Before You Install
-
-Install prerequisites:
-
-- `python3-venv`
-- `python3-pip`
-- `zenity`
-
-Backend-specific:
-
-- GNOME backend: compatible GNOME Shell session
-- Native Wayland backend: a compositor advertising `ext_idle_notifier_v1`
-  version 2 or newer and at least one `wl_seat`
-- Delegated Wayland backend: `swayidle`
-
-The GNOME backend requires a compatible GNOME session with:
-
-- GNOME Shell
-- `org.gnome.ScreenSaver`
-- `org.gnome.Mutter.IdleMonitor`
-
-Native Wayland monitoring is an explicit opt-in:
+The default `auto` backend uses GNOME when compatible, then falls back to
+`swayidle` when installed. Native Wayland is currently opt-in:
 
 ```bash
 lg-buddy settings set screen.backend wayland
 ```
 
-It creates a zero-timeout idle notification for every advertised seat and
-treats each resumed notification as desktop activity. LG Buddy's shared
-inactivity engine still owns `screen_idle_timeout`; compositor idle events do
-not blank the TV directly. Protocol or connection loss, removal of the bound
-notifier, and removal of the last seat stop the provider so the user service can
-retry. An unsupported compositor produces a specific capability diagnostic and
-does not fall back to another backend.
+See the [user guide](docs/user-guide.md#automatic-screen-blanking) for backend
+selection and troubleshooting. Protocol and event details are documented in the
+[session backend model](docs/session-backend-model.md).
 
-`screen_backend=auto` is unchanged: it prefers GNOME and otherwise uses
-`swayidle` when installed. The delegated `swayidle` backend remains supported.
+## Before You Install
 
-At runtime, GNOME support now uses a persistent in-process session-bus client
-for shell detection, ScreenSaver signals, and Mutter idletime polling.
-The GNOME monitor also observes readable Linux gamepad input devices so
-controller activity can keep the TV output awake even when GNOME does not count
-that input as desktop activity. It refreshes the watched device set when Linux
-reports input-device add, remove, or change events, with a periodic
-reconciliation scan as a fallback. For the Logitech G923 raw HID path, only
-meaningful control changes count as activity; unsolicited status reports do not.
+The native `lg_webos` control path does not require Python. Native-only packages
+can omit the Python client, `venv`, and `pip`. The current `install.sh` flow
+still provisions `bscpylgtv` as a compatibility fallback and installs the
+brightness dialog, so release-bundle installation checks for Python 3 with
+`venv` and `pip`, plus `zenity`. `swayidle` is required only when using that
+desktop backend.
 
-Typical package installs:
+### Debian, Ubuntu, and Pop!_OS
 
-**Debian/Ubuntu/Pop!_OS**
 ```bash
 sudo apt install python3-venv python3-pip zenity
-# Optional for non-GNOME Wayland sessions:
+# Optional swayidle backend:
 sudo apt install swayidle
 ```
 
-**Fedora**
+### Fedora
+
 ```bash
 sudo dnf install python3 python3-pip python3-virtualenv zenity
-# Optional for non-GNOME Wayland sessions:
+# Optional swayidle backend:
 sudo dnf install swayidle
 ```
 
-**Arch**
+### Arch Linux
+
 ```bash
 sudo pacman -S python python-pip python-virtualenv zenity
-# Optional for non-GNOME Wayland sessions:
+# Optional swayidle backend:
 sudo pacman -S swayidle
 ```
 
-For source builds, also install a C toolchain:
-
-- Debian/Ubuntu/Pop!_OS: `build-essential`
-- Fedora: `gcc`
-- Arch: `base-devel`
+Source builds also require a Rust toolchain and a working C toolchain because
+the vendored D-Bus library is compiled during the build. See the
+[development guide](docs/development.md) for build instructions.
 
 ## Install
 
-1. Download the release archive for your platform.
-2. Extract it.
-3. Run:
+1. Download and extract the release archive for your platform.
+2. Run the installer as your regular user:
 
 ```bash
 chmod +x ./install.sh
 ./install.sh
 ```
 
-The installer will prompt for your TV IP, MAC address, HDMI input, TV control platform, and session idle blanking details, then install the required services. If you choose the native `lg_webos` platform, accept the pairing prompt on the TV during setup. System sleep/wake handling uses the lifecycle service plus NetworkManager pre-down gate as cooperating suspend sources unless you opt out in `config.env`.
+Do not run the installer with `sudo`; it requests elevated access when needed.
 
-With the default `bscpylgtv` platform, you may instead see the pairing prompt on first use:
+The installer asks for the TV's IP address, MAC address, HDMI input, control
+platform, and desktop idle preferences, then installs the required services.
 
-<https://github.com/chros73/bscpylgtv/blob/master/docs/guides/first_use.md>
+If you select the native `lg_webos` control platform, accept the pairing prompt
+during setup. With the default `bscpylgtv` platform, the prompt may instead
+appear on first use; see the
+[bscpylgtv first-use guide](https://github.com/chros73/bscpylgtv/blob/master/docs/guides/first_use.md).
 
-## Day to Day
-
-LG Buddy is mostly automatic after installation.
-
-- To turn on the TV and restore the configured input, run `lg-buddy power on`
-- To turn off the TV when it is on the configured input, run `lg-buddy power off`
-- To blank or restore the TV screen, run `lg-buddy screen off` or `lg-buddy screen on`
-- To inspect settings, run `lg-buddy settings list`
-- To change supported settings, use `lg-buddy settings set <key> <value>`
-- To inspect the active TV platform, run `lg-buddy settings get tv.platform`
-- To inspect the configured and currently resolved desktop idle backend, run
-  `lg-buddy settings describe screen.backend`
-- To inspect TV brightness, run `lg-buddy brightness get`
-- To set TV brightness directly, run `lg-buddy brightness set <0-100>`
-- To inspect the installed runtime version, run `lg-buddy --version`
-- To check GitHub releases on demand, run `lg-buddy updates check`; add
-  `--notify` to send a desktop notification when an update is available
-- Weekly background update checks are installed by default; opt out with
-  `lg-buddy settings set updates.auto_check disabled`
-- To rerun full setup for TV identity, control platform, or idle behavior, run
-  `./configure.sh`
-- To check the user-session service, run `systemctl --user status LG_Buddy_screen.service`
-- To remove LG Buddy, run `./uninstall.sh`
-
-For scoped syntax, run `lg-buddy <command> --help` or
-`lg-buddy help <command>`. Package-owned service, hook, timer, and compatibility
-entrypoints are not intended for ordinary TV control; they are identified in
-the [user guide](docs/user-guide.md#package-owned-runtime-entrypoints).
-
-The settings CLI is a structured layer over `config.env`. These examples write
-the same file that manual editing and `configure.sh` use:
-
-```bash
-lg-buddy settings describe tv.input
-lg-buddy settings set tv.input HDMI_2
-lg-buddy settings get tv.platform
-lg-buddy settings set screen.idle_blank disabled
-lg-buddy settings describe screen.restore_policy
-lg-buddy settings set screen.idle_timeout 600
-lg-buddy settings set screen.restore_policy aggressive
-lg-buddy settings set system.sleep_wake_policy disabled
-lg-buddy settings set updates.auto_check disabled
-lg-buddy settings set updates.channel prerelease
-lg-buddy settings unset screen.restore_policy
-```
-
-Settings can also be edited directly in `config.env`:
-
-```ini
-tvs_primary_ip=192.168.1.100
-tvs_primary_mac=aa:bb:cc:dd:ee:ff
-tvs_primary_input=HDMI_2
-tvs_primary_platform=bscpylgtv
-screen_idle_blank=enabled
-screen_backend=auto
-screen_idle_timeout=300
-screen_restore_policy=conservative
-system_sleep_wake_policy=enabled
-updates_auto_check=enabled
-updates_channel=stable
-```
-
-`tv_ip`, `tv_mac`, and `input` are still accepted as legacy single-TV keys, but
-new writes use the `tvs_primary_*` shape so the storage can grow later without
-changing the current single-TV settings interface.
-
-The TV platform defaults to `bscpylgtv`, including when
-`tvs_primary_platform` is absent from an existing profile. The experimental
-native Rust webOS platform is an explicit opt-in:
-
-```bash
-lg-buddy settings set tv.platform lg_webos
-```
-
-Before saving that selection, LG Buddy connects in the foreground, reuses or
-acquires the profile's native credential, and verifies it with a safe TV state
-read. Accept any pairing prompt on the TV. If pairing or verification fails,
-the previous platform remains selected. Background services never initiate
-pairing. Switch back with `lg-buddy settings set tv.platform bscpylgtv`.
-
-Use the settings command for native opt-in rather than editing
-`tvs_primary_platform` directly, because a direct edit bypasses credential
-preflight.
-
-The native driver keeps the selected TV-control path inside the Rust runtime
-and does not depend on the Python client for those operations. This makes it a
-useful building block for declarative or immutable distributions such as
-NixOS. The current shell installer is not yet a first-class NixOS installation
-path: it still provisions the legacy fallback and writes conventional mutable
-system locations. That packaging work is tracked in
+The shell installer targets conventional Linux installations with mutable
+system locations. First-class NixOS packaging is tracked in
 [issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).
 
-If a direct `config.env` edit leaves a value malformed, `lg-buddy settings list`
-and `describe` show it as invalid instead of silently treating it as default or
-missing. `lg-buddy settings get <key>` fails with the validation error so the
-bad entry can be fixed with `settings set`, `settings unset` when supported, or
-by editing `config.env`.
+## Quick Start
 
-`screen_restore_policy=conservative` is the default. LG Buddy only restores when a matching LG Buddy marker says it previously blanked or powered off the TV.
+LG Buddy's services run automatically after installation. Common commands are:
 
-Set `screen_restore_policy=aggressive` to let session wake/activity and system wake restore the TV even when no LG Buddy marker exists. This is intentionally more aggressive and can turn the TV on in cases where another device or a manual action powered it off.
+```bash
+lg-buddy power on
+lg-buddy power off
+lg-buddy screen off
+lg-buddy screen on
+lg-buddy brightness
+lg-buddy brightness get
+lg-buddy brightness set 65
+lg-buddy settings list
+lg-buddy settings describe screen.backend
+lg-buddy updates check
+lg-buddy --version
+```
 
-`marker_only` is still accepted as a legacy alias for `conservative`.
+Change an individual setting with:
 
-`screen_idle_blank=enabled` is the default. Set
-`screen_idle_blank=disabled` if you want the user-session service to stay
-available for update notifications without running idle-driven TV blank/restore
-behavior.
+```bash
+lg-buddy settings set <key> <value>
+```
 
-`system_sleep_wake_policy=enabled` is the default. Set
-`system_sleep_wake_policy=disabled` if you do not want LG Buddy to control the
-TV around system sleep and wake. The lifecycle service and NetworkManager
-pre-down hook stay installed and no-op while the policy is disabled.
+For example:
 
-`updates_auto_check=enabled` is the default. Set
-`updates_auto_check=disabled` if you do not want the installed user timer to
-check for updates and notify you when a release is available. Manual
-`lg-buddy updates check` commands still work when automatic checks are disabled.
-Update notifications also include a `Never Notify Again` button when the
-desktop notification service supports actions; it disables automatic update
-checks through the same setting.
-`updates_channel=stable` is the default for scheduled checks. Set it to
-`prerelease` to opt in to prerelease update notifications.
+```bash
+lg-buddy settings set screen.idle_timeout 600
+lg-buddy settings set screen.restore_policy aggressive
+lg-buddy settings set updates.auto_check disabled
+```
 
-## More Help
+Run `lg-buddy <command> --help` for scoped syntax. To revisit the complete
+interactive setup, run `./configure.sh`.
+
+The [user guide](docs/user-guide.md) covers all settings, desktop backends, TV
+platform selection, updates, service checks, and uninstalling.
+
+## Documentation
 
 - [User guide](docs/user-guide.md)
-- [Development](docs/development.md)
+- [Development guide](docs/development.md)
+- [Architecture overview](docs/architecture-overview.md)
+- [Session backend model](docs/session-backend-model.md)
+- [Gamepad activity subsystem](docs/gamepad-subsystem.md)
 - [Defaults and configuration](docs/defaults-and-configuration.md)
 - [Runtime event handler map](docs/runtime-event-handler-map.md)
-- [Gamepad subsystem](docs/gamepad-subsystem.md)
 - [Contributing](CONTRIBUTING.md)
 - [Release process](docs/release-process.md)
 
 ## Credits
 
-- <https://github.com/chros73> for `bscpylgtv`
-- <https://github.com/JPersson77> for the original inspiration
-- <https://github.com/Faceless3882> for the original shell script implementation
+- [chros73](https://github.com/chros73) for `bscpylgtv`
+- [JPersson77](https://github.com/JPersson77) for the original inspiration
+- [Faceless3882](https://github.com/Faceless3882) for the original shell script
+  implementation

--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ compiled as part of the build.
 
 ## Desktop Compatibility
 
-| Functionality | GNOME | Non-GNOME Wayland with `swayidle` | Other Linux sessions | Notes |
-| --- | --- | --- | --- | --- |
-| Turn TV on at boot and wake | ✅ | ✅ | ✅ | Desktop-independent Linux lifecycle integration |
-| Turn TV off at shutdown and before system sleep | ✅ | ✅ | ✅ | Desktop-independent Linux lifecycle integration |
-| Blank and restore on desktop idle/activity | ✅ | ✅ | ❌ | `screen_backend=auto` prefers GNOME, then falls back to `swayidle` when installed |
-| Keep the panel awake from gamepad activity | ✅ | ❌ | ❌ | Implemented in the GNOME monitor runtime |
-| OLED brightness CLI | ✅ | ✅ | ✅ | Desktop-independent runtime command |
-| OLED brightness desktop dialog | ✅ | ✅ | ✅ | Requires `zenity` |
-| Settings CLI | ✅ | ✅ | ✅ | Desktop-independent runtime command |
-| Manual and background update checks | ✅ | ✅ | ✅ | Desktop notifications depend on the session notification service and desktop notification support |
+| Functionality | GNOME | Native Wayland | Wayland with `swayidle` | Other Linux sessions | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Turn TV on at boot and wake | ✅ | ✅ | ✅ | ✅ | Desktop-independent Linux lifecycle integration |
+| Turn TV off at shutdown and before system sleep | ✅ | ✅ | ✅ | ✅ | Desktop-independent Linux lifecycle integration |
+| Blank and restore on desktop idle/activity | ✅ | ✅ | ✅ | ❌ | Native Wayland is currently explicit opt-in; `auto` remains GNOME then `swayidle` |
+| Keep the panel awake from gamepad activity | ✅ | ✅ | ❌ | ❌ | Available through the shared native-session runtime |
+| OLED brightness CLI | ✅ | ✅ | ✅ | ✅ | Desktop-independent runtime command |
+| OLED brightness desktop dialog | ✅ | ✅ | ✅ | ✅ | Requires `zenity` |
+| Settings CLI | ✅ | ✅ | ✅ | ✅ | Desktop-independent runtime command |
+| Manual and background update checks | ✅ | ✅ | ✅ | ✅ | Desktop notifications depend on the session notification service and desktop notification support |
 
 ## Before You Install
 
@@ -41,13 +41,32 @@ Install prerequisites:
 Backend-specific:
 
 - GNOME backend: compatible GNOME Shell session
-- Non-GNOME Wayland backend: `swayidle`
+- Native Wayland backend: a compositor advertising `ext_idle_notifier_v1`
+  version 2 or newer and at least one `wl_seat`
+- Delegated Wayland backend: `swayidle`
 
 The GNOME backend requires a compatible GNOME session with:
 
 - GNOME Shell
 - `org.gnome.ScreenSaver`
 - `org.gnome.Mutter.IdleMonitor`
+
+Native Wayland monitoring is an explicit opt-in:
+
+```bash
+lg-buddy settings set screen.backend wayland
+```
+
+It creates a zero-timeout idle notification for every advertised seat and
+treats each resumed notification as desktop activity. LG Buddy's shared
+inactivity engine still owns `screen_idle_timeout`; compositor idle events do
+not blank the TV directly. Protocol or connection loss, removal of the bound
+notifier, and removal of the last seat stop the provider so the user service can
+retry. An unsupported compositor produces a specific capability diagnostic and
+does not fall back to another backend.
+
+`screen_backend=auto` is unchanged: it prefers GNOME and otherwise uses
+`swayidle` when installed. The delegated `swayidle` backend remains supported.
 
 At runtime, GNOME support now uses a persistent in-process session-bus client
 for shell detection, ScreenSaver signals, and Mutter idletime polling.

--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -229,7 +229,7 @@ lg_buddy_load_config() {
         echo "LG Buddy: invalid tv platform '$tv_platform'; expected bscpylgtv or lg_webos."
         return 2
     fi
-    screen_backend="$(lg_buddy_config_get_valid "screen_backend" '^(auto|gnome|swayidle)$' "$LG_BUDDY_DEFAULT_SCREEN_BACKEND" "$LG_BUDDY_CONFIG_FILE")"
+    screen_backend="$(lg_buddy_config_get_valid "screen_backend" '^(auto|gnome|wayland|swayidle)$' "$LG_BUDDY_DEFAULT_SCREEN_BACKEND" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_blank="$(lg_buddy_config_get_valid "screen_idle_blank" '^(enabled|disabled)$' "$LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_config_get_valid "screen_idle_timeout" '^[0-9]+$' "$LG_BUDDY_DEFAULT_IDLE_TIMEOUT" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_normalize_idle_timeout "$screen_idle_timeout")"

--- a/configure.sh
+++ b/configure.sh
@@ -52,7 +52,7 @@ validate_tv_platform() {
 
 validate_backend() {
     case "$1" in
-        auto|gnome|swayidle) return 0 ;;
+        auto|gnome|wayland|swayidle) return 0 ;;
         *) return 1 ;;
     esac
 }
@@ -161,7 +161,7 @@ if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
         exit 1
     }
     validate_backend "$screen_backend" || {
-        echo "LG_BUDDY_SCREEN_BACKEND must be one of auto, gnome, or swayidle."
+        echo "LG_BUDDY_SCREEN_BACKEND must be one of auto, gnome, wayland, or swayidle."
         exit 1
     }
     validate_screen_idle_blank "$screen_idle_blank" || {
@@ -309,22 +309,25 @@ else
         echo "Choose the screen idle backend:"
         echo "  1) auto"
         echo "  2) gnome"
-        echo "  3) swayidle"
+        echo "  3) wayland"
+        echo "  4) swayidle"
 
         case "$current_screen_backend" in
             auto) default_backend_choice="1" ;;
             gnome) default_backend_choice="2" ;;
-            swayidle) default_backend_choice="3" ;;
+            wayland) default_backend_choice="3" ;;
+            swayidle) default_backend_choice="4" ;;
             *) default_backend_choice="1" ;;
         esac
 
         while true; do
-            BACKEND_CHOICE="$(prompt_with_default "Enter number (1-3)" "$default_backend_choice")"
+            BACKEND_CHOICE="$(prompt_with_default "Enter number (1-4)" "$default_backend_choice")"
             case "$BACKEND_CHOICE" in
                 1) screen_backend="auto"; break ;;
                 2) screen_backend="gnome"; break ;;
-                3) screen_backend="swayidle"; break ;;
-                *) echo "  Please enter a number between 1 and 3." ;;
+                3) screen_backend="wayland"; break ;;
+                4) screen_backend="swayidle"; break ;;
+                *) echo "  Please enter a number between 1 and 4." ;;
             esac
         done
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -15,6 +15,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tungstenite = { version = "0.30", features = ["rustls-tls-webpki-roots"] }
 ureq = "2"
+wayland-client = { version = "0.31.15", default-features = false }
+wayland-protocols = { version = "0.32.13", default-features = false, features = ["client", "staging"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/lg-buddy/src/backend.rs
+++ b/crates/lg-buddy/src/backend.rs
@@ -10,6 +10,7 @@ use crate::sources::desktop::gnome::{
     GNOME_IDLE_MONITOR_NAME, GNOME_REQUIRED_SERVICES_REASON, GNOME_SCREEN_SAVER_NAME,
     GNOME_SHELL_NAME,
 };
+use crate::sources::desktop::wayland::probe_wayland_capabilities;
 
 const GNOME_SHELL_WAIT_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -23,7 +24,7 @@ impl fmt::Display for BackendSelectionError {
         match self {
             Self::InvalidOverride(value) => write!(
                 f,
-                "invalid LG_BUDDY_SCREEN_BACKEND value `{value}`; expected auto, gnome, or swayidle"
+                "invalid LG_BUDDY_SCREEN_BACKEND value `{value}`; expected auto, gnome, wayland, or swayidle"
             ),
         }
     }
@@ -36,7 +37,7 @@ pub enum BackendDetectionError {
     NoSupportedBackend,
     UnavailableBackend {
         backend: ScreenBackend,
-        reason: &'static str,
+        reason: String,
     },
     MissingRequiredCommand {
         backend: ScreenBackend,
@@ -72,6 +73,9 @@ pub trait BackendProbe {
     fn gnome_shell_available(&self) -> bool;
     fn gnome_screen_saver_available(&self) -> bool;
     fn gnome_idle_monitor_available(&self) -> bool;
+    fn wayland_capabilities(&self) -> Result<(), String> {
+        Err("native Wayland capability probing is unavailable".to_string())
+    }
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -109,6 +113,12 @@ impl BackendProbe for SystemBackendProbe {
             Err(_) => return false,
         };
         bus.name_has_owner(GNOME_IDLE_MONITOR_NAME).unwrap_or(false)
+    }
+
+    fn wayland_capabilities(&self) -> Result<(), String> {
+        probe_wayland_capabilities()
+            .map(|_| ())
+            .map_err(|err| err.to_string())
     }
 }
 
@@ -158,7 +168,7 @@ pub fn detect_backend_with_probe(
 
                 return Err(BackendDetectionError::UnavailableBackend {
                     backend: ScreenBackend::Gnome,
-                    reason: GNOME_REQUIRED_SERVICES_REASON,
+                    reason: GNOME_REQUIRED_SERVICES_REASON.to_string(),
                 });
             }
 
@@ -177,10 +187,17 @@ pub fn detect_backend_with_probe(
             } else {
                 Err(BackendDetectionError::UnavailableBackend {
                     backend: ScreenBackend::Gnome,
-                    reason: GNOME_REQUIRED_SERVICES_REASON,
+                    reason: GNOME_REQUIRED_SERVICES_REASON.to_string(),
                 })
             }
         }
+        ScreenBackend::Wayland => probe
+            .wayland_capabilities()
+            .map(|()| ScreenBackend::Wayland)
+            .map_err(|reason| BackendDetectionError::UnavailableBackend {
+                backend: ScreenBackend::Wayland,
+                reason,
+            }),
         ScreenBackend::Swayidle => {
             if probe.has_command("swayidle") {
                 Ok(ScreenBackend::Swayidle)
@@ -243,6 +260,30 @@ mod tests {
         }
     }
 
+    struct WaylandProbe(Result<(), &'static str>);
+
+    impl BackendProbe for WaylandProbe {
+        fn has_command(&self, _command: &str) -> bool {
+            false
+        }
+
+        fn gnome_shell_available(&self) -> bool {
+            false
+        }
+
+        fn gnome_screen_saver_available(&self) -> bool {
+            false
+        }
+
+        fn gnome_idle_monitor_available(&self) -> bool {
+            false
+        }
+
+        fn wayland_capabilities(&self) -> Result<(), String> {
+            self.0.map_err(str::to_string)
+        }
+    }
+
     #[test]
     fn env_override_wins_over_config_backend() {
         let backend = configured_backend_from_sources(Some("swayidle"), Some(ScreenBackend::Gnome))
@@ -265,6 +306,14 @@ mod tests {
             configured_backend_from_sources(None, None).expect("fallback to auto backend");
 
         assert_eq!(backend, ScreenBackend::Auto);
+    }
+
+    #[test]
+    fn wayland_override_is_accepted() {
+        let backend = configured_backend_from_sources(Some("wayland"), None)
+            .expect("parse native Wayland backend");
+
+        assert_eq!(backend, ScreenBackend::Wayland);
     }
 
     #[test]
@@ -340,7 +389,8 @@ mod tests {
             BackendDetectionError::UnavailableBackend {
                 backend: ScreenBackend::Gnome,
                 reason:
-                    "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required",
+                    "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required"
+                        .to_string(),
             }
         );
     }
@@ -362,7 +412,8 @@ mod tests {
             BackendDetectionError::UnavailableBackend {
                 backend: ScreenBackend::Gnome,
                 reason:
-                    "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required",
+                    "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required"
+                        .to_string(),
             }
         );
     }
@@ -399,7 +450,8 @@ mod tests {
             BackendDetectionError::UnavailableBackend {
                 backend: ScreenBackend::Gnome,
                 reason:
-                    "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required",
+                    "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required"
+                        .to_string(),
             }
         );
     }
@@ -423,5 +475,34 @@ mod tests {
                 command: "swayidle",
             }
         );
+    }
+
+    #[test]
+    fn forced_wayland_requires_the_native_protocol_surface() {
+        let err = detect_backend_with_probe(
+            &WaylandProbe(Err(
+                "ext_idle_notifier_v1 version 1 is unsupported; version 2 or newer is required",
+            )),
+            ScreenBackend::Wayland,
+        )
+        .expect_err("forced Wayland without protocol v2 should fail");
+
+        assert_eq!(
+            err,
+            BackendDetectionError::UnavailableBackend {
+                backend: ScreenBackend::Wayland,
+                reason:
+                    "ext_idle_notifier_v1 version 1 is unsupported; version 2 or newer is required"
+                        .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn forced_wayland_is_selected_when_the_native_protocol_surface_is_available() {
+        let backend = detect_backend_with_probe(&WaylandProbe(Ok(())), ScreenBackend::Wayland)
+            .expect("forced Wayland should be available");
+
+        assert_eq!(backend, ScreenBackend::Wayland);
     }
 }

--- a/crates/lg-buddy/src/config.rs
+++ b/crates/lg-buddy/src/config.rs
@@ -60,6 +60,7 @@ impl Error for ConfigPathError {}
 pub enum ScreenBackend {
     Auto,
     Gnome,
+    Wayland,
     Swayidle,
 }
 
@@ -68,6 +69,7 @@ impl ScreenBackend {
         match self {
             Self::Auto => "auto",
             Self::Gnome => "gnome",
+            Self::Wayland => "wayland",
             Self::Swayidle => "swayidle",
         }
     }
@@ -80,6 +82,7 @@ impl FromStr for ScreenBackend {
         match value {
             "auto" => Ok(Self::Auto),
             "gnome" => Ok(Self::Gnome),
+            "wayland" => Ok(Self::Wayland),
             "swayidle" => Ok(Self::Swayidle),
             _ => Err(()),
         }
@@ -680,7 +683,7 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
             tvs_primary_mac=aa:bb:cc:dd:ee:ff
             tvs_primary_input=HDMI_2
             tvs_primary_platform=lg_webos
-            screen_backend=gnome
+            screen_backend=wayland
             screen_idle_timeout=450
             screen_restore_policy=aggressive
             screen_idle_blank=disabled
@@ -693,7 +696,7 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
         assert_eq!(config.tv_mac.to_string(), "aa:bb:cc:dd:ee:ff");
         assert_eq!(config.input, HdmiInput::Hdmi2);
         assert_eq!(config.tv_platform, TvPlatform::LgWebOs);
-        assert_eq!(config.screen_backend, ScreenBackend::Gnome);
+        assert_eq!(config.screen_backend, ScreenBackend::Wayland);
         assert_eq!(config.screen_idle_timeout, 450);
         assert_eq!(
             config.screen_restore_policy,

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -24,7 +24,7 @@ pub mod web_os;
 pub mod wol;
 
 pub use dev::{DevCommand, DevError, DevParseError, WebOsControlProbeCommand};
-pub use sources::desktop::{gnome, swayidle};
+pub use sources::desktop::{gnome, swayidle, wayland};
 pub use sources::linux::{logind, network_manager};
 
 use crate::backend::{

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -509,6 +509,23 @@ fn lifecycle_policy_enabled_from_config(config_path: &Path) -> Result<bool, Sess
     Ok(config.system_sleep_wake_policy.is_enabled())
 }
 
+fn select_monitor_backend<F>(
+    configured: ScreenBackend,
+    detect: F,
+) -> Result<ScreenBackend, BackendDetectionError>
+where
+    F: FnOnce(ScreenBackend) -> Result<ScreenBackend, BackendDetectionError>,
+{
+    if configured == ScreenBackend::Wayland {
+        // The provider validates the protocol and seats while opening its
+        // production connection. A separate probe would consume an inherited
+        // WAYLAND_SOCKET before the provider can use it.
+        Ok(ScreenBackend::Wayland)
+    } else {
+        detect(configured)
+    }
+}
+
 fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     executor: E,
@@ -544,7 +561,7 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
         let configured = configured_backend_from_env_or_config()
             .map_err(SessionRunnerError::BackendSelection)?;
 
-        match detect_backend_from_system(configured) {
+        match select_monitor_backend(configured, detect_backend_from_system) {
             Ok(ScreenBackend::Gnome) => {
                 let mut dispatcher =
                     SessionEventDispatcher::new(executor.take().expect("executor available"));
@@ -1534,7 +1551,7 @@ mod tests {
         gamepad_device_event_refresh_requested, gamepad_refresh_due, handle_inactivity_observation,
         handle_inactivity_timeout, normalize_idle_timeout_secs, poll_gnome_idle_monitor_once,
         run_lifecycle_monitor_with_bus, run_native_session_monitor, schedule_gamepad_refresh,
-        shell_quote, GamepadDeviceEventMonitor, GamepadDeviceEventRefresh,
+        select_monitor_backend, shell_quote, GamepadDeviceEventMonitor, GamepadDeviceEventRefresh,
         GamepadDiagnosticEmitter, LatestInactivityObservation, RunnerMessage,
         SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
         TrustedScreenSaverSignals, GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL,
@@ -1566,6 +1583,27 @@ mod tests {
     fn env_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    #[test]
+    fn explicit_wayland_monitor_selection_does_not_probe_a_second_connection() {
+        let backend = select_monitor_backend(ScreenBackend::Wayland, |_| {
+            panic!("explicit Wayland monitor selection must not run capability detection")
+        })
+        .expect("select explicit Wayland backend");
+
+        assert_eq!(backend, ScreenBackend::Wayland);
+    }
+
+    #[test]
+    fn other_monitor_backend_selection_still_uses_detection() {
+        let backend = select_monitor_backend(ScreenBackend::Auto, |configured| {
+            assert_eq!(configured, ScreenBackend::Auto);
+            Ok(ScreenBackend::Swayidle)
+        })
+        .expect("resolve automatic backend");
+
+        assert_eq!(backend, ScreenBackend::Swayidle);
     }
 
     #[derive(Debug, Default)]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -41,6 +41,7 @@ use crate::sources::desktop::gnome::{
     screen_saver_owner_changed, GnomeBackend, SystemGnomeProbe, GNOME_SCREEN_SAVER_INTERFACE,
     GNOME_SCREEN_SAVER_PATH, GNOME_SHELL_NAME,
 };
+use crate::sources::desktop::wayland::run_wayland_activity_monitor;
 use crate::sources::linux::logind::{
     acquire_sleep_delay_inhibitor, add_logind_signal_match, map_prepare_for_sleep_signal,
 };
@@ -549,6 +550,11 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
                     SessionEventDispatcher::new(executor.take().expect("executor available"));
                 return run_gnome_monitor(writer, &mut dispatcher);
             }
+            Ok(ScreenBackend::Wayland) => {
+                let mut dispatcher =
+                    SessionEventDispatcher::new(executor.take().expect("executor available"));
+                return run_wayland_monitor(writer, &mut dispatcher);
+            }
             Ok(ScreenBackend::Swayidle) => return run_swayidle_monitor(writer),
             Ok(ScreenBackend::Auto) => {
                 return Err(SessionRunnerError::Failed {
@@ -644,6 +650,20 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
         dispatcher,
         ScreenBackend::Gnome,
         spawn_gnome_monitor_thread,
+    )
+}
+
+fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+) -> Result<(), SessionRunnerError> {
+    writeln!(writer, "LG Buddy Monitor: Using native Wayland backend.")?;
+
+    run_native_session_monitor(
+        writer,
+        dispatcher,
+        ScreenBackend::Wayland,
+        spawn_wayland_monitor_thread,
     )
 }
 
@@ -877,6 +897,27 @@ fn spawn_gnome_monitor_thread(
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let result = run_gnome_monitor_process(&sender, &latest_observation);
+        let _ = sender.send(RunnerMessage::MonitorExited(result));
+    })
+}
+
+fn spawn_wayland_monitor_thread(
+    sender: mpsc::Sender<RunnerMessage>,
+    latest_observation: Arc<LatestInactivityObservation>,
+) -> JoinHandle<()> {
+    thread::spawn(move || {
+        let activity_sender = sender.clone();
+        let result = run_wayland_activity_monitor(move |observed_at| {
+            latest_observation.publish(
+                &activity_sender,
+                InactivityObservation::DesktopActivityObserved,
+                observed_at,
+            )
+        })
+        .map_err(|err| SessionRunnerError::Failed {
+            backend: ScreenBackend::Wayland,
+            message: err.to_string(),
+        });
         let _ = sender.send(RunnerMessage::MonitorExited(result));
     })
 }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -41,7 +41,7 @@ use crate::sources::desktop::gnome::{
     screen_saver_owner_changed, GnomeBackend, SystemGnomeProbe, GNOME_SCREEN_SAVER_INTERFACE,
     GNOME_SCREEN_SAVER_PATH, GNOME_SHELL_NAME,
 };
-use crate::sources::desktop::wayland::run_wayland_activity_monitor;
+use crate::sources::desktop::wayland::{connect_wayland, run_wayland_activity_monitor};
 use crate::sources::linux::logind::{
     acquire_sleep_delay_inhibitor, add_logind_signal_match, map_prepare_for_sleep_signal,
 };
@@ -530,6 +530,26 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     executor: E,
 ) -> Result<(), SessionRunnerError> {
+    let screen_idle_blank_enabled = screen_idle_blank_enabled_from_config()?;
+    let configured = if screen_idle_blank_enabled {
+        Some(
+            configured_backend_from_env_or_config()
+                .map_err(SessionRunnerError::BackendSelection)?,
+        )
+    } else {
+        None
+    };
+    let mut wayland_connection = if configured == Some(ScreenBackend::Wayland) {
+        // wayland-client consumes an inherited WAYLAND_SOCKET by mutating the
+        // process environment. Do that while monitor startup is single-threaded.
+        Some(connect_wayland().map_err(|err| SessionRunnerError::Failed {
+            backend: ScreenBackend::Wayland,
+            message: err.to_string(),
+        })?)
+    } else {
+        None
+    };
+
     let _session_service = match spawn_session_notification_service() {
         Ok(service) => Some(service),
         Err(err) => {
@@ -541,7 +561,7 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
         }
     };
 
-    if !screen_idle_blank_enabled_from_config()? {
+    if !screen_idle_blank_enabled {
         writeln!(
             writer,
             "LG Buddy Monitor: screen idle blanking is disabled by config."
@@ -550,6 +570,7 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
     }
 
     let mut executor = Some(executor);
+    let mut initial_configured = configured;
     let started = Instant::now();
     let test_timeout = resolve_gnome_monitor_test_timeout();
 
@@ -558,8 +579,11 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
             return Ok(());
         }
 
-        let configured = configured_backend_from_env_or_config()
-            .map_err(SessionRunnerError::BackendSelection)?;
+        let configured = match initial_configured.take() {
+            Some(configured) => configured,
+            None => configured_backend_from_env_or_config()
+                .map_err(SessionRunnerError::BackendSelection)?,
+        };
 
         match select_monitor_backend(configured, detect_backend_from_system) {
             Ok(ScreenBackend::Gnome) => {
@@ -570,7 +594,14 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
             Ok(ScreenBackend::Wayland) => {
                 let mut dispatcher =
                     SessionEventDispatcher::new(executor.take().expect("executor available"));
-                return run_wayland_monitor(writer, &mut dispatcher);
+                let connection = wayland_connection.take().ok_or_else(|| {
+                    SessionRunnerError::Failed {
+                        backend: ScreenBackend::Wayland,
+                        message: "native Wayland was selected after threaded monitor startup; restart the monitor to acquire its connection safely"
+                            .to_string(),
+                    }
+                })?;
+                return run_wayland_monitor(writer, &mut dispatcher, connection);
             }
             Ok(ScreenBackend::Swayidle) => return run_swayidle_monitor(writer),
             Ok(ScreenBackend::Auto) => {
@@ -673,6 +704,7 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
 fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
+    connection: wayland_client::Connection,
 ) -> Result<(), SessionRunnerError> {
     writeln!(writer, "LG Buddy Monitor: Using native Wayland backend.")?;
 
@@ -680,7 +712,9 @@ fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
         writer,
         dispatcher,
         ScreenBackend::Wayland,
-        spawn_wayland_monitor_thread,
+        move |sender, latest_observation| {
+            spawn_wayland_monitor_thread(connection, sender, latest_observation)
+        },
     )
 }
 
@@ -919,12 +953,13 @@ fn spawn_gnome_monitor_thread(
 }
 
 fn spawn_wayland_monitor_thread(
+    connection: wayland_client::Connection,
     sender: mpsc::Sender<RunnerMessage>,
     latest_observation: Arc<LatestInactivityObservation>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
         let activity_sender = sender.clone();
-        let result = run_wayland_activity_monitor(move |observed_at| {
+        let result = run_wayland_activity_monitor(connection, move |observed_at| {
             latest_observation.publish(
                 &activity_sender,
                 InactivityObservation::DesktopActivityObserved,

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -48,7 +48,7 @@ const SCREEN_RESTORE_POLICY_ALIASES: &[SettingAlias] = &[SettingAlias {
 
 const TV_INPUT_VALUES: &[&str] = &["HDMI_1", "HDMI_2", "HDMI_3", "HDMI_4"];
 const TV_PLATFORM_VALUES: &[&str] = &["bscpylgtv", "lg_webos"];
-const SCREEN_BACKEND_VALUES: &[&str] = &["auto", "gnome", "swayidle"];
+const SCREEN_BACKEND_VALUES: &[&str] = &["auto", "gnome", "wayland", "swayidle"];
 const SCREEN_IDLE_BLANK_VALUES: &[&str] = &["enabled", "disabled"];
 const SCREEN_RESTORE_POLICY_VALUES: &[&str] = &["conservative", "aggressive"];
 const SYSTEM_SLEEP_WAKE_POLICY_VALUES: &[&str] = &["enabled", "disabled"];
@@ -2571,7 +2571,7 @@ mod tests {
                 "tv.mac | storage=tvs_primary_mac | fallbacks=tv_mac | type=mac-address | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=MAC address of the primary configured TV for Wake-on-LAN.",
                 "tv.input | storage=tvs_primary_input | fallbacks=input | type=enum values=HDMI_1,HDMI_2,HDMI_3,HDMI_4 aliases=(none) | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=HDMI input used by the primary configured TV.",
                 "tv.platform | storage=tvs_primary_platform | fallbacks=(none) | type=enum values=bscpylgtv,lg_webos aliases=(none) | default=bscpylgtv | mutability=read-write | ops=get,describe,set,unset | apply=no-runtime-apply-required | description=Control platform for the primary configured TV.",
-                "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Screen backend selection for user-session blanking and restore behavior.",
+                "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,wayland,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Screen backend selection for user-session blanking and restore behavior.",
                 "screen.idle_blank | storage=screen_idle_blank | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Idle-driven blanking and restore behavior for the configured screen.",
                 "screen.idle_timeout | storage=screen_idle_timeout | fallbacks=(none) | type=integer range=1..=86400 | default=300 | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Idle timeout in seconds before LG Buddy blanks the configured screen.",
                 "screen.restore_policy | storage=screen_restore_policy | fallbacks=(none) | type=enum values=conservative,aggressive aliases=marker_only->conservative | default=conservative | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Screen restore policy after LG Buddy blanks the configured screen.",
@@ -2735,7 +2735,7 @@ updates.channel=stable (default, read-write, ops: get,describe,set,unset)
 
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains("  current: auto (gnome)\n"));
-        assert!(output.contains("  allowed values: auto (gnome), gnome, swayidle\n"));
+        assert!(output.contains("  allowed values: auto (gnome), gnome, wayland, swayidle\n"));
 
         let mut raw_output = Vec::new();
         runner
@@ -2763,7 +2763,7 @@ updates.channel=stable (default, read-write, ops: get,describe,set,unset)
         let output = String::from_utf8(output).unwrap();
         assert!(output.contains("  current: auto (no backend currently available)\n"));
         assert!(output.contains(
-            "  allowed values: auto (no backend currently available), gnome, swayidle\n"
+            "  allowed values: auto (no backend currently available), gnome, wayland, swayidle\n"
         ));
     }
 
@@ -2835,7 +2835,7 @@ screen.backend
   default: auto
   mutability: read-write
   supported operations: get, describe, set, unset
-  allowed values: auto, gnome, swayidle
+  allowed values: auto, gnome, wayland, swayidle
   apply: restart-user-screen-service
   description: Screen backend selection for user-session blanking and restore behavior.
 
@@ -3860,7 +3860,7 @@ tvs_primary_ip=192.0.2.43
     fn screen_backend_values_are_validated() {
         let definition = SETTINGS_REGISTRY.get_by_name("screen.backend").unwrap();
 
-        for value in ["auto", "gnome", "swayidle"] {
+        for value in ["auto", "gnome", "wayland", "swayidle"] {
             assert_eq!(definition.parse_value(value), Ok(SettingValue::Enum(value)));
         }
 

--- a/crates/lg-buddy/src/sources/desktop/mod.rs
+++ b/crates/lg-buddy/src/sources/desktop/mod.rs
@@ -1,2 +1,3 @@
 pub mod gnome;
 pub mod swayidle;
+pub mod wayland;

--- a/crates/lg-buddy/src/sources/desktop/wayland.rs
+++ b/crates/lg-buddy/src/sources/desktop/wayland.rs
@@ -357,13 +357,12 @@ type InitializedWaylandProvider<F> = (
 );
 
 fn initialize_provider<F>(
+    connection: Connection,
     on_activity: F,
 ) -> Result<InitializedWaylandProvider<F>, WaylandProviderError>
 where
     F: FnMut(Instant) -> bool + 'static,
 {
-    let connection = Connection::connect_to_env()
-        .map_err(|err| WaylandProviderError::Connection(err.to_string()))?;
     let display = connection.display();
     let mut event_queue = connection.new_event_queue();
     let queue_handle = event_queue.handle();
@@ -385,16 +384,27 @@ where
     Ok((event_queue, state, capabilities))
 }
 
-pub fn probe_wayland_capabilities() -> Result<WaylandProviderCapabilities, WaylandProviderError> {
-    let (_, _, capabilities) = initialize_provider(|_| true)?;
+pub(crate) fn connect_wayland() -> Result<Connection, WaylandProviderError> {
+    // `connect_to_env` removes an inherited WAYLAND_SOCKET from the process
+    // environment. Monitor startup must call this before spawning any threads.
+    Connection::connect_to_env().map_err(|err| WaylandProviderError::Connection(err.to_string()))
+}
+
+pub(crate) fn probe_wayland_capabilities(
+) -> Result<WaylandProviderCapabilities, WaylandProviderError> {
+    let connection = connect_wayland()?;
+    let (_, _, capabilities) = initialize_provider(connection, |_| true)?;
     Ok(capabilities)
 }
 
-pub fn run_wayland_activity_monitor<F>(on_activity: F) -> Result<(), WaylandProviderError>
+pub(crate) fn run_wayland_activity_monitor<F>(
+    connection: Connection,
+    on_activity: F,
+) -> Result<(), WaylandProviderError>
 where
     F: FnMut(Instant) -> bool + 'static,
 {
-    let (mut event_queue, mut state, _) = initialize_provider(on_activity)?;
+    let (mut event_queue, mut state, _) = initialize_provider(connection, on_activity)?;
 
     while state.running {
         event_queue

--- a/crates/lg-buddy/src/sources/desktop/wayland.rs
+++ b/crates/lg-buddy/src/sources/desktop/wayland.rs
@@ -1,0 +1,517 @@
+use std::collections::HashMap;
+use std::error::Error;
+use std::fmt;
+use std::time::Instant;
+
+use wayland_client::protocol::{wl_registry, wl_seat};
+use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle};
+use wayland_protocols::ext::idle_notify::v1::client::{
+    ext_idle_notification_v1, ext_idle_notifier_v1,
+};
+
+const REQUIRED_IDLE_NOTIFIER_VERSION: u32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WaylandProviderCapabilities {
+    pub idle_notifier_version: u32,
+    pub seat_count: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WaylandProviderError {
+    Connection(String),
+    Dispatch(String),
+    MissingIdleNotifier,
+    UnsupportedIdleNotifierVersion(u32),
+    NoSeats,
+    IdleNotifierRemoved,
+    LastSeatRemoved,
+}
+
+impl fmt::Display for WaylandProviderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Connection(message) => {
+                write!(f, "failed to connect to the Wayland compositor: {message}")
+            }
+            Self::Dispatch(message) => {
+                write!(f, "Wayland event dispatch failed: {message}")
+            }
+            Self::MissingIdleNotifier => write!(
+                f,
+                "the compositor does not advertise ext_idle_notifier_v1; version 2 or newer is required"
+            ),
+            Self::UnsupportedIdleNotifierVersion(version) => write!(
+                f,
+                "the compositor advertises ext_idle_notifier_v1 version {version}; version 2 or newer is required"
+            ),
+            Self::NoSeats => write!(f, "the compositor does not advertise a Wayland seat"),
+            Self::IdleNotifierRemoved => write!(
+                f,
+                "the compositor removed the ext_idle_notifier_v1 global"
+            ),
+            Self::LastSeatRemoved => {
+                write!(f, "the compositor removed the last monitored Wayland seat")
+            }
+        }
+    }
+}
+
+impl Error for WaylandProviderError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GlobalInfo {
+    name: u32,
+    version: u32,
+}
+
+#[derive(Debug, Default)]
+struct RegistryFacts {
+    idle_notifiers: HashMap<u32, u32>,
+    seats: HashMap<u32, u32>,
+}
+
+impl RegistryFacts {
+    fn add(&mut self, name: u32, interface: &str, version: u32) {
+        if interface == ext_idle_notifier_v1::ExtIdleNotifierV1::interface().name {
+            self.idle_notifiers.insert(name, version);
+        } else if interface == wl_seat::WlSeat::interface().name {
+            self.seats.insert(name, version);
+        }
+    }
+
+    fn remove(&mut self, name: u32) {
+        self.idle_notifiers.remove(&name);
+        self.seats.remove(&name);
+    }
+
+    fn selected_idle_notifier(&self) -> Option<GlobalInfo> {
+        self.idle_notifiers
+            .iter()
+            .filter(|(_, version)| **version >= REQUIRED_IDLE_NOTIFIER_VERSION)
+            .max_by_key(|(_, version)| **version)
+            .map(|(name, version)| GlobalInfo {
+                name: *name,
+                version: *version,
+            })
+    }
+
+    fn maximum_idle_notifier_version(&self) -> Option<u32> {
+        self.idle_notifiers.values().copied().max()
+    }
+
+    fn capabilities(&self) -> Result<WaylandProviderCapabilities, WaylandProviderError> {
+        let Some(version) = self.maximum_idle_notifier_version() else {
+            return Err(WaylandProviderError::MissingIdleNotifier);
+        };
+        if version < REQUIRED_IDLE_NOTIFIER_VERSION {
+            return Err(WaylandProviderError::UnsupportedIdleNotifierVersion(
+                version,
+            ));
+        }
+        if self.seats.is_empty() {
+            return Err(WaylandProviderError::NoSeats);
+        }
+
+        Ok(WaylandProviderCapabilities {
+            idle_notifier_version: version,
+            seat_count: self.seats.len(),
+        })
+    }
+}
+
+struct SeatBinding {
+    seat: wl_seat::WlSeat,
+    notification: Option<ext_idle_notification_v1::ExtIdleNotificationV1>,
+}
+
+struct WaylandProviderState<F> {
+    registry: Option<wl_registry::WlRegistry>,
+    registry_facts: RegistryFacts,
+    idle_notifier: Option<(u32, ext_idle_notifier_v1::ExtIdleNotifierV1)>,
+    seats: HashMap<u32, SeatBinding>,
+    initialized: bool,
+    running: bool,
+    error: Option<WaylandProviderError>,
+    on_activity: F,
+}
+
+impl<F> WaylandProviderState<F>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    fn new(on_activity: F) -> Self {
+        Self {
+            registry: None,
+            registry_facts: RegistryFacts::default(),
+            idle_notifier: None,
+            seats: HashMap::new(),
+            initialized: false,
+            running: true,
+            error: None,
+            on_activity,
+        }
+    }
+
+    fn bind_idle_notifier(
+        &mut self,
+        registry: &wl_registry::WlRegistry,
+        queue_handle: &QueueHandle<Self>,
+    ) {
+        if self.idle_notifier.is_some() {
+            return;
+        }
+        let Some(global) = self.registry_facts.selected_idle_notifier() else {
+            return;
+        };
+
+        let notifier = registry.bind::<ext_idle_notifier_v1::ExtIdleNotifierV1, _, _>(
+            global.name,
+            REQUIRED_IDLE_NOTIFIER_VERSION.min(global.version),
+            queue_handle,
+            (),
+        );
+        self.idle_notifier = Some((global.name, notifier));
+        self.attach_unmonitored_seats(queue_handle);
+    }
+
+    fn bind_seat(
+        &mut self,
+        registry: &wl_registry::WlRegistry,
+        queue_handle: &QueueHandle<Self>,
+        name: u32,
+        _version: u32,
+    ) {
+        if self.seats.contains_key(&name) {
+            return;
+        }
+
+        let seat = registry.bind::<wl_seat::WlSeat, _, _>(name, 1, queue_handle, name);
+        self.seats.insert(
+            name,
+            SeatBinding {
+                seat,
+                notification: None,
+            },
+        );
+        self.attach_seat(name, queue_handle);
+    }
+
+    fn attach_unmonitored_seats(&mut self, queue_handle: &QueueHandle<Self>) {
+        let seat_names: Vec<u32> = self.seats.keys().copied().collect();
+        for name in seat_names {
+            self.attach_seat(name, queue_handle);
+        }
+    }
+
+    fn attach_seat(&mut self, name: u32, queue_handle: &QueueHandle<Self>) {
+        let Some((_, notifier)) = self.idle_notifier.as_ref() else {
+            return;
+        };
+        let Some(binding) = self.seats.get_mut(&name) else {
+            return;
+        };
+        if binding.notification.is_some() {
+            return;
+        }
+
+        binding.notification =
+            Some(notifier.get_input_idle_notification(0, &binding.seat, queue_handle, name));
+    }
+
+    fn remove_global(&mut self, name: u32) {
+        self.registry_facts.remove(name);
+
+        let removed_bound_notifier = self
+            .idle_notifier
+            .as_ref()
+            .is_some_and(|(global_name, _)| *global_name == name);
+
+        let removed_seat = if let Some(mut binding) = self.seats.remove(&name) {
+            if let Some(notification) = binding.notification.take() {
+                notification.destroy();
+            }
+            true
+        } else {
+            false
+        };
+
+        if let Some(err) = global_removal_error(
+            self.initialized,
+            removed_bound_notifier,
+            removed_seat,
+            self.seats.len(),
+        ) {
+            self.error = Some(err);
+            self.running = false;
+        }
+    }
+
+    fn take_error(&mut self) -> Option<WaylandProviderError> {
+        self.error.take()
+    }
+}
+
+fn global_removal_error(
+    initialized: bool,
+    removed_bound_notifier: bool,
+    removed_seat: bool,
+    remaining_seat_count: usize,
+) -> Option<WaylandProviderError> {
+    if removed_bound_notifier {
+        Some(WaylandProviderError::IdleNotifierRemoved)
+    } else if initialized && removed_seat && remaining_seat_count == 0 {
+        Some(WaylandProviderError::LastSeatRemoved)
+    } else {
+        None
+    }
+}
+
+fn notification_is_activity(event: &ext_idle_notification_v1::Event) -> bool {
+    matches!(event, ext_idle_notification_v1::Event::Resumed)
+}
+
+impl<F> Dispatch<wl_registry::WlRegistry, ()> for WaylandProviderState<F>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        queue_handle: &QueueHandle<Self>,
+    ) {
+        match event {
+            wl_registry::Event::Global {
+                name,
+                interface,
+                version,
+            } => {
+                state.registry_facts.add(name, interface.as_str(), version);
+                if interface == ext_idle_notifier_v1::ExtIdleNotifierV1::interface().name {
+                    state.bind_idle_notifier(registry, queue_handle);
+                } else if interface == wl_seat::WlSeat::interface().name {
+                    state.bind_seat(registry, queue_handle, name, version);
+                }
+            }
+            wl_registry::Event::GlobalRemove { name } => state.remove_global(name),
+            _ => {}
+        }
+    }
+}
+
+impl<F> Dispatch<wl_seat::WlSeat, u32> for WaylandProviderState<F>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    fn event(
+        _: &mut Self,
+        _: &wl_seat::WlSeat,
+        _: wl_seat::Event,
+        _: &u32,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl<F> Dispatch<ext_idle_notifier_v1::ExtIdleNotifierV1, ()> for WaylandProviderState<F>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    fn event(
+        _: &mut Self,
+        _: &ext_idle_notifier_v1::ExtIdleNotifierV1,
+        _: ext_idle_notifier_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl<F> Dispatch<ext_idle_notification_v1::ExtIdleNotificationV1, u32> for WaylandProviderState<F>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    fn event(
+        state: &mut Self,
+        _: &ext_idle_notification_v1::ExtIdleNotificationV1,
+        event: ext_idle_notification_v1::Event,
+        _: &u32,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        if notification_is_activity(&event) && !(state.on_activity)(Instant::now()) {
+            state.running = false;
+        }
+    }
+}
+
+type InitializedWaylandProvider<F> = (
+    EventQueue<WaylandProviderState<F>>,
+    WaylandProviderState<F>,
+    WaylandProviderCapabilities,
+);
+
+fn initialize_provider<F>(
+    on_activity: F,
+) -> Result<InitializedWaylandProvider<F>, WaylandProviderError>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    let connection = Connection::connect_to_env()
+        .map_err(|err| WaylandProviderError::Connection(err.to_string()))?;
+    let display = connection.display();
+    let mut event_queue = connection.new_event_queue();
+    let queue_handle = event_queue.handle();
+    let mut state = WaylandProviderState::new(on_activity);
+    state.registry = Some(display.get_registry(&queue_handle, ()));
+
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    let capabilities = state.registry_facts.capabilities()?;
+    state.initialized = true;
+    event_queue
+        .roundtrip(&mut state)
+        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    if let Some(err) = state.take_error() {
+        return Err(err);
+    }
+
+    Ok((event_queue, state, capabilities))
+}
+
+pub fn probe_wayland_capabilities() -> Result<WaylandProviderCapabilities, WaylandProviderError> {
+    let (_, _, capabilities) = initialize_provider(|_| true)?;
+    Ok(capabilities)
+}
+
+pub fn run_wayland_activity_monitor<F>(on_activity: F) -> Result<(), WaylandProviderError>
+where
+    F: FnMut(Instant) -> bool + 'static,
+{
+    let (mut event_queue, mut state, _) = initialize_provider(on_activity)?;
+
+    while state.running {
+        event_queue
+            .blocking_dispatch(&mut state)
+            .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+        if let Some(err) = state.take_error() {
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        ext_idle_notification_v1, global_removal_error, notification_is_activity, RegistryFacts,
+        WaylandProviderCapabilities, WaylandProviderError,
+    };
+
+    const NOTIFIER: &str = "ext_idle_notifier_v1";
+    const SEAT: &str = "wl_seat";
+
+    #[test]
+    fn version_two_notifier_and_any_seat_satisfy_the_contract() {
+        let mut facts = RegistryFacts::default();
+        facts.add(10, NOTIFIER, 2);
+        facts.add(11, SEAT, 9);
+
+        assert_eq!(
+            facts.capabilities(),
+            Ok(WaylandProviderCapabilities {
+                idle_notifier_version: 2,
+                seat_count: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn version_one_notifier_is_rejected_precisely() {
+        let mut facts = RegistryFacts::default();
+        facts.add(10, NOTIFIER, 1);
+        facts.add(11, SEAT, 9);
+
+        assert_eq!(
+            facts.capabilities(),
+            Err(WaylandProviderError::UnsupportedIdleNotifierVersion(1))
+        );
+    }
+
+    #[test]
+    fn missing_notifier_is_distinct_from_missing_seat() {
+        let mut facts = RegistryFacts::default();
+        facts.add(11, SEAT, 9);
+        assert_eq!(
+            facts.capabilities(),
+            Err(WaylandProviderError::MissingIdleNotifier)
+        );
+
+        facts.add(10, NOTIFIER, 2);
+        facts.remove(11);
+        assert_eq!(facts.capabilities(), Err(WaylandProviderError::NoSeats));
+    }
+
+    #[test]
+    fn all_advertised_seats_are_counted_without_capability_filtering() {
+        let mut facts = RegistryFacts::default();
+        facts.add(10, NOTIFIER, 2);
+        facts.add(11, SEAT, 1);
+        facts.add(12, SEAT, 9);
+
+        assert_eq!(facts.capabilities().unwrap().seat_count, 2);
+    }
+
+    #[test]
+    fn highest_notifier_version_is_selected() {
+        let mut facts = RegistryFacts::default();
+        facts.add(10, NOTIFIER, 1);
+        facts.add(20, NOTIFIER, 2);
+
+        assert_eq!(facts.selected_idle_notifier().unwrap().name, 20);
+    }
+
+    #[test]
+    fn registry_churn_updates_the_advertised_seat_set() {
+        let mut facts = RegistryFacts::default();
+        facts.add(10, NOTIFIER, 2);
+        facts.add(11, SEAT, 1);
+        facts.add(12, SEAT, 1);
+        facts.remove(11);
+        assert_eq!(facts.capabilities().unwrap().seat_count, 1);
+
+        facts.add(13, SEAT, 1);
+        assert_eq!(facts.capabilities().unwrap().seat_count, 2);
+    }
+
+    #[test]
+    fn bound_notifier_and_last_seat_removals_are_fatal_after_startup() {
+        assert_eq!(
+            global_removal_error(true, true, false, 1),
+            Some(WaylandProviderError::IdleNotifierRemoved)
+        );
+        assert_eq!(
+            global_removal_error(true, false, true, 0),
+            Some(WaylandProviderError::LastSeatRemoved)
+        );
+        assert_eq!(global_removal_error(true, false, true, 1), None);
+        assert_eq!(global_removal_error(false, false, true, 0), None);
+    }
+
+    #[test]
+    fn only_resumed_notifications_map_to_desktop_activity() {
+        assert!(!notification_is_activity(
+            &ext_idle_notification_v1::Event::Idled
+        ));
+        assert!(notification_is_activity(
+            &ext_idle_notification_v1::Event::Resumed
+        ));
+    }
+}

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -52,7 +52,7 @@ Feature: Settings CLI
     When I run the command "settings describe screen.backend"
     Then the command succeeds
     And stdout contains "current: auto (gnome)"
-    And stdout contains "allowed values: auto (gnome), gnome, swayidle"
+    And stdout contains "allowed values: auto (gnome), gnome, wayland, swayidle"
     When I run the command "settings get screen.backend"
     Then the command succeeds
     And stdout is "auto"
@@ -64,7 +64,7 @@ Feature: Settings CLI
     When I run the command "settings describe screen.backend"
     Then the command succeeds
     And stdout contains "current: auto (swayidle)"
-    And stdout contains "allowed values: auto (swayidle), gnome, swayidle"
+    And stdout contains "allowed values: auto (swayidle), gnome, wayland, swayidle"
 
   Scenario: settings describe remains available without a detected backend
     Given a temporary LG Buddy config using input HDMI_2
@@ -72,7 +72,7 @@ Feature: Settings CLI
     When I run the command "settings describe screen.backend"
     Then the command succeeds
     And stdout contains "current: auto (no backend currently available)"
-    And stdout contains "allowed values: auto (no backend currently available), gnome, swayidle"
+    And stdout contains "allowed values: auto (no backend currently available), gnome, wayland, swayidle"
 
   Scenario: settings describe shows required TV operations
     Given a temporary LG Buddy config using input HDMI_2

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -138,6 +138,7 @@ flowchart LR
                 LOGINDADAPTER["sources/linux/logind.rs<br/>logind lifecycle mapping"]
                 NMGATE["sources/linux/network_manager.rs<br/>pre-down event source"]
                 GADAPTER["sources/desktop/gnome.rs<br/>GNOME probe + signal mapping"]
+                WADAPTER["sources/desktop/wayland.rs<br/>Wayland registry + activity mapping"]
                 SADAPTER["sources/desktop/swayidle.rs<br/>hook mapping + capability probe"]
             end
         end
@@ -159,11 +160,13 @@ flowchart LR
     RUNNER --> BACKEND
     RUNNER --> BUS
     BACKEND --> GADAPTER
+    BACKEND --> WADAPTER
     BACKEND --> SADAPTER
 
     GNOME --> BUS
     BUS --> GADAPTER
     GADAPTER -->|"SessionEvent"| SESSIONMODEL
+    WADAPTER -->|"DesktopActivityObserved"| RUNNER
     LOGIND --> BUS
     BUS --> LOGINDADAPTER
     LOGINDADAPTER -->|"RuntimeEvent"| EVENTS
@@ -273,7 +276,7 @@ The intended split is:
   - native Wake-on-LAN packet generation and UDP send
 - `backend.rs`
   - backend selection and detection
-  - `auto`, `gnome`, and `swayidle` support
+  - `auto`, `gnome`, explicit `wayland`, and `swayidle` support
 - `session.rs`
   - backend-neutral session event model
   - capability surface for desktop backends
@@ -318,6 +321,9 @@ The intended split is:
 - `sources/desktop/gnome.rs`
   - GNOME-specific capability probing plus ScreenSaver signal and IdleMonitor
     method mapping
+- `sources/desktop/wayland.rs`
+  - native Wayland capability probing and dynamic registry/seat ownership
+  - maps zero-timeout resumed notifications into desktop activity facts
 - `sources/desktop/swayidle.rs`
   - `swayidle`-specific capability probing and hook-to-event mapping
   - models the `swayidle` hook surface; production timeout/resume handling
@@ -346,7 +352,8 @@ The session-facing pieces should be read as one subsystem:
   - owns the `lifecycle` event loop for system sleep/wake handling
 - `sources/linux/logind.rs`
   - adapts Linux system lifecycle signals into canonical lifecycle events
-- `sources/desktop/gnome.rs` and `sources/desktop/swayidle.rs`
+- `sources/desktop/gnome.rs`, `sources/desktop/wayland.rs`, and
+  `sources/desktop/swayidle.rs`
   - adapt or model backend-specific surfaces against that shared session
     contract; the production `swayidle` timeout/resume path enters through
     CLI/API commands
@@ -529,7 +536,10 @@ Detection behavior:
 
 - `auto` prefers GNOME when the current session satisfies the full GNOME contract and the session bus is reachable
 - otherwise falls back to `swayidle` if installed
-- forced backends validate required commands
+- explicit `wayland` validates `ext_idle_notifier_v1` version 2 or newer plus
+  at least one advertised seat and does not fall back
+- `auto` does not select native Wayland yet
+- other forced backends validate their required services or commands
 
 ## TV Integration Boundary
 
@@ -693,6 +703,11 @@ The detailed session model is documented in `docs/session-backend-model.md`.
 - mapping from GNOME D-Bus monitor lines into `SessionEvent`
 - the GNOME event and idletime sources used by `lg-buddy monitor`
 
+`sources/desktop/wayland.rs` is the native non-GNOME adapter. It owns the
+Wayland connection, registry, every advertised seat, and zero-timeout idle
+notifications. Resumed notifications become desktop activity observations in
+the shared inactivity runtime; compositor idle does not directly blank the TV.
+
 `sources/desktop/swayidle.rs` is the delegated-tool adapter. It currently provides:
 
 - capability probing
@@ -718,7 +733,7 @@ asymmetric:
   idle is not a blanking authority
 - the shared native-session runtime consumes gamepad activity directly from
   Linux input devices as `AuxiliaryInput`, independently of desktop providers;
-  GNOME is currently the only production provider using this runtime
+  GNOME and native Wayland use this runtime
 - the gamepad source refreshes its device set from Linux device add, remove, and
   change events, with periodic reconciliation for missed events
 - delegated `swayidle` monitor execution is implemented as CLI/API delegation
@@ -728,10 +743,9 @@ asymmetric:
   handled by the NetworkManager pre-down gate plus logind lifecycle service
   instead
 
-`swayidle` remains the current external-tool compatibility backend. Its
-delegated CLI/API shape is intentionally conservative: native non-GNOME Wayland
-idle/activity sources can later replace delegated timeout and resume execution
-without redefining screen policy.
+`swayidle` remains the external-tool compatibility backend while native
+Wayland is explicit opt-in. Automatic native selection and later deprecation of
+the delegated path are separate work.
 
 ## Configuration and Override Surface
 
@@ -796,7 +810,7 @@ The Rust runtime currently owns:
 - screen off
 - screen on
 - brightness control
-- `monitor` command with GNOME and `swayidle` parity paths
+- `monitor` command with GNOME, native Wayland, and `swayidle` paths
 
 The shell layer still owns:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -156,6 +156,7 @@ For the tagged GitHub release process, see [release-process.md](release-process.
 | `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle signal and property adapter |
 | `crates/lg-buddy/src/sources/linux/network_manager.rs` | NetworkManager pre-down lifecycle source adapter |
 | `crates/lg-buddy/src/sources/desktop/gnome.rs` | GNOME backend integration |
+| `crates/lg-buddy/src/sources/desktop/wayland.rs` | Native Wayland idle/activity provider |
 | `crates/lg-buddy/src/sources/desktop/swayidle.rs` | `swayidle` backend integration |
 | `crates/lg-buddy/src/tv.rs` | TV transport boundary and facade |
 | `crates/lg-buddy/src/web_os/` | Native webOS client, profile-bound TV adapter, domain operations, and test support |

--- a/docs/gamepad-subsystem.md
+++ b/docs/gamepad-subsystem.md
@@ -11,9 +11,9 @@ modes or device-specific configuration.
 
 The subsystem watches readable Linux input devices and reports controller input
 as auxiliary user activity to the session runner. The shared native-session
-runtime starts it independently of the selected desktop provider. GNOME is the
-only production provider using that runtime today, but neither the gamepad
-source nor its lifecycle belongs to GNOME or any other desktop environment.
+runtime starts it independently of the selected desktop provider. GNOME and
+native Wayland both use that runtime, but neither the gamepad source nor its
+lifecycle belongs to a desktop environment.
 
 The subsystem does not decide whether to blank or restore the TV. It only
 reports activity. The session runner and screen policy remain responsible for

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -28,9 +28,8 @@ the lifecycle policy domain. The inactivity observation layer owns one
 deadline. Every activity observation resets it; expiry produces an
 edge-triggered blank decision.
 
-GNOME is the production pilot for the native inactivity path today, but the
-model is not GNOME-specific. A future non-GNOME Wayland adapter should feed the
-same normalized inactivity observations.
+GNOME and native Wayland feed the same normalized inactivity observations into
+the shared native-session path.
 
 ## Current Top-Level Handlers
 
@@ -97,10 +96,9 @@ Examples:
 
 ### Native Inactivity Path
 
-The native inactivity path is the intended path for desktop adapters that can
-report activity facts directly. GNOME is the first production backend on this
-path. A future non-GNOME Wayland adapter should feed the same inactivity model
-instead of delegating blank/restore commands to an external tool.
+The native inactivity path is used by GNOME and the explicit native Wayland
+backend. Both feed activity facts into the same inactivity model instead of
+delegating blank/restore commands to an external tool.
 
 ```text
 native desktop activity facts
@@ -255,10 +253,10 @@ lifecycle path:
   not parallel runtime handlers
 - legacy cleanup honors a persisted opt-out config value
 
-## Target Non-GNOME Wayland Shape
+## Native Non-GNOME Wayland Shape
 
-Native non-GNOME Wayland idle work is separate from logind lifecycle work and
-should follow the same native inactivity path.
+Native non-GNOME Wayland idle monitoring is separate from logind lifecycle work
+and follows the same native inactivity path.
 
 Target event path:
 
@@ -285,8 +283,8 @@ lifecycle policy, runtime phase guard, and source adapter namespace in place.
 Remaining work should stay scoped:
 
 1. Keep native Wayland idle replacement separate from the logind lifecycle path.
-2. Retire the delegated `swayidle` monitor once native non-GNOME Wayland
-   activity facts are available.
+2. Keep `swayidle` available while native Wayland remains explicit opt-in;
+   automatic promotion and deprecation are separate work.
 3. Preserve the one-lifecycle-owner invariant in installer, release-bundle, and
    uninstall tests.
 4. Treat future platform lifecycle providers, such as a possible macOS provider,

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -8,7 +8,7 @@ For the broader map of systemd, lifecycle, desktop, and command-entrypoint
 events that consume these semantics, see
 [runtime-event-handler-map.md](runtime-event-handler-map.md).
 
-GNOME, `swayidle`, and future backends do not expose the same APIs or the same
+GNOME, native Wayland, `swayidle`, and future backends do not expose the same APIs or the same
 event richness. LG Buddy should not force them to look identical at the
 transport layer. Instead, the `session` module should define:
 
@@ -108,7 +108,7 @@ This needs to be explicit because different providers work differently.
 `LgBuddyConfigured`
 - LG Buddy must supply or manage the timeout value.
 - The backend tool or adapter consumes that LG Buddy-controlled value.
-- Examples: GNOME and `swayidle`.
+- Examples: GNOME, native Wayland, and `swayidle`.
 
 This is separate from startup and wake retry delays.
 
@@ -121,6 +121,7 @@ This is the current mapping for the known backends, with implementation status c
 | Backend | Idle | Active | WakeRequested | UserActivity | BeforeSleep | AfterResume | Lock/Unlock | Idle Timeout Source | Current Rust Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | GNOME | Yes | Yes | Yes | Yes | No current surface in LG Buddy | No current surface in LG Buddy | No current surface in LG Buddy | `LgBuddyConfigured` | Implemented with LG Buddy-owned timeout policy over ScreenSaver and Mutter observations |
+| Native Wayland | Observed but not authoritative | Resumed notification | No | Yes | No | No | No | `LgBuddyConfigured` | Explicit opt-in using `ext_idle_notifier_v1` version 2 or newer |
 | `swayidle` | Yes | Yes | No | No direct equivalent | Yes | Yes | Yes, when built with systemd support | `LgBuddyConfigured` | Implemented for delegated `timeout -> Idle` and `resume -> Active`; `before-sleep`, `after-resume`, `lock`, and `unlock` are modeled but not executed |
 
 ## Provider-Specific Mapping
@@ -161,9 +162,23 @@ reconciles in case an event is missed. Standard controller input is read from
 evdev. Logitech G923 wheel and pedal activity has a narrow raw HID fallback for
 hosts where those reports do not appear on the evdev node.
 
-GNOME is currently the only production desktop provider using the shared
-native-session runtime. A future native Wayland provider should plug into that
-runtime without acquiring any gamepad responsibility.
+GNOME and native Wayland use the shared native-session runtime. The Wayland
+provider owns only its connection, registry, seats, notifications, and activity
+facts; it does not acquire gamepad responsibility.
+
+### Native Wayland
+
+The explicit `wayland` backend requires `ext_idle_notifier_v1` version 2 or
+newer and at least one advertised `wl_seat`. It monitors every seat, including
+seats that currently advertise no input capabilities, using zero-timeout idle
+notifications. `resumed` maps to desktop activity; `idled` remains
+observational, so only LG Buddy's inactivity deadline can trigger blanking.
+
+Seats are added and removed dynamically. Connection or dispatch loss, removal
+of the bound notifier, or removal of the last seat is fatal to the provider and
+causes the user service to retry. Explicit selection reports capability errors
+without falling back. `auto` does not select this backend yet, and `swayidle`
+remains available.
 
 ### `swayidle`
 
@@ -198,6 +213,8 @@ The code split is:
   - desktop-independent auxiliary input discovery and activity observations
 - `crates/lg-buddy/src/sources/desktop/gnome.rs`
   - GNOME-specific probing and event mapping
+- `crates/lg-buddy/src/sources/desktop/wayland.rs`
+  - native Wayland registry, seat, idle-notification, and activity mapping
 - `crates/lg-buddy/src/sources/desktop/swayidle.rs`
   - `swayidle`-specific probing and event mapping
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -28,6 +28,7 @@ This is where most tests should live.
 - Wake-on-LAN packet construction
 - backend selection rules
 - GNOME signal-to-event mapping
+- native Wayland registry, seat, and resumed-notification mapping
 - gamepad device discovery, device-event filtering, raw event mapping, registry
   behavior, and activity policy
 - TV command output parsing
@@ -46,6 +47,7 @@ This is where most tests should live.
 - `crates/lg-buddy/src/state.rs`
 - `crates/lg-buddy/src/backend.rs`
 - `crates/lg-buddy/src/sources/desktop/gnome.rs`
+- `crates/lg-buddy/src/sources/desktop/wayland.rs`
 - `crates/lg-buddy/src/wol.rs`
 - `crates/lg-buddy/src/tv.rs`
 - `crates/lg-buddy/src/commands.rs`
@@ -77,6 +79,7 @@ This is the place for integration tests and contract tests.
 - subprocess contracts to external tools
 - backend detection against mocked command/process boundaries
 - GNOME runner behavior against a private session-bus harness
+- native Wayland provider capability and registry-churn behavior
 - logind lifecycle and NetworkManager gate behavior against a private system-bus
   harness
 - desktop and auxiliary gamepad activity resetting one LG Buddy-owned deadline
@@ -101,6 +104,9 @@ Examples:
 
 - the TV mock reproduces `bscpylgtvcommand` command line, exit status, stdout, and stderr behavior that LG Buddy cares about
 - GNOME monitor/runtime tests should use the private session-bus harness for ScreenSaver signals and Mutter idletime
+- native Wayland provider tests should model registry discovery, protocol-version
+  rejection, every advertised seat, resumed-only activity, and fatal provider
+  loss without requiring a compositor
 - logind lifecycle/runtime tests should use the private system-bus harness for
   `PreparingForSleep` and `PrepareForSleep` behavior
 
@@ -227,8 +233,17 @@ Examples:
 - GNOME capability probing
 - GNOME signal mapping
 - GNOME monitor and idletime integration over the session-bus seam
+- native Wayland protocol-version and seat discovery
+- native Wayland resumed-notification and registry-removal mapping
 - gamepad activity integration with the LG Buddy inactivity deadline
 - screen runtime-phase eligibility over the private logind system-bus seam
+
+Native Wayland changes also require manual opt-in checks on Plasma/KWin and at
+least one other target compositor. Verify that explicit `wayland` detection and
+monitor startup succeed, unsupported capability or connection cases fail with
+a precise diagnostic, and `auto` retains its existing GNOME-then-`swayidle`
+selection. Release-facing changes must keep the static x86_64 musl build and
+release-bundle smoke test green.
 
 ### Gamepad activity
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,40 +1,19 @@
 # User Guide
 
-This guide covers the parts of LG Buddy that users may want after installation: commands, configuration, and desktop-idle behavior.
+This guide covers day-to-day LG Buddy use after installation. For implementation
+details and package integration, see [Technical references](#technical-references).
 
-## Commands
+## Common Commands
 
-The installed runtime command is:
+The installed command is:
 
 ```bash
 lg-buddy <command>
 ```
 
-### Public commands
-
-The supported user-facing commands are:
-
-- `brightness`
-- `brightness get`
-- `brightness set <0-100>`
-- `power on`
-- `power off`
-- `screen off`
-- `screen on`
-- `settings list`
-- `settings describe [KEY]`
-- `settings get <KEY>`
-- `settings set <KEY> <VALUE>`
-- `settings unset <KEY>`
-- `updates check [--channel stable|prerelease] [--notify]`
-- `help [COMMAND...]`, `--help`, and `-h`
-- `--version` and `-V`
-
-Examples:
+Common commands include:
 
 ```bash
-lg-buddy settings list
-lg-buddy settings describe screen.backend
 lg-buddy power on
 lg-buddy power off
 lg-buddy screen off
@@ -42,365 +21,244 @@ lg-buddy screen on
 lg-buddy brightness
 lg-buddy brightness get
 lg-buddy brightness set 65
-lg-buddy --version
+lg-buddy settings list
+lg-buddy settings describe screen.backend
 lg-buddy updates check
-lg-buddy updates check --notify
+lg-buddy --version
 ```
 
-Use `lg-buddy <command> --help` or `lg-buddy help <command>` for scoped syntax.
-In normal use, LG Buddy's services run automatically; most users only need the
-commands above or `configure.sh`.
+Use `lg-buddy <command> --help` or `lg-buddy help <command>` for command-specific
+syntax.
 
-`power on` sends Wake-on-LAN and restores the configured input using cold-boot
-behavior. `power off` powers off the TV when it is on the configured input and
-no reboot is pending.
+- `power on` wakes the TV and restores the configured input.
+- `power off` powers off the TV when it is on the configured input and no reboot
+  is pending.
+- `screen off` blanks the TV output while remembering that LG Buddy blanked it.
+- `screen on` restores the output according to the configured restore policy.
+- `brightness` opens the desktop brightness dialog. `brightness get` and
+  `brightness set <0-100>` read or change OLED brightness directly.
+- `--version` reports the installed version and, for official builds, release
+  metadata.
 
-`screen off` blanks the configured TV output and records that LG Buddy owns the
-blanked state. `screen on` restores the output according to the configured
-restore policy.
-
-`brightness` opens the desktop brightness dialog. `brightness get` prints the
-current TV OLED brightness, and `brightness set <0-100>` updates it directly.
-The `settings` commands inspect and edit the same structured configuration used
-by the installer, configurator, and runtime; the complete registry is described
-in [Configuration](#configuration).
-
-`--version` prints the installed runtime version, release channel, and commit
-metadata when the binary was built as an official release artifact.
-`updates check` queries GitHub releases on demand and reports whether a newer
-release is available. Stable builds check stable releases by default, while
-prerelease builds check the prerelease channel, which includes both prerelease
-and stable releases. Use `--channel stable` or `--channel prerelease` to choose
-the channel explicitly. The command may cache GitHub response metadata to reduce
-repeated API downloads. Add `--notify` to send a desktop notification when the
-check finds an available update. Notification delivery is handled by the
-running user-session LG Buddy process; if that process is not running,
-`--notify` reports a notification failure after printing the update result. When
-the desktop notification service supports actions, the notification includes a
-`Never Notify Again` button that sets `updates.auto_check=disabled` and
-disables the installed update-check timer, plus a `View Release` button that
-opens the GitHub release page through the system opener.
-After a notification is delivered for a release, repeated `--notify`
-checks for the same release skip the notification and print the notification
-policy decision; a newer release can notify again.
-Automatic checks use the same release API, cache, notification handoff, and
-repeat-notification policy. The notification handoff expects the installed
-user-session service, `LG_Buddy_screen.service`, to be running.
-
-### Package-owned runtime entrypoints
-
-Installed services, hooks, timers, and compatibility callers still invoke the
-entrypoints below. They remain callable for package integration and migration,
-but they are not the stable interface for ordinary TV control.
-
-| Entrypoint | Owner and role |
-| --- | --- |
-| `startup boot`, `shutdown` | System service start/stop entrypoints; use `power on/off` manually. |
-| `startup auto`, `startup wake` | Compatibility and troubleshooting modes for boot/wake policy. |
-| `lifecycle` | System lifecycle service handling logind sleep and resume events. |
-| `nm-pre-down` | NetworkManager dispatcher gate before sleep-related network teardown. |
-| `monitor` | User-session service for idle monitoring and notification handoff. |
-| `updates background-check` | Installed user timer entrypoint; respects update settings. |
-| `detect-backend` | Installer compatibility entrypoint; use `settings describe screen.backend` manually. |
-| `sleep-pre`, `sleep` | Direct or legacy pre-sleep compatibility paths. |
-| `screen-off`, `screen-on` | Hidden compatibility aliases for `screen off/on`. |
-
-The `dev webos-*` commands are unstable development diagnostics and are not
-user commands. For service troubleshooting, inspect the corresponding systemd
-unit instead of manually invoking its runtime entrypoint.
-
-## Desktop Idle Monitoring
-
-LG Buddy supports three session backends:
-
-- `gnome`
-- `wayland`
-- `swayidle`
-
-`LG_Buddy_screen.service` is the user-session service. It owns the LG Buddy
-session D-Bus surface used by update notifications and, when idle blanking is
-enabled, it also runs screen idle/restore monitoring.
-
-`screen_idle_blank=enabled` turns on automatic idle blank/restore behavior.
-`screen_idle_blank=disabled` keeps the user-session service running for
-notifications but makes idle blank/restore behavior passive.
-
-`screen_backend=auto` prefers GNOME when the current session satisfies the full
-GNOME contract, then falls back to `swayidle` if installed. It does not select
-native Wayland yet.
-
-The GNOME backend requires:
-
-- GNOME Shell
-- `org.gnome.ScreenSaver`
-- `org.gnome.Mutter.IdleMonitor`
-
-The monitor runtime keeps one persistent session-bus connection open for GNOME
-shell detection, ScreenSaver signals, and Mutter idletime polling.
-
-The native Wayland backend is an explicit opt-in. It requires
-`ext_idle_notifier_v1` version 2 or newer and at least one advertised `wl_seat`:
-
-```bash
-lg-buddy settings set screen.backend wayland
-```
-
-LG Buddy monitors every advertised seat with a zero-timeout notification,
-treats resumed notifications as desktop activity, and keeps ownership of the
-configured inactivity deadline. If the protocol is unsupported, backend
-detection reports the missing capability and does not fall back. The provider
-also exits on connection loss, notifier removal, or removal of its last seat so
-the user service can retry.
-
-When either native-session backend (`gnome` or `wayland`) is active, LG Buddy
-also watches readable Linux gamepad input devices and treats controller activity
-as user activity. This is automatic and has no configuration switch. Devices
-are discovered at monitor startup,
-refreshed when Linux reports input-device add, remove, or change events, and
-periodically reconciled so hot-plugged controllers can be picked up without
-restarting the service. Standard controllers are read through evdev. The
-Logitech G923 also has a raw HID fallback for wheel and pedal activity that is
-not exposed as evdev events on some Linux hosts. That fallback reports activity
-only for meaningful control changes, not unsolicited vendor or status reports.
-
-Gamepad activity detection requires the user session running
-`LG_Buddy_screen.service` to have read access to the relevant `/dev/input/event*`
-and, for the G923 fallback, `/dev/hidraw*` nodes. On normal desktop sessions this
-is typically granted by logind/udev seat ACLs.
-
-Check the user-session monitor:
-
-```bash
-systemctl --user status LG_Buddy_screen.service
-```
-
-Temporarily force a backend:
-
-```bash
-systemctl --user edit LG_Buddy_screen.service
-```
-
-Then add:
-
-```ini
-[Service]
-Environment=LG_BUDDY_SCREEN_BACKEND=gnome
-```
-
-Supported values are `auto`, `gnome`, `wayland`, and `swayidle`.
-
-For backend semantics and implementation details, see [session-backend-model.md](session-backend-model.md).
-
-## System Sleep And Wake
-
-Default installs enable system sleep/wake TV control. To inspect the installed
-lifecycle service:
-
-```bash
-systemctl status LG_Buddy_lifecycle.service
-```
-
-When Linux reports that the machine is going to sleep, LG Buddy runs one
-pre-sleep TV power-off attempt while the TV can still be reached.
-Ordinary network disconnects return quickly. After wake, LG Buddy runs wake
-restore policy and clears temporary sleep state.
-
-While system sleep is pending, session idle/activity events do not run screen
-blank or restore TV commands. This avoids racing session-level TV control
-against the lifecycle sleep path.
-
-LG Buddy does not leave old sleep and wake handlers active. The installer and
-uninstaller remove legacy artifacts from existing installs so there is only one
-system lifecycle owner.
+LG Buddy's services normally run automatically, so most users only need these
+commands and the settings described below.
 
 ## Configuration
 
-To inspect structured settings after installation:
-
-```bash
-lg-buddy settings list
-lg-buddy settings describe screen.restore_policy
-lg-buddy settings get screen.idle_timeout
-```
-
-To change supported settings:
-
-```bash
-lg-buddy settings set tv.input HDMI_2
-lg-buddy settings set tv.platform lg_webos
-lg-buddy settings set screen.idle_blank disabled
-lg-buddy settings set screen.idle_timeout 600
-lg-buddy settings set screen.restore_policy aggressive
-lg-buddy settings set updates.auto_check disabled
-lg-buddy settings set updates.channel prerelease
-lg-buddy settings unset screen.restore_policy
-```
-
-`set` and `unset` write `config.env` and then apply the setting when an explicit
-runtime apply step is needed. User-session screen settings restart
-`LG_Buddy_screen.service` when the user service is installed and active or
-enabled. `updates.auto_check` enables or disables the installed user timer for
-background update checks. Selecting `tv.platform` performs a foreground
-credential preflight before writing the setting. TV identity, system sleep/wake
-policy, and update channel changes are read by later runtime actions and do not
-require a service restart.
-
-To rerun full setup for TV identity, control platform, idle behavior, or
-install-time service wiring:
+Run the configurator to change TV identity, control platform, idle behavior, or
+installed service wiring:
 
 ```bash
 ./configure.sh
 ```
 
-The settings CLI, configurator, installer, and manual edits all use the same
-`config.env` file. It is resolved from:
+For individual changes, use the settings commands:
 
-- `LG_BUDDY_CONFIG`, if set
-- otherwise `${XDG_CONFIG_HOME}/lg-buddy/config.env`
-- otherwise `~/.config/lg-buddy/config.env`
-
-Current config keys:
-
-- `tvs_primary_ip`
-- `tvs_primary_mac`
-- `tvs_primary_input`
-- `tvs_primary_platform`
-- `screen_idle_blank`
-- `screen_backend`
-- `screen_idle_timeout`
-- `screen_restore_policy`
-- `system_sleep_wake_policy`
-- `updates_auto_check`
-- `updates_channel`
-
-Legacy single-TV keys `tv_ip`, `tv_mac`, and `input` are still read as fallback
-values for existing installs. New writes use `tvs_primary_*` storage keys.
-
-If a direct edit leaves a malformed value in `config.env`, `settings list` and
-`settings describe` show the raw value as invalid with an `invalid config.env`
-source. `settings get <key>` fails with the validation error instead of
-pretending the value is missing or defaulted. Repair the entry with
-`settings set <key> <value>`, `settings unset <key>` when supported, or a manual
-config edit.
-
-Current structured settings:
-
-| Setting key | `config.env` key | Operations |
-| --- | --- | --- |
-| `tv.ip` | `tvs_primary_ip` | `get`, `describe`, `set` |
-| `tv.mac` | `tvs_primary_mac` | `get`, `describe`, `set` |
-| `tv.input` | `tvs_primary_input` | `get`, `describe`, `set` |
-| `tv.platform` | `tvs_primary_platform` | `get`, `describe`, `set`, `unset` |
-| `screen.backend` | `screen_backend` | `get`, `describe`, `set`, `unset` |
-| `screen.idle_blank` | `screen_idle_blank` | `get`, `describe`, `set`, `unset` |
-| `screen.idle_timeout` | `screen_idle_timeout` | `get`, `describe`, `set`, `unset` |
-| `screen.restore_policy` | `screen_restore_policy` | `get`, `describe`, `set`, `unset` |
-| `system.sleep_wake_policy` | `system_sleep_wake_policy` | `get`, `describe`, `set`, `unset` |
-| `updates.auto_check` | `updates_auto_check` | `get`, `describe`, `set`, `unset` |
-| `updates.channel` | `updates_channel` | `get`, `describe`, `set`, `unset` |
-
-`settings describe screen.backend` annotates the `auto` choice with the backend
-currently resolved from the desktop session, such as `auto (gnome)` or
-`auto (swayidle)`. If neither backend is currently available, it reports
-`auto (no backend currently available)`. Detection is best-effort and does not
-make settings inspection fail. `settings get screen.backend` remains raw and
-prints values such as `auto` for scripts.
-
-The `tv.*` settings expose the single supported TV in the public API. Their
-storage keys are profile-shaped only to leave room for future storage growth;
-this version does not expose multiple TVs or TV profile selection. TV identity
-values are required, so `unset` is not supported for them. Unsetting
-`tv.platform` removes its storage key and restores the `bscpylgtv` default.
-
-`tv.platform` selects one of two control implementations:
-
-- `bscpylgtv`: compatibility default, including existing profiles without a
-  platform value
-- `lg_webos`: experimental native Rust webOS driver
-
-Selecting `lg_webos` through `lg-buddy settings set` connects in the foreground,
-reuses or acquires the profile credential, and verifies it with a safe TV state
-read before saving the choice. Accept the pairing prompt on the TV. Ordinary
-foreground TV operations can also pair or repair credentials when needed.
-Unattended startup, shutdown, suspend, resume, and network-teardown commands
-never initiate pairing: they use a stored credential or skip promptly when one
-is unavailable. Editing `tvs_primary_platform` directly bypasses the selection
-preflight.
-
-The native path removes the Python TV client from selected runtime operations,
-which makes it useful groundwork for declarative or immutable distributions
-such as NixOS. The current installer still provisions the legacy fallback and
-writes conventional mutable system locations, so first-class NixOS packaging is
-future work tracked in
-[issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).
-
-`screen_idle_blank` controls whether the user-session service performs automatic
-idle-driven blank/restore behavior:
-
-- `enabled`: default behavior, run the configured screen backend and control
-  the TV around session idle/activity
-- `disabled`: keep the user-session service running for notification handling,
-  but skip idle-driven TV blank/restore behavior
-
-`screen_idle_timeout` is the inactivity threshold in seconds used by the session monitor.
-LG Buddy currently uses that timeout for both the GNOME and `swayidle` backends.
-Values above 86400 seconds are capped at 86400 seconds.
-On GNOME, activity reported by desktop and gamepad sources resets one LG
-Buddy-owned timer. The TV is blanked only when that timer reaches
-`screen_idle_timeout`.
-
-`screen_restore_policy` controls how aggressively LG Buddy reclaims the display on wake and user activity:
-
-- `conservative`: default behavior, only restore when an LG Buddy marker says it previously blanked or powered off the TV
-- `aggressive`: attempt restore on session wake/activity and system wake even without a marker
-
-`marker_only` is still accepted as a legacy alias for `conservative`.
-
-`system_sleep_wake_policy` controls automatic system sleep/wake TV handling:
-
-- `enabled`: default behavior, let the installed lifecycle integration control
-  the TV around system sleep and wake
-- `disabled`: leave lifecycle integration installed, but make those commands
-  no-op for sleep/wake TV handling
-
-The installed lifecycle integration rereads config and suppresses sleep/wake TV
-actions while this value is `disabled`, so
-`lg-buddy settings set system.sleep_wake_policy <value>` changes runtime policy
-without reinstalling services.
-
-`updates_auto_check` controls automatic background update checks:
-
-- `enabled`: default behavior, let the installed user timer periodically check
-  GitHub releases about weekly and notify when an update is available
-- `disabled`: leave the timer units installed, but disable the timer and skip
-  background update work
-
-Manual `lg-buddy updates check` commands still work when automatic checks are
-disabled.
-
-`updates_channel` controls the channel used by automatic background checks:
-
-- `stable`: default behavior, only consider stable releases
-- `prerelease`: opt in to prerelease update notifications; consider
-  prereleases and stable releases
-
-Example:
-
-```ini
-tvs_primary_ip=192.168.1.100
-tvs_primary_mac=aa:bb:cc:dd:ee:ff
-tvs_primary_input=HDMI_2
-tvs_primary_platform=bscpylgtv
-screen_idle_blank=enabled
-screen_backend=auto
-screen_idle_timeout=300
-screen_restore_policy=aggressive
-system_sleep_wake_policy=enabled
-updates_auto_check=enabled
-updates_channel=stable
+```bash
+lg-buddy settings list
+lg-buddy settings describe screen.restore_policy
+lg-buddy settings get screen.idle_timeout
+lg-buddy settings set tv.input HDMI_2
+lg-buddy settings set screen.idle_timeout 600
+lg-buddy settings unset screen.restore_policy
 ```
 
-Installed services receive the resolved config path through `LG_BUDDY_CONFIG`.
+`settings describe` shows a setting's current value, default, accepted values,
+and where the current value came from. `settings unset` restores the default
+when the setting supports it.
+
+Current settings are:
+
+| Setting | Purpose |
+| --- | --- |
+| `tv.ip` | TV network address. |
+| `tv.mac` | TV MAC address used for Wake-on-LAN. |
+| `tv.input` | Input LG Buddy manages, such as `HDMI_2`. |
+| `tv.platform` | TV control implementation: `bscpylgtv` or experimental `lg_webos`. |
+| `screen.backend` | Desktop idle backend: `auto`, `gnome`, `wayland`, or `swayidle`. |
+| `screen.idle_blank` | Enable or disable automatic idle blanking. |
+| `screen.idle_timeout` | Seconds of inactivity before blanking; defaults to 300. |
+| `screen.restore_policy` | `conservative` or `aggressive` restore behavior. |
+| `system.sleep_wake_policy` | Enable or disable TV handling around system sleep. |
+| `updates.auto_check` | Enable or disable automatic update checks. |
+| `updates.channel` | Check the `stable` or `prerelease` release channel. |
+
+Changes that affect desktop monitoring automatically restart the user service
+when it is installed and active or enabled. Update settings also apply to the
+installed update timer.
+
+LG Buddy stores these settings in `config.env`, normally at
+`$XDG_CONFIG_HOME/lg-buddy/config.env`, or `~/.config/lg-buddy/config.env` when
+`XDG_CONFIG_HOME` is unset. The settings CLI, configurator, installer, and
+manual edits all use this file. Prefer the settings CLI for ordinary changes
+because it validates values and applies any required service changes.
+
+If a manual edit leaves an invalid value, `settings list` and
+`settings describe` identify it. Repair it with `settings set`, `settings
+unset`, or another manual edit.
+
+## Automatic Screen Blanking
+
+Automatic blanking is enabled by default. Change its main settings with:
+
+```bash
+lg-buddy settings set screen.idle_blank enabled
+lg-buddy settings set screen.idle_timeout 600
+lg-buddy settings set screen.restore_policy conservative
+```
+
+Set `screen.idle_blank` to `disabled` to stop idle-driven TV blanking and
+restoring. The user service remains available for update notifications.
+
+The restore policies are:
+
+- `conservative`: restore only when LG Buddy previously blanked or powered off
+  the TV. This is the default.
+- `aggressive`: also attempt to restore the TV on activity or system wake when
+  no LG Buddy marker exists.
+
+### Choosing a Desktop Backend
+
+| Backend | When to use it |
+| --- | --- |
+| `auto` | Default. Uses GNOME when the session is compatible, otherwise `swayidle` when installed. It does not select native Wayland yet. |
+| `gnome` | A GNOME Shell session with the required GNOME idle services. |
+| `wayland` | A compatible recent Wayland compositor. This backend is currently opt-in. |
+| `swayidle` | A Wayland session with `swayidle` installed. |
+
+Select a backend persistently:
+
+```bash
+lg-buddy settings set screen.backend wayland
+```
+
+Return to automatic selection:
+
+```bash
+lg-buddy settings unset screen.backend
+```
+
+An explicitly selected backend reports a compatibility error rather than
+silently switching to another backend. If native Wayland is unavailable, use
+`auto` or `swayidle` instead.
+
+Check the selected backend and user service:
+
+```bash
+lg-buddy settings describe screen.backend
+systemctl --user status LG_Buddy_screen.service
+journalctl --user -u LG_Buddy_screen.service --since today
+```
+
+For `auto`, `settings describe` also shows the backend currently detected, such
+as `auto (gnome)` or `auto (swayidle)`.
+
+### Gamepad Activity
+
+With the `gnome` and `wayland` backends, supported controller activity resets
+the same idle timer as desktop activity. No additional setting is required.
+
+If controller activity is ignored, verify that the user running
+`LG_Buddy_screen.service` can read the controller's Linux input devices. Normal
+desktop sessions usually receive this access automatically through seat device
+permissions. See [gamepad-subsystem.md](gamepad-subsystem.md) for supported
+input paths and hardware troubleshooting.
+
+## TV Control Platform
+
+`tv.platform` selects the TV control implementation:
+
+- `bscpylgtv`: the compatibility default.
+- `lg_webos`: the experimental native Rust webOS implementation.
+
+Select the native implementation with:
+
+```bash
+lg-buddy settings set tv.platform lg_webos
+```
+
+LG Buddy connects to the TV and verifies the credential before saving this
+choice. Accept the pairing prompt on the TV if one appears. Foreground TV
+commands can pair or repair credentials when necessary; unattended startup,
+shutdown, suspend, and resume handling use an existing credential and do not
+open a pairing prompt.
+
+Return to the default with:
+
+```bash
+lg-buddy settings unset tv.platform
+```
+
+## System Sleep And Wake
+
+Default installs power off the TV before system sleep and restore it after
+wake. Disable this behavior without removing the integration:
+
+```bash
+lg-buddy settings set system.sleep_wake_policy disabled
+```
+
+Re-enable it with:
+
+```bash
+lg-buddy settings set system.sleep_wake_policy enabled
+```
+
+While system sleep is pending, desktop idle events do not issue competing TV
+commands.
+
+Check the lifecycle service with:
+
+```bash
+systemctl status LG_Buddy_lifecycle.service
+journalctl -u LG_Buddy_lifecycle.service --since today
+```
+
+## Updates
+
+Check for updates manually:
+
+```bash
+lg-buddy updates check
+lg-buddy updates check --channel prerelease
+lg-buddy updates check --notify
+```
+
+Stable builds check stable releases by default. Prerelease builds check both
+prerelease and stable releases. `--channel` overrides that choice for one
+command.
+
+`--notify` sends a desktop notification through the running user service. When
+supported by the desktop, the notification includes actions to open the release
+or disable future automatic notifications. LG Buddy does not repeatedly notify
+for the same release.
+
+Control scheduled checks with:
+
+```bash
+lg-buddy settings set updates.auto_check disabled
+lg-buddy settings set updates.auto_check enabled
+lg-buddy settings set updates.channel prerelease
+```
+
+Disabling automatic checks does not disable manual `updates check` commands.
+
+## Technical References
+
+These documents cover details intentionally omitted from this user guide:
+
+- [Session backend model](session-backend-model.md): backend capabilities,
+  event semantics, protocol requirements, and idle-timeout ownership.
+- [Gamepad activity subsystem](gamepad-subsystem.md): device discovery,
+  permissions, adapters, and hardware testing.
+- [Defaults and configuration](defaults-and-configuration.md): configuration
+  storage, defaults, compatibility, and installer policy.
+- [Runtime event handler map](runtime-event-handler-map.md): service
+  entrypoints and lifecycle event routing.
+- [Architecture overview](architecture-overview.md): runtime boundaries and
+  TV integration architecture.
+- [Development guide](development.md): building, installing, and validating a
+  local binary.
 
 ## Uninstall
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -111,9 +111,10 @@ unit instead of manually invoking its runtime entrypoint.
 
 ## Desktop Idle Monitoring
 
-LG Buddy supports two session backends:
+LG Buddy supports three session backends:
 
 - `gnome`
+- `wayland`
 - `swayidle`
 
 `LG_Buddy_screen.service` is the user-session service. It owns the LG Buddy
@@ -124,7 +125,9 @@ enabled, it also runs screen idle/restore monitoring.
 `screen_idle_blank=disabled` keeps the user-session service running for
 notifications but makes idle blank/restore behavior passive.
 
-`screen_backend=auto` prefers GNOME when the current session satisfies the full GNOME contract, then falls back to `swayidle` if installed.
+`screen_backend=auto` prefers GNOME when the current session satisfies the full
+GNOME contract, then falls back to `swayidle` if installed. It does not select
+native Wayland yet.
 
 The GNOME backend requires:
 
@@ -135,9 +138,24 @@ The GNOME backend requires:
 The monitor runtime keeps one persistent session-bus connection open for GNOME
 shell detection, ScreenSaver signals, and Mutter idletime polling.
 
-When the GNOME backend is active, LG Buddy also watches readable Linux gamepad
-input devices and treats controller activity as user activity. This is automatic
-and has no configuration switch. Devices are discovered at monitor startup,
+The native Wayland backend is an explicit opt-in. It requires
+`ext_idle_notifier_v1` version 2 or newer and at least one advertised `wl_seat`:
+
+```bash
+lg-buddy settings set screen.backend wayland
+```
+
+LG Buddy monitors every advertised seat with a zero-timeout notification,
+treats resumed notifications as desktop activity, and keeps ownership of the
+configured inactivity deadline. If the protocol is unsupported, backend
+detection reports the missing capability and does not fall back. The provider
+also exits on connection loss, notifier removal, or removal of its last seat so
+the user service can retry.
+
+When either native-session backend (`gnome` or `wayland`) is active, LG Buddy
+also watches readable Linux gamepad input devices and treats controller activity
+as user activity. This is automatic and has no configuration switch. Devices
+are discovered at monitor startup,
 refreshed when Linux reports input-device add, remove, or change events, and
 periodically reconciled so hot-plugged controllers can be picked up without
 restarting the service. Standard controllers are read through evdev. The
@@ -169,7 +187,7 @@ Then add:
 Environment=LG_BUDDY_SCREEN_BACKEND=gnome
 ```
 
-Supported values are `auto`, `gnome`, and `swayidle`.
+Supported values are `auto`, `gnome`, `wayland`, and `swayidle`.
 
 For backend semantics and implementation details, see [session-backend-model.md](session-backend-model.md).
 

--- a/install.sh
+++ b/install.sh
@@ -322,6 +322,18 @@ else
                 echo "            The user-session service will retry until a compatible session is available."
             fi
             ;;
+        wayland)
+            SCREEN_MONITOR_AVAILABLE=1
+            SCREEN_MONITOR_RUNTIME_BACKEND="$(LG_BUDDY_SCREEN_BACKEND=wayland "$RUNTIME_BINARY" detect-backend 2>/dev/null || true)"
+            if [ "$SCREEN_MONITOR_RUNTIME_BACKEND" = "wayland" ]; then
+                echo "  [OK]      current session satisfies the native Wayland backend contract"
+            else
+                SCREEN_MONITOR_RUNTIME_BACKEND=""
+                echo "  [INFO]    current session did not verify the native Wayland backend contract"
+                echo "            Wayland requires ext_idle_notifier_v1 version 2 or newer and at least one advertised seat."
+                echo "            The user-session service will retry until a compatible session is available."
+            fi
+            ;;
         swayidle)
             if command -v swayidle &>/dev/null; then
                 echo "  [OK]      swayidle (configured backend)"

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -288,7 +288,7 @@ grep -q '^screen_idle_blank=enabled$' "$CONFIG_FILE"
 grep -q '^screen_backend=auto$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
 grep -q "$CONFIG_FILE" "$INSTALLED_POINTER"
-grep -q 'cooperating suspend sources' "$BUNDLE_DIR/README.md"
+grep -F -q 'TV control at boot, shutdown, sleep, and wake' "$BUNDLE_DIR/README.md"
 grep -q 'cooperative suspend rail' "$BUNDLE_DIR/docs/architecture-overview.md"
 grep -q 'NetworkManager and logind cooperate through one suspend rail' "$BUNDLE_DIR/docs/runtime-event-handler-map.md"
 


### PR DESCRIPTION
## Summary

Adds an explicit native Wayland idle/activity backend while retaining GNOME and swayidle behavior.

- Uses the validated ext-idle-notify contract and monitors every advertised seat.
- Feeds desktop and gamepad activity through the shared LG Buddy inactivity deadline.
- Preserves marker-aware restoration, restore policy, and logind lifecycle ownership.
- Keeps auto selection unchanged: GNOME first, then swayidle.
- Reports unsupported protocol surfaces and provider loss explicitly.
- Avoids consuming inherited WAYLAND_SOCKET twice by opening one production connection.
- Simplifies the README and user guide around user tasks, with implementation details linked separately.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read CONTRIBUTING.md and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

Users can opt in with:

    lg-buddy settings set screen.backend wayland

Explicit selection fails with a capability diagnostic instead of silently falling back. The auto backend continues to prefer GNOME and then swayidle.

Native GNOME and Wayland monitoring both treat supported gamepad input as activity. Native-only lg_webos packages can omit the Python TV client, while the current shell installer still provisions the compatibility fallback.

## Validation

- cargo fmt --all -- --check
- cargo test -p lg-buddy --lib: 623 passed, 1 hardware-only test ignored
- cargo clippy --all-targets --all-features -- -D warnings
- Shell syntax checks for installer, configurator, common helper, and release scripts
- Full cargo test: 109 of 110 acceptance scenarios passed; the remaining initial-configuration scenario cannot spawn configure.sh because this NixOS host intentionally has no /bin/bash. The failure occurs before project code runs.
- Plasma/KWin hardware smoke: native provider started and idle blanking was confirmed on the real TV
- Inherited WAYLAND_SOCKET smoke: provider remained alive and selected the native backend

Not yet performed locally: a second compositor hardware run and the x86_64 musl release-bundle smoke test.

## Related Issue

Closes #85