### PR TITLE
Add PR-gated release promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Validate shell scripts
         run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
 
+      - name: Validate release promotion contract
+        run: python3 scripts/test_release_promotion.py
+
   bundle-smoke-test:
     runs-on: ubuntu-latest
     needs: verify

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -1,0 +1,97 @@
+name: Promotion
+
+on:
+  pull_request_target:
+    branches:
+      - main
+      - prerelease
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate-promotion:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate promotion PR source
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+        run: |
+          [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ] || {
+              echo "Promotion PRs must originate in this repository."
+              exit 1
+          }
+          [ "$HEAD_REF" = "dev" ] || {
+              echo "Only the exact dev branch may target $BASE_REF."
+              exit 1
+          }
+          case "$BASE_REF" in
+              main|prerelease) ;;
+              *)
+                  echo "Unsupported promotion target: $BASE_REF"
+                  exit 1
+                  ;;
+          esac
+          [ "$IS_DRAFT" = "false" ] || {
+              echo "Promotion PR must be ready for review."
+              exit 1
+          }
+
+      - name: Check out trusted promotion validator
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Fetch channel refs and release tags
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git fetch --force origin \
+              +refs/heads/main:refs/remotes/origin/main \
+              +refs/heads/prerelease:refs/remotes/origin/prerelease \
+              +refs/heads/dev:refs/remotes/origin/dev \
+              +refs/tags/*:refs/tags/*
+          [ "$(git rev-parse refs/remotes/origin/dev)" = "$HEAD_SHA" ]
+
+      - name: Validate promotion contract
+        id: contract
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 scripts/release_promotion.py \
+              --target "$BASE_REF" \
+              --head-ref "$HEAD_SHA" \
+              --base-sha "$BASE_SHA" \
+              --github-output "$GITHUB_OUTPUT"
+
+      - name: Reject conflicting GitHub release state
+        env:
+          CHANNEL: ${{ steps.contract.outputs.channel }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.contract.outputs.tag }}
+        run: |
+          if release_state="$(gh release view "$RELEASE_TAG" --json isDraft,isPrerelease 2>/dev/null)"; then
+              [ "$(printf '%s' "$release_state" | jq -r .isDraft)" = "false" ]
+              expected_prerelease="false"
+              [ "$CHANNEL" = "stable" ] || expected_prerelease="true"
+              [ "$(printf '%s' "$release_state" | jq -r .isPrerelease)" = "$expected_prerelease" ]
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,47 +1,119 @@
-name: Release
+name: Release promotion
 
 on:
-  push:
-    tags:
-      - "v[0-9]*"
+  pull_request_target:
+    branches:
+      - main
+      - prerelease
+    types:
+      - labeled
 
 permissions:
-  contents: write
+  actions: read
+  checks: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-promotion
+  cancel-in-progress: false
 
 jobs:
-  verify:
+  authorize:
+    if: github.event.label.name == 'release:promote'
     runs-on: ubuntu-latest
+    outputs:
+      base_ref: ${{ steps.authorize.outputs.base_ref }}
+      base_sha: ${{ steps.authorize.outputs.base_sha }}
+      head_sha: ${{ steps.authorize.outputs.head_sha }}
+      pr_number: ${{ steps.authorize.outputs.pr_number }}
 
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - name: Authorize promotion request
+        id: authorize
+        env:
+          ACTOR: ${{ github.actor }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          IS_DRAFT: ${{ github.event.pull_request.draft }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          [ "$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" --jq .permission)" = "admin" ] || {
+              echo "Only a repository administrator may request release promotion."
+              exit 1
+          }
+          [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]
+          [ "$HEAD_REF" = "dev" ]
+          [ "$IS_DRAFT" = "false" ]
+          case "$BASE_REF" in
+              main|prerelease) ;;
+              *) exit 1 ;;
+          esac
+          gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --required
+          {
+              echo "base_ref=$BASE_REF"
+              echo "base_sha=$BASE_SHA"
+              echo "head_sha=$HEAD_SHA"
+              echo "pr_number=$PR_NUMBER"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+  validate:
+    runs-on: ubuntu-latest
+    needs: authorize
+    outputs:
+      channel: ${{ steps.contract.outputs.channel }}
+      head_sha: ${{ steps.contract.outputs.head_sha }}
+      main_sha: ${{ steps.contract.outputs.main_sha }}
+      prerelease_sha: ${{ steps.contract.outputs.prerelease_sha }}
+      tag: ${{ steps.contract.outputs.tag }}
+      version: ${{ steps.contract.outputs.version }}
+
+    steps:
+      - name: Check out trusted promotion validator
+        uses: actions/checkout@v4
         with:
-          components: clippy
+          ref: ${{ needs.authorize.outputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
-      - name: Run Rust test suite
-        run: cargo test -p lg-buddy
+      - name: Fetch channel refs and release tags
+        run: |
+          git fetch --force origin \
+              +refs/heads/main:refs/remotes/origin/main \
+              +refs/heads/prerelease:refs/remotes/origin/prerelease \
+              +refs/heads/dev:refs/remotes/origin/dev \
+              +refs/tags/*:refs/tags/*
 
-      - name: Run clippy
-        run: cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
-
-      - name: Validate shell scripts
-        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
+      - name: Validate promotion contract
+        id: contract
+        run: |
+          python3 scripts/release_promotion.py \
+              --target "${{ needs.authorize.outputs.base_ref }}" \
+              --head-ref "${{ needs.authorize.outputs.head_sha }}" \
+              --base-sha "${{ needs.authorize.outputs.base_sha }}" \
+              --github-output "$GITHUB_OUTPUT"
 
   build-release-bundle:
     runs-on: ubuntu-latest
-    needs: verify
+    needs:
+      - authorize
+      - validate
 
     steps:
-      - name: Check out repository
+      - name: Check out exact reviewed dev commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.head_sha }}
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -56,34 +128,23 @@ jobs:
       - name: Install release prerequisites
         run: sudo apt-get update && sudo apt-get install -y musl-tools zenity
 
-      - name: Validate release tag
-        run: |
-          case "$GITHUB_REF_NAME" in
-              v[0-9]*) ;;
-              *)
-                  echo "Release tag must start with v followed by a digit, for example v1.0.0."
-                  exit 1
-                  ;;
-          esac
-
-          version="${GITHUB_REF_NAME#v}"
-          if [ -z "$version" ]; then
-              echo "Release tag must include a version after v."
-              exit 1
-          fi
-
-          echo "LG_BUDDY_RELEASE_VERSION=$version" >> "$GITHUB_ENV"
-
       - name: Build lg-buddy
         env:
-          LG_BUDDY_BUILD_COMMIT: ${{ github.sha }}
-        run: LG_BUDDY_RELEASE_VERSION="$LG_BUDDY_RELEASE_VERSION" cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
+          LG_BUDDY_BUILD_COMMIT: ${{ needs.validate.outputs.head_sha }}
+          LG_BUDDY_RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+        run: cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
 
       - name: Create release bundle
-        run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version "$LG_BUDDY_RELEASE_VERSION" --output-dir dist
+        run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version "${{ needs.validate.outputs.version }}" --output-dir dist
 
       - name: Smoke test release bundle
-        run: ./scripts/test-release-bundle.sh --skip-pip-install --archive "dist/lg-buddy-${LG_BUDDY_RELEASE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+        run: |
+          ./scripts/test-release-bundle.sh \
+              --skip-pip-install \
+              --archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
+              --expected-version "${{ needs.validate.outputs.version }}" \
+              --expected-channel "${{ needs.validate.outputs.channel }}" \
+              --expected-commit "${{ needs.validate.outputs.head_sha }}"
 
       - name: Generate checksums
         run: |
@@ -98,12 +159,127 @@ jobs:
       - name: Upload workflow artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: lg-buddy-release-bundle
+          name: lg-buddy-release-${{ needs.validate.outputs.tag }}
           path: |
             dist/*.tar.gz
             dist/sha256sums.txt
+          if-no-files-found: error
+          retention-days: 7
 
-      - name: Publish GitHub release assets
+  finalize:
+    runs-on: ubuntu-latest
+    environment: release-promotion
+    needs:
+      - authorize
+      - validate
+      - build-release-bundle
+
+    steps:
+      - name: Check out trusted finalizer
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.authorize.outputs.base_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Fetch and revalidate current refs
+        id: recheck
+        run: |
+          git fetch --force origin \
+              +refs/heads/main:refs/remotes/origin/main \
+              +refs/heads/prerelease:refs/remotes/origin/prerelease \
+              +refs/heads/dev:refs/remotes/origin/dev \
+              +refs/tags/*:refs/tags/*
+          python3 scripts/release_promotion.py \
+              --target "${{ needs.authorize.outputs.base_ref }}" \
+              --head-ref "${{ needs.authorize.outputs.head_sha }}" \
+              --base-sha "${{ needs.authorize.outputs.base_sha }}" \
+              --github-output "$GITHUB_OUTPUT"
+          [ "$(git rev-parse refs/remotes/origin/dev)" = "${{ needs.validate.outputs.head_sha }}" ]
+
+      - name: Revalidate required PR checks
         env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: ./scripts/publish-release-assets.sh --dist-dir dist
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checks "${{ needs.authorize.outputs.pr_number }}" --repo "$GITHUB_REPOSITORY" --required
+
+      - name: Create repository-scoped promotion token
+        id: promotion-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          app-id: ${{ vars.RELEASE_PROMOTION_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PROMOTION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: LG_Buddy
+          permission-contents: write
+
+      - name: Download verified release bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: lg-buddy-release-${{ needs.validate.outputs.tag }}
+          path: dist
+
+      - name: Verify downloaded checksums
+        run: cd dist && sha256sum -c sha256sums.txt
+
+      - name: Publish release and advance channel refs
+        env:
+          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
+          EXPECTED_MAIN_SHA: ${{ needs.validate.outputs.main_sha }}
+          EXPECTED_PRERELEASE_SHA: ${{ needs.validate.outputs.prerelease_sha }}
+          GH_TOKEN: ${{ steps.promotion-token.outputs.token }}
+          HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          remote_tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq .object.sha 2>/dev/null || true)"
+          if [ -z "$remote_tag_sha" ]; then
+              gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+                  -f ref="refs/tags/$RELEASE_TAG" \
+                  -f sha="$HEAD_SHA" >/dev/null
+          elif [ "$remote_tag_sha" != "$HEAD_SHA" ]; then
+              echo "Tag $RELEASE_TAG points to $remote_tag_sha, expected $HEAD_SHA."
+              exit 1
+          fi
+
+          if ! git rev-parse --verify "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+              git tag "$RELEASE_TAG" "$HEAD_SHA"
+          fi
+          ./scripts/publish-release-assets.sh \
+              --dist-dir dist \
+              --tag "$RELEASE_TAG" \
+              --commit "$HEAD_SHA"
+
+          verify_dir="$(mktemp -d)"
+          gh release download "$RELEASE_TAG" --dir "$verify_dir"
+          (cd "$verify_dir" && sha256sum -c sha256sums.txt)
+
+          update_ref() {
+              local ref_name="$1"
+              local expected_sha="$2"
+              local current_sha=""
+
+              current_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$ref_name" --jq .object.sha)"
+              if [ "$current_sha" = "$HEAD_SHA" ]; then
+                  return
+              fi
+              [ "$current_sha" = "$expected_sha" ] || {
+                  echo "$ref_name moved from $expected_sha to $current_sha."
+                  exit 1
+              }
+              gh api --method PATCH "repos/$GITHUB_REPOSITORY/git/refs/heads/$ref_name" \
+                  -f sha="$HEAD_SHA" \
+                  -F force=false >/dev/null
+          }
+
+          if [ "$BASE_REF" = "main" ]; then
+              update_ref prerelease "$EXPECTED_PRERELEASE_SHA"
+              update_ref main "$EXPECTED_MAIN_SHA"
+          else
+              update_ref prerelease "$EXPECTED_PRERELEASE_SHA"
+          fi
+
+          [ "$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$BASE_REF" --jq .object.sha)" = "$HEAD_SHA" ]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: gh pr checks "${{ needs.authorize.outputs.pr_number }}" --repo "$GITHUB_REPOSITORY" --required
 
+      - name: Download verified release bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: lg-buddy-release-${{ needs.validate.outputs.tag }}
+          path: dist
+
+      - name: Verify downloaded checksums
+        run: cd dist && sha256sum -c sha256sums.txt
+
       - name: Create repository-scoped promotion token
         id: promotion-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
@@ -216,15 +225,6 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: LG_Buddy
           permission-contents: write
-
-      - name: Download verified release bundle
-        uses: actions/download-artifact@v4
-        with:
-          name: lg-buddy-release-${{ needs.validate.outputs.tag }}
-          path: dist
-
-      - name: Verify downloaded checksums
-        run: cd dist && sha256sum -c sha256sums.txt
 
       - name: Publish release and advance channel refs
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dbus_log.txt
 
 # Python virtual environment
 .venv/
+__pycache__/
 
 # Security - sensitive files
 .env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,11 @@ For changes in these areas, also read the matching design docs:
 
 Keep one concern per pull request.
 
+Base ordinary contribution PRs on `dev` and target `dev`. The persistent
+`main` and `prerelease` branches accept only release promotion PRs whose head is
+the exact same-repository `dev` branch; see the
+[release process](docs/release-process.md).
+
 Good PRs usually fit one of these shapes:
 
 - a single confirmed bug fix

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,7 +47,7 @@ cargo build --release -p lg-buddy
 Official release builds inject version identity into the binary:
 
 ```bash
-LG_BUDDY_RELEASE_VERSION=1.3.0 LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
+LG_BUDDY_RELEASE_VERSION=X.Y.Z LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" cargo build --release -p lg-buddy
 ```
 
 Without those environment variables, `lg-buddy --version` reports the Cargo
@@ -85,6 +85,7 @@ cargo test -p lg-buddy --lib
 cargo test -p lg-buddy --test cucumber
 cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
 bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
+python3 scripts/test_release_promotion.py
 ```
 
 Optional hardware smoke for gamepad activity:
@@ -136,7 +137,9 @@ Dry-run the GitHub release publish step with:
 GH_RELEASE_DRY_RUN=1 ./scripts/publish-release-assets.sh --dist-dir ./dist --tag v0.0.0-dev
 ```
 
-For the tagged GitHub release process, see [release-process.md](release-process.md).
+Official releases are created only through a reviewed `dev` promotion PR. For
+the branch contract and recovery process, see
+[release-process.md](release-process.md).
 
 ## Repository Layout
 
@@ -167,8 +170,10 @@ For the tagged GitHub release process, see [release-process.md](release-process.
 | `scripts/build-release-bundle.sh` | Release bundle builder |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |
 | `scripts/publish-release-assets.sh` | GitHub release publish helper |
+| `scripts/release_promotion.py` | Promotion version, ancestry, and tag validator |
 | `.github/workflows/ci.yml` | CI validation workflow |
-| `.github/workflows/release.yml` | Tagged GitHub release workflow |
+| `.github/workflows/promotion-check.yml` | Trusted promotion PR contract check |
+| `.github/workflows/release.yml` | Approved promotion build, publication, and ref finalizer |
 | `bin/LG_Buddy_Common` | Shared shell config helper used by setup scripts |
 | `systemd/` | Installed unit files and tmpfiles config, including the logind lifecycle service |
 | `docs/architecture-overview.md` | Runtime architecture |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,48 +1,85 @@
 # Release Process
 
-LG Buddy release automation is triggered by pushing a version tag that starts
-with `v` followed by a digit, such as `v1.0.0` or `v1.0.0-beta.1`.
+LG Buddy uses three persistent branches as source channels:
 
-## What the release workflow does
+- `main` points to the current stable release.
+- `prerelease` is equal to `main` or ahead of it and points to the current
+  prerelease when ahead.
+- `dev` is the ordinary integration branch and may contain unreleased work.
 
-1. Runs the release validation suite:
-   - `cargo test -p lg-buddy`
-   - `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
-   - `bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh`
-2. Builds a static Linux binary for `x86_64-unknown-linux-musl`.
-3. Packages a release bundle that contains:
-   - `lg-buddy`
-   - `install.sh`
-   - `configure.sh`
-   - `uninstall.sh`
-   - `bin/LG_Buddy_Common`
-   - `systemd/`
-   - `docs/`
-   - `README.md`
-   - `LICENSE`
-4. Smoke tests the generated release bundle by unpacking it, running a non-interactive install into a temporary root, checking both TV platform modes and the lifecycle service plus NetworkManager pre-down hook topology, and then uninstalling from that temporary install.
-5. Generates and verifies `sha256sums.txt` for the release archive.
-6. Publishes the release assets through `scripts/publish-release-assets.sh`.
+The intended ancestry is `main <= prerelease <= dev`. Ordinary changes merge
+into `dev`. An official release requires a promotion PR whose head is the exact
+same-repository `dev` branch and whose base is `main` or `prerelease`.
 
-`install.sh` is only an installer. It does not build the runtime.
+## Promotion contract
 
-The tagged commit should already have passed normal branch CI. Branch CI also
-runs the privileged root-ownership tests; the tag workflow does not repeat
-those two checks.
+The promotion PR is the review and approval surface. Do not merge it with
+GitHub's merge, squash, or rebase buttons: those methods would create a commit
+different from the reviewed `dev` commit.
+
+Required promotion checks prove that:
+
+- the PR is `dev -> main` or `dev -> prerelease`
+- `Cargo.toml` and `Cargo.lock` declare the same `lg-buddy` version
+- a stable target has a stable SemVer and a prerelease target has a prerelease
+  SemVer
+- the version advances both existing release-channel heads
+- the persistent branches have not diverged or moved since review
+- the derived `v<crate-version>` tag is absent or already points to the same
+  commit during an idempotent retry
+- normal CI and the release-bundle smoke test pass
+
+The tag, binary, archive, and GitHub release all use the Cargo package version.
+There is no separate version input.
 
 ## Creating a release
 
-1. Make sure the branch you want to release has passed CI.
-2. Create a tag such as `v1.3.0`.
-3. Push the tag.
-4. After the workflow publishes the release, verify the archive against
-   `sha256sums.txt` and replace the generated generic description with concise
-   release-specific notes.
+1. Prepare the exact release version in `Cargo.toml` and `Cargo.lock` on `dev`.
+2. Open a PR from `dev` to `prerelease` or `main`.
+3. Wait for `verify`, `bundle-smoke-test`, and `validate-promotion` to pass.
+4. After review, a repository administrator applies the `release:promote`
+   label.
+5. The serialized release workflow rebuilds and smoke-tests the exact reviewed
+   commit without write credentials.
+6. A separate finalization job obtains a short-lived token from the dedicated
+   repository-only GitHub App, publishes the immutable tag and release, verifies
+   the published checksums, and only then fast-forwards the channel branch.
 
-```bash
-git tag v1.3.0
-git push origin v1.3.0
-```
+Stable finalization advances `prerelease` before `main`, preserving
+`main <= prerelease` even if the second ref update needs to be retried.
+Prerelease finalization advances only `prerelease`; `dev` already points to the
+reviewed commit in both cases.
+
+Do not push version tags manually. Protected `v*` tags and release-channel
+branches permit bypass only to the dedicated promotion App. Failed finalization
+can be rerun safely, but an existing tag or asset is accepted only when it is
+byte-for-byte consistent with the same reviewed commit.
+
+## What the release workflow validates
+
+The workflow:
+
+1. Revalidates the live PR, refs, required checks, Cargo version, and tag state.
+2. Builds a static `x86_64-unknown-linux-musl` binary with exact version and
+   commit identity.
+3. Packages and installs the release bundle in an isolated smoke-test root.
+4. Verifies the built and installed binary's exact version, channel, and commit.
+5. Generates and verifies `sha256sums.txt`.
+6. Publishes the tag and GitHub release without replacing conflicting assets.
+7. Downloads the published assets and verifies their checksums independently.
+8. Fast-forwards the selected branch only after publication succeeds.
+
+`install.sh` is only an installer. It does not build the runtime.
+
+## Nix source selection
+
+Nix configurations may select `main`, `prerelease`, or `dev` as the upstream
+source according to the desired stability. The Nix lock file must continue to
+pin an exact commit: the branch selects the update stream, not an implicitly
+moving deployment.
+
+This source selection is separate from LG Buddy's runtime `updates.channel`
+setting, which controls GitHub release discovery for installed release bundles.
 
 ## Installing from a release bundle
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,9 +13,12 @@ same-repository `dev` branch and whose base is `main` or `prerelease`.
 
 ## Promotion contract
 
-The promotion PR is the review and approval surface. Do not merge it with
-GitHub's merge, squash, or rebase buttons: those methods would create a commit
-different from the reviewed `dev` commit.
+The promotion PR is the review and approval surface. The release-channel
+ruleset blocks GitHub's merge, squash, and rebase buttons from updating the
+branch because those methods would create a commit different from the reviewed
+`dev` commit; only the promotion App may perform the final fast-forward.
+Repository-wide automatic head-branch deletion stays disabled so GitHub cannot
+remove the persistent `dev` branch when a promotion PR becomes merged.
 
 Required promotion checks prove that:
 

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -3,12 +3,13 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>]"
+    echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
     exit 1
 }
 
 DIST_DIR="dist"
 TAG="${GITHUB_REF_NAME:-}"
+EXPECTED_COMMIT=""
 DRY_RUN="${GH_RELEASE_DRY_RUN:-0}"
 
 while [ "$#" -gt 0 ]; do
@@ -19,6 +20,10 @@ while [ "$#" -gt 0 ]; do
             ;;
         --tag)
             TAG="${2:-}"
+            shift 2
+            ;;
+        --commit)
+            EXPECTED_COMMIT="${2:-}"
             shift 2
             ;;
         *)
@@ -82,8 +87,49 @@ if [ "$DRY_RUN" = "1" ]; then
     exit 0
 fi
 
-if gh release view "$TAG" >/dev/null 2>&1; then
-    gh release upload "$TAG" "${ARCHIVES[@]}" "$CHECKSUM_FILE" --clobber
-else
-    gh release create "$TAG" "${ARCHIVES[@]}" "$CHECKSUM_FILE" --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
+[ -n "$EXPECTED_COMMIT" ] || {
+    echo "Release commit must be provided via --commit."
+    exit 1
+}
+
+TAG_COMMIT="$(git rev-list -n 1 "$TAG" 2>/dev/null || true)"
+[ "$TAG_COMMIT" = "$EXPECTED_COMMIT" ] || {
+    echo "Release tag $TAG points to ${TAG_COMMIT:-nothing}, expected $EXPECTED_COMMIT."
+    exit 1
+}
+
+EXPECTED_PRERELEASE="false"
+if [ "${#RELEASE_FLAGS[@]}" -gt 0 ]; then
+    EXPECTED_PRERELEASE="true"
 fi
+
+if gh release view "$TAG" >/dev/null 2>&1; then
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
+        echo "Existing release $TAG is still a draft."
+        exit 1
+    }
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+        echo "Existing release $TAG has the wrong prerelease classification."
+        exit 1
+    }
+else
+    gh release create "$TAG" --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
+fi
+
+
+for asset in "${ARCHIVES[@]}" "$CHECKSUM_FILE"; do
+    asset_name="$(basename "$asset")"
+    if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -F -x -q "$asset_name"; then
+        compare_dir="$(mktemp -d)"
+        gh release download "$TAG" --pattern "$asset_name" --dir "$compare_dir"
+        if ! cmp -s "$asset" "$compare_dir/$asset_name"; then
+            echo "Existing release asset differs from the candidate: $asset_name"
+            rm -rf "$compare_dir"
+            exit 1
+        fi
+        rm -rf "$compare_dir"
+    else
+        gh release upload "$TAG" "$asset"
+    fi
+done

--- a/scripts/release_promotion.py
+++ b/scripts/release_promotion.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+
+"""Validate an LG Buddy release promotion against the persistent branch contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tomllib
+from dataclasses import dataclass
+from functools import total_ordering
+from pathlib import Path
+
+
+MANIFEST_PATH = "crates/lg-buddy/Cargo.toml"
+LOCK_PATH = "Cargo.lock"
+SEMVER_RE = re.compile(
+    r"^(?P<major>0|[1-9][0-9]*)\."
+    r"(?P<minor>0|[1-9][0-9]*)\."
+    r"(?P<patch>0|[1-9][0-9]*)"
+    r"(?:-(?P<prerelease>(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)"
+    r"(?:\.(?:0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*))*))?"
+    r"(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+class PromotionError(RuntimeError):
+    pass
+
+
+@total_ordering
+@dataclass(frozen=True)
+class SemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: tuple[str, ...]
+    build: tuple[str, ...]
+
+    @classmethod
+    def parse(cls, value: str) -> "SemVer":
+        match = SEMVER_RE.fullmatch(value)
+        if match is None:
+            raise PromotionError(f"invalid semantic version: {value}")
+
+        prerelease = tuple((match.group("prerelease") or "").split("."))
+        build = tuple((match.group("build") or "").split("."))
+        return cls(
+            int(match.group("major")),
+            int(match.group("minor")),
+            int(match.group("patch")),
+            tuple(identifier for identifier in prerelease if identifier),
+            tuple(identifier for identifier in build if identifier),
+        )
+
+    def _prerelease_key(self) -> tuple[object, ...]:
+        if not self.prerelease:
+            return (1,)
+
+        identifiers: list[tuple[int, object]] = []
+        for identifier in self.prerelease:
+            if identifier.isdigit():
+                identifiers.append((0, int(identifier)))
+            else:
+                identifiers.append((1, identifier))
+        return (0, *identifiers)
+
+    def _precedence_key(self) -> tuple[object, ...]:
+        return (self.major, self.minor, self.patch, self._prerelease_key())
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return self._precedence_key() < other._precedence_key()
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, SemVer):
+            return NotImplemented
+        return self._precedence_key() == other._precedence_key()
+
+
+def git(repository: Path, *arguments: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *arguments],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise PromotionError(f"git {' '.join(arguments)} failed: {detail}")
+    return result.stdout.strip()
+
+
+def object_at_ref(repository: Path, ref: str, path: str) -> bytes:
+    result = subprocess.run(
+        ["git", "show", f"{ref}:{path}"],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.decode(errors="replace").strip()
+        raise PromotionError(f"cannot read {path} at {ref}: {detail}")
+    return result.stdout
+
+
+def package_version_at_ref(repository: Path, ref: str) -> str:
+    manifest = tomllib.loads(object_at_ref(repository, ref, MANIFEST_PATH).decode())
+    try:
+        version = manifest["package"]["version"]
+    except (KeyError, TypeError) as error:
+        raise PromotionError(f"missing package.version in {MANIFEST_PATH} at {ref}") from error
+    if not isinstance(version, str):
+        raise PromotionError(f"package.version in {MANIFEST_PATH} at {ref} is not a string")
+    SemVer.parse(version)
+    return version
+
+
+def lock_version_at_ref(repository: Path, ref: str) -> str:
+    lock = tomllib.loads(object_at_ref(repository, ref, LOCK_PATH).decode())
+    matches = [
+        package.get("version")
+        for package in lock.get("package", [])
+        if package.get("name") == "lg-buddy"
+    ]
+    if len(matches) != 1 or not isinstance(matches[0], str):
+        raise PromotionError(f"expected exactly one lg-buddy package in {LOCK_PATH} at {ref}")
+    SemVer.parse(matches[0])
+    return matches[0]
+
+
+def resolve(repository: Path, ref: str) -> str:
+    return git(repository, "rev-parse", "--verify", f"{ref}^{{commit}}")
+
+
+def require_ancestor(repository: Path, ancestor: str, descendant: str) -> None:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", ancestor, descendant],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode == 1:
+        raise PromotionError(f"{ancestor} is not an ancestor of {descendant}")
+    if result.returncode != 0:
+        raise PromotionError(result.stderr.strip() or "git merge-base failed")
+
+
+def validate_promotion(
+    repository: Path,
+    *,
+    target: str,
+    head_ref: str,
+    base_sha: str,
+    main_ref: str,
+    prerelease_ref: str,
+    dev_ref: str,
+) -> dict[str, object]:
+    if target not in {"main", "prerelease"}:
+        raise PromotionError(f"unsupported promotion target: {target}")
+
+    head_sha = resolve(repository, head_ref)
+    dev_sha = resolve(repository, dev_ref)
+    main_sha = resolve(repository, main_ref)
+    prerelease_sha = resolve(repository, prerelease_ref)
+    target_sha = main_sha if target == "main" else prerelease_sha
+
+    if head_sha != dev_sha:
+        raise PromotionError(f"reviewed head {head_sha} is not the current dev commit {dev_sha}")
+    if target_sha != resolve(repository, base_sha):
+        raise PromotionError(f"promotion target moved from reviewed base {base_sha} to {target_sha}")
+
+    require_ancestor(repository, main_sha, prerelease_sha)
+    require_ancestor(repository, prerelease_sha, head_sha)
+
+    version_text = package_version_at_ref(repository, head_sha)
+    lock_version = lock_version_at_ref(repository, head_sha)
+    if lock_version != version_text:
+        raise PromotionError(
+            f"crate version {version_text} does not match Cargo.lock version {lock_version}"
+        )
+
+    version = SemVer.parse(version_text)
+    if version.build:
+        raise PromotionError("official release versions must not contain build metadata")
+    if target == "main" and version.prerelease:
+        raise PromotionError(f"main requires a stable version, found {version_text}")
+    if target == "prerelease" and not version.prerelease:
+        raise PromotionError(f"prerelease requires a prerelease version, found {version_text}")
+
+    current_main_text = package_version_at_ref(repository, main_sha)
+    current_prerelease_text = package_version_at_ref(repository, prerelease_sha)
+    for channel, current_text in (
+        ("main", current_main_text),
+        ("prerelease", current_prerelease_text),
+    ):
+        if version <= SemVer.parse(current_text):
+            raise PromotionError(
+                f"candidate {version_text} must advance {channel} from {current_text}"
+            )
+
+    tag = f"v{version_text}"
+    tag_result = subprocess.run(
+        ["git", "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}"],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    retry = tag_result.returncode == 0
+    if retry and tag_result.stdout.strip() != head_sha:
+        raise PromotionError(
+            f"tag {tag} already points to {tag_result.stdout.strip()}, not {head_sha}"
+        )
+
+    return {
+        "version": version_text,
+        "tag": tag,
+        "channel": "stable" if target == "main" else "prerelease",
+        "head_sha": head_sha,
+        "base_sha": target_sha,
+        "main_sha": main_sha,
+        "prerelease_sha": prerelease_sha,
+        "retry": retry,
+    }
+
+
+def write_github_output(path: Path, result: dict[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for key, value in result.items():
+            rendered = str(value).lower() if isinstance(value, bool) else str(value)
+            output.write(f"{key}={rendered}\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    parser.add_argument("--target", required=True, choices=("main", "prerelease"))
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--base-sha", required=True)
+    parser.add_argument("--main-ref", default="refs/remotes/origin/main")
+    parser.add_argument("--prerelease-ref", default="refs/remotes/origin/prerelease")
+    parser.add_argument("--dev-ref", default="refs/remotes/origin/dev")
+    parser.add_argument("--github-output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        result = validate_promotion(
+            args.repository.resolve(),
+            target=args.target,
+            head_ref=args.head_ref,
+            base_sha=args.base_sha,
+            main_ref=args.main_ref,
+            prerelease_ref=args.prerelease_ref,
+            dev_ref=args.dev_ref,
+        )
+    except PromotionError as error:
+        raise SystemExit(f"release promotion validation failed: {error}") from error
+
+    if args.github_output is not None:
+        write_github_output(args.github_output, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -3,8 +3,19 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 --archive <path-to-release-tar.gz> [--work-dir <dir>] [--skip-pip-install]"
+    echo "Usage: $0 --archive <path-to-release-tar.gz> [--work-dir <dir>] [--skip-pip-install] [--expected-version <version> --expected-channel <channel> --expected-commit <sha>]"
     exit 1
+}
+
+assert_version_identity() {
+    local binary="$1"
+    local output=""
+
+    output="$("$binary" --version)"
+    printf '%s\n' "$output" | grep -F -x -q "lg-buddy $EXPECTED_VERSION"
+    printf '%s\n' "$output" | grep -F -x -q "version: $EXPECTED_VERSION"
+    printf '%s\n' "$output" | grep -F -x -q "channel: $EXPECTED_CHANNEL"
+    printf '%s\n' "$output" | grep -F -x -q "commit: $EXPECTED_COMMIT"
 }
 
 assert_file() {
@@ -166,6 +177,9 @@ validate_archive_paths() {
 ARCHIVE=""
 WORK_DIR=""
 SKIP_PIP_INSTALL=0
+EXPECTED_VERSION=""
+EXPECTED_CHANNEL=""
+EXPECTED_COMMIT=""
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
@@ -181,6 +195,18 @@ while [ "$#" -gt 0 ]; do
             SKIP_PIP_INSTALL=1
             shift
             ;;
+        --expected-version)
+            EXPECTED_VERSION="${2:-}"
+            shift 2
+            ;;
+        --expected-channel)
+            EXPECTED_CHANNEL="${2:-}"
+            shift 2
+            ;;
+        --expected-commit)
+            EXPECTED_COMMIT="${2:-}"
+            shift 2
+            ;;
         *)
             usage
             ;;
@@ -188,6 +214,9 @@ while [ "$#" -gt 0 ]; do
 done
 
 [ -n "$ARCHIVE" ] || usage
+[ -z "$EXPECTED_VERSION$EXPECTED_CHANNEL$EXPECTED_COMMIT" ] || {
+    [ -n "$EXPECTED_VERSION" ] && [ -n "$EXPECTED_CHANNEL" ] && [ -n "$EXPECTED_COMMIT" ] || usage
+}
 [ -f "$ARCHIVE" ] || {
     echo "Archive not found: $ARCHIVE"
     exit 1
@@ -249,6 +278,9 @@ printf '%s\n' "$VERSION_OUTPUT" | grep -q "^lg-buddy "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^version: "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^channel: "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^commit: "
+if [ -n "$EXPECTED_VERSION" ]; then
+    assert_version_identity "$BUNDLE_DIR/lg-buddy"
+fi
 
 export HOME="$HOME_DIR"
 export XDG_CONFIG_HOME="$XDG_CONFIG_HOME"
@@ -330,6 +362,9 @@ printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^lg-buddy "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^version: "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^channel: "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^commit: "
+if [ -n "$EXPECTED_VERSION" ]; then
+    assert_version_identity "$INSTALLED_BINARY"
+fi
 
 # Existing profiles without the platform key remain on bscpylgtv. Materialize
 # that choice through settings, then use a controlled raw-config fixture to

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from release_promotion import PromotionError, SemVer, validate_promotion
+
+
+class RepositoryFixture:
+    def __init__(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.path = Path(self.temporary_directory.name)
+        self.git("init", "--initial-branch=main")
+        self.git("config", "user.name", "Release Test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        self.write_version("1.3.0")
+        self.git("add", ".")
+        self.git("commit", "-m", "stable")
+        self.stable_sha = self.git("rev-parse", "HEAD")
+        self.git("branch", "prerelease")
+        self.git("branch", "dev")
+
+    def close(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git(self, *arguments: str) -> str:
+        result = subprocess.run(
+            ["git", *arguments],
+            cwd=self.path,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    def write_version(self, version: str, lock_version: str | None = None) -> None:
+        manifest = self.path / "crates/lg-buddy/Cargo.toml"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(
+            f'[package]\nname = "lg-buddy"\nversion = "{version}"\n',
+            encoding="utf-8",
+        )
+        (self.path / "Cargo.lock").write_text(
+            'version = 4\n\n[[package]]\nname = "lg-buddy"\n'
+            f'version = "{lock_version or version}"\n',
+            encoding="utf-8",
+        )
+
+    def candidate(self, version: str, lock_version: str | None = None) -> str:
+        self.git("switch", "dev")
+        self.write_version(version, lock_version)
+        self.git("add", ".")
+        self.git("commit", "-m", f"prepare {version}")
+        return self.git("rev-parse", "HEAD")
+
+    def validate(self, target: str, head_sha: str) -> dict[str, object]:
+        base_sha = self.git("rev-parse", target)
+        return validate_promotion(
+            self.path,
+            target=target,
+            head_ref=head_sha,
+            base_sha=base_sha,
+            main_ref="main",
+            prerelease_ref="prerelease",
+            dev_ref="dev",
+        )
+
+
+class SemVerTests(unittest.TestCase):
+    def test_semver_precedence(self) -> None:
+        ordered = [
+            "1.4.0-alpha",
+            "1.4.0-alpha.1",
+            "1.4.0-beta.2",
+            "1.4.0-beta.10",
+            "1.4.0-rc.1",
+            "1.4.0",
+            "1.5.0",
+        ]
+        self.assertEqual(sorted(ordered, key=SemVer.parse), ordered)
+
+    def test_invalid_semver_is_rejected(self) -> None:
+        for value in ("1.4", "v1.4.0", "1.04.0", "1.4.0-beta.01"):
+            with self.subTest(value=value), self.assertRaises(PromotionError):
+                SemVer.parse(value)
+
+
+class PromotionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repository = RepositoryFixture()
+
+    def tearDown(self) -> None:
+        self.repository.close()
+
+    def test_prerelease_promotion(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1")
+
+        result = self.repository.validate("prerelease", head)
+
+        self.assertEqual(result["tag"], "v1.4.0-beta.1")
+        self.assertEqual(result["channel"], "prerelease")
+        self.assertFalse(result["retry"])
+
+    def test_stable_promotion_after_prerelease(self) -> None:
+        prerelease = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("branch", "-f", "prerelease", prerelease)
+        self.repository.write_version("1.4.0")
+        self.repository.git("add", ".")
+        self.repository.git("commit", "-m", "prepare stable")
+        head = self.repository.git("rev-parse", "HEAD")
+
+        result = validate_promotion(
+            self.repository.path,
+            target="main",
+            head_ref=head,
+            base_sha=self.repository.stable_sha,
+            main_ref="main",
+            prerelease_ref="prerelease",
+            dev_ref="dev",
+        )
+
+        self.assertEqual(result["tag"], "v1.4.0")
+        self.assertEqual(result["channel"], "stable")
+
+    def test_channel_mismatch_is_rejected(self) -> None:
+        prerelease = self.repository.candidate("1.4.0-beta.1")
+        with self.assertRaisesRegex(PromotionError, "main requires a stable version"):
+            self.repository.validate("main", prerelease)
+
+    def test_lockfile_mismatch_is_rejected(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1", "1.3.0")
+        with self.assertRaisesRegex(PromotionError, "does not match Cargo.lock"):
+            self.repository.validate("prerelease", head)
+
+    def test_stale_target_is_rejected(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1")
+        with self.assertRaisesRegex(PromotionError, "promotion target moved"):
+            validate_promotion(
+                self.repository.path,
+                target="prerelease",
+                head_ref=head,
+                base_sha=head,
+                main_ref="main",
+                prerelease_ref="prerelease",
+                dev_ref="dev",
+            )
+
+    def test_diverged_prerelease_is_rejected(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("switch", "prerelease")
+        (self.repository.path / "diverged").write_text("diverged\n", encoding="utf-8")
+        self.repository.git("add", "diverged")
+        self.repository.git("commit", "-m", "diverge")
+
+        with self.assertRaisesRegex(PromotionError, "is not an ancestor"):
+            self.repository.validate("prerelease", head)
+
+    def test_matching_existing_tag_is_an_idempotent_retry(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("tag", "v1.4.0-beta.1", head)
+
+        result = self.repository.validate("prerelease", head)
+
+        self.assertTrue(result["retry"])
+
+    def test_conflicting_existing_tag_is_rejected(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("tag", "v1.4.0-beta.1", self.repository.stable_sha)
+
+        with self.assertRaisesRegex(PromotionError, "already points"):
+            self.repository.validate("prerelease", head)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- establish the trusted `dev -> prerelease|main` promotion contract
- derive release identity from Cargo metadata and publish only the reviewed dev commit
- finalize with the repository-only GitHub App after artifact verification
- document the persistent release channels and Nix branch selection

## Bootstrap note

Current `main` is ahead of the historical v1.3.0 release tag while still declaring 1.3.0. This PR deliberately does not move `main`, recreate v1.3.0, or claim that today’s branch head is already a released stable commit. After this PR merges, `dev` and `prerelease` will be created at the merge commit as a one-time migration baseline; the first versioned promotion will establish the strict release-pointer invariant.

## Validation

- `python3 scripts/test_release_promotion.py`
- `actionlint`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- 636 Rust library tests passed (1 ignored)
- 120/121 Cucumber scenarios passed; the remaining existing step requires `/bin/bash`, which is absent on the NixOS host and available on GitHub Ubuntu runners
- exact release binary version/channel/commit identity verified from a generated archive
- shell syntax and `git diff --check`

Fixes #101