### PR TITLE
Prepare v1.4.0-beta.2 bootstrap updater release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.3.0"
+version = "1.4.0-beta.2"
 dependencies = [
  "base64",
  "cucumber",

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.3.0"
+version = "1.4.0-beta.2"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- set the LG Buddy crate and lockfile version to `1.4.0-beta.2`
- establish the first public updater-capable prerelease intended to become the pinned cross-version baseline for #99

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo test -p lg-buddy --lib` — 731 passed, 1 ignored manual hardware smoke
- injected release identity reports version `1.4.0-beta.2` and channel `prerelease`
- 10 release-promotion tests passed
- 17 release-bundle manifest tests passed
- `git diff --check`

After this merges into `dev`, release publication still requires the separate reviewed `dev` → `prerelease` promotion PR and `release:promote` approval.