### PR TITLE
Publish releases when promotion PRs merge

### DIFF
--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -32,7 +32,7 @@ jobs:
               exit 1
           }
           [ "$HEAD_REF" = "dev" ] || {
-              echo "Only the exact dev branch may target $BASE_REF."
+              echo "Only the dev branch may target $BASE_REF."
               exit 1
           }
           case "$BASE_REF" in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,82 +1,37 @@
 name: Release promotion
 
 on:
-  pull_request_target:
+  push:
     branches:
       - main
       - prerelease
-    types:
-      - labeled
 
 permissions:
   actions: read
-  checks: read
   contents: read
-  pull-requests: read
 
 concurrency:
   group: release-promotion
   cancel-in-progress: false
 
 jobs:
-  authorize:
-    if: github.event.label.name == 'release:promote'
-    runs-on: ubuntu-latest
-    outputs:
-      base_ref: ${{ steps.authorize.outputs.base_ref }}
-      base_sha: ${{ steps.authorize.outputs.base_sha }}
-      head_sha: ${{ steps.authorize.outputs.head_sha }}
-      pr_number: ${{ steps.authorize.outputs.pr_number }}
-
-    steps:
-      - name: Authorize promotion request
-        id: authorize
-        env:
-          ACTOR: ${{ github.actor }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          GH_TOKEN: ${{ github.token }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          IS_DRAFT: ${{ github.event.pull_request.draft }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          [ "$(gh api "repos/$GITHUB_REPOSITORY/collaborators/$ACTOR/permission" --jq .permission)" = "admin" ] || {
-              echo "Only a repository administrator may request release promotion."
-              exit 1
-          }
-          [ "$HEAD_REPOSITORY" = "$GITHUB_REPOSITORY" ]
-          [ "$HEAD_REF" = "dev" ]
-          [ "$IS_DRAFT" = "false" ]
-          case "$BASE_REF" in
-              main|prerelease) ;;
-              *) exit 1 ;;
-          esac
-          gh pr checks "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --required
-          {
-              echo "base_ref=$BASE_REF"
-              echo "base_sha=$BASE_SHA"
-              echo "head_sha=$HEAD_SHA"
-              echo "pr_number=$PR_NUMBER"
-          } >> "$GITHUB_OUTPUT"
-
   validate:
     runs-on: ubuntu-latest
-    needs: authorize
     outputs:
+      base_sha: ${{ steps.contract.outputs.base_sha }}
       channel: ${{ steps.contract.outputs.channel }}
       head_sha: ${{ steps.contract.outputs.head_sha }}
-      main_sha: ${{ steps.contract.outputs.main_sha }}
       prerelease_sha: ${{ steps.contract.outputs.prerelease_sha }}
+      publish: ${{ steps.contract.outputs.publish }}
+      source_sha: ${{ steps.contract.outputs.source_sha }}
       tag: ${{ steps.contract.outputs.tag }}
       version: ${{ steps.contract.outputs.version }}
 
     steps:
-      - name: Check out trusted promotion validator
+      - name: Check out merged release commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.authorize.outputs.base_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -85,7 +40,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Fetch channel refs and release tags
+      - name: Fetch release refs and tags
         run: |
           git fetch --force origin \
               +refs/heads/main:refs/remotes/origin/main \
@@ -93,23 +48,27 @@ jobs:
               +refs/heads/dev:refs/remotes/origin/dev \
               +refs/tags/*:refs/tags/*
 
-      - name: Validate promotion contract
+      - name: Validate merged promotion
         id: contract
+        env:
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          TARGET: ${{ github.ref_name }}
         run: |
           python3 scripts/release_promotion.py \
-              --target "${{ needs.authorize.outputs.base_ref }}" \
-              --head-ref "${{ needs.authorize.outputs.head_sha }}" \
-              --base-sha "${{ needs.authorize.outputs.base_sha }}" \
+              --merged \
+              --target "$TARGET" \
+              --head-ref "$HEAD_SHA" \
+              --base-sha "$BASE_SHA" \
               --github-output "$GITHUB_OUTPUT"
 
   build-release-bundle:
+    if: needs.validate.outputs.publish == 'true'
     runs-on: ubuntu-latest
-    needs:
-      - authorize
-      - validate
+    needs: validate
 
     steps:
-      - name: Check out exact reviewed dev commit
+      - name: Check out merged release commit
         uses: actions/checkout@v4
         with:
           ref: ${{ needs.validate.outputs.head_sha }}
@@ -168,19 +127,19 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  finalize:
+  publish:
+    if: needs.validate.outputs.publish == 'true'
     runs-on: ubuntu-latest
     environment: release-promotion
     needs:
-      - authorize
       - validate
       - build-release-bundle
 
     steps:
-      - name: Check out trusted finalizer
+      - name: Check out merged release commit
         uses: actions/checkout@v4
         with:
-          ref: ${{ needs.authorize.outputs.base_sha }}
+          ref: ${{ needs.validate.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -189,8 +148,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - name: Fetch and revalidate current refs
-        id: recheck
+      - name: Fetch and revalidate release refs
         run: |
           git fetch --force origin \
               +refs/heads/main:refs/remotes/origin/main \
@@ -198,16 +156,10 @@ jobs:
               +refs/heads/dev:refs/remotes/origin/dev \
               +refs/tags/*:refs/tags/*
           python3 scripts/release_promotion.py \
-              --target "${{ needs.authorize.outputs.base_ref }}" \
-              --head-ref "${{ needs.authorize.outputs.head_sha }}" \
-              --base-sha "${{ needs.authorize.outputs.base_sha }}" \
-              --github-output "$GITHUB_OUTPUT"
-          [ "$(git rev-parse refs/remotes/origin/dev)" = "${{ needs.validate.outputs.head_sha }}" ]
-
-      - name: Revalidate required PR checks
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr checks "${{ needs.authorize.outputs.pr_number }}" --repo "$GITHUB_REPOSITORY" --required
+              --merged \
+              --target "${{ github.ref_name }}" \
+              --head-ref "${{ needs.validate.outputs.head_sha }}" \
+              --base-sha "${{ needs.validate.outputs.base_sha }}"
 
       - name: Download verified release bundle
         uses: actions/download-artifact@v4
@@ -218,8 +170,8 @@ jobs:
       - name: Verify downloaded checksums
         run: cd dist && sha256sum -c sha256sums.txt
 
-      - name: Create repository-scoped promotion token
-        id: promotion-token
+      - name: Create repository-scoped release token
+        id: release-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
           app-id: ${{ vars.RELEASE_PROMOTION_APP_ID }}
@@ -228,37 +180,14 @@ jobs:
           repositories: LG_Buddy
           permission-contents: write
 
-      - name: Publish release and advance channel refs
+      - name: Align release streams
         env:
-          BASE_REF: ${{ needs.authorize.outputs.base_ref }}
-          EXPECTED_MAIN_SHA: ${{ needs.validate.outputs.main_sha }}
-          EXPECTED_PRERELEASE_SHA: ${{ needs.validate.outputs.prerelease_sha }}
-          GH_TOKEN: ${{ steps.promotion-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
           HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
-          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+          PRERELEASE_SHA: ${{ needs.validate.outputs.prerelease_sha }}
+          SOURCE_SHA: ${{ needs.validate.outputs.source_sha }}
+          TARGET: ${{ github.ref_name }}
         run: |
-          remote_tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq .object.sha 2>/dev/null || true)"
-          if [ -z "$remote_tag_sha" ]; then
-              gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
-                  -f ref="refs/tags/$RELEASE_TAG" \
-                  -f sha="$HEAD_SHA" >/dev/null
-          elif [ "$remote_tag_sha" != "$HEAD_SHA" ]; then
-              echo "Tag $RELEASE_TAG points to $remote_tag_sha, expected $HEAD_SHA."
-              exit 1
-          fi
-
-          if ! git rev-parse --verify "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
-              git tag "$RELEASE_TAG" "$HEAD_SHA"
-          fi
-          ./scripts/publish-release-assets.sh \
-              --dist-dir dist \
-              --tag "$RELEASE_TAG" \
-              --commit "$HEAD_SHA"
-
-          verify_dir="$(mktemp -d)"
-          gh release download "$RELEASE_TAG" --dir "$verify_dir"
-          (cd "$verify_dir" && sha256sum -c sha256sums.txt)
-
           update_ref() {
               local ref_name="$1"
               local expected_sha="$2"
@@ -277,11 +206,36 @@ jobs:
                   -F force=false >/dev/null
           }
 
-          if [ "$BASE_REF" = "main" ]; then
-              update_ref prerelease "$EXPECTED_PRERELEASE_SHA"
-              update_ref main "$EXPECTED_MAIN_SHA"
+          if [ "$TARGET" = "main" ]; then
+              update_ref prerelease "$PRERELEASE_SHA"
+          fi
+          update_ref dev "$SOURCE_SHA"
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ steps.release-token.outputs.token }}
+          HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          if remote_tag_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" --jq .object.sha 2>/dev/null)"; then
+              [ "$remote_tag_sha" = "$HEAD_SHA" ] || {
+                  echo "Tag $RELEASE_TAG points to $remote_tag_sha, expected $HEAD_SHA."
+                  exit 1
+              }
           else
-              update_ref prerelease "$EXPECTED_PRERELEASE_SHA"
+              gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+                  -f ref="refs/tags/$RELEASE_TAG" \
+                  -f sha="$HEAD_SHA" >/dev/null
           fi
 
-          [ "$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/$BASE_REF" --jq .object.sha)" = "$HEAD_SHA" ]
+          if ! git rev-parse --verify "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+              git tag "$RELEASE_TAG" "$HEAD_SHA"
+          fi
+          ./scripts/publish-release-assets.sh \
+              --dist-dir dist \
+              --tag "$RELEASE_TAG" \
+              --commit "$HEAD_SHA"
+
+          verify_dir="$(mktemp -d)"
+          gh release download "$RELEASE_TAG" --dir "$verify_dir"
+          (cd "$verify_dir" && sha256sum -c sha256sums.txt)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Keep one concern per pull request.
 
 Base ordinary contribution PRs on `dev` and target `dev`. The persistent
 `main` and `prerelease` branches accept only release promotion PRs whose head is
-the exact same-repository `dev` branch; see the
+the same-repository `dev` branch; see the
 [release process](docs/release-process.md).
 
 Good PRs usually fit one of these shapes:

--- a/docs/development.md
+++ b/docs/development.md
@@ -182,10 +182,10 @@ the branch contract and recovery process, see
 | `scripts/build-release-bundle.sh` | Release bundle builder |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |
 | `scripts/publish-release-assets.sh` | GitHub release publish helper |
-| `scripts/release_promotion.py` | Promotion version, ancestry, and tag validator |
+| `scripts/release_promotion.py` | Promotion version, branch, and tag validator |
 | `.github/workflows/ci.yml` | CI validation workflow |
 | `.github/workflows/promotion-check.yml` | Trusted promotion PR contract check |
-| `.github/workflows/release.yml` | Approved promotion build, publication, and ref finalizer |
+| `.github/workflows/release.yml` | Post-merge promotion build and publication workflow |
 | `bin/LG_Buddy_Common` | Shared shell config helper used by setup scripts |
 | `systemd/` | Installed unit files and tmpfiles config, including the logind lifecycle service |
 | `docs/architecture-overview.md` | Runtime architecture |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,17 +8,21 @@ LG Buddy uses three persistent branches as source channels:
 - `dev` is the ordinary integration branch and may contain unreleased work.
 
 The intended ancestry is `main <= prerelease <= dev`. Ordinary changes merge
-into `dev`. An official release requires a promotion PR whose head is the exact
+into `dev`. An official release requires a promotion PR whose head is the
 same-repository `dev` branch and whose base is `main` or `prerelease`.
 
 ## Promotion contract
 
-The promotion PR is the review and approval surface. The release-channel
-ruleset blocks GitHub's merge, squash, and rebase buttons from updating the
-branch because those methods would create a commit different from the reviewed
-`dev` commit; only the promotion App may perform the final fast-forward.
-Repository-wide automatic head-branch deletion stays disabled so GitHub cannot
-remove the persistent `dev` branch when a promotion PR becomes merged.
+The promotion PR is the review and approval surface. Required checks gate its
+merge, and merging the PR is the release authorization. The merged target-branch
+commit is the release commit; there is no separate approval label or publish
+action.
+
+The release App is not a substitute for merging. After the merged commit has
+passed the release build and smoke test, the App performs protected tag and
+release writes and keeps the persistent streams aligned. A prerelease merge
+advances `dev` to the merged prerelease commit. A stable merge advances both
+`prerelease` and `dev` to the merged stable commit.
 
 Required promotion checks prove that:
 
@@ -27,9 +31,8 @@ Required promotion checks prove that:
 - a stable target has a stable SemVer and a prerelease target has a prerelease
   SemVer
 - the version advances both existing release-channel heads
-- the persistent branches have not diverged or moved since review
-- the derived `v<crate-version>` tag is absent or already points to the same
-  commit during an idempotent retry
+- the persistent branches have not moved or diverged before merge
+- the derived `v<crate-version>` tag is absent before merge
 - normal CI and the release-bundle smoke test pass
 
 The tag, binary, archive, and GitHub release all use the Cargo package version.
@@ -40,38 +43,32 @@ There is no separate version input.
 1. Prepare the exact release version in `Cargo.toml` and `Cargo.lock` on `dev`.
 2. Open a PR from `dev` to `prerelease` or `main`.
 3. Wait for `verify`, `bundle-smoke-test`, and `validate-promotion` to pass.
-4. After review, a repository administrator applies the `release:promote`
-   label.
-5. The serialized release workflow rebuilds and smoke-tests the exact reviewed
-   commit without write credentials.
-6. A separate finalization job obtains a short-lived token from the dedicated
-   repository-only GitHub App, publishes the immutable tag and release, verifies
-   the published checksums, and only then fast-forwards the channel branch.
+4. Merge the promotion PR. This is the release authorization.
+5. The resulting push starts the serialized release workflow, which builds and
+   smoke-tests the merged release commit without write credentials.
+6. The final job obtains a short-lived token from the dedicated repository-only
+   GitHub App, aligns the remaining release streams, publishes the immutable tag
+   and release, and verifies the published checksums.
 
-Stable finalization advances `prerelease` before `main`, preserving
-`main <= prerelease` even if the second ref update needs to be retried.
-Prerelease finalization advances only `prerelease`; `dev` already points to the
-reviewed commit in both cases.
-
-Do not push version tags manually. Protected `v*` tags and release-channel
-branches permit bypass only to the dedicated promotion App. Failed finalization
-can be rerun safely, but an existing tag or asset is accepted only when it is
-byte-for-byte consistent with the same reviewed commit.
+Do not push version tags manually. Protected `v*` tags and stream-alignment
+writes permit bypass only to the dedicated release App. A failed post-merge
+release run can be rerun safely, but an existing tag or asset is accepted only
+when it is byte-for-byte consistent with the merged release commit.
 
 ## What the release workflow validates
 
 The workflow:
 
-1. Revalidates the live PR, refs, required checks, Cargo version, and tag state.
+1. Validates the merged target-branch commit, Cargo version, and tag state.
 2. Builds a static `x86_64-unknown-linux-musl` binary with exact version and
    commit identity.
 3. Generates a versioned identity manifest and packages the release bundle.
 4. Validates the manifest and installs the bundle in an isolated smoke-test root.
 5. Verifies the built and installed binary's exact version, channel, and commit.
 6. Generates and verifies `sha256sums.txt`.
-7. Publishes the tag and GitHub release without replacing conflicting assets.
-8. Downloads the published assets and verifies their checksums independently.
-9. Fast-forwards the selected branch only after publication succeeds.
+7. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
+8. Publishes the tag and GitHub release without replacing conflicting assets.
+9. Downloads the published assets and verifies their checksums independently.
 
 `install.sh` is only an installer. It does not build the runtime.
 

--- a/scripts/release_promotion.py
+++ b/scripts/release_promotion.py
@@ -154,6 +154,64 @@ def require_ancestor(repository: Path, ancestor: str, descendant: str) -> None:
         raise PromotionError(result.stderr.strip() or "git merge-base failed")
 
 
+def validate_release_identity(
+    repository: Path,
+    *,
+    target: str,
+    head_sha: str,
+    current_main_ref: str,
+    current_prerelease_ref: str,
+) -> dict[str, object]:
+    version_text = package_version_at_ref(repository, head_sha)
+    lock_version = lock_version_at_ref(repository, head_sha)
+    if lock_version != version_text:
+        raise PromotionError(
+            f"crate version {version_text} does not match Cargo.lock version {lock_version}"
+        )
+
+    version = SemVer.parse(version_text)
+    if version.build:
+        raise PromotionError("official release versions must not contain build metadata")
+    if target == "main" and version.prerelease:
+        raise PromotionError(f"main requires a stable version, found {version_text}")
+    if target == "prerelease" and not version.prerelease:
+        raise PromotionError(f"prerelease requires a prerelease version, found {version_text}")
+
+    for channel, current_ref in (
+        ("main", current_main_ref),
+        ("prerelease", current_prerelease_ref),
+    ):
+        if resolve(repository, current_ref) == head_sha:
+            continue
+        current_text = package_version_at_ref(repository, current_ref)
+        if version <= SemVer.parse(current_text):
+            raise PromotionError(
+                f"candidate {version_text} must advance {channel} from {current_text}"
+            )
+
+    tag = f"v{version_text}"
+    tag_result = subprocess.run(
+        ["git", "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}"],
+        cwd=repository,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    retry = tag_result.returncode == 0
+    if retry and tag_result.stdout.strip() != head_sha:
+        raise PromotionError(
+            f"tag {tag} already points to {tag_result.stdout.strip()}, not {head_sha}"
+        )
+
+    return {
+        "version": version_text,
+        "tag": tag,
+        "channel": "stable" if target == "main" else "prerelease",
+        "retry": retry,
+    }
+
+
 def validate_promotion(
     repository: Path,
     *,
@@ -181,56 +239,85 @@ def validate_promotion(
     require_ancestor(repository, main_sha, prerelease_sha)
     require_ancestor(repository, prerelease_sha, head_sha)
 
-    version_text = package_version_at_ref(repository, head_sha)
-    lock_version = lock_version_at_ref(repository, head_sha)
-    if lock_version != version_text:
-        raise PromotionError(
-            f"crate version {version_text} does not match Cargo.lock version {lock_version}"
-        )
-
-    version = SemVer.parse(version_text)
-    if version.build:
-        raise PromotionError("official release versions must not contain build metadata")
-    if target == "main" and version.prerelease:
-        raise PromotionError(f"main requires a stable version, found {version_text}")
-    if target == "prerelease" and not version.prerelease:
-        raise PromotionError(f"prerelease requires a prerelease version, found {version_text}")
-
-    current_main_text = package_version_at_ref(repository, main_sha)
-    current_prerelease_text = package_version_at_ref(repository, prerelease_sha)
-    for channel, current_text in (
-        ("main", current_main_text),
-        ("prerelease", current_prerelease_text),
-    ):
-        if version <= SemVer.parse(current_text):
-            raise PromotionError(
-                f"candidate {version_text} must advance {channel} from {current_text}"
-            )
-
-    tag = f"v{version_text}"
-    tag_result = subprocess.run(
-        ["git", "rev-parse", "--verify", f"refs/tags/{tag}^{{commit}}"],
-        cwd=repository,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.DEVNULL,
-        text=True,
+    identity = validate_release_identity(
+        repository,
+        target=target,
+        head_sha=head_sha,
+        current_main_ref=main_sha,
+        current_prerelease_ref=prerelease_sha,
     )
-    retry = tag_result.returncode == 0
-    if retry and tag_result.stdout.strip() != head_sha:
-        raise PromotionError(
-            f"tag {tag} already points to {tag_result.stdout.strip()}, not {head_sha}"
-        )
+    if identity["retry"]:
+        raise PromotionError(f"tag {identity['tag']} already exists before promotion merge")
 
     return {
-        "version": version_text,
-        "tag": tag,
-        "channel": "stable" if target == "main" else "prerelease",
+        **identity,
+        "publish": True,
         "head_sha": head_sha,
+        "source_sha": dev_sha,
         "base_sha": target_sha,
         "main_sha": main_sha,
         "prerelease_sha": prerelease_sha,
-        "retry": retry,
+    }
+
+
+def validate_merged_promotion(
+    repository: Path,
+    *,
+    target: str,
+    head_ref: str,
+    base_sha: str,
+    main_ref: str,
+    prerelease_ref: str,
+) -> dict[str, object]:
+    if target not in {"main", "prerelease"}:
+        raise PromotionError(f"unsupported promotion target: {target}")
+
+    head_sha = resolve(repository, head_ref)
+    previous_sha = resolve(repository, base_sha)
+    main_sha = resolve(repository, main_ref)
+    prerelease_sha = resolve(repository, prerelease_ref)
+    target_sha = main_sha if target == "main" else prerelease_sha
+    if target_sha != head_sha:
+        raise PromotionError(f"merged {target} moved from release commit {head_sha} to {target_sha}")
+    require_ancestor(repository, previous_sha, head_sha)
+
+    if target == "prerelease" and main_sha == head_sha:
+        version = package_version_at_ref(repository, head_sha)
+        return {
+            "publish": False,
+            "version": version,
+            "tag": f"v{version}",
+            "channel": "stable",
+            "retry": False,
+            "head_sha": head_sha,
+            "source_sha": "",
+            "base_sha": previous_sha,
+            "main_sha": main_sha,
+            "prerelease_sha": prerelease_sha,
+        }
+
+    parents = git(repository, "rev-list", "--parents", "-n", "1", head_sha).split()
+    if len(parents) != 3:
+        raise PromotionError("release promotion must produce a two-parent merge commit")
+    source_sha = parents[2]
+
+    identity = validate_release_identity(
+        repository,
+        target=target,
+        head_sha=head_sha,
+        current_main_ref=previous_sha if target == "main" else main_sha,
+        current_prerelease_ref=(
+            previous_sha if target == "prerelease" else prerelease_sha
+        ),
+    )
+    return {
+        **identity,
+        "publish": True,
+        "head_sha": head_sha,
+        "source_sha": source_sha,
+        "base_sha": previous_sha,
+        "main_sha": main_sha,
+        "prerelease_sha": prerelease_sha,
     }
 
 
@@ -251,21 +338,32 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--prerelease-ref", default="refs/remotes/origin/prerelease")
     parser.add_argument("--dev-ref", default="refs/remotes/origin/dev")
     parser.add_argument("--github-output", type=Path)
+    parser.add_argument("--merged", action="store_true")
     return parser.parse_args()
 
 
 def main() -> int:
     args = parse_args()
     try:
-        result = validate_promotion(
-            args.repository.resolve(),
-            target=args.target,
-            head_ref=args.head_ref,
-            base_sha=args.base_sha,
-            main_ref=args.main_ref,
-            prerelease_ref=args.prerelease_ref,
-            dev_ref=args.dev_ref,
-        )
+        if args.merged:
+            result = validate_merged_promotion(
+                args.repository.resolve(),
+                target=args.target,
+                head_ref=args.head_ref,
+                base_sha=args.base_sha,
+                main_ref=args.main_ref,
+                prerelease_ref=args.prerelease_ref,
+            )
+        else:
+            result = validate_promotion(
+                args.repository.resolve(),
+                target=args.target,
+                head_ref=args.head_ref,
+                base_sha=args.base_sha,
+                main_ref=args.main_ref,
+                prerelease_ref=args.prerelease_ref,
+                dev_ref=args.dev_ref,
+            )
     except PromotionError as error:
         raise SystemExit(f"release promotion validation failed: {error}") from error
 

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -7,7 +7,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from release_promotion import PromotionError, SemVer, validate_promotion
+from release_promotion import (
+    PromotionError,
+    SemVer,
+    validate_merged_promotion,
+    validate_promotion,
+)
 
 
 class RepositoryFixture:
@@ -68,6 +73,25 @@ class RepositoryFixture:
             main_ref="main",
             prerelease_ref="prerelease",
             dev_ref="dev",
+        )
+
+    def merge_promotion(self, target: str) -> tuple[str, str, str]:
+        source_sha = self.git("rev-parse", "dev")
+        base_sha = self.git("rev-parse", target)
+        self.git("switch", target)
+        self.git("merge", "--no-ff", "dev", "-m", f"promote dev to {target}")
+        return base_sha, source_sha, self.git("rev-parse", "HEAD")
+
+    def validate_merged(
+        self, target: str, head_sha: str, base_sha: str
+    ) -> dict[str, object]:
+        return validate_merged_promotion(
+            self.path,
+            target=target,
+            head_ref=head_sha,
+            base_sha=base_sha,
+            main_ref="main",
+            prerelease_ref="prerelease",
         )
 
 
@@ -160,13 +184,12 @@ class PromotionTests(unittest.TestCase):
         with self.assertRaisesRegex(PromotionError, "is not an ancestor"):
             self.repository.validate("prerelease", head)
 
-    def test_matching_existing_tag_is_an_idempotent_retry(self) -> None:
+    def test_existing_candidate_tag_is_rejected_before_merge(self) -> None:
         head = self.repository.candidate("1.4.0-beta.1")
         self.repository.git("tag", "v1.4.0-beta.1", head)
 
-        result = self.repository.validate("prerelease", head)
-
-        self.assertTrue(result["retry"])
+        with self.assertRaisesRegex(PromotionError, "already exists before promotion merge"):
+            self.repository.validate("prerelease", head)
 
     def test_conflicting_existing_tag_is_rejected(self) -> None:
         head = self.repository.candidate("1.4.0-beta.1")
@@ -174,6 +197,87 @@ class PromotionTests(unittest.TestCase):
 
         with self.assertRaisesRegex(PromotionError, "already points"):
             self.repository.validate("prerelease", head)
+
+    def test_merged_prerelease_is_publishable(self) -> None:
+        self.repository.candidate("1.4.0-beta.1")
+        base, source, merged = self.repository.merge_promotion("prerelease")
+
+        result = self.repository.validate_merged("prerelease", merged, base)
+
+        self.assertTrue(result["publish"])
+        self.assertEqual(result["head_sha"], merged)
+        self.assertEqual(result["source_sha"], source)
+        self.assertEqual(result["tag"], "v1.4.0-beta.1")
+        self.assertEqual(result["channel"], "prerelease")
+
+    def test_merged_stable_release_after_prerelease_is_publishable(self) -> None:
+        prerelease = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("branch", "-f", "prerelease", prerelease)
+        self.repository.write_version("1.4.0")
+        self.repository.git("add", ".")
+        self.repository.git("commit", "-m", "prepare stable")
+        base, source, merged = self.repository.merge_promotion("main")
+
+        result = self.repository.validate_merged("main", merged, base)
+
+        self.assertTrue(result["publish"])
+        self.assertEqual(result["source_sha"], source)
+        self.assertEqual(result["tag"], "v1.4.0")
+        self.assertEqual(result["channel"], "stable")
+
+    def test_stable_alignment_push_to_prerelease_does_not_publish_again(self) -> None:
+        prerelease = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("branch", "-f", "prerelease", prerelease)
+        self.repository.write_version("1.4.0")
+        self.repository.git("add", ".")
+        self.repository.git("commit", "-m", "prepare stable")
+        _, _, merged = self.repository.merge_promotion("main")
+        self.repository.git("branch", "-f", "prerelease", merged)
+
+        result = self.repository.validate_merged("prerelease", merged, prerelease)
+
+        self.assertFalse(result["publish"])
+        self.assertEqual(result["head_sha"], merged)
+        self.assertEqual(result["base_sha"], prerelease)
+        self.assertEqual(result["channel"], "stable")
+
+    def test_release_branch_fast_forward_without_a_merge_is_rejected(self) -> None:
+        head = self.repository.candidate("1.4.0-beta.1")
+        self.repository.git("branch", "-f", "prerelease", head)
+
+        with self.assertRaisesRegex(PromotionError, "two-parent merge commit"):
+            self.repository.validate_merged("prerelease", head, self.repository.stable_sha)
+
+    def test_matching_merged_release_tag_is_an_idempotent_retry(self) -> None:
+        self.repository.candidate("1.4.0-beta.1")
+        base, _, merged = self.repository.merge_promotion("prerelease")
+        self.repository.git("tag", "v1.4.0-beta.1", merged)
+
+        result = self.repository.validate_merged("prerelease", merged, base)
+
+        self.assertTrue(result["retry"])
+
+    def test_merged_release_lockfile_mismatch_is_rejected(self) -> None:
+        self.repository.candidate("1.4.0-beta.1", "1.3.0")
+        base, _, merged = self.repository.merge_promotion("prerelease")
+
+        with self.assertRaisesRegex(PromotionError, "does not match Cargo.lock"):
+            self.repository.validate_merged("prerelease", merged, base)
+
+    def test_merged_release_channel_mismatch_is_rejected(self) -> None:
+        self.repository.candidate("1.4.0")
+        base, _, merged = self.repository.merge_promotion("prerelease")
+
+        with self.assertRaisesRegex(PromotionError, "requires a prerelease version"):
+            self.repository.validate_merged("prerelease", merged, base)
+
+    def test_conflicting_merged_release_tag_is_rejected(self) -> None:
+        self.repository.candidate("1.4.0-beta.1")
+        base, _, merged = self.repository.merge_promotion("prerelease")
+        self.repository.git("tag", "v1.4.0-beta.1", self.repository.stable_sha)
+
+        with self.assertRaisesRegex(PromotionError, "already points"):
+            self.repository.validate_merged("prerelease", merged, base)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- make required CI checks gate ordinary `dev` promotion PR merges and treat the merge as the sole release authorization
- trigger release building, smoke testing, tagging, and publication from the resulting `main` or `prerelease` push
- remove the `release:promote` label and administrator-authorization job
- keep the repository App limited to final protected stream/tag/release writes
- validate the merged release commit and avoid republishing when stable alignment advances `prerelease`
- fix the existing missing-tag probe that treated GitHub 404 JSON as a tag SHA
- update the promotion tests and documentation to match the merge-triggered contract

## Validation
- live beta.2 pre-merge promotion contract passes
- 18 release-promotion tests passed
- 17 release-bundle manifest tests passed
- Actionlint and ShellCheck passed for all workflows
- 731 Rust library tests passed; 1 manual hardware smoke ignored
- shell syntax, formatting, and `git diff --check` passed
- the absent `v1.4.0-beta.2` tag follows the corrected creation branch

## Post-merge repository configuration
The live ruleset is intentionally unchanged by this PR. After merge:

- remove the release-channel restricted-update rule so checked promotion PRs can merge
- allow only the normal merge method for release-channel PRs, preserving safe fast-forward stream alignment
- give the release App bypass on `dev` only for the automated post-merge alignment write
- retain `verify`, `bundle-smoke-test`, and `validate-promotion` as required promotion checks

Then a fresh `dev` → `prerelease` beta.2 promotion PR can use the corrected flow.