### PR TITLE
Add versioned release-bundle manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py
 
+      - name: Validate release bundle manifest contract
+        run: python3 scripts/test_release_bundle_manifest.py
+
   bundle-smoke-test:
     runs-on: ubuntu-latest
     needs: verify
@@ -65,13 +68,24 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y musl-tools zenity
 
       - name: Build lg-buddy release binary
+        env:
+          LG_BUDDY_BUILD_COMMIT: ${{ github.sha }}
+          LG_BUDDY_RELEASE_VERSION: 0.0.0-ci.smoke
         run: cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
 
       - name: Create release bundle
-        run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version ci-smoke --output-dir dist
+        run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version 0.0.0-ci.smoke --output-dir dist
 
       - name: Smoke test release bundle
-        run: ./scripts/test-release-bundle.sh --skip-pip-install --archive dist/lg-buddy-ci-smoke-x86_64-unknown-linux-musl.tar.gz
+        run: |
+          ./scripts/test-release-bundle.sh \
+              --skip-pip-install \
+              --archive dist/lg-buddy-0.0.0-ci.smoke-x86_64-unknown-linux-musl.tar.gz \
+              --expected-tag v0.0.0-ci.smoke \
+              --expected-version 0.0.0-ci.smoke \
+              --expected-channel prerelease \
+              --expected-target x86_64-unknown-linux-musl \
+              --expected-commit "${{ github.sha }}"
 
       - name: Generate checksums
         run: |
@@ -86,4 +100,4 @@ jobs:
       - name: Dry-run publish release assets
         env:
           GH_RELEASE_DRY_RUN: "1"
-        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag v0.0.0-ci-smoke
+        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag v0.0.0-ci.smoke --commit "${{ github.sha }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,8 +142,10 @@ jobs:
           ./scripts/test-release-bundle.sh \
               --skip-pip-install \
               --archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
+              --expected-tag "${{ needs.validate.outputs.tag }}" \
               --expected-version "${{ needs.validate.outputs.version }}" \
               --expected-channel "${{ needs.validate.outputs.channel }}" \
+              --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ needs.validate.outputs.head_sha }}"
 
       - name: Generate checksums

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,10 +111,14 @@ For gamepad subsystem internals and adapter contribution guidance, see
 Build a release bundle locally with:
 
 ```bash
+LG_BUDDY_RELEASE_VERSION=0.0.0-dev \
+LG_BUDDY_BUILD_COMMIT="$(git rev-parse HEAD)" \
+cargo build --release -p lg-buddy --target x86_64-unknown-linux-gnu
 ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-gnu --version 0.0.0-dev
 ```
 
-That script expects the matching release binary to already exist under:
+The builder requires a full release commit and expects the matching release
+binary to exist under:
 
 ```text
 ./target/<target>/release/lg-buddy
@@ -126,10 +130,17 @@ Smoke test a generated release bundle with:
 ./scripts/test-release-bundle.sh --archive ./dist/lg-buddy-0.0.0-dev-x86_64-unknown-linux-gnu.tar.gz
 ```
 
-The smoke test unpacks the archive, verifies expected files, and installs into a
-temporary root. It checks both TV platforms, native credential preservation
-across upgrades, lifecycle and NetworkManager hook topology, and uninstall
-cleanup without mutating the host installation.
+The smoke test validates `release-manifest.json` against the archive name and
+bundled binary before running installer code. It then installs into a temporary
+root and checks both TV platforms, native credential preservation across
+upgrades, lifecycle and NetworkManager hook topology, and uninstall cleanup
+without mutating the host installation.
+
+Run the focused manifest contract tests with:
+
+```bash
+python3 scripts/test_release_bundle_manifest.py
+```
 
 Dry-run the GitHub release publish step with:
 
@@ -167,6 +178,7 @@ the branch contract and recovery process, see
 | `configure.sh` | Interactive configuration tool |
 | `install.sh` | Installer for an existing binary |
 | `uninstall.sh` | Uninstaller |
+| `scripts/release_bundle_manifest.py` | Release-bundle identity manifest creator and validator |
 | `scripts/build-release-bundle.sh` | Release bundle builder |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |
 | `scripts/publish-release-assets.sh` | GitHub release publish helper |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -65,14 +65,36 @@ The workflow:
 1. Revalidates the live PR, refs, required checks, Cargo version, and tag state.
 2. Builds a static `x86_64-unknown-linux-musl` binary with exact version and
    commit identity.
-3. Packages and installs the release bundle in an isolated smoke-test root.
-4. Verifies the built and installed binary's exact version, channel, and commit.
-5. Generates and verifies `sha256sums.txt`.
-6. Publishes the tag and GitHub release without replacing conflicting assets.
-7. Downloads the published assets and verifies their checksums independently.
-8. Fast-forwards the selected branch only after publication succeeds.
+3. Generates a versioned identity manifest and packages the release bundle.
+4. Validates the manifest and installs the bundle in an isolated smoke-test root.
+5. Verifies the built and installed binary's exact version, channel, and commit.
+6. Generates and verifies `sha256sums.txt`.
+7. Publishes the tag and GitHub release without replacing conflicting assets.
+8. Downloads the published assets and verifies their checksums independently.
+9. Fast-forwards the selected branch only after publication succeeds.
 
 `install.sh` is only an installer. It does not build the runtime.
+
+## Release bundle identity
+
+Every release archive contains `release-manifest.json` at the bundle root. The
+schema-versioned JSON records the exact release tag, semantic version, release
+channel, Rust target triple, and full lowercase commit SHA. Version, tag, and
+channel must agree: stable SemVer maps to `stable`, prerelease SemVer maps to
+`prerelease`, and the tag is exactly `v<version>`.
+
+Schema 1 marks all five identity fields as critical. Validators reject an
+unsupported schema, duplicate JSON fields, missing identity fields, and unknown
+critical fields. Unknown non-critical fields may be ignored for compatible
+schema evolution. Official manifests use a deterministic field order and JSON
+rendering.
+
+The bundle builder derives version, channel, and commit from `lg-buddy
+--version`; it cannot package a binary whose identity disagrees with its tag.
+Smoke validation checks the manifest before executing installer code and then
+compares it with both the bundled and installed binary. Publishing validates
+the manifest directly from each archive without extracting or executing archive
+content.
 
 ## Nix source selection
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -300,6 +300,12 @@ that a missing TV platform remains `bscpylgtv`, explicit platform values survive
 reconfiguration, and `lg_webos` routes to the stored-credential-only native path
 and reports a missing credential without initiating background pairing.
 
+The focused release-manifest suite covers deterministic serialization, schema
+and critical-field handling, duplicate and missing fields, canonical identity
+formats, archive layout, and binary version/channel/commit mismatches. The
+bundle smoke test then exercises the same validator against the generated and
+installed release binary.
+
 ## Current Practical Gaps
 
 The most important remaining gaps are:

--- a/scripts/build-release-bundle.sh
+++ b/scripts/build-release-bundle.sh
@@ -61,6 +61,11 @@ install -m 755 "$REPO_ROOT/bin/LG_Buddy_Common" "$BUNDLE_DIR/bin/LG_Buddy_Common
 install -m 644 "$REPO_ROOT/LG_Buddy_Brightness.desktop" "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 install -m 644 "$REPO_ROOT/README.md" "$BUNDLE_DIR/README.md"
 install -m 644 "$REPO_ROOT/LICENSE" "$BUNDLE_DIR/LICENSE"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" create \
+    --output "$BUNDLE_DIR/release-manifest.json" \
+    --release-tag "v$VERSION" \
+    --target "$TARGET" \
+    --binary "$BUNDLE_DIR/lg-buddy"
 install -m 644 "$REPO_ROOT/systemd/LG_Buddy.service" "$BUNDLE_DIR/systemd/LG_Buddy.service"
 install -m 644 "$REPO_ROOT/systemd/LG_Buddy_lifecycle.service" "$BUNDLE_DIR/systemd/LG_Buddy_lifecycle.service"
 install -m 644 "$REPO_ROOT/systemd/LG_Buddy_screen.service" "$BUNDLE_DIR/systemd/LG_Buddy_screen.service"

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+
 usage() {
     echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
     exit 1
@@ -71,10 +73,26 @@ VERSION="${TAG#v}"
 TITLE="LG Buddy ${VERSION}"
 NOTES="Prebuilt LG Buddy release bundle for Linux. Extract the archive and run ./install.sh from inside the bundle."
 RELEASE_FLAGS=()
+EXPECTED_CHANNEL="stable"
 
 if [[ "$VERSION" == *-* ]]; then
     RELEASE_FLAGS+=(--prerelease)
+    EXPECTED_CHANNEL="prerelease"
 fi
+
+for archive in "${ARCHIVES[@]}"; do
+    manifest_expectations=(
+        --expected-release-tag "$TAG"
+        --expected-version "$VERSION"
+        --expected-channel "$EXPECTED_CHANNEL"
+    )
+    if [ -n "$EXPECTED_COMMIT" ]; then
+        manifest_expectations+=(--expected-commit "$EXPECTED_COMMIT")
+    fi
+    python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+        --archive "$archive" \
+        "${manifest_expectations[@]}"
+done
 
 if [ "$DRY_RUN" = "1" ]; then
     echo "Dry run: would publish tag $TAG"

--- a/scripts/release_bundle_manifest.py
+++ b/scripts/release_bundle_manifest.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+
+"""Create and validate the identity manifest embedded in LG Buddy release bundles."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import tarfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from release_promotion import PromotionError, SemVer
+
+
+MANIFEST_NAME = "release-manifest.json"
+SCHEMA_VERSION = 1
+IDENTITY_FIELDS = ("release_tag", "version", "channel", "target", "commit")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+TARGET_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+MAX_MANIFEST_BYTES = 64 * 1024
+
+
+class ManifestError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class ReleaseIdentity:
+    release_tag: str
+    version: str
+    channel: str
+    target: str
+    commit: str
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ManifestError(f"duplicate manifest field: {key}")
+        result[key] = value
+    return result
+
+
+def parse_manifest(content: bytes) -> dict[str, Any]:
+    if len(content) > MAX_MANIFEST_BYTES:
+        raise ManifestError("release manifest exceeds the 64 KiB size limit")
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ManifestError("release manifest is not valid UTF-8") from error
+    try:
+        value = json.loads(text, object_pairs_hook=reject_duplicate_keys)
+    except ManifestError:
+        raise
+    except json.JSONDecodeError as error:
+        raise ManifestError(
+            f"release manifest is not valid JSON: {error.msg}"
+        ) from error
+    if not isinstance(value, dict):
+        raise ManifestError("release manifest root must be a JSON object")
+    return value
+
+
+def validate_manifest(value: dict[str, Any]) -> ReleaseIdentity:
+    schema_version = value.get("schema_version")
+    if type(schema_version) is not int or schema_version != SCHEMA_VERSION:
+        raise ManifestError(
+            f"unsupported release manifest schema_version: {schema_version!r}"
+        )
+
+    critical = value.get("critical")
+    if not isinstance(critical, list) or any(
+        not isinstance(field, str) for field in critical
+    ):
+        raise ManifestError("release manifest critical must be an array of field names")
+    if len(critical) != len(set(critical)):
+        raise ManifestError("release manifest critical contains a duplicate field name")
+
+    unknown_critical = sorted(set(critical) - set(IDENTITY_FIELDS))
+    if unknown_critical:
+        raise ManifestError(
+            f"unknown critical release manifest field: {unknown_critical[0]}"
+        )
+    missing_critical = sorted(set(IDENTITY_FIELDS) - set(critical))
+    if missing_critical:
+        raise ManifestError(
+            f"required identity field is not marked critical: {missing_critical[0]}"
+        )
+
+    fields: dict[str, str] = {}
+    for field in IDENTITY_FIELDS:
+        field_value = value.get(field)
+        if not isinstance(field_value, str) or not field_value:
+            raise ManifestError(f"missing or invalid release manifest field: {field}")
+        fields[field] = field_value
+
+    version_text = fields["version"]
+    try:
+        version = SemVer.parse(version_text)
+    except PromotionError as error:
+        raise ManifestError(str(error)) from error
+    if version.build:
+        raise ManifestError("release manifest version must not contain build metadata")
+
+    if fields["release_tag"] != f"v{version_text}":
+        raise ManifestError(
+            "release manifest tag must be exactly v followed by the manifest version"
+        )
+
+    expected_channel = "prerelease" if version.prerelease else "stable"
+    if fields["channel"] != expected_channel:
+        raise ManifestError(
+            f"release manifest channel must be {expected_channel} for version {version_text}"
+        )
+
+    if TARGET_RE.fullmatch(fields["target"]) is None:
+        raise ManifestError(f"invalid release manifest target: {fields['target']}")
+    if COMMIT_RE.fullmatch(fields["commit"]) is None:
+        raise ManifestError(
+            "release manifest commit must be a full lowercase 40-character SHA"
+        )
+
+    return ReleaseIdentity(**fields)
+
+
+def render_manifest(identity: ReleaseIdentity) -> bytes:
+    value = {
+        "schema_version": SCHEMA_VERSION,
+        "critical": list(IDENTITY_FIELDS),
+        "release_tag": identity.release_tag,
+        "version": identity.version,
+        "channel": identity.channel,
+        "target": identity.target,
+        "commit": identity.commit,
+    }
+    validate_manifest(value)
+    return (json.dumps(value, indent=2, ensure_ascii=True) + "\n").encode("utf-8")
+
+
+def parse_binary_identity(
+    output: str, *, target: str, release_tag: str
+) -> ReleaseIdentity:
+    lines = output.splitlines()
+    if len(lines) != 4:
+        raise ManifestError("lg-buddy --version must emit exactly four identity lines")
+
+    prefixes = ("lg-buddy ", "version: ", "channel: ", "commit: ")
+    if any(not line.startswith(prefix) for line, prefix in zip(lines, prefixes)):
+        raise ManifestError("lg-buddy --version output has an unexpected format")
+
+    headline_version = lines[0][len(prefixes[0]) :]
+    version = lines[1][len(prefixes[1]) :]
+    if headline_version != version:
+        raise ManifestError("lg-buddy --version headline and version field disagree")
+
+    identity = ReleaseIdentity(
+        release_tag=release_tag,
+        version=version,
+        channel=lines[2][len(prefixes[2]) :],
+        target=target,
+        commit=lines[3][len(prefixes[3]) :],
+    )
+    validate_manifest(parse_manifest(render_manifest(identity)))
+    return identity
+
+
+def binary_identity(binary: Path, *, target: str, release_tag: str) -> ReleaseIdentity:
+    result = subprocess.run(
+        [binary, "--version"],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip()
+        raise ManifestError(f"cannot read bundled binary identity: {detail}")
+    return parse_binary_identity(result.stdout, target=target, release_tag=release_tag)
+
+
+def manifest_from_archive(archive: Path) -> tuple[dict[str, Any], str]:
+    try:
+        with tarfile.open(archive, mode="r:gz") as bundle:
+            matches = []
+            for member in bundle.getmembers():
+                path = PurePosixPath(member.name)
+                if (
+                    member.isfile()
+                    and len(path.parts) == 2
+                    and path.parts[1] == MANIFEST_NAME
+                ):
+                    matches.append(member)
+            if len(matches) != 1:
+                raise ManifestError(
+                    f"release archive must contain exactly one top-level {MANIFEST_NAME}"
+                )
+            member = matches[0]
+            if member.size > MAX_MANIFEST_BYTES:
+                raise ManifestError("release manifest exceeds the 64 KiB size limit")
+            extracted = bundle.extractfile(member)
+            if extracted is None:
+                raise ManifestError(f"cannot read {member.name} from release archive")
+            return parse_manifest(extracted.read()), PurePosixPath(member.name).parts[0]
+    except ManifestError:
+        raise
+    except (OSError, tarfile.TarError) as error:
+        raise ManifestError(f"cannot read release archive: {error}") from error
+
+
+def validate_archive(archive: Path) -> ReleaseIdentity:
+    value, bundle_root = manifest_from_archive(archive)
+    identity = validate_manifest(value)
+    expected_bundle_name = f"lg-buddy-{identity.version}-{identity.target}"
+    if bundle_root != expected_bundle_name:
+        raise ManifestError(
+            f"release manifest identity expects bundle root {expected_bundle_name}, found {bundle_root}"
+        )
+    expected_archive_name = f"{expected_bundle_name}.tar.gz"
+    if archive.name != expected_archive_name:
+        raise ManifestError(
+            f"release manifest identity expects archive name {expected_archive_name}, found {archive.name}"
+        )
+    return identity
+
+
+def validate_expected(identity: ReleaseIdentity, args: argparse.Namespace) -> None:
+    for field in IDENTITY_FIELDS:
+        expected = getattr(args, f"expected_{field}", None)
+        if expected is not None and getattr(identity, field) != expected:
+            raise ManifestError(
+                f"release manifest {field} is {getattr(identity, field)}, expected {expected}"
+            )
+
+
+def validate_binary_matches(identity: ReleaseIdentity, binary: Path) -> None:
+    observed = binary_identity(
+        binary,
+        target=identity.target,
+        release_tag=identity.release_tag,
+    )
+    for field in ("version", "channel", "commit"):
+        if getattr(observed, field) != getattr(identity, field):
+            raise ManifestError(
+                f"bundled binary {field} is {getattr(observed, field)}, "
+                f"manifest records {getattr(identity, field)}"
+            )
+
+
+def add_expected_arguments(parser: argparse.ArgumentParser) -> None:
+    for field in IDENTITY_FIELDS:
+        parser.add_argument(f"--expected-{field.replace('_', '-')}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create")
+    create.add_argument("--output", type=Path, required=True)
+    create.add_argument("--release-tag", required=True)
+    create.add_argument("--target", required=True)
+    create.add_argument("--binary", type=Path, required=True)
+
+    validate = subparsers.add_parser("validate")
+    source = validate.add_mutually_exclusive_group(required=True)
+    source.add_argument("--manifest", type=Path)
+    source.add_argument("--archive", type=Path)
+    validate.add_argument("--binary", type=Path)
+    add_expected_arguments(validate)
+
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "create":
+            identity = binary_identity(
+                args.binary,
+                target=args.target,
+                release_tag=args.release_tag,
+            )
+            args.output.write_bytes(render_manifest(identity))
+            print(f"Created {args.output}")
+            return 0
+
+        if args.archive is not None:
+            identity = validate_archive(args.archive)
+        else:
+            identity = validate_manifest(parse_manifest(args.manifest.read_bytes()))
+        validate_expected(identity, args)
+        if args.binary is not None:
+            validate_binary_matches(identity, args.binary)
+    except (ManifestError, OSError) as error:
+        raise SystemExit(
+            f"release bundle manifest validation failed: {error}"
+        ) from error
+
+    print(
+        f"Validated {identity.release_tag} for {identity.target} at {identity.commit}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -3,19 +3,8 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 --archive <path-to-release-tar.gz> [--work-dir <dir>] [--skip-pip-install] [--expected-version <version> --expected-channel <channel> --expected-commit <sha>]"
+    echo "Usage: $0 --archive <path-to-release.tar.gz> [--work-dir <dir>] [--skip-pip-install] [--expected-tag <tag> --expected-version <version> --expected-channel <channel> --expected-target <target> --expected-commit <sha>]"
     exit 1
-}
-
-assert_version_identity() {
-    local binary="$1"
-    local output=""
-
-    output="$("$binary" --version)"
-    printf '%s\n' "$output" | grep -F -x -q "lg-buddy $EXPECTED_VERSION"
-    printf '%s\n' "$output" | grep -F -x -q "version: $EXPECTED_VERSION"
-    printf '%s\n' "$output" | grep -F -x -q "channel: $EXPECTED_CHANNEL"
-    printf '%s\n' "$output" | grep -F -x -q "commit: $EXPECTED_COMMIT"
 }
 
 assert_file() {
@@ -174,11 +163,14 @@ validate_archive_paths() {
     done < <(tar -tzf "$archive")
 }
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
 ARCHIVE=""
 WORK_DIR=""
 SKIP_PIP_INSTALL=0
+EXPECTED_TAG=""
 EXPECTED_VERSION=""
 EXPECTED_CHANNEL=""
+EXPECTED_TARGET=""
 EXPECTED_COMMIT=""
 
 while [ "$#" -gt 0 ]; do
@@ -195,12 +187,20 @@ while [ "$#" -gt 0 ]; do
             SKIP_PIP_INSTALL=1
             shift
             ;;
+        --expected-tag)
+            EXPECTED_TAG="${2:-}"
+            shift 2
+            ;;
         --expected-version)
             EXPECTED_VERSION="${2:-}"
             shift 2
             ;;
         --expected-channel)
             EXPECTED_CHANNEL="${2:-}"
+            shift 2
+            ;;
+        --expected-target)
+            EXPECTED_TARGET="${2:-}"
             shift 2
             ;;
         --expected-commit)
@@ -215,7 +215,14 @@ done
 
 [ -n "$ARCHIVE" ] || usage
 [ -z "$EXPECTED_VERSION$EXPECTED_CHANNEL$EXPECTED_COMMIT" ] || {
-    [ -n "$EXPECTED_VERSION" ] && [ -n "$EXPECTED_CHANNEL" ] && [ -n "$EXPECTED_COMMIT" ] || usage
+    [ -n "$EXPECTED_VERSION" ] && \
+        [ -n "$EXPECTED_CHANNEL" ] && \
+        [ -n "$EXPECTED_COMMIT" ] || usage
+}
+[ -z "$EXPECTED_TAG$EXPECTED_TARGET" ] || {
+    [ -n "$EXPECTED_TAG" ] && \
+        [ -n "$EXPECTED_TARGET" ] && \
+        [ -n "$EXPECTED_VERSION" ] || usage
 }
 [ -f "$ARCHIVE" ] || {
     echo "Archive not found: $ARCHIVE"
@@ -243,6 +250,25 @@ XDG_CONFIG_HOME="$HOME_DIR/.config"
 
 mkdir -p "$EXTRACT_DIR" "$INSTALL_ROOT" "$HOME_DIR"
 
+MANIFEST_EXPECTATIONS=()
+if [ -n "$EXPECTED_VERSION" ]; then
+    MANIFEST_EXPECTATIONS=(
+        --expected-version "$EXPECTED_VERSION"
+        --expected-channel "$EXPECTED_CHANNEL"
+        --expected-commit "$EXPECTED_COMMIT"
+    )
+fi
+if [ -n "$EXPECTED_TAG" ]; then
+    MANIFEST_EXPECTATIONS+=(
+        --expected-release-tag "$EXPECTED_TAG"
+        --expected-target "$EXPECTED_TARGET"
+    )
+fi
+
+# Validate archive identity without extracting or executing archive content.
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$ARCHIVE" \
+    "${MANIFEST_EXPECTATIONS[@]}"
 validate_archive_paths "$ARCHIVE"
 tar -C "$EXTRACT_DIR" -xzf "$ARCHIVE"
 BUNDLE_DIR="$(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)"
@@ -260,6 +286,7 @@ assert_executable "$BUNDLE_DIR/bin/LG_Buddy_Common"
 assert_file "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 assert_file "$BUNDLE_DIR/README.md"
 assert_file "$BUNDLE_DIR/LICENSE"
+assert_file "$BUNDLE_DIR/release-manifest.json"
 assert_file "$BUNDLE_DIR/docs/architecture-overview.md"
 assert_file "$BUNDLE_DIR/docs/runtime-event-handler-map.md"
 assert_file "$BUNDLE_DIR/docs/user-guide.md"
@@ -271,6 +298,11 @@ assert_file "$BUNDLE_DIR/systemd/LG_Buddy_screen.service"
 assert_file "$BUNDLE_DIR/systemd/LG_Buddy_update_check.service"
 assert_file "$BUNDLE_DIR/systemd/LG_Buddy_update_check.timer"
 
+# The identity query is the first command executed from the extracted bundle.
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$BUNDLE_DIR/release-manifest.json" \
+    --binary "$BUNDLE_DIR/lg-buddy" \
+    "${MANIFEST_EXPECTATIONS[@]}"
 assert_cli_surface "$BUNDLE_DIR/lg-buddy"
 
 VERSION_OUTPUT="$("$BUNDLE_DIR/lg-buddy" --version)"
@@ -278,9 +310,6 @@ printf '%s\n' "$VERSION_OUTPUT" | grep -q "^lg-buddy "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^version: "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^channel: "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^commit: "
-if [ -n "$EXPECTED_VERSION" ]; then
-    assert_version_identity "$BUNDLE_DIR/lg-buddy"
-fi
 
 export HOME="$HOME_DIR"
 export XDG_CONFIG_HOME="$XDG_CONFIG_HOME"
@@ -362,9 +391,10 @@ printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^lg-buddy "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^version: "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^channel: "
 printf '%s\n' "$INSTALLED_VERSION_OUTPUT" | grep -q "^commit: "
-if [ -n "$EXPECTED_VERSION" ]; then
-    assert_version_identity "$INSTALLED_BINARY"
-fi
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$BUNDLE_DIR/release-manifest.json" \
+    --binary "$INSTALLED_BINARY" \
+    "${MANIFEST_EXPECTATIONS[@]}"
 
 # Existing profiles without the platform key remain on bscpylgtv. Materialize
 # that choice through settings, then use a controlled raw-config fixture to

--- a/scripts/test_release_bundle_manifest.py
+++ b/scripts/test_release_bundle_manifest.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import io
+import tarfile
+import tempfile
+import unittest
+from argparse import Namespace
+from pathlib import Path
+
+from release_bundle_manifest import (
+    IDENTITY_FIELDS,
+    MANIFEST_NAME,
+    ManifestError,
+    ReleaseIdentity,
+    parse_binary_identity,
+    parse_manifest,
+    render_manifest,
+    validate_archive,
+    validate_binary_matches,
+    validate_expected,
+    validate_manifest,
+)
+
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+IDENTITY = ReleaseIdentity(
+    release_tag="v1.4.0-beta.1",
+    version="1.4.0-beta.1",
+    channel="prerelease",
+    target="x86_64-unknown-linux-musl",
+    commit=COMMIT,
+)
+
+
+def manifest_value(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": 1,
+        "critical": list(IDENTITY_FIELDS),
+        "release_tag": IDENTITY.release_tag,
+        "version": IDENTITY.version,
+        "channel": IDENTITY.channel,
+        "target": IDENTITY.target,
+        "commit": IDENTITY.commit,
+    }
+    value.update(overrides)
+    return value
+
+
+class ManifestTests(unittest.TestCase):
+    def test_render_is_deterministic_and_round_trips(self) -> None:
+        first = render_manifest(IDENTITY)
+        second = render_manifest(IDENTITY)
+
+        self.assertEqual(first, second)
+        self.assertEqual(validate_manifest(parse_manifest(first)), IDENTITY)
+        self.assertTrue(first.endswith(b"\n"))
+
+    def test_duplicate_json_field_is_rejected(self) -> None:
+        content = render_manifest(IDENTITY).replace(
+            b'  "version": "1.4.0-beta.1",',
+            b'  "version": "1.4.0-beta.1",\n  "version": "1.4.0-beta.2",',
+        )
+
+        with self.assertRaisesRegex(ManifestError, "duplicate manifest field: version"):
+            parse_manifest(content)
+
+    def test_missing_identity_field_is_rejected(self) -> None:
+        value = manifest_value()
+        del value["target"]
+
+        with self.assertRaisesRegex(ManifestError, "missing or invalid.*target"):
+            validate_manifest(value)
+
+    def test_unknown_critical_field_is_rejected(self) -> None:
+        value = manifest_value(critical=[*IDENTITY_FIELDS, "signature"])
+        value["signature"] = "future"
+
+        with self.assertRaisesRegex(ManifestError, "unknown critical.*signature"):
+            validate_manifest(value)
+
+    def test_unknown_noncritical_field_is_ignored(self) -> None:
+        value = manifest_value(annotation="future")
+
+        self.assertEqual(validate_manifest(value), IDENTITY)
+
+    def test_schema_version_must_be_supported_integer(self) -> None:
+        for schema_version in (True, "1", 2):
+            with (
+                self.subTest(schema_version=schema_version),
+                self.assertRaisesRegex(ManifestError, "unsupported.*schema_version"),
+            ):
+                validate_manifest(manifest_value(schema_version=schema_version))
+
+    def test_tag_must_match_version(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "tag must be exactly"):
+            validate_manifest(manifest_value(release_tag="v1.4.0-beta.2"))
+
+    def test_channel_must_match_semver_stage(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "channel must be prerelease"):
+            validate_manifest(manifest_value(channel="stable"))
+
+        stable = manifest_value(
+            release_tag="v1.4.0", version="1.4.0", channel="prerelease"
+        )
+        with self.assertRaisesRegex(ManifestError, "channel must be stable"):
+            validate_manifest(stable)
+
+    def test_version_must_be_canonical_release_semver(self) -> None:
+        for version in ("1.4", "v1.4.0", "1.4.0+local"):
+            value = manifest_value(release_tag=f"v{version}", version=version)
+            with self.subTest(version=version), self.assertRaises(ManifestError):
+                validate_manifest(value)
+
+    def test_target_and_commit_have_canonical_formats(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "invalid release manifest target"):
+            validate_manifest(manifest_value(target="../../host"))
+        with self.assertRaisesRegex(ManifestError, "full lowercase 40-character SHA"):
+            validate_manifest(manifest_value(commit="ABC123"))
+
+    def test_external_identity_mismatches_are_rejected(self) -> None:
+        for field in IDENTITY_FIELDS:
+            expected = {f"expected_{name}": None for name in IDENTITY_FIELDS}
+            expected[f"expected_{field}"] = "different"
+            with (
+                self.subTest(field=field),
+                self.assertRaisesRegex(ManifestError, f"release manifest {field}"),
+            ):
+                validate_expected(IDENTITY, Namespace(**expected))
+
+    def test_binary_identity_requires_exact_output(self) -> None:
+        output = (
+            "lg-buddy 1.4.0-beta.1\n"
+            "version: 1.4.0-beta.1\n"
+            "channel: prerelease\n"
+            f"commit: {COMMIT}\n"
+        )
+
+        self.assertEqual(
+            parse_binary_identity(
+                output,
+                target=IDENTITY.target,
+                release_tag=IDENTITY.release_tag,
+            ),
+            IDENTITY,
+        )
+
+        with self.assertRaisesRegex(ManifestError, "exactly four"):
+            parse_binary_identity(
+                f"{output}extra\n",
+                target=IDENTITY.target,
+                release_tag=IDENTITY.release_tag,
+            )
+
+
+class ArchiveTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.path = Path(self.temporary_directory.name)
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def archive(
+        self, manifest: bytes | None = None, *, duplicate: bool = False
+    ) -> Path:
+        bundle_name = f"lg-buddy-{IDENTITY.version}-{IDENTITY.target}"
+        archive = self.path / f"{bundle_name}.tar.gz"
+        with tarfile.open(archive, mode="w:gz") as bundle:
+            if manifest is not None:
+                for _ in range(2 if duplicate else 1):
+                    info = tarfile.TarInfo(f"{bundle_name}/{MANIFEST_NAME}")
+                    info.size = len(manifest)
+                    bundle.addfile(info, io.BytesIO(manifest))
+        return archive
+
+    def test_archive_identity_round_trips(self) -> None:
+        self.assertEqual(
+            validate_archive(self.archive(render_manifest(IDENTITY))), IDENTITY
+        )
+
+    def test_missing_and_duplicate_archive_manifests_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "exactly one"):
+            validate_archive(self.archive())
+        with self.assertRaisesRegex(ManifestError, "exactly one"):
+            validate_archive(self.archive(render_manifest(IDENTITY), duplicate=True))
+
+    def test_archive_name_must_match_manifest_identity(self) -> None:
+        archive = self.archive(render_manifest(IDENTITY))
+        renamed = archive.with_name("renamed.tar.gz")
+        archive.rename(renamed)
+
+        with self.assertRaisesRegex(ManifestError, "expects archive name"):
+            validate_archive(renamed)
+
+    def test_malformed_archive_manifest_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ManifestError, "not valid JSON"):
+            validate_archive(self.archive(b"not json\n"))
+
+
+class BinaryComparisonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.binary = Path(self.temporary_directory.name) / "lg-buddy"
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def write_binary(self, *, version: str, channel: str, commit: str) -> None:
+        self.binary.write_text(
+            "#!/bin/sh\n"
+            "cat <<'EOF'\n"
+            f"lg-buddy {version}\n"
+            f"version: {version}\n"
+            f"channel: {channel}\n"
+            f"commit: {commit}\n"
+            "EOF\n",
+            encoding="utf-8",
+        )
+        self.binary.chmod(0o755)
+
+    def test_binary_identity_must_match_manifest(self) -> None:
+        self.write_binary(
+            version=IDENTITY.version,
+            channel=IDENTITY.channel,
+            commit=IDENTITY.commit,
+        )
+        validate_binary_matches(IDENTITY, self.binary)
+
+        mismatches = (
+            ("1.4.0-beta.2", IDENTITY.channel, IDENTITY.commit, "version"),
+            (IDENTITY.version, "stable", IDENTITY.commit, "channel"),
+            (IDENTITY.version, IDENTITY.channel, "f" * 40, "commit"),
+        )
+        for version, channel, commit, field in mismatches:
+            with self.subTest(field=field):
+                self.write_binary(version=version, channel=channel, commit=commit)
+                with self.assertRaises(ManifestError):
+                    validate_binary_matches(IDENTITY, self.binary)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a deterministic schema-1 `release-manifest.json` with tag, version, channel, target, and full commit identity
- derive the manifest from the bundled binary and validate it during build, smoke testing, and publication
- reject malformed, duplicate, missing, unknown-critical, and inconsistent identity data
- document the manifest contract and include focused CI coverage

## Promotion compatibility

The smoke script continues to accept the existing version/channel/commit expectation set used by the trusted workflow currently on `main`. The updated workflow adds explicit tag and target checks once it reaches the trusted release branch, so this change does not block its own first promotion.

## Validation

- `python3 scripts/test_release_bundle_manifest.py` — 17 passed
- `python3 scripts/test_release_promotion.py` — 10 passed
- `actionlint`
- Ruff lint and format checks
- shell syntax and `git diff --check`
- fresh metadata-stamped release build, archive checksum verification, and publish dry-run
- full release-bundle smoke test in an isolated NixOS-compatible environment

Fixes #95
