### PR TITLE
Add user-confirmed release-bundle installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,11 @@ during setup. With the default `bscpylgtv` platform, the prompt may instead
 appear on first use; see the
 [bscpylgtv first-use guide](https://github.com/chros73/bscpylgtv/blob/master/docs/guides/first_use.md).
 
-To update an existing compatible release-bundle installation from an already
-verified and extracted newer bundle, run `./install.sh --upgrade`. Upgrade mode
-preserves configuration and credentials and does not repeat setup or pairing;
+To check, verify, and install the next release from your saved update channel,
+run `lg-buddy updates install` as your regular user. It checks host
+compatibility, shows the exact target identity, asks for explicit confirmation,
+and then runs the verified bundle's upgrade installer. Upgrade mode preserves
+configuration and credentials and does not repeat setup or pairing;
 incompatible and legacy layouts are refused rather than migrated.
 
 The shell installer targets conventional Linux installations with mutable
@@ -123,6 +125,7 @@ lg-buddy volume mute
 lg-buddy settings list
 lg-buddy settings describe screen.backend
 lg-buddy updates check
+lg-buddy updates install
 lg-buddy --version
 ```
 

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -19,6 +19,7 @@ pub mod settings;
 pub mod sources;
 pub mod state;
 pub mod tv;
+pub mod update_install;
 pub mod updates;
 pub mod upgrade_preflight;
 pub mod version;
@@ -47,6 +48,7 @@ use crate::tv::{
     OledBrightness, OledBrightnessParseError, TvClientBuildError, VolumeLevel,
     VolumeLevelParseError,
 };
+use crate::update_install::{run_update_install, UpdateInstallError};
 use crate::updates::{run_updates_command, UpdatesCommand, UpdatesError, UpdatesParseError};
 use crate::upgrade_preflight::CompatibilityReport;
 use std::fmt;
@@ -140,12 +142,14 @@ impl SettingsHelpTopic {
 pub enum UpdatesHelpTopic {
     Root,
     Check,
+    Install,
 }
 
 impl UpdatesHelpTopic {
     fn from_subcommand(subcommand: &str) -> Option<Self> {
         match subcommand {
             "check" => Some(Self::Check),
+            "install" => Some(Self::Install),
             _ => None,
         }
     }
@@ -291,6 +295,7 @@ pub enum RunError {
     Dev(DevError),
     Settings(SettingsError),
     Updates(UpdatesError),
+    UpdateInstall(UpdateInstallError),
     UpgradePreflight(CompatibilityReport),
     NotificationAfterPrimary {
         primary: Box<RunError>,
@@ -312,6 +317,7 @@ impl fmt::Display for RunError {
             Self::Dev(err) => write!(f, "{err}"),
             Self::Settings(err) => write!(f, "{err}"),
             Self::Updates(err) => write!(f, "{err}"),
+            Self::UpdateInstall(err) => write!(f, "{err}"),
             Self::UpgradePreflight(report) => write!(f, "{report}"),
             Self::NotificationAfterPrimary {
                 primary,
@@ -338,6 +344,7 @@ impl std::error::Error for RunError {
             Self::Dev(err) => Some(err),
             Self::Settings(err) => Some(err),
             Self::Updates(err) => Some(err),
+            Self::UpdateInstall(err) => Some(err),
             Self::UpgradePreflight(_) => None,
             Self::NotificationAfterPrimary { primary, .. } => Some(primary.as_ref()),
         }
@@ -483,7 +490,7 @@ Commands:
   screen off      Blank the configured TV output if active
   screen on       Restore the TV output after an LG Buddy screen blank
   settings        Inspect and edit structured LG Buddy settings
-  updates         Check for LG Buddy releases
+  updates         Check for and install LG Buddy releases
   help [COMMAND...]
                   Show global or scoped command help
 
@@ -496,6 +503,7 @@ Settings:
 
 Updates:
   updates check [--notify]
+  updates install
 "
     )
 }
@@ -637,14 +645,16 @@ pub fn updates_usage(program: &str, topic: UpdatesHelpTopic) -> String {
     match topic {
         UpdatesHelpTopic::Root => format!(
             "\
-LG Buddy update checks
+LG Buddy updates
 
 Usage:
   {program} updates check [--notify]
+  {program} updates install
   {program} updates --help
 
 Commands:
   check           Check GitHub releases for an available update
+  install         Interactively verify and install an available update
 "
         ),
         UpdatesHelpTopic::Check => format!(
@@ -656,6 +666,17 @@ Usage:
 
 Options:
   --notify        Request a desktop notification when an update is available
+"
+        ),
+        UpdatesHelpTopic::Install => format!(
+            "\
+LG Buddy update installation
+
+Usage:
+  {program} updates install
+
+Installs the next release from the saved updates.channel after host checks and
+explicit confirmation. Channel and version arguments are not accepted.
 "
         ),
     }
@@ -798,6 +819,9 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         Command::Settings(command) => {
             run_settings_command(command, writer).map_err(RunError::Settings)
         }
+        Command::Updates(UpdatesCommand::Install) => {
+            run_update_install(writer).map_err(RunError::UpdateInstall)
+        }
         Command::Updates(command) => {
             run_updates_command(command, writer).map_err(RunError::Updates)
         }
@@ -909,10 +933,10 @@ where
                     ))
                 }),
             [subcommand, arguments @ ..] => {
-                if UpdatesHelpTopic::from_subcommand(subcommand).is_some() {
+                if let Some(topic) = UpdatesHelpTopic::from_subcommand(subcommand) {
                     Err(ParseError::Updates(
                         UpdatesParseError::UnexpectedArguments {
-                            subcommand: "check",
+                            subcommand: updates_help_subcommand(topic),
                             arguments: arguments.to_vec(),
                         },
                     ))
@@ -924,6 +948,14 @@ where
             }
         },
         other => Err(ParseError::UnknownCommand(other.to_string())),
+    }
+}
+
+fn updates_help_subcommand(topic: UpdatesHelpTopic) -> &'static str {
+    match topic {
+        UpdatesHelpTopic::Root => "updates",
+        UpdatesHelpTopic::Check => "check",
+        UpdatesHelpTopic::Install => "install",
     }
 }
 
@@ -992,14 +1024,13 @@ where
         )));
     }
 
-    if UpdatesHelpTopic::from_subcommand(subcommand).is_some()
-        && arguments[1..]
+    if let Some(topic) = UpdatesHelpTopic::from_subcommand(subcommand) {
+        if arguments[1..]
             .iter()
             .any(|argument| matches!(argument.as_str(), "-h" | "--help"))
-    {
-        return Ok(ParseOutcome::Help(HelpTopic::Updates(
-            UpdatesHelpTopic::Check,
-        )));
+        {
+            return Ok(ParseOutcome::Help(HelpTopic::Updates(topic)));
+        }
     }
 
     UpdatesCommand::parse(arguments)
@@ -1365,6 +1396,12 @@ mod tests {
             )))
         );
         assert_eq!(
+            parse_args(["help", "updates", "install"]),
+            Ok(ParseOutcome::Help(HelpTopic::Updates(
+                UpdatesHelpTopic::Install
+            )))
+        );
+        assert_eq!(
             parse_args(["updates", "--help"]),
             Ok(ParseOutcome::Help(HelpTopic::Updates(
                 UpdatesHelpTopic::Root
@@ -1374,6 +1411,12 @@ mod tests {
             parse_args(["updates", "check", "--help"]),
             Ok(ParseOutcome::Help(HelpTopic::Updates(
                 UpdatesHelpTopic::Check
+            )))
+        );
+        assert_eq!(
+            parse_args(["updates", "install", "--help"]),
+            Ok(ParseOutcome::Help(HelpTopic::Updates(
+                UpdatesHelpTopic::Install
             )))
         );
     }
@@ -1601,6 +1644,12 @@ mod tests {
             parse_args(["updates", "check", "--notify"]),
             Ok(ParseOutcome::Command(Command::Updates(
                 UpdatesCommand::Check { notify: true }
+            )))
+        );
+        assert_eq!(
+            parse_args(["updates", "install"]),
+            Ok(ParseOutcome::Command(Command::Updates(
+                UpdatesCommand::Install
             )))
         );
         assert_eq!(
@@ -1887,6 +1936,18 @@ mod tests {
                 }
             ))
         );
+        let error = parse_args(["updates", "install", "stable"]).unwrap_err();
+        assert_eq!(
+            error,
+            ParseError::Updates(UpdatesParseError::UnexpectedArguments {
+                subcommand: "install",
+                arguments: vec!["stable".to_string()]
+            })
+        );
+        assert_eq!(
+            error.help_topic(),
+            HelpTopic::Updates(UpdatesHelpTopic::Install)
+        );
         assert_eq!(
             parse_args(["updates", "check", "--notify", "--notify"]),
             Err(ParseError::Updates(UpdatesParseError::DuplicateNotify))
@@ -2050,6 +2111,7 @@ mod tests {
     fn updates_usage_is_scoped_and_hides_the_timer_entrypoint() {
         let root = updates_usage("lg-buddy", UpdatesHelpTopic::Root);
         assert!(root.contains("lg-buddy updates check [--notify]"));
+        assert!(root.contains("lg-buddy updates install"));
         assert!(!root.contains("--channel"));
         assert!(!root.contains("background-check"));
 
@@ -2057,6 +2119,11 @@ mod tests {
         assert!(!check.contains("--channel"));
         assert!(check.contains("--notify"));
         assert!(!check.contains("background-check"));
+
+        let install = updates_usage("lg-buddy", UpdatesHelpTopic::Install);
+        assert!(install.contains("lg-buddy updates install"));
+        assert!(install.contains("saved updates.channel"));
+        assert!(!install.contains("--channel"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/release_bundle.rs
+++ b/crates/lg-buddy/src/release_bundle.rs
@@ -60,6 +60,22 @@ pub struct ReleaseIdentity {
 }
 
 impl ReleaseIdentity {
+    pub(crate) fn from_parts(
+        release_tag: impl Into<String>,
+        version: Version,
+        channel: UpdateChannel,
+        target: impl Into<String>,
+        commit: impl Into<String>,
+    ) -> Self {
+        Self {
+            release_tag: release_tag.into(),
+            version,
+            channel,
+            target: target.into(),
+            commit: commit.into(),
+        }
+    }
+
     pub fn release_tag(&self) -> &str {
         &self.release_tag
     }
@@ -202,6 +218,27 @@ pub fn acquire_release_bundle(
     acquire_release_bundle_with(release, &cache_root, &source, &EmbeddedBinaryIdentityReader)
 }
 
+pub(crate) fn resolve_release_identity(
+    release: &ReleaseInfo,
+) -> Result<ReleaseIdentity, BundleAcquisitionError> {
+    let source = UreqGitHubSource::new();
+    resolve_release_with(release, &source).map(|resolved| resolved.identity)
+}
+
+pub(crate) fn verify_release_binary_identity(
+    binary: &Path,
+    expected: &ReleaseIdentity,
+) -> Result<ReleaseIdentity, BundleAcquisitionError> {
+    let observed =
+        read_embedded_binary_identity(binary, expected.target(), expected.release_tag())?;
+    if observed != *expected {
+        return Err(BundleAcquisitionError::Binary(format!(
+            "identity {observed:?} does not match verified release identity {expected:?}"
+        )));
+    }
+    Ok(observed)
+}
+
 fn acquisition_cache_root_from_env() -> Result<PathBuf, BundleAcquisitionError> {
     let base = std::env::var_os("XDG_CACHE_HOME")
         .filter(|value| !value.is_empty())
@@ -221,21 +258,11 @@ fn acquire_release_bundle_with<S: GitHubSource, B: BinaryIdentityReader>(
     source: &S,
     binary_reader: &B,
 ) -> Result<VerifiedReleaseBundle, BundleAcquisitionError> {
-    validate_release_identity(release)?;
     let staging = StagingDirectory::create(cache_root)?;
-    let fresh_release = source.fetch_release_by_tag(release)?;
-    validate_release_identity(&fresh_release)?;
-    if fresh_release.version() != release.version()
-        || fresh_release.channel() != release.channel()
-        || fresh_release.tag_name() != release.tag_name()
-    {
-        return Err(BundleAcquisitionError::ReleaseMetadata(
-            "fresh release-by-tag metadata disagrees with the selected release".to_string(),
-        ));
-    }
+    let resolved = resolve_release_with(release, source)?;
+    let fresh_release = resolved.release;
+    let expected = resolved.identity;
     let selected = select_release_assets(&fresh_release)?;
-    let commit = source.resolve_tag_commit(fresh_release.tag_name())?;
-    validate_commit_sha(&commit).map_err(BundleAcquisitionError::TagResolution)?;
 
     let checksum_path = staging.path.join(CHECKSUM_ASSET_NAME);
     let archive_path = staging.path.join(selected.archive.name());
@@ -259,13 +286,6 @@ fn acquire_release_bundle_with<S: GitHubSource, B: BinaryIdentityReader>(
         )));
     }
 
-    let expected = ReleaseIdentity {
-        release_tag: fresh_release.tag_name().to_string(),
-        version: fresh_release.version().clone(),
-        channel: fresh_release.channel(),
-        target: RELEASE_TARGET.to_string(),
-        commit,
-    };
     let plan = inspect_archive(&archive_download.file, selected.archive.name(), &expected)?;
     let root = extract_archive(&archive_download.file, &staging.path, &plan)?;
     let observed = binary_reader.read_identity(
@@ -284,6 +304,42 @@ fn acquire_release_bundle_with<S: GitHubSource, B: BinaryIdentityReader>(
         root,
         identity: expected,
         _staging: staging,
+    })
+}
+
+struct ResolvedRelease {
+    release: ReleaseInfo,
+    identity: ReleaseIdentity,
+}
+
+fn resolve_release_with<S: GitHubSource>(
+    release: &ReleaseInfo,
+    source: &S,
+) -> Result<ResolvedRelease, BundleAcquisitionError> {
+    validate_release_identity(release)?;
+    let fresh_release = source.fetch_release_by_tag(release)?;
+    validate_release_identity(&fresh_release)?;
+    if fresh_release.version() != release.version()
+        || fresh_release.channel() != release.channel()
+        || fresh_release.tag_name() != release.tag_name()
+    {
+        return Err(BundleAcquisitionError::ReleaseMetadata(
+            "fresh release-by-tag metadata disagrees with the selected release".to_string(),
+        ));
+    }
+    select_release_assets(&fresh_release)?;
+    let commit = source.resolve_tag_commit(fresh_release.tag_name())?;
+    validate_commit_sha(&commit).map_err(BundleAcquisitionError::TagResolution)?;
+    let identity = ReleaseIdentity::from_parts(
+        fresh_release.tag_name(),
+        fresh_release.version().clone(),
+        fresh_release.channel(),
+        RELEASE_TARGET,
+        commit,
+    );
+    Ok(ResolvedRelease {
+        release: fresh_release,
+        identity,
     })
 }
 
@@ -2592,6 +2648,25 @@ mod tests {
         let redirect = request_budget(redirect_remaining);
         assert_eq!(redirect.connect, redirect_remaining);
         assert_eq!(redirect.request, redirect_remaining);
+    }
+
+    #[test]
+    fn release_identity_resolution_validates_metadata_without_downloading_assets() {
+        let identity = stable_identity();
+        let archive_name = format!("lg-buddy-1.4.0-{RELEASE_TARGET}.tar.gz");
+        let source = FakeSource {
+            fresh_release: release_info(vec![
+                release_asset(1, &archive_name, b"archive"),
+                release_asset(2, CHECKSUM_ASSET_NAME, b"checksum"),
+            ]),
+            payloads: HashMap::new(),
+            commit: identity.commit.clone(),
+        };
+
+        let resolved = resolve_release_with(&release_info(Vec::new()), &source)
+            .expect("metadata-only resolution should not download assets");
+
+        assert_eq!(resolved.identity, identity);
     }
 
     #[test]

--- a/crates/lg-buddy/src/session_notifications.rs
+++ b/crates/lg-buddy/src/session_notifications.rs
@@ -154,7 +154,7 @@ impl UpdateNotificationRequest {
         let mut notification = Notification::new(
             "LG Buddy update available",
             format!(
-                "LG Buddy {} ({}) is available.\nCurrent: {} ({})\n{}",
+                "LG Buddy {} ({}) is available.\nCurrent: {} ({})\nInstall: lg-buddy updates install\n{}",
                 self.latest_version,
                 self.latest_channel.as_str(),
                 self.current_version,
@@ -1389,6 +1389,12 @@ mod tests {
         assert_eq!(notifications[0].actions[0].label, "Never Notify Again");
         assert_eq!(notifications[0].actions[1].key, VIEW_RELEASE_ACTION_KEY);
         assert_eq!(notifications[0].actions[1].label, "View Release");
+        assert!(notifications[0]
+            .body
+            .contains("Install: lg-buddy updates install"));
+        assert!(notifications[0]
+            .body
+            .contains("https://github.test/releases/tag/v1.1.1"));
         assert_eq!(dispatcher.pending_len(), 1);
     }
 

--- a/crates/lg-buddy/src/update_install.rs
+++ b/crates/lg-buddy/src/update_install.rs
@@ -1,0 +1,877 @@
+use std::error::Error;
+use std::fmt;
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use semver::Version;
+
+use crate::release_bundle::{
+    acquire_release_bundle, resolve_release_identity, verify_release_binary_identity,
+    BundleAcquisitionError, ReleaseIdentity, VerifiedReleaseBundle,
+};
+use crate::updates::{discover_install_candidate, ReleaseInfo, UpdatesError};
+use crate::upgrade_preflight::{current_host_preflight, CompatibilityReport};
+use crate::version::VersionInfo;
+
+#[derive(Debug)]
+pub enum UpdateInstallError {
+    Updates(UpdatesError),
+    Bundle(BundleAcquisitionError),
+    InvalidCurrentVersion {
+        version: String,
+        source: semver::Error,
+    },
+    InitialPreflight(CompatibilityReport),
+    DowngradeRefused {
+        current: Version,
+        candidate: Version,
+    },
+    Output(io::Error),
+    ConfirmationRequiresTerminal,
+    ConfirmationIo(io::Error),
+    TargetChanged {
+        confirmed: Box<ReleaseIdentity>,
+        acquired: Box<ReleaseIdentity>,
+    },
+    CandidatePreflightLaunch(io::Error),
+    CandidatePreflightFailed(Option<i32>),
+    InstallerLaunch(io::Error),
+    InstallerFailed(Option<i32>),
+    InstalledIdentity(BundleAcquisitionError),
+    InstalledIdentityMismatch {
+        expected: Box<ReleaseIdentity>,
+        observed: Box<ReleaseIdentity>,
+    },
+}
+
+impl fmt::Display for UpdateInstallError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Updates(error) => write!(formatter, "update discovery failed: {error}"),
+            Self::Bundle(error) => write!(formatter, "release bundle verification failed: {error}"),
+            Self::InvalidCurrentVersion { version, source } => {
+                write!(formatter, "installed version `{version}` is invalid: {source}")
+            }
+            Self::InitialPreflight(report) => formatter.write_str(&report.render()),
+            Self::DowngradeRefused { current, candidate } => write!(
+                formatter,
+                "refusing to downgrade LG Buddy from {current} to {candidate}"
+            ),
+            Self::Output(error) => write!(formatter, "could not write upgrade output: {error}"),
+            Self::ConfirmationRequiresTerminal => write!(
+                formatter,
+                "upgrade confirmation requires an interactive terminal"
+            ),
+            Self::ConfirmationIo(error) => {
+                write!(formatter, "could not read upgrade confirmation: {error}")
+            }
+            Self::TargetChanged {
+                confirmed,
+                acquired,
+            } => write!(
+                formatter,
+                "verified release identity changed after confirmation (confirmed {confirmed:?}, acquired {acquired:?})"
+            ),
+            Self::CandidatePreflightLaunch(error) => {
+                write!(formatter, "could not run candidate upgrade preflight: {error}")
+            }
+            Self::CandidatePreflightFailed(code) => write!(
+                formatter,
+                "candidate upgrade preflight refused the host{}",
+                render_exit_code(*code)
+            ),
+            Self::InstallerLaunch(error) => {
+                write!(formatter, "could not start the verified upgrade installer: {error}")
+            }
+            Self::InstallerFailed(code) => write!(
+                formatter,
+                "verified upgrade installer failed{}",
+                render_exit_code(*code)
+            ),
+            Self::InstalledIdentity(error) => {
+                write!(formatter, "installed release identity verification failed: {error}")
+            }
+            Self::InstalledIdentityMismatch { expected, observed } => write!(
+                formatter,
+                "installed release identity {observed:?} does not match verified release identity {expected:?}"
+            ),
+        }
+    }
+}
+
+impl Error for UpdateInstallError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Updates(error) => Some(error),
+            Self::Bundle(error) => Some(error),
+            Self::InvalidCurrentVersion { source, .. } => Some(source),
+            Self::Output(error)
+            | Self::ConfirmationIo(error)
+            | Self::CandidatePreflightLaunch(error)
+            | Self::InstallerLaunch(error) => Some(error),
+            Self::InstalledIdentity(error) => Some(error),
+            Self::InitialPreflight(_)
+            | Self::DowngradeRefused { .. }
+            | Self::ConfirmationRequiresTerminal
+            | Self::TargetChanged { .. }
+            | Self::CandidatePreflightFailed(_)
+            | Self::InstallerFailed(_)
+            | Self::InstalledIdentityMismatch { .. } => None,
+        }
+    }
+}
+
+fn render_exit_code(code: Option<i32>) -> String {
+    code.map(|code| format!(" with exit status {code}"))
+        .unwrap_or_else(|| " after termination by signal".to_string())
+}
+
+trait BundleView {
+    fn identity(&self) -> &ReleaseIdentity;
+}
+
+impl BundleView for VerifiedReleaseBundle {
+    fn identity(&self) -> &ReleaseIdentity {
+        self.identity()
+    }
+}
+
+trait UpdateInstallRuntime {
+    type Bundle: BundleView;
+
+    fn current_version(&mut self) -> VersionInfo;
+    fn initial_preflight(&mut self) -> Result<(), UpdateInstallError>;
+    fn discover_candidate(
+        &mut self,
+        current: VersionInfo,
+    ) -> Result<ReleaseInfo, UpdateInstallError>;
+    fn resolve_target(
+        &mut self,
+        release: &ReleaseInfo,
+    ) -> Result<ReleaseIdentity, UpdateInstallError>;
+    fn confirm(&mut self) -> Result<bool, UpdateInstallError>;
+    fn acquire(&mut self, release: &ReleaseInfo) -> Result<Self::Bundle, UpdateInstallError>;
+    fn candidate_preflight(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError>;
+    fn run_installer(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError>;
+    fn installed_identity(
+        &mut self,
+        expected: &ReleaseIdentity,
+    ) -> Result<ReleaseIdentity, UpdateInstallError>;
+}
+
+struct SystemUpdateInstallRuntime;
+
+impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
+    type Bundle = VerifiedReleaseBundle;
+
+    fn current_version(&mut self) -> VersionInfo {
+        VersionInfo::current()
+    }
+
+    fn initial_preflight(&mut self) -> Result<(), UpdateInstallError> {
+        let report = current_host_preflight();
+        if report.compatible() {
+            Ok(())
+        } else {
+            Err(UpdateInstallError::InitialPreflight(report))
+        }
+    }
+
+    fn discover_candidate(
+        &mut self,
+        current: VersionInfo,
+    ) -> Result<ReleaseInfo, UpdateInstallError> {
+        discover_install_candidate(current).map_err(UpdateInstallError::Updates)
+    }
+
+    fn resolve_target(
+        &mut self,
+        release: &ReleaseInfo,
+    ) -> Result<ReleaseIdentity, UpdateInstallError> {
+        resolve_release_identity(release).map_err(UpdateInstallError::Bundle)
+    }
+
+    fn confirm(&mut self) -> Result<bool, UpdateInstallError> {
+        if !io::stdin().is_terminal() || !io::stdout().is_terminal() {
+            return Err(UpdateInstallError::ConfirmationRequiresTerminal);
+        }
+        let mut answer = String::new();
+        io::stdin()
+            .lock()
+            .read_line(&mut answer)
+            .map_err(UpdateInstallError::ConfirmationIo)?;
+        Ok(confirmation_is_yes(&answer))
+    }
+
+    fn acquire(&mut self, release: &ReleaseInfo) -> Result<Self::Bundle, UpdateInstallError> {
+        acquire_release_bundle(release).map_err(UpdateInstallError::Bundle)
+    }
+
+    fn candidate_preflight(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError> {
+        let status = candidate_preflight_command(bundle.root())
+            .status()
+            .map_err(UpdateInstallError::CandidatePreflightLaunch)?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(UpdateInstallError::CandidatePreflightFailed(status.code()))
+        }
+    }
+
+    fn run_installer(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError> {
+        let status = installer_command(bundle.root())
+            .status()
+            .map_err(UpdateInstallError::InstallerLaunch)?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(UpdateInstallError::InstallerFailed(status.code()))
+        }
+    }
+
+    fn installed_identity(
+        &mut self,
+        expected: &ReleaseIdentity,
+    ) -> Result<ReleaseIdentity, UpdateInstallError> {
+        verify_release_binary_identity(&installed_binary_path(), expected)
+            .map_err(UpdateInstallError::InstalledIdentity)
+    }
+}
+
+fn candidate_preflight_command(candidate_root: &Path) -> Command {
+    let mut command = Command::new(candidate_root.join("lg-buddy"));
+    command.arg("upgrade-preflight").arg(candidate_root);
+    command
+}
+
+fn installer_command(candidate_root: &Path) -> Command {
+    let mut command = Command::new(candidate_root.join("install.sh"));
+    command.arg("--upgrade");
+    command
+}
+
+fn confirmation_is_yes(answer: &str) -> bool {
+    answer.trim() == "yes"
+}
+
+fn installed_binary_path() -> PathBuf {
+    let install_root = std::env::var_os("LG_BUDDY_INSTALL_ROOT")
+        .filter(|root| !root.is_empty())
+        .map(PathBuf::from);
+    installed_binary_path_for_root(install_root)
+}
+
+fn installed_binary_path_for_root(install_root: Option<PathBuf>) -> PathBuf {
+    install_root
+        .unwrap_or_else(|| PathBuf::from("/"))
+        .join("usr/bin/lg-buddy")
+}
+
+pub fn run_update_install<W: Write>(writer: &mut W) -> Result<(), UpdateInstallError> {
+    run_update_install_with(writer, &mut SystemUpdateInstallRuntime)
+}
+
+fn run_update_install_with<W: Write, R: UpdateInstallRuntime>(
+    writer: &mut W,
+    runtime: &mut R,
+) -> Result<(), UpdateInstallError> {
+    let current = runtime.current_version();
+    runtime.initial_preflight()?;
+    let current_version = Version::parse(current.version()).map_err(|source| {
+        UpdateInstallError::InvalidCurrentVersion {
+            version: current.version().to_string(),
+            source,
+        }
+    })?;
+    let release = runtime.discover_candidate(current)?;
+
+    match release.version().cmp(&current_version) {
+        std::cmp::Ordering::Equal => {
+            writeln!(
+                writer,
+                "LG Buddy {} ({}) is already up to date.",
+                current.version(),
+                current.channel().as_str()
+            )
+            .map_err(UpdateInstallError::Output)?;
+            return Ok(());
+        }
+        std::cmp::Ordering::Less => {
+            return Err(UpdateInstallError::DowngradeRefused {
+                current: current_version,
+                candidate: release.version().clone(),
+            });
+        }
+        std::cmp::Ordering::Greater => {}
+    }
+
+    let confirmed_target = runtime.resolve_target(&release)?;
+    writeln!(
+        writer,
+        "Current: {} ({}, commit {})",
+        current.version(),
+        current.channel().as_str(),
+        current.commit().unwrap_or("unknown")
+    )
+    .map_err(UpdateInstallError::Output)?;
+    writeln!(
+        writer,
+        "Target: {} ({}, commit {})",
+        confirmed_target.version(),
+        confirmed_target.channel().as_str(),
+        confirmed_target.commit()
+    )
+    .map_err(UpdateInstallError::Output)?;
+    writeln!(writer, "Release: {}", release.url()).map_err(UpdateInstallError::Output)?;
+    write!(writer, "Type `yes` to install this update: ").map_err(UpdateInstallError::Output)?;
+    writer.flush().map_err(UpdateInstallError::Output)?;
+
+    if !runtime.confirm()? {
+        writeln!(writer, "Upgrade cancelled.").map_err(UpdateInstallError::Output)?;
+        return Ok(());
+    }
+
+    let bundle = runtime.acquire(&release)?;
+    if bundle.identity() != &confirmed_target {
+        return Err(UpdateInstallError::TargetChanged {
+            confirmed: Box::new(confirmed_target),
+            acquired: Box::new(bundle.identity().clone()),
+        });
+    }
+    runtime.candidate_preflight(&bundle)?;
+    runtime.run_installer(&bundle)?;
+    let installed = runtime.installed_identity(bundle.identity())?;
+    if &installed != bundle.identity() {
+        return Err(UpdateInstallError::InstalledIdentityMismatch {
+            expected: Box::new(bundle.identity().clone()),
+            observed: Box::new(installed),
+        });
+    }
+    writeln!(
+        writer,
+        "Installed: {} ({}, commit {})",
+        installed.version(),
+        installed.channel().as_str(),
+        installed.commit()
+    )
+    .map_err(UpdateInstallError::Output)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        candidate_preflight_command, confirmation_is_yes, installed_binary_path_for_root,
+        installer_command, run_update_install_with, BundleView, UpdateInstallError,
+        UpdateInstallRuntime,
+    };
+    use crate::release_bundle::{BundleAcquisitionError, ReleaseIdentity};
+    use crate::updates::{ReleaseInfo, UpdateChannel};
+    use crate::version::{ReleaseChannel, VersionInfo};
+    use semver::Version;
+    use std::cell::RefCell;
+    use std::ffi::OsStr;
+    use std::path::{Path, PathBuf};
+    use std::rc::Rc;
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Failure {
+        Initial,
+        Resolve,
+        Confirmation,
+        Acquire,
+        CandidatePreflight,
+        Installer,
+        InstalledIdentity,
+    }
+
+    struct FakeBundle {
+        identity: ReleaseIdentity,
+        events: Rc<RefCell<Vec<&'static str>>>,
+    }
+
+    impl BundleView for FakeBundle {
+        fn identity(&self) -> &ReleaseIdentity {
+            &self.identity
+        }
+    }
+
+    impl Drop for FakeBundle {
+        fn drop(&mut self) {
+            self.events.borrow_mut().push("drop_bundle");
+        }
+    }
+
+    struct FakeRuntime {
+        events: Rc<RefCell<Vec<&'static str>>>,
+        current_version: &'static str,
+        candidate_version: &'static str,
+        confirmed: bool,
+        failure: Option<Failure>,
+        resolved_identity: ReleaseIdentity,
+        acquired_identity: ReleaseIdentity,
+        installed_identity: ReleaseIdentity,
+    }
+
+    impl FakeRuntime {
+        fn new(candidate_version: &'static str) -> Self {
+            let events = Rc::new(RefCell::new(Vec::new()));
+            let identity = identity(candidate_version, "target-commit");
+            Self {
+                events,
+                current_version: "1.4.0",
+                candidate_version,
+                confirmed: true,
+                failure: None,
+                resolved_identity: identity.clone(),
+                acquired_identity: identity.clone(),
+                installed_identity: identity,
+            }
+        }
+
+        fn event_names(&self) -> Vec<&'static str> {
+            self.events.borrow().clone()
+        }
+    }
+
+    impl UpdateInstallRuntime for FakeRuntime {
+        type Bundle = FakeBundle;
+
+        fn current_version(&mut self) -> VersionInfo {
+            self.events.borrow_mut().push("current");
+            VersionInfo::for_testing(
+                self.current_version,
+                ReleaseChannel::Stable,
+                Some("current-commit"),
+            )
+        }
+
+        fn initial_preflight(&mut self) -> Result<(), UpdateInstallError> {
+            self.events.borrow_mut().push("initial_preflight");
+            if self.failure == Some(Failure::Initial) {
+                Err(UpdateInstallError::ConfirmationRequiresTerminal)
+            } else {
+                Ok(())
+            }
+        }
+
+        fn discover_candidate(
+            &mut self,
+            _current: VersionInfo,
+        ) -> Result<ReleaseInfo, UpdateInstallError> {
+            self.events.borrow_mut().push("discover");
+            Ok(ReleaseInfo::from_github(
+                Version::parse(self.candidate_version).unwrap(),
+                UpdateChannel::Stable,
+                format!("https://example.test/releases/v{}", self.candidate_version),
+                format!("v{}", self.candidate_version),
+                Vec::new(),
+            ))
+        }
+
+        fn resolve_target(
+            &mut self,
+            _release: &ReleaseInfo,
+        ) -> Result<ReleaseIdentity, UpdateInstallError> {
+            self.events.borrow_mut().push("resolve");
+            if self.failure == Some(Failure::Resolve) {
+                Err(bundle_error())
+            } else {
+                Ok(self.resolved_identity.clone())
+            }
+        }
+
+        fn confirm(&mut self) -> Result<bool, UpdateInstallError> {
+            self.events.borrow_mut().push("confirm");
+            if self.failure == Some(Failure::Confirmation) {
+                Err(UpdateInstallError::ConfirmationRequiresTerminal)
+            } else {
+                Ok(self.confirmed)
+            }
+        }
+
+        fn acquire(&mut self, _release: &ReleaseInfo) -> Result<Self::Bundle, UpdateInstallError> {
+            self.events.borrow_mut().push("acquire");
+            if self.failure == Some(Failure::Acquire) {
+                Err(UpdateInstallError::Bundle(
+                    BundleAcquisitionError::ConcurrentAcquisition,
+                ))
+            } else {
+                Ok(FakeBundle {
+                    identity: self.acquired_identity.clone(),
+                    events: Rc::clone(&self.events),
+                })
+            }
+        }
+
+        fn candidate_preflight(
+            &mut self,
+            _bundle: &Self::Bundle,
+        ) -> Result<(), UpdateInstallError> {
+            self.events.borrow_mut().push("candidate_preflight");
+            if self.failure == Some(Failure::CandidatePreflight) {
+                Err(UpdateInstallError::CandidatePreflightFailed(Some(1)))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn run_installer(&mut self, _bundle: &Self::Bundle) -> Result<(), UpdateInstallError> {
+            self.events.borrow_mut().push("installer");
+            if self.failure == Some(Failure::Installer) {
+                Err(UpdateInstallError::InstallerFailed(Some(1)))
+            } else {
+                Ok(())
+            }
+        }
+
+        fn installed_identity(
+            &mut self,
+            _expected: &ReleaseIdentity,
+        ) -> Result<ReleaseIdentity, UpdateInstallError> {
+            self.events.borrow_mut().push("installed_identity");
+            if self.failure == Some(Failure::InstalledIdentity) {
+                Err(UpdateInstallError::InstalledIdentity(
+                    BundleAcquisitionError::Binary("mismatch".to_string()),
+                ))
+            } else {
+                Ok(self.installed_identity.clone())
+            }
+        }
+    }
+
+    fn identity(version: &str, commit: &str) -> ReleaseIdentity {
+        ReleaseIdentity::from_parts(
+            format!("v{version}"),
+            Version::parse(version).unwrap(),
+            UpdateChannel::Stable,
+            "x86_64-unknown-linux-musl",
+            commit,
+        )
+    }
+
+    fn bundle_error() -> UpdateInstallError {
+        UpdateInstallError::Bundle(BundleAcquisitionError::ReleaseMetadata(
+            "test failure".to_string(),
+        ))
+    }
+
+    #[test]
+    fn candidate_and_installer_processes_use_exact_argv_without_a_shell() {
+        let root = Path::new("/tmp/release bundle; touch escaped");
+        let candidate = candidate_preflight_command(root);
+        assert_eq!(
+            candidate.get_program(),
+            OsStr::new("/tmp/release bundle; touch escaped/lg-buddy")
+        );
+        assert_eq!(
+            candidate.get_args().collect::<Vec<_>>(),
+            [OsStr::new("upgrade-preflight"), root.as_os_str()]
+        );
+
+        let installer = installer_command(root);
+        assert_eq!(
+            installer.get_program(),
+            OsStr::new("/tmp/release bundle; touch escaped/install.sh")
+        );
+        assert_eq!(
+            installer.get_args().collect::<Vec<_>>(),
+            [OsStr::new("--upgrade")]
+        );
+    }
+
+    #[test]
+    fn confirmation_accepts_only_an_explicit_lowercase_yes() {
+        assert!(confirmation_is_yes("yes\n"));
+        for answer in ["", "y", "YES", "yes please", "no"] {
+            assert!(!confirmation_is_yes(answer), "accepted `{answer}`");
+        }
+    }
+
+    #[test]
+    fn installed_binary_path_is_absolute_without_an_install_root_override() {
+        assert_eq!(
+            installed_binary_path_for_root(None),
+            Path::new("/usr/bin/lg-buddy")
+        );
+        assert_eq!(
+            installed_binary_path_for_root(Some(PathBuf::from("/tmp/install-root"))),
+            Path::new("/tmp/install-root/usr/bin/lg-buddy")
+        );
+    }
+
+    #[test]
+    fn initial_refusal_stops_before_discovery() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::Initial);
+
+        assert!(run_update_install_with(&mut Vec::new(), &mut runtime).is_err());
+        assert_eq!(runtime.event_names(), ["current", "initial_preflight"]);
+    }
+
+    #[test]
+    fn invalid_current_version_stops_before_discovery() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.current_version = "invalid";
+
+        let error = run_update_install_with(&mut Vec::new(), &mut runtime).unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateInstallError::InvalidCurrentVersion { .. }
+        ));
+        assert_eq!(runtime.event_names(), ["current", "initial_preflight"]);
+    }
+
+    #[test]
+    fn equal_version_stops_before_resolution_and_confirmation() {
+        let mut runtime = FakeRuntime::new("1.4.0");
+        let mut output = Vec::new();
+
+        run_update_install_with(&mut output, &mut runtime).unwrap();
+
+        assert_eq!(
+            runtime.event_names(),
+            ["current", "initial_preflight", "discover"]
+        );
+        assert!(String::from_utf8(output)
+            .unwrap()
+            .contains("already up to date"));
+    }
+
+    #[test]
+    fn downgrade_stops_before_resolution_and_confirmation() {
+        let mut runtime = FakeRuntime::new("1.3.0");
+
+        let error = run_update_install_with(&mut Vec::new(), &mut runtime).unwrap_err();
+
+        assert!(matches!(error, UpdateInstallError::DowngradeRefused { .. }));
+        assert_eq!(
+            runtime.event_names(),
+            ["current", "initial_preflight", "discover"]
+        );
+    }
+
+    #[test]
+    fn declined_confirmation_does_not_acquire_or_mutate() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.confirmed = false;
+
+        run_update_install_with(&mut Vec::new(), &mut runtime).unwrap();
+
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm"
+            ]
+        );
+    }
+
+    #[test]
+    fn unavailable_terminal_stops_before_acquisition() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::Confirmation);
+
+        let error = run_update_install_with(&mut Vec::new(), &mut runtime).unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateInstallError::ConfirmationRequiresTerminal
+        ));
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm"
+            ]
+        );
+    }
+
+    #[test]
+    fn acquisition_failure_does_not_run_candidate_or_installer() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::Acquire);
+
+        let error = run_update_install_with(&mut Vec::new(), &mut runtime).unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateInstallError::Bundle(BundleAcquisitionError::ConcurrentAcquisition)
+        ));
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire"
+            ]
+        );
+    }
+
+    #[test]
+    fn changed_identity_stops_before_candidate_preflight() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.acquired_identity = identity("1.5.0", "different-commit");
+
+        let error = run_update_install_with(&mut Vec::new(), &mut runtime).unwrap_err();
+
+        assert!(matches!(error, UpdateInstallError::TargetChanged { .. }));
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire",
+                "drop_bundle"
+            ]
+        );
+    }
+
+    #[test]
+    fn candidate_refusal_stops_before_installer() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::CandidatePreflight);
+
+        assert!(run_update_install_with(&mut Vec::new(), &mut runtime).is_err());
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire",
+                "candidate_preflight",
+                "drop_bundle"
+            ]
+        );
+    }
+
+    #[test]
+    fn installer_failure_skips_post_install_verification() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::Installer);
+
+        assert!(run_update_install_with(&mut Vec::new(), &mut runtime).is_err());
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire",
+                "candidate_preflight",
+                "installer",
+                "drop_bundle"
+            ]
+        );
+    }
+
+    #[test]
+    fn installed_identity_failure_is_reported_before_bundle_cleanup() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::InstalledIdentity);
+
+        assert!(run_update_install_with(&mut Vec::new(), &mut runtime).is_err());
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire",
+                "candidate_preflight",
+                "installer",
+                "installed_identity",
+                "drop_bundle"
+            ]
+        );
+    }
+
+    #[test]
+    fn installed_identity_mismatch_is_rejected_before_bundle_cleanup() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.installed_identity = identity("1.5.0", "wrong-commit");
+
+        let error = run_update_install_with(&mut Vec::new(), &mut runtime).unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateInstallError::InstalledIdentityMismatch { .. }
+        ));
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire",
+                "candidate_preflight",
+                "installer",
+                "installed_identity",
+                "drop_bundle"
+            ]
+        );
+    }
+
+    #[test]
+    fn successful_upgrade_preserves_order_and_reports_identities() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        let mut output = Vec::new();
+
+        run_update_install_with(&mut output, &mut runtime).unwrap();
+
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "current",
+                "initial_preflight",
+                "discover",
+                "resolve",
+                "confirm",
+                "acquire",
+                "candidate_preflight",
+                "installer",
+                "installed_identity",
+                "drop_bundle"
+            ]
+        );
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Current: 1.4.0 (stable, commit current-commit)"));
+        assert!(output.contains("Target: 1.5.0 (stable, commit target-commit)"));
+        assert!(output.contains("Installed: 1.5.0 (stable, commit target-commit)"));
+    }
+
+    #[test]
+    fn resolver_failure_stops_before_confirmation() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.failure = Some(Failure::Resolve);
+
+        assert!(run_update_install_with(&mut Vec::new(), &mut runtime).is_err());
+        assert_eq!(
+            runtime.event_names(),
+            ["current", "initial_preflight", "discover", "resolve"]
+        );
+    }
+}

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -31,6 +31,7 @@ const UPDATE_CHECK_CACHE_FILE_NAME: &str = "update-check.json";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum UpdatesCommand {
     Check { notify: bool },
+    Install,
     BackgroundCheck,
 }
 
@@ -47,6 +48,7 @@ impl UpdatesCommand {
 
         match subcommand.as_ref() {
             "check" => parse_check_args(args),
+            "install" => parse_no_args("install", UpdatesCommand::Install, args),
             "background-check" => parse_background_check_args(args),
             other => Err(UpdatesParseError::UnknownSubcommand(other.to_string())),
         }
@@ -55,6 +57,7 @@ impl UpdatesCommand {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Check { .. } => "check",
+            Self::Install => "install",
             Self::BackgroundCheck => "background-check",
         }
     }
@@ -62,8 +65,32 @@ impl UpdatesCommand {
     fn notify(&self) -> bool {
         match self {
             Self::Check { notify } => *notify,
+            Self::Install => false,
             Self::BackgroundCheck => true,
         }
+    }
+}
+
+fn parse_no_args<I, S>(
+    subcommand: &'static str,
+    command: UpdatesCommand,
+    args: I,
+) -> Result<UpdatesCommand, UpdatesParseError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let arguments = args
+        .into_iter()
+        .map(|arg| arg.as_ref().to_string())
+        .collect::<Vec<_>>();
+    if arguments.is_empty() {
+        Ok(command)
+    } else {
+        Err(UpdatesParseError::UnexpectedArguments {
+            subcommand,
+            arguments,
+        })
     }
 }
 
@@ -133,7 +160,7 @@ impl fmt::Display for UpdatesParseError {
         match self {
             Self::MissingSubcommand => write!(
                 f,
-                "missing updates command; expected `updates check [--notify]`"
+                "missing updates command; expected `updates check [--notify]` or `updates install`"
             ),
             Self::UnknownSubcommand(subcommand) => {
                 write!(f, "unknown updates command `{subcommand}`")
@@ -352,6 +379,7 @@ pub enum UpdatesError {
     CacheEncode(serde_json::Error),
     Settings(SettingsError),
     SettingsInvariant(String),
+    CommandInvariant(String),
     DeferredFailures(Vec<UpdatesDeferredFailure>),
     Notification(UpdateNotificationError),
     Io(io::Error),
@@ -441,6 +469,7 @@ impl fmt::Display for UpdatesError {
             Self::SettingsInvariant(message) => {
                 write!(f, "invalid update settings metadata: {message}")
             }
+            Self::CommandInvariant(message) => write!(f, "invalid update command: {message}"),
             Self::DeferredFailures(failures) => {
                 write!(f, "update check completed with deferred failure")?;
                 if failures.len() != 1 {
@@ -482,7 +511,8 @@ impl Error for UpdatesError {
             | Self::ResponseTooLarge { .. }
             | Self::NoMatchingRelease { .. }
             | Self::NotModifiedWithoutCache { .. }
-            | Self::SettingsInvariant(_) => None,
+            | Self::SettingsInvariant(_)
+            | Self::CommandInvariant(_) => None,
         }
     }
 }
@@ -829,14 +859,18 @@ impl UpdateCheckResult {
             "up to date"
         };
 
-        format!(
+        let mut output = format!(
             "status: {status}\ncurrent: {} ({})\nlatest: {} ({})\nurl: {}\n",
             self.current_version,
             self.current_channel.as_str(),
             self.latest.version(),
             self.latest.channel().as_str(),
             self.latest.url()
-        )
+        );
+        if self.update_available() {
+            output.push_str("install: lg-buddy updates install\n");
+        }
+        output
     }
 
     fn notification_request(&self) -> Result<UpdateNotificationRequest, UpdateNotificationError> {
@@ -1128,6 +1162,11 @@ pub fn run_updates_command<W: io::Write>(
     command: UpdatesCommand,
     writer: &mut W,
 ) -> Result<(), UpdatesError> {
+    if matches!(command, UpdatesCommand::Install) {
+        return Err(UpdatesError::CommandInvariant(
+            "updates install must use the install orchestrator".to_string(),
+        ));
+    }
     let client = UreqGitHubReleasesClient::default();
     let version = VersionInfo::current();
     let notification_handoff = SessionBusUpdateNotificationHandoff;
@@ -1143,6 +1182,23 @@ pub fn run_updates_command<W: io::Write>(
     };
 
     run_updates_command_with_update_settings(command, writer, context)
+}
+
+pub(crate) fn discover_install_candidate(
+    current: VersionInfo,
+) -> Result<ReleaseInfo, UpdatesError> {
+    let client = UreqGitHubReleasesClient::default();
+    let settings = EnvUpdateSettings::from_env()?;
+    discover_install_candidate_with(current, &client, &settings)
+}
+
+fn discover_install_candidate_with<C: GitHubReleasesClient, U: UpdateSettings>(
+    current: VersionInfo,
+    client: &C,
+    settings: &U,
+) -> Result<ReleaseInfo, UpdatesError> {
+    let channel = settings.channel()?;
+    check_updates(channel, current, client).map(|result| result.latest)
 }
 
 #[cfg(test)]
@@ -1265,7 +1321,6 @@ fn run_updates_command_with_update_settings<
     Ok(())
 }
 
-#[cfg(test)]
 fn check_updates<C: GitHubReleasesClient>(
     channel: UpdateChannel,
     current: VersionInfo,
@@ -1446,16 +1501,16 @@ fn current_unix_seconds() -> u64 {
 mod tests {
     use super::{
         atomic_write_file, check_updates, check_updates_with_cache,
-        evaluate_update_notification_policy, parse_release_version, resolve_update_cache_path,
-        run_updates_command_with, run_updates_command_with_update_settings, CachedReleaseInfo,
-        CachedUpdateCheck, CachedUpdateNotification, DefaultUpdateCacheStore, EnvUpdateSettings,
-        FileUpdateCacheStore, GitHubReleaseResponse, GitHubReleasesClient, ReleaseAsset,
-        ReleaseEndpoint, ReleaseInfo, StaticUpdateSettings, UpdateCachePathError,
-        UpdateCachePathSources, UpdateCacheStore, UpdateChannel, UpdateCheckCache,
-        UpdateNotificationDecision, UpdateNotificationPolicyInput, UpdateNotificationReason,
-        UpdateNotificationSkipReason, UpdateSettings, UpdatesCommand, UpdatesDeferredFailure,
-        UpdatesError, UpdatesRunContext, UreqGitHubReleasesClient, MAX_GITHUB_RESPONSE_BYTES,
-        PRERELEASE_PAGE_SIZE,
+        discover_install_candidate_with, evaluate_update_notification_policy,
+        parse_release_version, resolve_update_cache_path, run_updates_command_with,
+        run_updates_command_with_update_settings, CachedReleaseInfo, CachedUpdateCheck,
+        CachedUpdateNotification, DefaultUpdateCacheStore, EnvUpdateSettings, FileUpdateCacheStore,
+        GitHubReleaseResponse, GitHubReleasesClient, ReleaseAsset, ReleaseEndpoint, ReleaseInfo,
+        StaticUpdateSettings, UpdateCachePathError, UpdateCachePathSources, UpdateCacheStore,
+        UpdateChannel, UpdateCheckCache, UpdateNotificationDecision, UpdateNotificationPolicyInput,
+        UpdateNotificationReason, UpdateNotificationSkipReason, UpdateSettings, UpdatesCommand,
+        UpdatesDeferredFailure, UpdatesError, UpdatesRunContext, UreqGitHubReleasesClient,
+        MAX_GITHUB_RESPONSE_BYTES, PRERELEASE_PAGE_SIZE,
     };
     use crate::session_notifications::{
         UpdateNotificationError, UpdateNotificationHandoff, UpdateNotificationOutcome,
@@ -2327,7 +2382,7 @@ mod tests {
         assert!(result.update_available());
         assert_eq!(
             result.render(),
-            "status: update available\ncurrent: 1.1.0 (stable)\nlatest: 1.1.1 (stable)\nurl: https://github.test/releases/tag/v1.1.1\n"
+            "status: update available\ncurrent: 1.1.0 (stable)\nlatest: 1.1.1 (stable)\nurl: https://github.test/releases/tag/v1.1.1\ninstall: lg-buddy updates install\n"
         );
         assert_eq!(
             client.requests_with_etags(),
@@ -2984,6 +3039,33 @@ mod tests {
     }
 
     #[test]
+    fn install_discovery_uses_saved_channel_and_ignores_automatic_check_gate() {
+        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
+            "[{},{}]",
+            stable_release("v1.1.0"),
+            prerelease("v1.2.0-beta.1")
+        ))]);
+        let update_settings = StaticUpdateSettings::disabled(UpdateChannel::Prerelease);
+
+        let release = discover_install_candidate_with(
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &update_settings,
+        )
+        .expect("install discovery should use the saved prerelease channel");
+
+        assert_eq!(release.version(), &Version::parse("1.2.0-beta.1").unwrap());
+        assert_eq!(release.channel(), UpdateChannel::Prerelease);
+        assert_eq!(
+            client.requests(),
+            vec![(
+                "https://api.example.test/releases?per_page=20".to_string(),
+                "lg-buddy/1.1.0".to_string()
+            )]
+        );
+    }
+
+    #[test]
     fn saved_channel_drives_manual_checks_for_every_binary_identity() {
         for saved_channel in [UpdateChannel::Stable, UpdateChannel::Prerelease] {
             let update_settings = stored_update_settings("disabled", saved_channel);
@@ -3491,7 +3573,7 @@ mod tests {
         assert!(result.update_available());
         assert_eq!(
             result.render(),
-            "status: update available\ncurrent: 1.2.0-beta.1 (prerelease)\nlatest: 1.2.0 (stable)\nurl: https://github.test/releases/tag/v1.2.0\n"
+            "status: update available\ncurrent: 1.2.0-beta.1 (prerelease)\nlatest: 1.2.0 (stable)\nurl: https://github.test/releases/tag/v1.2.0\ninstall: lg-buddy updates install\n"
         );
     }
 

--- a/crates/lg-buddy/tests/features/help.feature
+++ b/crates/lg-buddy/tests/features/help.feature
@@ -22,6 +22,7 @@ Feature: Public CLI help
     And stdout contains "settings set <KEY> <VALUE>"
     And stdout contains "settings unset <KEY>"
     And stdout contains "updates check [--notify]"
+    And stdout contains "updates install"
     And stdout contains "help [COMMAND...]"
     And stdout contains "--help, -h"
     And stdout contains "--version, -V"

--- a/crates/lg-buddy/tests/features/updates.feature
+++ b/crates/lg-buddy/tests/features/updates.feature
@@ -1,10 +1,11 @@
 Feature: Updates CLI
-  LG Buddy should expose manual update checks without advertising its timer entrypoint.
+  LG Buddy should expose manual checks and assisted installation without advertising its timer entrypoint.
 
   Scenario: Updates help describes the public check command
     When I run the command "updates --help"
     Then the command succeeds
     And stdout contains "updates check [--notify]"
+    And stdout contains "updates install"
     And stdout does not contain "--channel"
     And stdout does not contain "background-check"
 
@@ -27,10 +28,26 @@ Feature: Updates CLI
     And stderr contains "updates check [--notify]"
     And stderr does not contain "background-check"
 
+  Scenario: Updates install has scoped help and accepts no target arguments
+    When I run the command "updates install --help"
+    Then the command succeeds
+    And stdout contains "updates install"
+    And stdout contains "saved updates.channel"
+    And stdout does not contain "--channel"
+    When I run the command "help updates install"
+    Then the command succeeds
+    And stdout contains "updates install"
+    When I run the command "updates install 1.5.0"
+    Then the command fails
+    And the command exits with status 2
+    And stderr contains "unexpected arguments for `updates install`: 1.5.0"
+    And stderr contains "updates install"
+
   Scenario: Global help hides the timer entrypoint
     When I run the command "--help"
     Then the command succeeds
     And stdout contains "updates check [--notify]"
+    And stdout contains "updates install"
     And stdout does not contain "updates background-check"
 
   Scenario: The hidden background check entrypoint remains operational

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -388,6 +388,7 @@ The intended public user-action surface is:
 - `settings set <KEY> <VALUE>`
 - `settings unset <KEY>`
 - `updates check [--notify]`
+- `updates install`
 
 The binary also retains package-owned and compatibility entrypoints during the
 public-surface migration:
@@ -410,11 +411,16 @@ the runtime command handlers in `commands.rs` and `session/runner.rs`.
 modules and delegates platform ingestion to `sources/`. The on-demand
 `updates check` command reads the saved `updates.channel` policy and consumes
 the GitHub Releases API without entering the screen, lifecycle, or scheduling
-paths. `updates background-check` is the timer-owned wrapper: it exits before
-GitHub/cache work when `updates.auto_check` is disabled and otherwise delegates
-to the same settings-driven check path with notification intent enabled. When
-notification is
-requested and an update is available, the one-shot CLI process hands the
+paths. `updates install` adds the user-confirmed upgrade orchestration: initial
+host preflight, fresh settings-driven discovery, target identity resolution,
+explicit terminal confirmation, verified bundle acquisition, candidate
+preflight, direct `install.sh --upgrade` execution, and installed identity
+verification. The verified bundle and acquisition lock remain owned until the
+installer and final verification finish. `updates background-check` is the
+timer-owned wrapper: it exits before GitHub/cache work when
+`updates.auto_check` is disabled and otherwise delegates to the same
+settings-driven check path with notification intent enabled. When notification
+is requested and an update is available, the one-shot CLI process hands the
 resolved update facts to the LG Buddy-owned user-session D-Bus surface. The
 running session process then owns desktop notification dispatch, notification
 ids, the `View Release` action, and the notification opt-out action. The

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -44,6 +44,7 @@ the shared native-session path.
 | manual screen blank | `lg-buddy screen off` | `commands` -> `screen` | Blank or power off the TV if LG Buddy owns the configured input. |
 | manual screen restore | `lg-buddy screen on` | `commands` -> `screen` | Restore the screen when marker and restore-policy rules allow it. |
 | manual update check | `lg-buddy updates check` | `updates` -> saved channel policy -> GitHub releases API | Check for an available release independently of the automatic update-check setting. |
+| user-confirmed update install | `lg-buddy updates install` | `update_install` -> host preflight -> release verification -> candidate preflight -> `install.sh --upgrade` -> installed identity verification | Install only a newer release from the saved channel after explicit terminal confirmation. |
 | user update-check timer | `lg-buddy updates background-check` | `updates` -> saved channel policy -> GitHub releases API -> session notification handoff | Check for updates when automatic checks are enabled and notify once per release. |
 
 Compatibility command surfaces still exist for direct/manual invocation:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -83,6 +83,9 @@ This is the place for integration tests and contract tests.
 - logind lifecycle and NetworkManager gate behavior against a private system-bus
   harness
 - desktop and auxiliary gamepad activity resetting one LG Buddy-owned deadline
+- update-install orchestration ordering against an injected runtime, including
+  refusal, decline, concurrent acquisition, candidate preflight, installer,
+  identity mismatch, cleanup, and success paths
 
 ### How to test it
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -231,12 +231,21 @@ lg-buddy updates check
 lg-buddy updates check --notify
 lg-buddy settings set updates.channel prerelease
 lg-buddy updates check
+lg-buddy updates install
 ```
 
 The saved `updates.channel` setting controls every check, regardless of the
 installed binary's own release channel. `stable` checks stable releases only;
 `prerelease` considers both stable and prerelease releases and selects the
 highest semantic version.
+
+`updates install` is an assisted, foreground upgrade. It checks whether the
+current host and installation are safely upgradeable before discovery, shows
+the current and target version/channel/commit, and requires you to type `yes`
+in a terminal before downloading the release bundle. It then verifies the
+bundle, reruns preflight from the candidate, invokes `install.sh --upgrade`,
+and verifies the installed release identity. It does not accept channel or
+version arguments, downgrade, migrate legacy installations, or run unattended.
 
 `--notify` sends a desktop notification through the running user service. When
 supported by the desktop, the notification includes actions to open the release
@@ -251,7 +260,8 @@ lg-buddy settings set updates.auto_check enabled
 lg-buddy settings set updates.channel prerelease
 ```
 
-Disabling automatic checks does not disable manual `updates check` commands.
+Disabling automatic checks does not disable manual `updates check` or
+`updates install` commands. Both use the saved `updates.channel` setting.
 
 ## Technical References
 

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -66,6 +66,8 @@ assert_cli_surface() {
     local no_args_output=""
     local removed_channel_output=""
     local removed_channel_status=0
+    local install_argument_output=""
+    local install_argument_status=0
 
     help_output="$("$binary" --help)"
     no_args_output="$("$binary")"
@@ -88,6 +90,7 @@ assert_cli_surface() {
     printf '%s\n' "$help_output" | grep -q "settings list"
     printf '%s\n' "$help_output" | grep -q "settings set <KEY> <VALUE>"
     printf '%s\n' "$help_output" | grep -F -q "updates check [--notify]"
+    printf '%s\n' "$help_output" | grep -F -q "updates install"
     if printf '%s\n' "$help_output" | grep -F -q -- "--channel"; then
         echo "Removed updates --channel option appeared in public help: $binary"
         exit 1
@@ -104,6 +107,19 @@ assert_cli_surface() {
         exit 1
     fi
     printf '%s\n' "$removed_channel_output" | grep -F -q 'unexpected arguments for `updates check`: --channel stable'
+
+    "$binary" updates install --help | grep -F -q "updates install"
+    if install_argument_output="$("$binary" updates install 1.5.0 2>&1)"; then
+        echo "Updates install unexpectedly accepted a version argument: $binary"
+        exit 1
+    else
+        install_argument_status=$?
+    fi
+    if [ "$install_argument_status" -ne 2 ]; then
+        echo "Updates install argument rejection returned status $install_argument_status instead of 2: $binary"
+        exit 1
+    fi
+    printf '%s\n' "$install_argument_output" | grep -F -q 'unexpected arguments for `updates install`: 1.5.0'
 
     for hidden in startup shutdown screen-off screen-on "updates background-check" upgrade-preflight; do
         if printf '%s\n' "$help_output" | grep -F -q "$hidden"; then


### PR DESCRIPTION
## Summary
- add `lg-buddy updates install` as the foreground, user-confirmed upgrade flow governed by the saved update channel
- perform host checks, immutable release resolution, verified acquisition, candidate preflight, direct installer invocation, and post-install identity verification in order
- point update output, notifications, help, smoke coverage, and documentation to the assisted install command while keeping background checks detection-only

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p lg-buddy --all-targets -- -D warnings`
- `cargo test -p lg-buddy --lib` — 731 passed, 1 ignored manual hardware smoke
- affected Cucumber features — 8 scenarios and 92 steps passed
- shell syntax checks for installer and release scripts
- `python3 scripts/test_release_promotion.py` — 10 passed

The complete release-bundle installer smoke is left to hosted CI because this unsupported NixOS development host does not provide `/bin/bash`.

Closes #98