### PR TITLE
Add non-interactive release bundle upgrade mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ selection and troubleshooting. Protocol and event details are documented in the
 ## Before You Install
 
 The native `lg_webos` control path does not require Python. Native-only packages
-can omit the Python client, `venv`, and `pip`. The current `install.sh` flow
+can omit the Python client, `venv`, and `pip`. The current fresh-install flow
 still provisions `bscpylgtv` as a compatibility fallback and installs the
-brightness dialog, so release-bundle installation checks for Python 3 with
-`venv` and `pip`, plus `zenity`. `swayidle` is required only when using that
-desktop backend.
+brightness dialog, so release-bundle installation checks for Python 3 with a
+`venv` that provisions `pip`, plus `zenity`. `swayidle` is required only when
+using that desktop backend.
 
 ### Debian, Ubuntu, and Pop!_OS
 
@@ -94,6 +94,11 @@ If you select the native `lg_webos` control platform, accept the pairing prompt
 during setup. With the default `bscpylgtv` platform, the prompt may instead
 appear on first use; see the
 [bscpylgtv first-use guide](https://github.com/chros73/bscpylgtv/blob/master/docs/guides/first_use.md).
+
+To update an existing compatible release-bundle installation from an already
+verified and extracted newer bundle, run `./install.sh --upgrade`. Upgrade mode
+preserves configuration and credentials and does not repeat setup or pairing;
+incompatible and legacy layouts are refused rather than migrated.
 
 The shell installer targets conventional Linux installations with mutable
 system locations. First-class NixOS packaging is tracked in

--- a/crates/lg-buddy/src/events.rs
+++ b/crates/lg-buddy/src/events.rs
@@ -109,7 +109,8 @@ impl RuntimeEventKind {
             | Command::DetectBackend
             | Command::Dev(_)
             | Command::Settings(_)
-            | Command::Updates(_) => None,
+            | Command::Updates(_)
+            | Command::UpgradePreflight { .. } => None,
         }
     }
 }

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -47,8 +47,10 @@ use crate::tv::{
     VolumeLevelParseError,
 };
 use crate::updates::{run_updates_command, UpdatesCommand, UpdatesError, UpdatesParseError};
+use crate::upgrade_preflight::CompatibilityReport;
 use std::fmt;
 use std::io::{self, Write};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Command {
@@ -69,6 +71,10 @@ pub enum Command {
     Dev(DevCommand),
     Settings(SettingsCommand),
     Updates(UpdatesCommand),
+    UpgradePreflight {
+        candidate_root: PathBuf,
+        repair_python: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,6 +211,7 @@ pub enum ParseError {
     Dev(DevParseError),
     Settings(SettingsParseError),
     Updates(UpdatesParseError),
+    MissingUpgradePreflightRoot,
     UnexpectedArguments {
         command: Command,
         arguments: Vec<String>,
@@ -255,6 +262,9 @@ impl fmt::Display for ParseError {
             Self::Dev(err) => write!(f, "{err}"),
             Self::Settings(err) => write!(f, "{err}"),
             Self::Updates(err) => write!(f, "{err}"),
+            Self::MissingUpgradePreflightRoot => {
+                write!(f, "missing candidate root for `upgrade-preflight`")
+            }
             Self::UnexpectedArguments { command, arguments } => {
                 write!(
                     f,
@@ -280,6 +290,7 @@ pub enum RunError {
     Dev(DevError),
     Settings(SettingsError),
     Updates(UpdatesError),
+    UpgradePreflight(CompatibilityReport),
     NotificationAfterPrimary {
         primary: Box<RunError>,
         notification: NotificationError,
@@ -300,6 +311,7 @@ impl fmt::Display for RunError {
             Self::Dev(err) => write!(f, "{err}"),
             Self::Settings(err) => write!(f, "{err}"),
             Self::Updates(err) => write!(f, "{err}"),
+            Self::UpgradePreflight(report) => write!(f, "{report}"),
             Self::NotificationAfterPrimary {
                 primary,
                 notification,
@@ -325,6 +337,7 @@ impl std::error::Error for RunError {
             Self::Dev(err) => Some(err),
             Self::Settings(err) => Some(err),
             Self::Updates(err) => Some(err),
+            Self::UpgradePreflight(_) => None,
             Self::NotificationAfterPrimary { primary, .. } => Some(primary.as_ref()),
         }
     }
@@ -413,6 +426,7 @@ impl Command {
             Self::Dev(command) => command.as_str(),
             Self::Settings(_) => "settings",
             Self::Updates(_) => "updates",
+            Self::UpgradePreflight { .. } => "upgrade-preflight",
         }
     }
 
@@ -435,6 +449,7 @@ impl Command {
             Self::Dev(_) => "TODO: implemented via temporary dev command handler",
             Self::Settings(_) => "TODO: implemented via command handler",
             Self::Updates(_) => "TODO: implemented via command handler",
+            Self::UpgradePreflight { .. } => "TODO: implemented via command handler",
         }
     }
 }
@@ -701,6 +716,33 @@ where
         }
         "settings" => return parse_settings_command(args),
         "updates" => return parse_updates_command(args),
+        "upgrade-preflight" => {
+            let candidate_root = PathBuf::from(
+                args.next()
+                    .ok_or(ParseError::MissingUpgradePreflightRoot)?
+                    .as_ref(),
+            );
+            let mut repair_python = false;
+            let mut unexpected = Vec::new();
+            for argument in args {
+                if argument.as_ref() == "--repair-python" && !repair_python {
+                    repair_python = true;
+                } else {
+                    unexpected.push(argument.as_ref().to_string());
+                }
+            }
+            let command = Command::UpgradePreflight {
+                candidate_root,
+                repair_python,
+            };
+            if !unexpected.is_empty() {
+                return Err(ParseError::UnexpectedArguments {
+                    command,
+                    arguments: unexpected,
+                });
+            }
+            return Ok(ParseOutcome::Command(command));
+        }
         "dev" => {
             return DevCommand::parse(args)
                 .map(|command| ParseOutcome::Command(Command::Dev(command)))
@@ -757,6 +799,19 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         }
         Command::Updates(command) => {
             run_updates_command(command, writer).map_err(RunError::Updates)
+        }
+        Command::UpgradePreflight {
+            candidate_root,
+            repair_python,
+        } => {
+            let report =
+                crate::upgrade_preflight::candidate_host_preflight(&candidate_root, repair_python);
+            if report.compatible() {
+                write!(writer, "{report}")?;
+                Ok(())
+            } else {
+                Err(RunError::UpgradePreflight(report))
+            }
         }
     }
 }
@@ -1176,6 +1231,7 @@ mod tests {
     use crate::{notifications::NotificationError, RunError};
     use std::error::Error;
     use std::io;
+    use std::path::PathBuf;
 
     #[test]
     fn no_args_prints_help() {
@@ -1552,6 +1608,24 @@ mod tests {
                 UpdatesCommand::BackgroundCheck
             )))
         );
+        assert_eq!(
+            parse_args(["upgrade-preflight", "/tmp/lg-buddy-candidate"]),
+            Ok(ParseOutcome::Command(Command::UpgradePreflight {
+                candidate_root: PathBuf::from("/tmp/lg-buddy-candidate"),
+                repair_python: false,
+            }))
+        );
+        assert_eq!(
+            parse_args([
+                "upgrade-preflight",
+                "/tmp/lg-buddy-candidate",
+                "--repair-python"
+            ]),
+            Ok(ParseOutcome::Command(Command::UpgradePreflight {
+                candidate_root: PathBuf::from("/tmp/lg-buddy-candidate"),
+                repair_python: true,
+            }))
+        );
     }
 
     #[test]
@@ -1828,6 +1902,39 @@ mod tests {
     }
 
     #[test]
+    fn invalid_upgrade_preflight_command_is_rejected() {
+        assert_eq!(
+            parse_args(["upgrade-preflight"]),
+            Err(ParseError::MissingUpgradePreflightRoot)
+        );
+        assert_eq!(
+            parse_args(["upgrade-preflight", "/tmp/candidate", "extra"]),
+            Err(ParseError::UnexpectedArguments {
+                command: Command::UpgradePreflight {
+                    candidate_root: PathBuf::from("/tmp/candidate"),
+                    repair_python: false,
+                },
+                arguments: vec!["extra".to_string()],
+            })
+        );
+        assert_eq!(
+            parse_args([
+                "upgrade-preflight",
+                "/tmp/candidate",
+                "--repair-python",
+                "--repair-python"
+            ]),
+            Err(ParseError::UnexpectedArguments {
+                command: Command::UpgradePreflight {
+                    candidate_root: PathBuf::from("/tmp/candidate"),
+                    repair_python: true,
+                },
+                arguments: vec!["--repair-python".to_string()],
+            })
+        );
+    }
+
+    #[test]
     fn global_usage_only_mentions_public_commands() {
         let help = usage("lg-buddy");
 
@@ -1868,6 +1975,7 @@ mod tests {
             "screen-on",
             "detect-backend",
             "updates background-check",
+            "upgrade-preflight",
             "webos-auth-probe",
             "webos-read-probe",
         ] {

--- a/crates/lg-buddy/src/upgrade_preflight.rs
+++ b/crates/lg-buddy/src/upgrade_preflight.rs
@@ -17,6 +17,7 @@ enum InstallerPathPolicy {
     RecursiveClear,
     ExactDropInDirectory { expected_entry: &'static str },
     ReadableInput,
+    SystemReadableInput,
     ExecutableInput,
     InputDirectory,
 }
@@ -28,6 +29,7 @@ impl InstallerPathPolicy {
             Self::ReplaceFile
                 | Self::ReplaceExecutable
                 | Self::ReadableInput
+                | Self::SystemReadableInput
                 | Self::ExecutableInput
         )
     }
@@ -84,8 +86,6 @@ const SYSTEM_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[
         InstallerPathPolicy::ReplaceFile,
     ),
     requirement("/usr/bin", InstallerPathPolicy::MutateDirectory),
-    requirement("/usr/bin/LG_Buddy_PIP", InstallerPathPolicy::RecursiveClear),
-    requirement("/usr/lib/lg-buddy", InstallerPathPolicy::MutateDirectory),
     requirement("/etc/systemd/system", InstallerPathPolicy::MutateDirectory),
     requirement(
         "/etc/systemd/system/LG_Buddy.service.d",
@@ -109,6 +109,11 @@ const SYSTEM_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[
         InstallerPathPolicy::MutateDirectory,
     ),
 ];
+
+const PYTHON_REPAIR_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[requirement(
+    "/usr/bin/LG_Buddy_PIP",
+    InstallerPathPolicy::RecursiveClear,
+)];
 
 const LEGACY_SYSTEM_PATHS: &[&str] = &[
     "/usr/bin/LG_Buddy_Startup",
@@ -410,6 +415,10 @@ impl InstalledLayout {
     fn user_systemd_path(&self, path: &str) -> PathBuf {
         self.user_home.join(".config/systemd/user").join(path)
     }
+
+    fn user_desktop_entry(&self) -> PathBuf {
+        self.user_home.join("Desktop/LG_Buddy_Brightness.desktop")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -501,12 +510,12 @@ pub fn current_host_preflight() -> CompatibilityReport {
     evaluate_initial_preflight(&OsFilesystemFacts, &facts)
 }
 
-pub fn candidate_host_preflight(candidate_root: &Path) -> CompatibilityReport {
+pub fn candidate_host_preflight(candidate_root: &Path, repair_python: bool) -> CompatibilityReport {
     let facts = match observe_current_process() {
         Ok(facts) => facts,
         Err(report) => return report,
     };
-    evaluate_candidate_host_preflight(&OsFilesystemFacts, &facts, candidate_root)
+    evaluate_candidate_host_preflight(&OsFilesystemFacts, &facts, candidate_root, repair_python)
 }
 
 fn observe_current_process() -> Result<HostPreflightFacts, CompatibilityReport> {
@@ -536,13 +545,24 @@ fn observe_current_process() -> Result<HostPreflightFacts, CompatibilityReport> 
         }
     };
     let effective_uid = unsafe { libc::geteuid() };
+    let install_root = env::var_os("LG_BUDDY_INSTALL_ROOT")
+        .filter(|root| !root.is_empty())
+        .map(PathBuf::from);
+    let sandboxed_install = install_root.is_some();
+    let system_root = install_root.unwrap_or_else(|| PathBuf::from("/"));
+    let service_managers =
+        if sandboxed_install && env::var("LG_BUDDY_SKIP_SYSTEMD_ACTIONS").as_deref() == Ok("1") {
+            ServiceManagerFacts::available()
+        } else {
+            ServiceManagerFacts::observe()
+        };
     Ok(HostPreflightFacts {
-        layout: InstalledLayout::new("/", user_home),
+        layout: InstalledLayout::new(system_root, user_home),
         running_executable,
         effective_uid,
-        system_owner_uid: 0,
+        system_owner_uid: if sandboxed_install { effective_uid } else { 0 },
         user_owner_uid: effective_uid,
-        service_managers: ServiceManagerFacts::observe(),
+        service_managers,
     })
 }
 
@@ -556,6 +576,7 @@ pub fn evaluate_initial_preflight(
         &facts.layout.installed_executable(),
         "running-executable",
         "run the release-bundle installation at /usr/bin/lg-buddy, or use the host's native package manager",
+        false,
     )
 }
 
@@ -565,6 +586,7 @@ fn evaluate_installed_state(
     expected_running_executable: &Path,
     executable_check: &'static str,
     executable_remedy: &'static str,
+    repair_python: bool,
 ) -> CompatibilityReport {
     let mut checker = Checker::new(filesystem);
     let system_trust = TrustedRoot::strict(&facts.layout.system_root, facts.system_owner_uid);
@@ -613,6 +635,17 @@ fn evaluate_installed_state(
             check,
         );
     }
+    if repair_python {
+        for requirement in PYTHON_REPAIR_PATH_REQUIREMENTS {
+            checker.check_requirement(
+                &facts.layout.system_path(requirement.path),
+                facts.system_owner_uid,
+                Some(system_trust),
+                requirement.policy,
+                "python-environment-repair",
+            );
+        }
+    }
     for requirement in USER_PATH_REQUIREMENTS {
         let check = match requirement.policy {
             InstallerPathPolicy::MutateDirectory => "mutable-user-integration",
@@ -627,6 +660,13 @@ fn evaluate_installed_state(
             check,
         );
     }
+    checker.check_optional_requirement(
+        &facts.layout.user_desktop_entry(),
+        facts.user_owner_uid,
+        Some(user_trust),
+        InstallerPathPolicy::ReplaceFile,
+        "user-desktop",
+    );
 
     for path in LEGACY_SYSTEM_PATHS {
         checker.check_absent(&facts.layout.system_path(path));
@@ -699,6 +739,7 @@ pub fn evaluate_candidate_host_preflight(
     filesystem: &impl FilesystemFacts,
     facts: &HostPreflightFacts,
     candidate_root: &Path,
+    repair_python: bool,
 ) -> CompatibilityReport {
     let expected_candidate_executable = candidate_root.join("lg-buddy");
     let mut report = evaluate_installed_state(
@@ -707,6 +748,7 @@ pub fn evaluate_candidate_host_preflight(
         &expected_candidate_executable,
         "candidate-executable",
         "run the preflight with the verified candidate binary from this bundle",
+        repair_python,
     );
     report.extend(evaluate_candidate_preflight(
         filesystem,
@@ -820,9 +862,27 @@ impl<'a, F: FilesystemFacts> Checker<'a, F> {
         check: &'static str,
     ) {
         self.check_ancestors(path, trusted_root);
-        let facts = match self.path_facts(path, check) {
-            Some(facts) => facts,
-            None => return,
+        let facts = match self.filesystem.path_facts(path) {
+            Ok(facts) => facts,
+            Err(err)
+                if policy == InstallerPathPolicy::RecursiveClear
+                    && err.kind() == io::ErrorKind::NotFound =>
+            {
+                return;
+            }
+            Err(err) => {
+                self.report.refuse(
+                    check,
+                    Some(path.to_path_buf()),
+                    if err.kind() == io::ErrorKind::NotFound {
+                        "required path is missing".to_string()
+                    } else {
+                        format!("could not inspect required path: {err}")
+                    },
+                    "restore this path from a current release-bundle installation",
+                );
+                return;
+            }
         };
         if policy.expects_file() && facts.kind != PathKind::File {
             self.report.refuse(
@@ -877,6 +937,13 @@ impl<'a, F: FilesystemFacts> Checker<'a, F> {
                 check,
                 "input is not readable by its owner",
             ),
+            InstallerPathPolicy::SystemReadableInput => self.check_permissions(
+                path,
+                &facts,
+                0o404,
+                check,
+                "system input is not readable by its owner and the invoking user",
+            ),
             InstallerPathPolicy::ExecutableInput => self.check_permissions(
                 path,
                 &facts,
@@ -891,6 +958,20 @@ impl<'a, F: FilesystemFacts> Checker<'a, F> {
                 check,
                 "input directory is not readable and searchable by its owner",
             ),
+        }
+    }
+
+    fn check_optional_requirement(
+        &mut self,
+        path: &Path,
+        owner_uid: u32,
+        trusted_root: Option<TrustedRoot<'_>>,
+        policy: InstallerPathPolicy,
+        check: &'static str,
+    ) {
+        match self.filesystem.path_facts(path) {
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            _ => self.check_requirement(path, owner_uid, trusted_root, policy, check),
         }
     }
 
@@ -1103,7 +1184,7 @@ impl<'a, F: FilesystemFacts> Checker<'a, F> {
             path,
             owner_uid,
             Some(TrustedRoot::strict(system_root, owner_uid)),
-            InstallerPathPolicy::ReplaceFile,
+            InstallerPathPolicy::SystemReadableInput,
             "config-discovery",
         );
         if self
@@ -1402,10 +1483,79 @@ mod tests {
             &OsFilesystemFacts,
             &candidate_facts,
             &fixture.candidate_root,
+            false,
         );
 
         assert!(initial.compatible(), "{}", initial.render());
         assert!(candidate.compatible(), "{}", candidate.render());
+    }
+
+    #[test]
+    fn python_environment_safety_is_required_only_when_repair_is_requested() {
+        let fixture = InstalledFixture::new("conditional-python-repair");
+        let virtualenv = fixture.facts.layout.system_path("/usr/bin/LG_Buddy_PIP");
+        let mut candidate_facts = fixture.facts.clone();
+        candidate_facts.running_executable = fixture.candidate_root.join("lg-buddy");
+
+        let missing = evaluate_candidate_host_preflight(
+            &OsFilesystemFacts,
+            &candidate_facts,
+            &fixture.candidate_root,
+            true,
+        );
+        assert!(missing.compatible(), "{}", missing.render());
+
+        fs::create_dir_all(&virtualenv).unwrap();
+        let repair = evaluate_candidate_host_preflight(
+            &OsFilesystemFacts,
+            &candidate_facts,
+            &fixture.candidate_root,
+            true,
+        );
+        assert!(repair.compatible(), "{}", repair.render());
+
+        fs::remove_dir(&virtualenv).unwrap();
+        symlink(&fixture.config_directory, &virtualenv).unwrap();
+        let preserving = evaluate_candidate_host_preflight(
+            &OsFilesystemFacts,
+            &candidate_facts,
+            &fixture.candidate_root,
+            false,
+        );
+        let repair = evaluate_candidate_host_preflight(
+            &OsFilesystemFacts,
+            &candidate_facts,
+            &fixture.candidate_root,
+            true,
+        );
+
+        assert!(preserving.compatible(), "{}", preserving.render());
+        assert_failure(&repair, "python-environment-repair", &virtualenv, "Symlink");
+    }
+
+    #[test]
+    fn existing_user_desktop_launcher_must_be_safely_replaceable() {
+        let fixture = InstalledFixture::new("user-desktop-launcher");
+        let launcher = fixture.facts.layout.user_desktop_entry();
+        fs::create_dir_all(launcher.parent().unwrap()).unwrap();
+        write_file(&launcher, false);
+        set_mode(&launcher, 0o400);
+        let mut candidate_facts = fixture.facts.clone();
+        candidate_facts.running_executable = fixture.candidate_root.join("lg-buddy");
+
+        let report = evaluate_candidate_host_preflight(
+            &OsFilesystemFacts,
+            &candidate_facts,
+            &fixture.candidate_root,
+            false,
+        );
+
+        assert_failure(
+            &report,
+            "user-desktop",
+            &launcher,
+            "not writable by its owner",
+        );
     }
 
     #[test]
@@ -1461,6 +1611,12 @@ mod tests {
                 "not readable by its owner",
             ),
             (
+                "system-readable-input",
+                InstallerPathPolicy::SystemReadableInput,
+                0o400,
+                "invoking user",
+            ),
+            (
                 "executable-input",
                 InstallerPathPolicy::ExecutableInput,
                 0o400,
@@ -1513,6 +1669,11 @@ mod tests {
                     fixture.candidate_root.clone(),
                     fixture.facts.user_owner_uid,
                 ),
+                InstallerPathPolicy::SystemReadableInput => (
+                    fixture.facts.layout.config_pointer(),
+                    fixture.facts.layout.system_root.clone(),
+                    fixture.facts.system_owner_uid,
+                ),
                 InstallerPathPolicy::ExecutableInput => (
                     fixture.candidate_root.join("install.sh"),
                     fixture.candidate_root.clone(),
@@ -1524,6 +1685,9 @@ mod tests {
                     fixture.facts.user_owner_uid,
                 ),
             };
+            if policy == InstallerPathPolicy::RecursiveClear {
+                fs::create_dir_all(&path).unwrap();
+            }
             let filesystem = OverriddenFilesystem {
                 path: path.clone(),
                 owner_uid: None,
@@ -1650,27 +1814,37 @@ mod tests {
     }
 
     #[test]
-    fn initial_preflight_refuses_a_symlinked_installed_virtualenv() {
+    fn python_repair_preflight_refuses_a_symlinked_installed_virtualenv() {
         let fixture = InstalledFixture::new("symlink-virtualenv");
         let virtualenv = fixture.facts.layout.system_path("/usr/bin/LG_Buddy_PIP");
         let target = fixture.root.join("external-virtualenv");
+        fs::create_dir(&virtualenv).unwrap();
         fs::remove_dir(&virtualenv).unwrap();
         fs::create_dir(&target).unwrap();
         symlink(&target, &virtualenv).unwrap();
+        let mut candidate_facts = fixture.facts.clone();
+        candidate_facts.running_executable = fixture.candidate_root.join("lg-buddy");
 
-        let report = evaluate_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        let report = evaluate_candidate_host_preflight(
+            &OsFilesystemFacts,
+            &candidate_facts,
+            &fixture.candidate_root,
+            true,
+        );
 
-        assert_failure(&report, "mutable-installation", &virtualenv, "Symlink");
+        assert_failure(&report, "python-environment-repair", &virtualenv, "Symlink");
     }
 
     #[test]
-    fn initial_preflight_refuses_a_nested_mount_in_the_recursively_cleared_virtualenv() {
+    fn python_repair_preflight_refuses_a_nested_virtualenv_mount() {
         let fixture = InstalledFixture::new("nested-virtualenv-mount");
         let nested_mount = fixture
             .facts
             .layout
             .system_path("/usr/bin/LG_Buddy_PIP/lib/python/site-packages");
         fs::create_dir_all(&nested_mount).unwrap();
+        let mut candidate_facts = fixture.facts.clone();
+        candidate_facts.running_executable = fixture.candidate_root.join("lg-buddy");
         let filesystem = OverriddenFilesystem {
             path: nested_mount.clone(),
             owner_uid: None,
@@ -1679,11 +1853,16 @@ mod tests {
             mount_point: Some(true),
         };
 
-        let report = evaluate_initial_preflight(&filesystem, &fixture.facts);
+        let report = evaluate_candidate_host_preflight(
+            &filesystem,
+            &candidate_facts,
+            &fixture.candidate_root,
+            true,
+        );
 
         assert_failure(
             &report,
-            "mutable-installation",
+            "python-environment-repair",
             &nested_mount,
             "nested mount point",
         );
@@ -2067,6 +2246,7 @@ mod tests {
             &OsFilesystemFacts,
             &fixture.facts,
             &fixture.candidate_root,
+            false,
         );
 
         let failure = report
@@ -2092,6 +2272,7 @@ mod tests {
             &OsFilesystemFacts,
             &candidate_facts,
             &fixture.candidate_root,
+            false,
         );
 
         assert_failure(&report, "installed-layout", &installed_service, "missing");

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -445,14 +445,13 @@ The initial preflight expects the running binary to be the mutable
 filesystem topology, ordinary file and directory types, ownership, writable
 mounts, config-pointer discovery, readable configuration state, user and system
 integrations, systemd manager availability, and the absence of legacy layouts
-that would require migration. Each path is tied to the future upgrade
+that would require migration. Each path is tied to the upgrade
 operation that consumes it: file replacement, executable replacement,
-directory mutation, recursive virtualenv repair, or exact drop-in replacement.
-Those policies carry their ownership, permission, link, mount, and containment
-invariants. Symlinks, mounted or multiply linked replacement targets, nested
-mounts below a recursively cleared virtualenv, untrusted writable system paths,
-unexpected systemd drop-ins, read-only mutation targets, and special files in
-owned config state are refused.
+directory mutation, read-only input, or exact drop-in replacement. Those
+policies carry their ownership, permission, link, mount, and containment
+invariants. Symlinks, mounted or multiply linked replacement targets,
+untrusted writable system paths, unexpected systemd drop-ins, read-only
+mutation targets, and special files in owned config state are refused.
 
 After a bundle has been verified, its candidate binary can run the second
 preflight. That pass rechecks the installed state, proves it is executing the
@@ -464,6 +463,13 @@ shared-writable unless sticky-directory semantics protect its trusted child.
 Configuration and pairing scripts are deliberately excluded because the
 non-interactive upgrade mode preserves existing configuration and credentials
 without invoking them.
+
+The installer then reads the existing platform choice and checks the legacy
+Python environment without mutating either. Native installations and healthy
+compatibility environments preserve that directory unchanged. Only an
+unhealthy compatibility environment triggers a second candidate preflight for
+recursive repair; that conditional pass also refuses unsafe virtualenv roots
+and nested mounts before the directory is cleared.
 
 These checks are a conservative, evolving safety boundary, not an exhaustive
 host-support declaration or a promise that no later privileged operation can

--- a/docs/development.md
+++ b/docs/development.md
@@ -132,9 +132,9 @@ Smoke test a generated release bundle with:
 
 The smoke test validates `release-manifest.json` against the archive name and
 bundled binary before running installer code. It then installs into a temporary
-root and checks both TV platforms, native credential preservation across
-upgrades, lifecycle and NetworkManager hook topology, and uninstall cleanup
-without mutating the host installation.
+root and exercises upgrade refusal, preservation, Python repair, owned-file
+replacement, service ordering, installed identity, lifecycle topology, and
+uninstall cleanup without mutating the host installation.
 
 Run the focused manifest contract tests with:
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -110,6 +110,16 @@ The checker assigns each target an installer-operation policy so replacement,
 directory mutation, recursive repair, exact drop-in, and candidate-input
 requirements cannot silently lose their operation-specific safeguards.
 
+The extracted candidate exposes this second pass through the hidden
+`upgrade-preflight` installer entrypoint. `install.sh --upgrade` invokes it
+before sudo or installation writes, loads the existing config pointer and
+settings without rewriting them, and never runs configuration, discovery, or
+pairing. Native and healthy compatibility installations preserve their Python
+environment; an unhealthy compatibility environment must pass the additional
+recursive-repair checks before it is rebuilt. After replacing owned runtime and
+integration files, the installer reloads system integrations before user
+integrations and verifies that the installed binary matches the candidate.
+
 This is intentionally a conservative and evolving refusal boundary. It does
 not migrate legacy layouts, declare broad host support, or guarantee that a
 later privileged operation cannot fail.
@@ -133,6 +143,17 @@ End users can extract the release archive and run:
 ```
 
 That path uses the bundled `lg-buddy` binary and does not require a Rust toolchain.
+
+To update an existing compatible release-bundle installation from an already
+verified and extracted newer bundle, run as the installed user:
+
+```bash
+./install.sh --upgrade
+```
+
+An incompatible or legacy layout is refused rather than migrated. If a failure
+occurs after installation writes begin, correct the reported cause and rerun the
+same verified bundle with `--upgrade`.
 
 ## Installing a locally built binary
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -295,10 +295,11 @@ These should not dominate the Rust test suite, but they still matter because ins
 
 The release-bundle smoke test covers the current installed lifecycle topology:
 the logind lifecycle service remains installed, the NetworkManager pre-down hook
-remains installed, and legacy systemd sleep hooks are absent. It also verifies
-that a missing TV platform remains `bscpylgtv`, explicit platform values survive
-reconfiguration, and `lg_webos` routes to the stored-credential-only native path
-and reports a missing credential without initiating background pairing.
+remains installed, and legacy systemd sleep hooks are absent. Its upgrade phase
+proves refusal before sudo, skips configuration, preserves config and native
+credentials byte-for-byte, conditionally preserves or repairs the Python
+environment, replaces the owned bundle assets, checks service action order, and
+verifies the installed runtime against the candidate bytes and identity.
 
 The focused release-manifest suite covers deterministic serialization, schema
 and critical-field handling, duplicate and missing fields, canonical identity
@@ -314,8 +315,9 @@ hard-linked, legacy, conflicting-drop-in, malformed-candidate, and
 unavailable-service-manager refusals. Table-driven cases exercise every path
 policy's permission contract and every declared candidate input. Candidate
 containment cases reject untrusted and non-sticky shared-writable ancestors
-while preserving root-owned sticky temporary directories; recursive repair
-coverage also refuses nested mount points below the virtualenv root. Run it with:
+while preserving root-owned sticky temporary directories. Virtualenv mutation
+checks are conditional on an actual compatibility-environment repair and refuse
+unsafe roots or nested mount points before clearing. Run it with:
 
 ```bash
 cargo test -p lg-buddy upgrade_preflight::tests --lib

--- a/install.sh
+++ b/install.sh
@@ -12,12 +12,19 @@ SKIP_SYSTEMD_ACTIONS="${LG_BUDDY_SKIP_SYSTEMD_ACTIONS:-0}"
 SKIP_PIP_INSTALL="${LG_BUDDY_SKIP_PIP_INSTALL:-0}"
 DEFAULT_RUNTIME_BINARY="$SCRIPT_DIR/lg-buddy"
 RUNTIME_BINARY="$DEFAULT_RUNTIME_BINARY"
+RUNTIME_BINARY_OVERRIDDEN=0
+UPGRADE_MODE=0
+MUTATION_STARTED=0
+UPGRADE_COMPLETED=0
 
 usage() {
     cat <<EOF
-Usage: $0 [--runtime-binary /path/to/lg-buddy]
+Usage: $0 [--upgrade] [--runtime-binary /path/to/lg-buddy]
 
 Install LG Buddy from an existing runtime binary.
+
+Options:
+  --upgrade         Upgrade an existing compatible release-bundle installation
 
 Defaults:
   --runtime-binary defaults to ./lg-buddy next to install.sh
@@ -30,7 +37,13 @@ while [ "$#" -gt 0 ]; do
         --runtime-binary)
             RUNTIME_BINARY="${2:-}"
             [ -n "$RUNTIME_BINARY" ] || usage
+            RUNTIME_BINARY_OVERRIDDEN=1
             shift 2
+            ;;
+        --upgrade)
+            [ "$UPGRADE_MODE" -eq 0 ] || usage
+            UPGRADE_MODE=1
+            shift
             ;;
         -h|--help)
             usage
@@ -41,19 +54,34 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
+if [ "$UPGRADE_MODE" -eq 1 ] && [ "$RUNTIME_BINARY_OVERRIDDEN" -eq 1 ]; then
+    echo "Error: --upgrade uses the verified lg-buddy binary from this release bundle."
+    exit 1
+fi
+
+if [ -n "$INSTALL_ROOT" ]; then
+    case "$INSTALL_ROOT" in
+        /*) ;;
+        *)
+            echo "Error: LG_BUDDY_INSTALL_ROOT must be an absolute path."
+            exit 1
+            ;;
+    esac
+fi
+
 if [ "$(id -u)" -eq 0 ]; then
     echo "Error: Do not run this script with sudo. It will prompt for sudo when needed."
     exit 1
 fi
 
-echo "Starting LG Buddy Installation"
+if [ "$UPGRADE_MODE" -eq 1 ]; then
+    echo "Starting LG Buddy Upgrade"
+else
+    echo "Starting LG Buddy Installation"
+fi
 if [ -n "$INSTALL_ROOT" ]; then
     echo "Install root override: $INSTALL_ROOT"
 fi
-
-# 1. CHECK PREREQUISITES
-echo ""
-echo "Checking prerequisites..."
 
 MISSING_PKGS=()
 SCREEN_MONITOR_AVAILABLE=0
@@ -129,7 +157,8 @@ check_python3_venv() {
     local tmp_venv_dir=""
     tmp_venv_dir="$(mktemp -d)" || return 1
 
-    if python3 -m venv "$tmp_venv_dir" >/dev/null 2>&1; then
+    if python3 -m venv "$tmp_venv_dir" >/dev/null 2>&1 &&
+        "$tmp_venv_dir/bin/pip" --version >/dev/null 2>&1; then
         rm -rf "$tmp_venv_dir"
         return 0
     fi
@@ -137,10 +166,6 @@ check_python3_venv() {
     rm -rf "$tmp_venv_dir"
     return 1
 }
-
-check_dep "python3-venv" "python3-venv" "check_python3_venv"
-check_dep "python3-pip" "python3-pip" "/usr/bin/python3 -m pip --version"
-check_dep "zenity" "zenity" "command -v zenity"
 
 write_config_override() {
     local override_file="$1"
@@ -214,28 +239,15 @@ resolve_runtime_binary() {
     echo "Using lg-buddy runtime binary: $RUNTIME_BINARY"
 }
 
-cleanup() {
-    if [ -n "$SYSTEM_CONFIG_OVERRIDE_TMP" ]; then
-        rm -f "$SYSTEM_CONFIG_OVERRIDE_TMP"
+install_missing_prerequisites() {
+    if [ ${#MISSING_PKGS[@]} -eq 0 ]; then
+        echo "All prerequisites satisfied."
+        return
     fi
 
-    if [ -n "$CONFIG_POINTER_TMP" ]; then
-        rm -f "$CONFIG_POINTER_TMP"
-    fi
-
-    if [ -n "$NM_HOOK_TMP" ]; then
-        rm -f "$NM_HOOK_TMP"
-    fi
-
-}
-
-trap cleanup EXIT
-
-if [ ${#MISSING_PKGS[@]} -gt 0 ]; then
     echo ""
     echo "Missing: ${MISSING_PKGS[*]}"
 
-    # Detect package manager
     if command -v apt &>/dev/null; then
         PM="apt"
         INSTALL_CMD=(apt install -y)
@@ -268,14 +280,120 @@ if [ ${#MISSING_PKGS[@]} -gt 0 ]; then
         echo "Please install the missing packages manually and re-run install.sh."
         exit 1
     fi
-else
-    echo "All prerequisites satisfied."
-fi
+}
 
-# 2. RESOLVE RUST RUNTIME
+check_fresh_install_prerequisites() {
+    echo ""
+    echo "Checking prerequisites..."
+    MISSING_PKGS=()
+    check_dep "python3-venv" "python3-venv" "check_python3_venv"
+    check_dep "zenity" "zenity" "command -v zenity"
+    install_missing_prerequisites
+}
+
+require_python_repair_prerequisites() {
+    echo "Checking Python compatibility-platform repair prerequisites..."
+    MISSING_PKGS=()
+    check_dep "python3-venv" "python3-venv" "check_python3_venv"
+    if [ ${#MISSING_PKGS[@]} -gt 0 ]; then
+        echo "Upgrade requires Python environment repair, but these prerequisites are missing: ${MISSING_PKGS[*]}"
+        echo "Install them manually and rerun the upgrade. No installation files were changed."
+        exit 1
+    fi
+}
+
+python_environment_healthy() {
+    local python_version=""
+    local site_packages=""
+
+    python_version="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" || return 1
+    site_packages="$VENV_DIR/lib/python$python_version/site-packages"
+
+    [ -f "$VENV_DIR/pyvenv.cfg" ] &&
+        [ -x "$VENV_DIR/bin/python" ] &&
+        [ -x "$VENV_DIR/bin/pip" ] &&
+        [ -x "$VENV_DIR/bin/bscpylgtvcommand" ] &&
+        { [ -d "$site_packages/bscpylgtv" ] || [ -f "$site_packages/bscpylgtv.py" ]; }
+}
+
+load_upgrade_configuration() {
+    CONFIG_FILE="$(sed -n '/[^[:space:]]/{p;q;}' "$CONFIG_POINTER_PATH")"
+    [ -n "$CONFIG_FILE" ] || {
+        echo "Installed config pointer is empty: $CONFIG_POINTER_PATH"
+        exit 1
+    }
+
+    TV_PLATFORM="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get tv.platform)"
+    SCREEN_IDLE_BLANK="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get screen.idle_blank)"
+    SCREEN_MONITOR_CONFIGURED_BACKEND="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get screen.backend)"
+    SYSTEM_SLEEP_WAKE_POLICY="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get system.sleep_wake_policy)"
+    UPDATE_AUTO_CHECK="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get updates.auto_check)"
+    UPDATE_CHANNEL="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get updates.channel)"
+    CANDIDATE_VERSION_OUTPUT="$("$RUNTIME_BINARY" --version)"
+
+    echo "Using existing configuration file at $CONFIG_FILE"
+    echo "Preserving update channel: $UPDATE_CHANNEL"
+}
+
+prepare_installation_files() {
+    if [ "$UPGRADE_MODE" -eq 0 ]; then
+        CONFIG_POINTER_TMP="$(mktemp)"
+        write_config_pointer "$CONFIG_POINTER_TMP" "$CONFIG_FILE"
+    fi
+    SYSTEM_CONFIG_OVERRIDE_TMP="$(mktemp)"
+    write_config_override "$SYSTEM_CONFIG_OVERRIDE_TMP" "$CONFIG_FILE"
+    NM_HOOK_TMP="$(mktemp)"
+    write_nm_pre_down_hook "$NM_HOOK_TMP"
+}
+
+cleanup() {
+    local status=$?
+
+    if [ -n "$SYSTEM_CONFIG_OVERRIDE_TMP" ]; then
+        rm -f "$SYSTEM_CONFIG_OVERRIDE_TMP"
+    fi
+
+    if [ -n "$CONFIG_POINTER_TMP" ]; then
+        rm -f "$CONFIG_POINTER_TMP"
+    fi
+
+    if [ -n "$NM_HOOK_TMP" ]; then
+        rm -f "$NM_HOOK_TMP"
+    fi
+
+    if [ "$status" -ne 0 ] && [ "$UPGRADE_MODE" -eq 1 ] && [ "$MUTATION_STARTED" -eq 1 ] && [ "$UPGRADE_COMPLETED" -eq 0 ]; then
+        echo "LG Buddy upgrade did not complete after installation changes began." >&2
+        echo "The installation may be partial; rerun this verified bundle with --upgrade after correcting the reported failure." >&2
+    fi
+
+    trap - EXIT
+    exit "$status"
+}
+
+trap cleanup EXIT
+
 resolve_runtime_binary
+REPAIR_PYTHON_ENVIRONMENT=0
 
-# 3. CONFIGURE SCRIPTS
+if [ "$UPGRADE_MODE" -eq 1 ]; then
+    echo ""
+    echo "Running candidate upgrade preflight..."
+    "$RUNTIME_BINARY" upgrade-preflight "$SCRIPT_DIR"
+    load_upgrade_configuration
+
+    if [ "$TV_PLATFORM" = "lg_webos" ]; then
+        echo "Native TV platform selected; preserving the existing Python environment unchanged."
+    elif python_environment_healthy; then
+        echo "Python compatibility environment is healthy; preserving it unchanged."
+    else
+        REPAIR_PYTHON_ENVIRONMENT=1
+        "$RUNTIME_BINARY" upgrade-preflight "$SCRIPT_DIR" --repair-python
+        require_python_repair_prerequisites
+    fi
+else
+    check_fresh_install_prerequisites
+
+# CONFIGURE FRESH INSTALLATION
 echo ""
 echo "Running configuration script..."
 # Make sure configure.sh is executable
@@ -363,77 +481,77 @@ else
             ;;
     esac
 fi
+fi
+
+prepare_installation_files
 
 # 4. CREATE VIRTUAL ENVIRONMENT
-echo "Creating Python virtual environment at $VENV_DIR..."
-# Recreate the helper venv so OS Python minor-version upgrades do not leave
-# bscpylgtv installed under an interpreter-specific site-packages directory
-# that the new `/usr/bin/python3` no longer reads.
-run_privileged python3 -m venv --clear "$VENV_DIR"
-echo "Done."
-
-# 5. INSTALL BSCPYLGTV
-if [ "$SKIP_PIP_INSTALL" = "1" ]; then
-    echo "Skipping bscpylgtv installation because LG_BUDDY_SKIP_PIP_INSTALL=1."
-else
-    echo "Installing bscpylgtv into the virtual environment..."
-    run_privileged "$VENV_DIR/bin/pip" install bscpylgtv
+if [ "$UPGRADE_MODE" -eq 0 ] || [ "$REPAIR_PYTHON_ENVIRONMENT" -eq 1 ]; then
+    MUTATION_STARTED=1
+    echo "Creating Python virtual environment at $VENV_DIR..."
+    # Recreate the helper venv so OS Python minor-version upgrades do not leave
+    # bscpylgtv installed under an interpreter-specific site-packages directory
+    # that the new `/usr/bin/python3` no longer reads.
+    run_privileged python3 -m venv --clear "$VENV_DIR"
     echo "Done."
+
+    if [ "$SKIP_PIP_INSTALL" = "1" ]; then
+        echo "Skipping bscpylgtv installation because LG_BUDDY_SKIP_PIP_INSTALL=1."
+    else
+        echo "Installing bscpylgtv into the virtual environment..."
+        run_privileged "$VENV_DIR/bin/pip" install bscpylgtv
+        echo "Done."
+    fi
 fi
 
 # 6. INSTALL RUST RUNTIME AND SUPPORT FILES
+MUTATION_STARTED=1
 echo "Installing Rust runtime and support files..."
 run_privileged install -m 755 "$RUNTIME_BINARY" "$RUNTIME_INSTALL_PATH"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Startup"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Shutdown"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_On"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Off"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Monitor"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_sleep_pre"
-run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Brightness"
-run_privileged rm -f "$COMMON_HELPER_PATH"
-run_privileged rm -f "$CONFIG_POINTER_PATH"
-run_privileged rmdir "$SYSTEM_LIB_DIR" 2>/dev/null || true
-run_privileged install -d "$SYSTEM_LIB_DIR"
-CONFIG_POINTER_TMP="$(mktemp)"
-write_config_pointer "$CONFIG_POINTER_TMP" "$CONFIG_FILE"
-run_privileged install -m 644 "$CONFIG_POINTER_TMP" "$CONFIG_POINTER_PATH"
-rm -f "$CONFIG_POINTER_TMP"
-CONFIG_POINTER_TMP=""
+if [ "$UPGRADE_MODE" -eq 0 ]; then
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Startup"
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Shutdown"
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_On"
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Off"
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Monitor"
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_sleep_pre"
+    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Brightness"
+    run_privileged rm -f "$COMMON_HELPER_PATH"
+    run_privileged rm -f "$CONFIG_POINTER_PATH"
+    run_privileged rmdir "$SYSTEM_LIB_DIR" 2>/dev/null || true
+fi
+if [ "$UPGRADE_MODE" -eq 0 ]; then
+    run_privileged install -d "$SYSTEM_LIB_DIR"
+    run_privileged install -m 644 "$CONFIG_POINTER_TMP" "$CONFIG_POINTER_PATH"
+fi
 echo "Installing brightness control desktop entry..."
-run_privileged mkdir -p "$APPLICATIONS_DIR"
-run_privileged cp "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" "$DESKTOP_ENTRY_PATH"
-cp "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" ~/Desktop/ 2>/dev/null || true
+run_privileged install -d "$APPLICATIONS_DIR"
+run_privileged install -m 644 "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" "$DESKTOP_ENTRY_PATH"
+if [ "$UPGRADE_MODE" -eq 0 ]; then
+    cp "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" ~/Desktop/ 2>/dev/null || true
+elif [ -f "$HOME/Desktop/LG_Buddy_Brightness.desktop" ]; then
+    cp "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" "$HOME/Desktop/LG_Buddy_Brightness.desktop"
+fi
 echo "Done."
 
 # 7. SETUP SYSTEMD SERVICES
 echo "Copying and enabling systemd services..."
 run_privileged install -d "$SYSTEMD_SYSTEM_DIR"
 run_privileged install -d "$TMPFILES_CONF_DIR"
-run_privileged cp "$SCRIPT_DIR/systemd/LG_Buddy.service" "$SYSTEMD_SERVICE_PATH"
-run_privileged cp "$SCRIPT_DIR/systemd/lg_buddy.conf" "$TMPFILES_CONF_PATH"
+run_privileged install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy.service" "$SYSTEMD_SERVICE_PATH"
+run_privileged install -m 644 "$SCRIPT_DIR/systemd/lg_buddy.conf" "$TMPFILES_CONF_PATH"
 run_privileged install -d "$SYSTEMD_SERVICE_OVERRIDE_DIR"
-SYSTEM_CONFIG_OVERRIDE_TMP="$(mktemp)"
-write_config_override "$SYSTEM_CONFIG_OVERRIDE_TMP" "$CONFIG_FILE"
 run_privileged install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_SERVICE_OVERRIDE_DIR}/config.conf"
-rm -f "$SYSTEM_CONFIG_OVERRIDE_TMP"
-SYSTEM_CONFIG_OVERRIDE_TMP=""
 
-cleanup_legacy_sleep_wake_handlers
+if [ "$UPGRADE_MODE" -eq 0 ]; then
+    cleanup_legacy_sleep_wake_handlers
+fi
 
-run_privileged cp "$SCRIPT_DIR/systemd/LG_Buddy_lifecycle.service" "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
+run_privileged install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy_lifecycle.service" "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
 run_privileged install -d "$SYSTEMD_LIFECYCLE_OVERRIDE_DIR"
-SYSTEM_CONFIG_OVERRIDE_TMP="$(mktemp)"
-write_config_override "$SYSTEM_CONFIG_OVERRIDE_TMP" "$CONFIG_FILE"
 run_privileged install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_LIFECYCLE_OVERRIDE_DIR}/config.conf"
-rm -f "$SYSTEM_CONFIG_OVERRIDE_TMP"
-SYSTEM_CONFIG_OVERRIDE_TMP=""
 run_privileged install -d "$NM_PRE_DOWN_DIR"
-NM_HOOK_TMP="$(mktemp)"
-write_nm_pre_down_hook "$NM_HOOK_TMP"
 run_privileged install -m 755 "$NM_HOOK_TMP" "$NM_LIFECYCLE_HOOK_PATH"
-rm -f "$NM_HOOK_TMP"
-NM_HOOK_TMP=""
 
 if [ "$SKIP_SYSTEMD_ACTIONS" = "1" ]; then
     echo "Skipping systemd tmpfiles and enable actions because LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1."
@@ -449,16 +567,16 @@ echo "Done."
 # 8. INSTALL USER SERVICES
 echo "Installing background update check user timer..."
 mkdir -p "$USER_SYSTEMD_DIR"
-cp "$SCRIPT_DIR/systemd/LG_Buddy_update_check.service" "$USER_UPDATE_CHECK_SERVICE_PATH"
-cp "$SCRIPT_DIR/systemd/LG_Buddy_update_check.timer" "$USER_UPDATE_CHECK_TIMER_PATH"
+install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy_update_check.service" "$USER_UPDATE_CHECK_SERVICE_PATH"
+install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy_update_check.timer" "$USER_UPDATE_CHECK_TIMER_PATH"
 mkdir -p "$USER_UPDATE_CHECK_OVERRIDE_DIR"
-write_config_override "${USER_UPDATE_CHECK_OVERRIDE_DIR}/config.conf" "$CONFIG_FILE"
+install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${USER_UPDATE_CHECK_OVERRIDE_DIR}/config.conf"
 echo "Done."
 
 echo "Installing screen monitor user service..."
-cp "$SCRIPT_DIR/systemd/LG_Buddy_screen.service" "$USER_SCREEN_SERVICE_PATH"
+install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy_screen.service" "$USER_SCREEN_SERVICE_PATH"
 mkdir -p "$USER_SCREEN_OVERRIDE_DIR"
-write_config_override "${USER_SCREEN_OVERRIDE_DIR}/config.conf" "$CONFIG_FILE"
+install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${USER_SCREEN_OVERRIDE_DIR}/config.conf"
 if [ "$SKIP_SYSTEMD_ACTIONS" != "1" ]; then
     systemctl --user daemon-reload
 fi
@@ -499,7 +617,19 @@ else
     echo "System sleep/wake TV control disabled by config. Lifecycle integration is installed and will no-op until re-enabled."
 fi
 
-echo "Installation complete!"
-echo "The user-session service has been installed."
-echo "Please restart your computer for all changes to take full effect."
-echo "NOTE: On first use, you may need to accept a prompt on your TV to allow this application to connect."
+if [ "$UPGRADE_MODE" -eq 1 ]; then
+    INSTALLED_VERSION_OUTPUT="$("$RUNTIME_INSTALL_PATH" --version)"
+    if ! cmp -s "$RUNTIME_BINARY" "$RUNTIME_INSTALL_PATH" || [ "$INSTALLED_VERSION_OUTPUT" != "$CANDIDATE_VERSION_OUTPUT" ]; then
+        echo "Installed binary identity does not match the verified candidate." >&2
+        echo "Rerun this verified bundle with --upgrade to repair the partial installation." >&2
+        exit 1
+    fi
+    UPGRADE_COMPLETED=1
+    echo "Upgrade complete!"
+    echo "$INSTALLED_VERSION_OUTPUT"
+else
+    echo "Installation complete!"
+    echo "The user-session service has been installed."
+    echo "Please restart your computer for all changes to take full effect."
+    echo "NOTE: On first use, you may need to accept a prompt on your TV to allow this application to connect."
+fi

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+umask 0022
 
 usage() {
     echo "Usage: $0 --archive <path-to-release.tar.gz> [--work-dir <dir>] [--skip-pip-install] [--expected-tag <tag> --expected-version <version> --expected-channel <channel> --expected-target <target> --expected-commit <sha>]"
@@ -104,7 +105,7 @@ assert_cli_surface() {
     fi
     printf '%s\n' "$removed_channel_output" | grep -F -q 'unexpected arguments for `updates check`: --channel stable'
 
-    for hidden in startup shutdown screen-off screen-on "updates background-check"; do
+    for hidden in startup shutdown screen-off screen-on "updates background-check" upgrade-preflight; do
         if printf '%s\n' "$help_output" | grep -F -q "$hidden"; then
             echo "Hidden entrypoint appeared in public help: $hidden"
             exit 1
@@ -123,6 +124,7 @@ assert_cli_surface() {
     assert_hidden_compatibility_alias "$binary" shutdown shutdown
     assert_hidden_compatibility_alias "$binary" screen-off screen-off
     assert_hidden_compatibility_alias "$binary" screen-on screen-on
+    assert_hidden_compatibility_alias "$binary" upgrade-preflight upgrade-preflight "$BUNDLE_DIR"
 }
 
 assert_lifecycle_topology_installed() {
@@ -355,6 +357,7 @@ STALE_VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/lib/python-old/site-packag
 INSTALLED_POINTER="$INSTALL_ROOT/usr/lib/lg-buddy/config-path"
 SYSTEM_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service"
 LIFECYCLE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service"
+TMPFILES_CONFIG="$INSTALL_ROOT/etc/tmpfiles.d/lg_buddy.conf"
 LEGACY_SLEEP_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_sleep.service"
 LEGACY_WAKE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_wake.service"
 SYSTEM_SLEEP_HOOK="$INSTALL_ROOT/usr/lib/systemd/system-sleep/LG_Buddy_sleep_hook"
@@ -363,6 +366,7 @@ USER_UPDATE_CHECK_SERVICE="$HOME/.config/systemd/user/LG_Buddy_update_check.serv
 USER_UPDATE_CHECK_TIMER="$HOME/.config/systemd/user/LG_Buddy_update_check.timer"
 USER_UPDATE_CHECK_OVERRIDE="$HOME/.config/systemd/user/LG_Buddy_update_check.service.d/config.conf"
 DESKTOP_ENTRY="$INSTALL_ROOT/usr/share/applications/LG_Buddy_Brightness.desktop"
+USER_DESKTOP_ENTRY="$HOME/Desktop/LG_Buddy_Brightness.desktop"
 NM_SLEEP_HOOK="$INSTALL_ROOT/etc/NetworkManager/dispatcher.d/pre-down.d/LG_Buddy_sleep"
 NM_LIFECYCLE_HOOK="$INSTALL_ROOT/etc/NetworkManager/dispatcher.d/pre-down.d/LG_Buddy_lifecycle"
 
@@ -507,41 +511,274 @@ done
 cp "$VALID_PLATFORM_CONFIG" "$CONFIG_FILE"
 rm -f "$VALID_PLATFORM_CONFIG" "$INVALID_PLATFORM_CONFIG" "$INVALID_PLATFORM_OUTPUT"
 
-# A real in-place install must preserve an opted-in platform and its
-# profile-scoped native credential. Do this before the existing uninstall and
-# fresh-install coverage below, without removing the user configuration.
+# A real upgrade must refuse before sudo when preflight fails, then preserve an
+# opted-in native installation while replacing every owned candidate asset.
 NATIVE_ACCESS_TOKEN_FILE="$(dirname "$CONFIG_FILE")/tvs/primary/access-token.json"
 NATIVE_PROFILE_DIR="$(dirname "$NATIVE_ACCESS_TOKEN_FILE")"
 NATIVE_PROFILES_DIR="$(dirname "$NATIVE_PROFILE_DIR")"
 NATIVE_ACCESS_TOKEN_SNAPSHOT="$WORK_DIR/native-access-token.snapshot"
+CONFIG_SNAPSHOT="$WORK_DIR/config.snapshot"
+CONFIG_POINTER_SNAPSHOT="$WORK_DIR/config-pointer.snapshot"
+NATIVE_VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/native-upgrade-marker"
 NATIVE_ACCESS_TOKEN_CONTENT='{"access_token":"release-smoke-native-token"}'
 mkdir -p "$NATIVE_PROFILE_DIR"
 printf '%s\n' "$NATIVE_ACCESS_TOKEN_CONTENT" >"$NATIVE_ACCESS_TOKEN_FILE"
 chmod 600 "$NATIVE_ACCESS_TOKEN_FILE"
 cp "$NATIVE_ACCESS_TOKEN_FILE" "$NATIVE_ACCESS_TOKEN_SNAPSHOT"
+cp "$CONFIG_FILE" "$CONFIG_SNAPSHOT"
+cp "$INSTALLED_POINTER" "$CONFIG_POINTER_SNAPSHOT"
+touch "$NATIVE_VENV_MARKER"
 "$INSTALLED_BINARY" settings get tv.platform | grep -q '^lg_webos$'
 
-(
-    unset LG_BUDDY_TV_IP
-    unset LG_BUDDY_TV_MAC
-    unset LG_BUDDY_INPUT
-    unset LG_BUDDY_SCREEN_BACKEND
-    unset LG_BUDDY_SCREEN_IDLE_TIMEOUT
-    unset LG_BUDDY_SCREEN_RESTORE_POLICY
-    unset LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY
-    unset LG_BUDDY_DISABLE_SLEEP_WAKE
+printf '#!/bin/sh\nprintf "stale installed runtime\\n"\n' >"$INSTALLED_BINARY"
+chmod 755 "$INSTALLED_BINARY"
+for stale_target in \
+    "$SYSTEM_SERVICE" \
+    "$LIFECYCLE_SERVICE" \
+    "$TMPFILES_CONFIG" \
+    "$DESKTOP_ENTRY" \
+    "$USER_SCREEN_SERVICE" \
+    "$USER_UPDATE_CHECK_SERVICE" \
+    "$USER_UPDATE_CHECK_TIMER" \
+    "$NM_LIFECYCLE_HOOK"
+do
+    printf 'stale installed integration\n' >"$stale_target"
+done
+
+INSTALLER_STUB_DIR="$WORK_DIR/installer-stubs"
+SUDO_MARKER="$WORK_DIR/sudo-invoked"
+SUDO_SPY="$INSTALLER_STUB_DIR/sudo-spy"
+REFUSAL_OUTPUT="$WORK_DIR/upgrade-refusal.output"
+mkdir -p "$INSTALLER_STUB_DIR"
+cat >"$SUDO_SPY" <<'EOF'
+#!/bin/sh
+: >"${LG_BUDDY_SUDO_MARKER:?}"
+exit 97
+EOF
+chmod 755 "$SUDO_SPY"
+mv "$SYSTEM_SERVICE" "$SYSTEM_SERVICE.preflight-refusal"
+if (
+    export LG_BUDDY_SUDO_CMD="$SUDO_SPY"
+    export LG_BUDDY_SUDO_MARKER="$SUDO_MARKER"
     cd "$BUNDLE_DIR"
-    ./install.sh
-)
-
-assert_file "$CONFIG_FILE"
-grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
-"$INSTALLED_BINARY" settings get tv.platform | grep -q '^lg_webos$'
-assert_file "$NATIVE_ACCESS_TOKEN_FILE"
-cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE" || {
-    echo "In-place install changed the stored native access token."
+    ./install.sh --upgrade >"$REFUSAL_OUTPUT" 2>&1
+); then
+    echo "Upgrade unexpectedly passed with a missing installed service."
+    exit 1
+fi
+mv "$SYSTEM_SERVICE.preflight-refusal" "$SYSTEM_SERVICE"
+grep -F -q 'upgrade preflight: refused' "$REFUSAL_OUTPUT"
+[ ! -e "$SUDO_MARKER" ] || {
+    echo "Upgrade requested sudo after a candidate preflight refusal."
     exit 1
 }
+grep -F -q 'stale installed integration' "$DESKTOP_ENTRY"
+grep -F -q 'stale installed runtime' "$INSTALLED_BINARY"
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || {
+    echo "Refused upgrade changed the user configuration."
+    exit 1
+}
+
+CONFIGURE_SCRIPT_SNAPSHOT="$WORK_DIR/configure.sh.snapshot"
+CONFIGURE_MARKER="$WORK_DIR/configure-invoked"
+SERVICE_ACTION_LOG="$WORK_DIR/upgrade-service-actions.log"
+PARTIAL_SERVICE_ACTION_LOG="$WORK_DIR/partial-upgrade-service-actions.log"
+EXPECTED_SERVICE_ACTION_LOG="$WORK_DIR/expected-upgrade-service-actions.log"
+UPGRADE_OUTPUT="$WORK_DIR/upgrade.output"
+PARTIAL_UPGRADE_OUTPUT="$WORK_DIR/partial-upgrade.output"
+cp -p "$BUNDLE_DIR/configure.sh" "$CONFIGURE_SCRIPT_SNAPSHOT"
+cat >"$BUNDLE_DIR/configure.sh" <<'EOF'
+#!/bin/sh
+: >"${LG_BUDDY_CONFIGURE_MARKER:?}"
+exit 91
+EOF
+chmod 755 "$BUNDLE_DIR/configure.sh"
+cat >"$INSTALLER_STUB_DIR/systemctl" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'systemctl %s\n' "$*" >>"${LG_BUDDY_SERVICE_ACTION_LOG:?}"
+case "$*" in
+    is-system-running|"--user is-system-running")
+        printf 'running\n'
+        ;;
+    daemon-reload)
+        if [ "${LG_BUDDY_FAIL_SYSTEM_RELOAD:-0}" = "1" ]; then
+            exit 73
+        fi
+        ;;
+esac
+EOF
+cat >"$INSTALLER_STUB_DIR/systemd-tmpfiles" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'tmpfiles %s\n' "$*" >>"${LG_BUDDY_SERVICE_ACTION_LOG:?}"
+EOF
+chmod 755 "$INSTALLER_STUB_DIR/systemctl" "$INSTALLER_STUB_DIR/systemd-tmpfiles"
+
+PARTIAL_UPGRADE_STATUS=0
+if (
+    export PATH="$INSTALLER_STUB_DIR:$PATH"
+    export LG_BUDDY_CONFIGURE_MARKER="$CONFIGURE_MARKER"
+    export LG_BUDDY_SERVICE_ACTION_LOG="$PARTIAL_SERVICE_ACTION_LOG"
+    export LG_BUDDY_FAIL_SYSTEM_RELOAD="1"
+    export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
+    cd "$BUNDLE_DIR"
+    ./install.sh --upgrade >"$PARTIAL_UPGRADE_OUTPUT" 2>&1
+); then
+    echo "Upgrade unexpectedly succeeded after a simulated post-mutation failure."
+    exit 1
+else
+    PARTIAL_UPGRADE_STATUS=$?
+fi
+[ "$PARTIAL_UPGRADE_STATUS" -eq 73 ] || {
+    cat "$PARTIAL_UPGRADE_OUTPUT"
+    echo "Partial upgrade returned status $PARTIAL_UPGRADE_STATUS instead of 73."
+    exit 1
+}
+grep -F -q 'upgrade did not complete after installation changes began' "$PARTIAL_UPGRADE_OUTPUT"
+grep -F -q 'installation may be partial' "$PARTIAL_UPGRADE_OUTPUT"
+grep -F -q 'rerun this verified bundle with --upgrade' "$PARTIAL_UPGRADE_OUTPUT"
+[ ! -e "$CONFIGURE_MARKER" ] || {
+    echo "Partial upgrade invoked configure.sh."
+    exit 1
+}
+[ -e "$NATIVE_VENV_MARKER" ] || {
+    echo "Partial native upgrade recreated the Python virtual environment."
+    exit 1
+}
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE"
+cmp -s "$CONFIG_POINTER_SNAPSHOT" "$INSTALLED_POINTER"
+cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE"
+
+mkdir -p "$(dirname "$USER_DESKTOP_ENTRY")"
+printf 'stale user desktop launcher\n' >"$USER_DESKTOP_ENTRY"
+
+UPGRADE_STATUS=0
+if (
+    export PATH="$INSTALLER_STUB_DIR:$PATH"
+    export LG_BUDDY_CONFIGURE_MARKER="$CONFIGURE_MARKER"
+    export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
+    export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
+    cd "$BUNDLE_DIR"
+    ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
+); then
+    :
+else
+    UPGRADE_STATUS=$?
+fi
+cp -p "$CONFIGURE_SCRIPT_SNAPSHOT" "$BUNDLE_DIR/configure.sh"
+if [ "$UPGRADE_STATUS" -ne 0 ]; then
+    cat "$UPGRADE_OUTPUT"
+    echo "Native release-bundle upgrade failed with status $UPGRADE_STATUS."
+    exit 1
+fi
+
+[ ! -e "$CONFIGURE_MARKER" ] || {
+    echo "Upgrade invoked configure.sh."
+    exit 1
+}
+grep -F -q 'Upgrade complete!' "$UPGRADE_OUTPUT"
+cat >"$EXPECTED_SERVICE_ACTION_LOG" <<EOF
+systemctl is-system-running
+systemctl --user is-system-running
+tmpfiles --create $TMPFILES_CONFIG
+systemctl daemon-reload
+systemctl enable LG_Buddy.service
+systemctl enable LG_Buddy_lifecycle.service
+systemctl restart LG_Buddy_lifecycle.service
+systemctl --user daemon-reload
+systemctl --user enable LG_Buddy_screen.service
+systemctl --user restart LG_Buddy_screen.service
+systemctl --user disable --now LG_Buddy_update_check.timer
+EOF
+cmp -s "$EXPECTED_SERVICE_ACTION_LOG" "$SERVICE_ACTION_LOG" || {
+    echo "Upgrade service actions did not match the defined order."
+    diff -u "$EXPECTED_SERVICE_ACTION_LOG" "$SERVICE_ACTION_LOG" || true
+    exit 1
+}
+
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || {
+    echo "Upgrade changed the user configuration."
+    exit 1
+}
+cmp -s "$CONFIG_POINTER_SNAPSHOT" "$INSTALLED_POINTER" || {
+    echo "Upgrade changed the installed config pointer."
+    exit 1
+}
+cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE" || {
+    echo "Upgrade changed the stored native access token."
+    exit 1
+}
+[ -e "$NATIVE_VENV_MARKER" ] || {
+    echo "Native upgrade recreated the Python virtual environment."
+    exit 1
+}
+cmp -s "$BUNDLE_DIR/lg-buddy" "$INSTALLED_BINARY"
+cmp -s "$BUNDLE_DIR/systemd/LG_Buddy.service" "$SYSTEM_SERVICE"
+cmp -s "$BUNDLE_DIR/systemd/LG_Buddy_lifecycle.service" "$LIFECYCLE_SERVICE"
+cmp -s "$BUNDLE_DIR/systemd/lg_buddy.conf" "$TMPFILES_CONFIG"
+cmp -s "$BUNDLE_DIR/LG_Buddy_Brightness.desktop" "$DESKTOP_ENTRY"
+cmp -s "$BUNDLE_DIR/LG_Buddy_Brightness.desktop" "$USER_DESKTOP_ENTRY"
+cmp -s "$BUNDLE_DIR/systemd/LG_Buddy_screen.service" "$USER_SCREEN_SERVICE"
+cmp -s "$BUNDLE_DIR/systemd/LG_Buddy_update_check.service" "$USER_UPDATE_CHECK_SERVICE"
+cmp -s "$BUNDLE_DIR/systemd/LG_Buddy_update_check.timer" "$USER_UPDATE_CHECK_TIMER"
+assert_lifecycle_topology_installed
+"$INSTALLED_BINARY" settings get updates.channel | grep -q '^prerelease$'
+
+# Healthy compatibility-platform environments are preserved; an unhealthy one
+# takes the separately preflighted repair path.
+"$INSTALLED_BINARY" settings set tv.platform bscpylgtv
+VENV_PYTHON="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/bin/python"
+VENV_SITE_PACKAGES="$("$VENV_PYTHON" -c 'import site; print(site.getsitepackages()[0])')"
+if ! "$VENV_PYTHON" -c 'import bscpylgtv' >/dev/null 2>&1; then
+    mkdir -p "$VENV_SITE_PACKAGES/bscpylgtv"
+    printf '__version__ = "smoke"\n' >"$VENV_SITE_PACKAGES/bscpylgtv/__init__.py"
+fi
+if [ ! -x "$INSTALLED_BSCPYLGTV" ]; then
+    printf '#!/bin/sh\nexit 0\n' >"$INSTALLED_BSCPYLGTV"
+    chmod 755 "$INSTALLED_BSCPYLGTV"
+fi
+rm -f "$USER_DESKTOP_ENTRY"
+HEALTHY_VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/healthy-upgrade-marker"
+touch "$HEALTHY_VENV_MARKER"
+(
+    export LG_BUDDY_SKIP_PIP_INSTALL="1"
+    cd "$BUNDLE_DIR"
+    ./install.sh --upgrade
+)
+[ -e "$HEALTHY_VENV_MARKER" ] || {
+    echo "Healthy compatibility environment was recreated during upgrade."
+    exit 1
+}
+[ ! -e "$USER_DESKTOP_ENTRY" ] || {
+    echo "Upgrade recreated a user-removed Desktop launcher."
+    exit 1
+}
+
+rm -f "$INSTALLED_BSCPYLGTV"
+REPAIR_VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/repair-upgrade-marker"
+touch "$REPAIR_VENV_MARKER"
+(
+    export LG_BUDDY_SKIP_PIP_INSTALL="1"
+    cd "$BUNDLE_DIR"
+    ./install.sh --upgrade
+)
+[ ! -e "$REPAIR_VENV_MARKER" ] || {
+    echo "Unhealthy compatibility environment was not repaired."
+    exit 1
+}
+assert_executable "$INSTALLED_VENV_PIP"
+
+rm -rf "$INSTALL_ROOT/usr/bin/LG_Buddy_PIP"
+(
+    export LG_BUDDY_SKIP_PIP_INSTALL="1"
+    cd "$BUNDLE_DIR"
+    ./install.sh --upgrade
+)
+assert_executable "$INSTALLED_VENV_PIP"
+
+assert_file "$CONFIG_FILE"
+assert_file "$NATIVE_ACCESS_TOKEN_FILE"
 rm -f "$NATIVE_ACCESS_TOKEN_SNAPSHOT"
 
 export LG_BUDDY_REMOVE_CONFIG="1"


### PR DESCRIPTION
Closes #96.

## Summary

- add an explicit `install.sh --upgrade` path guarded by the candidate-specific host preflight
- preserve configuration, update policy, native credentials, and healthy or native-only Python environments
- safely repair unhealthy or missing compatibility virtualenvs, replace owned assets, order service reloads, verify the installed binary, and report partial failures
- expand release-bundle smoke coverage for refusal-before-sudo, preservation, repair, Desktop launcher behavior, service ordering, and identity verification
- document the supported release-bundle upgrade workflow and safety boundary

## Validation

- `cargo test -p lg-buddy --lib` (673 passed, 1 ignored)
- `cargo test -p lg-buddy upgrade_preflight::tests --lib` (36 passed)
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `bash -n install.sh scripts/test-release-bundle.sh`
- full release-bundle smoke test in Ubuntu 24.04
