### PR TITLE
Gate releases on cross-version upgrade smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
 
 permissions:
+  checks: read
   contents: read
 
 jobs:
@@ -38,7 +39,7 @@ jobs:
         run: cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
 
       - name: Validate shell scripts
-        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
+        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py
@@ -46,9 +47,33 @@ jobs:
       - name: Validate release bundle manifest contract
         run: python3 scripts/test_release_bundle_manifest.py
 
+      - name: Validate GitHub response recorder
+        run: python3 scripts/test_record_github_release_responses.py
+
+      - name: Require successful production prerelease canary for stable promotion
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prerelease_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/prerelease" --jq .object.sha)"
+          [ "$prerelease_sha" != "${{ github.event.pull_request.base.sha }}" ] || {
+              echo "Stable promotion requires a distinct prerelease candidate."
+              exit 1
+          }
+          matching_checks="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$prerelease_sha/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "production-prerelease-canary" and .status == "completed" and .conclusion == "success" and .app.slug == "github-actions")] | length')"
+          [ "$matching_checks" -gt 0 ] || {
+              echo "No successful production-prerelease canary exists for $prerelease_sha."
+              exit 1
+          }
+
   bundle-smoke-test:
     runs-on: ubuntu-latest
     needs: verify
+    env:
+      SMOKE_VERSION: 1.4.0-beta.2.ci
 
     steps:
       - name: Check out repository
@@ -65,29 +90,53 @@ jobs:
           python-version: "3.x"
 
       - name: Install smoke-test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y musl-tools zenity
+        run: sudo apt-get update && sudo apt-get install -y musl-tools strace zenity
 
       - name: Build lg-buddy release binary
         env:
           LG_BUDDY_BUILD_COMMIT: ${{ github.sha }}
-          LG_BUDDY_RELEASE_VERSION: 0.0.0-ci.smoke
+          LG_BUDDY_RELEASE_VERSION: ${{ env.SMOKE_VERSION }}
         run: cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
 
       - name: Create release bundle
         run: |
           umask 0002
-          ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version 0.0.0-ci.smoke --output-dir dist
+          ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version "$SMOKE_VERSION" --output-dir dist
 
       - name: Smoke test release bundle
         run: |
           ./scripts/test-release-bundle.sh \
               --skip-pip-install \
-              --archive dist/lg-buddy-0.0.0-ci.smoke-x86_64-unknown-linux-musl.tar.gz \
-              --expected-tag v0.0.0-ci.smoke \
-              --expected-version 0.0.0-ci.smoke \
+              --archive "dist/lg-buddy-${SMOKE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+              --expected-tag "v${SMOKE_VERSION}" \
+              --expected-version "$SMOKE_VERSION" \
               --expected-channel prerelease \
               --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ github.sha }}"
+
+      - name: Download pinned cross-version baseline
+        run: |
+          curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --output "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Smoke test cross-version upgrade
+        run: |
+          ./scripts/test-cross-version-upgrade.sh \
+              --previous-archive "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              --previous-sha256 883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32 \
+              --previous-tag v1.4.0-beta.2 \
+              --previous-version 1.4.0-beta.2 \
+              --previous-channel prerelease \
+              --previous-target x86_64-unknown-linux-musl \
+              --previous-commit 77c8f46c66b9e385f3d90c15dee33d775639bbeb \
+              --candidate-archive "dist/lg-buddy-${SMOKE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+              --candidate-tag "v${SMOKE_VERSION}" \
+              --candidate-version "$SMOKE_VERSION" \
+              --candidate-channel prerelease \
+              --candidate-target x86_64-unknown-linux-musl \
+              --candidate-commit "${{ github.sha }}"
 
       - name: Generate checksums
         run: |
@@ -102,4 +151,4 @@ jobs:
       - name: Dry-run publish release assets
         env:
           GH_RELEASE_DRY_RUN: "1"
-        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag v0.0.0-ci.smoke --commit "${{ github.sha }}"
+        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag "v${SMOKE_VERSION}" --commit "${{ github.sha }}"

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -12,6 +12,7 @@ on:
       - ready_for_review
 
 permissions:
+  checks: read
   contents: read
   pull-requests: read
 
@@ -95,3 +96,23 @@ jobs:
               [ "$CHANNEL" = "stable" ] || expected_prerelease="true"
               [ "$(printf '%s' "$release_state" | jq -r .isPrerelease)" = "$expected_prerelease" ]
           fi
+
+      - name: Require production prerelease upgrade canary
+        if: github.event.pull_request.base.ref == 'main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ steps.contract.outputs.main_sha }}
+          PRERELEASE_SHA: ${{ steps.contract.outputs.prerelease_sha }}
+        run: |
+          [ "$PRERELEASE_SHA" != "$MAIN_SHA" ] || {
+              echo "Stable promotion requires a distinct prerelease candidate."
+              exit 1
+          }
+          matching_checks="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$PRERELEASE_SHA/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "production-prerelease-canary" and .status == "completed" and .conclusion == "success" and .app.slug == "github-actions")] | length')"
+          [ "$matching_checks" -gt 0 ] || {
+              echo "No successful production-prerelease canary exists for $PRERELEASE_SHA."
+              exit 1
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install release prerequisites
-        run: sudo apt-get update && sudo apt-get install -y musl-tools zenity
+        run: sudo apt-get update && sudo apt-get install -y musl-tools strace zenity
 
       - name: Build lg-buddy
         env:
@@ -106,6 +106,30 @@ jobs:
               --expected-channel "${{ needs.validate.outputs.channel }}" \
               --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Download pinned cross-version baseline
+        run: |
+          curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --output "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Smoke test cross-version upgrade
+        run: |
+          ./scripts/test-cross-version-upgrade.sh \
+              --previous-archive "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              --previous-sha256 883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32 \
+              --previous-tag v1.4.0-beta.2 \
+              --previous-version 1.4.0-beta.2 \
+              --previous-channel prerelease \
+              --previous-target x86_64-unknown-linux-musl \
+              --previous-commit 77c8f46c66b9e385f3d90c15dee33d775639bbeb \
+              --candidate-archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
+              --candidate-tag "${{ needs.validate.outputs.tag }}" \
+              --candidate-version "${{ needs.validate.outputs.version }}" \
+              --candidate-channel "${{ needs.validate.outputs.channel }}" \
+              --candidate-target x86_64-unknown-linux-musl \
+              --candidate-commit "${{ needs.validate.outputs.head_sha }}"
 
       - name: Generate checksums
         run: |
@@ -239,3 +263,71 @@ jobs:
           verify_dir="$(mktemp -d)"
           gh release download "$RELEASE_TAG" --dir "$verify_dir"
           (cd "$verify_dir" && sha256sum -c sha256sums.txt)
+
+  production-prerelease-canary:
+    name: production-prerelease-canary
+    if: needs.validate.outputs.publish == 'true' && needs.validate.outputs.channel == 'prerelease'
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - publish
+
+    steps:
+      - name: Check out published prerelease
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install canary prerequisites
+        run: sudo apt-get update && sudo apt-get install -y python3-venv util-linux zenity
+
+      - name: Download pinned updater-capable baseline
+        run: |
+          curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --output "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Exercise production GitHub upgrade path
+        run: |
+          ./scripts/test-production-upgrade-canary.sh \
+              --work-dir "$RUNNER_TEMP/production-canary" \
+              --previous-archive "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              --previous-sha256 883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32 \
+              --previous-tag v1.4.0-beta.2 \
+              --previous-version 1.4.0-beta.2 \
+              --previous-channel prerelease \
+              --previous-target x86_64-unknown-linux-musl \
+              --previous-commit 77c8f46c66b9e385f3d90c15dee33d775639bbeb \
+              --expected-tag "${{ needs.validate.outputs.tag }}" \
+              --expected-version "${{ needs.validate.outputs.version }}" \
+              --expected-channel prerelease \
+              --expected-target x86_64-unknown-linux-musl \
+              --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Record sanitized production GitHub responses
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/record_github_release_responses.py \
+              --repository "$GITHUB_REPOSITORY" \
+              --tag "${{ needs.validate.outputs.tag }}" \
+              --output "$RUNNER_TEMP/production-canary/github-responses.json"
+
+      - name: Upload canary evidence for the offline mock
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-upgrade-canary-${{ needs.validate.outputs.tag }}
+          path: |
+            ${{ runner.temp }}/production-canary/production-upgrade-canary.output
+            ${{ runner.temp }}/production-canary/github-responses.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ and then runs the verified bundle's upgrade installer. Upgrade mode preserves
 configuration and credentials and does not repeat setup or pairing;
 incompatible and legacy layouts are refused rather than migrated.
 
+`v1.4.0-beta.2` is the first release with `updates install`; older versions
+need one normal manual release-bundle installation before assisted upgrades are
+available.
+
 The shell installer targets conventional Linux installations with mutable
 system locations. First-class NixOS packaging is tracked in
 [issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -2324,6 +2324,44 @@ mod tests {
     }
 
     #[test]
+    fn observed_beta_2_response_is_replayed_as_the_upgrade_baseline() {
+        // Reduced to the fields consumed by GitHubRelease from the production
+        // response recorded in https://github.com/Staphylococcus/LG_Buddy/issues/99.
+        let body = include_str!("../testdata/github/releases-v1.4.0-beta.2.json");
+        let client = MockGitHubReleasesClient::new(vec![Ok(body.to_string())]);
+        let release = discover_install_candidate_with(
+            version_info("1.4.0-beta.1", ReleaseChannel::Prerelease),
+            &client,
+            &StaticUpdateSettings::enabled(UpdateChannel::Prerelease),
+        )
+        .expect("observed prerelease response should select beta.2");
+
+        assert_eq!(release.version(), &Version::parse("1.4.0-beta.2").unwrap());
+        assert_eq!(release.channel(), UpdateChannel::Prerelease);
+        assert_eq!(release.tag_name(), "v1.4.0-beta.2");
+        assert_eq!(release.assets().len(), 2);
+        let archive = &release.assets()[0];
+        assert_eq!(archive.id(), 539980839);
+        assert_eq!(archive.size(), 3_051_471);
+        assert_eq!(
+            archive.digest(),
+            Some("sha256:883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32")
+        );
+        assert_eq!(
+            archive.api_url(),
+            "https://api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/539980839"
+        );
+        assert_eq!(
+            archive.download_url(),
+            "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz"
+        );
+        let checksums = &release.assets()[1];
+        assert_eq!(checksums.id(), 539980872);
+        assert_eq!(checksums.name(), "sha256sums.txt");
+        assert_eq!(checksums.size(), 123);
+    }
+
+    #[test]
     fn ureq_client_rejects_oversized_release_metadata() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test server");
         let address = listener.local_addr().expect("read local test address");

--- a/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
+++ b/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
@@ -1,0 +1,42 @@
+[
+  {
+    "tag_name": "v1.4.0-beta.2",
+    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.4.0-beta.2",
+    "draft": false,
+    "prerelease": true,
+    "assets": [
+      {
+        "id": 539980839,
+        "name": "lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz",
+        "state": "uploaded",
+        "size": 3051471,
+        "digest": "sha256:883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32",
+        "url": "https://api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/539980839",
+        "browser_download_url": "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz"
+      },
+      {
+        "id": 539980872,
+        "name": "sha256sums.txt",
+        "state": "uploaded",
+        "size": 123,
+        "digest": "sha256:581c539163fc8477b464d05c598fdcb19f654c83b124c9986665b1a531093dd1",
+        "url": "https://api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/539980872",
+        "browser_download_url": "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/sha256sums.txt"
+      }
+    ]
+  },
+  {
+    "tag_name": "v1.4.0-beta.1",
+    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.4.0-beta.1",
+    "draft": false,
+    "prerelease": true,
+    "assets": []
+  },
+  {
+    "tag_name": "v1.3.0",
+    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.3.0",
+    "draft": false,
+    "prerelease": false,
+    "assets": []
+  }
+]

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,8 +84,9 @@ Useful checks during development:
 cargo test -p lg-buddy --lib
 cargo test -p lg-buddy --test cucumber
 cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
-bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
+bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 python3 scripts/test_release_promotion.py
+python3 scripts/test_record_github_release_responses.py
 ```
 
 Optional hardware smoke for gamepad activity:
@@ -136,6 +137,25 @@ root and exercises upgrade refusal, preservation, Python repair, owned-file
 replacement, service ordering, installed identity, lifecycle topology, and
 uninstall cleanup without mutating the host installation.
 
+Run the cross-version smoke with explicit previous and candidate archives:
+
+```bash
+./scripts/test-cross-version-upgrade.sh \
+  --previous-archive /path/to/previous.tar.gz \
+  --previous-sha256 <pinned-digest> \
+  --previous-tag <tag> --previous-version <version> \
+  --previous-channel <channel> --previous-target <target> \
+  --previous-commit <sha> \
+  --candidate-archive /path/to/candidate.tar.gz \
+  --candidate-tag <tag> --candidate-version <version> \
+  --candidate-channel <channel> --candidate-target <target> \
+  --candidate-commit <sha>
+```
+
+The production upgrade canary is CI-only because it requires the candidate to
+already be published. It records sanitized GitHub responses as a workflow
+artifact so the observed production shapes can be replayed offline.
+
 Run the focused manifest contract tests with:
 
 ```bash
@@ -181,6 +201,9 @@ the branch contract and recovery process, see
 | `scripts/release_bundle_manifest.py` | Release-bundle identity manifest creator and validator |
 | `scripts/build-release-bundle.sh` | Release bundle builder |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |
+| `scripts/test-cross-version-upgrade.sh` | Pinned previous-to-candidate archive upgrade smoke test |
+| `scripts/test-production-upgrade-canary.sh` | Post-publication production GitHub upgrade canary |
+| `scripts/record_github_release_responses.py` | Sanitized production response recorder for offline mocks |
 | `scripts/publish-release-assets.sh` | GitHub release publish helper |
 | `scripts/release_promotion.py` | Promotion version, branch, and tag validator |
 | `.github/workflows/ci.yml` | CI validation workflow |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,7 +33,10 @@ Required promotion checks prove that:
 - the version advances both existing release-channel heads
 - the persistent branches have not moved or diverged before merge
 - the derived `v<crate-version>` tag is absent before merge
-- normal CI and the release-bundle smoke test pass
+- normal CI and the release-bundle smoke test pass; the bundle smoke includes a
+  pinned cross-version upgrade from `v1.4.0-beta.2`
+- a stable promotion has a successful production upgrade canary on the exact
+  prerelease commit
 
 The tag, binary, archive, and GitHub release all use the Cargo package version.
 There is no separate version input.
@@ -45,10 +48,15 @@ There is no separate version input.
 3. Wait for `verify`, `bundle-smoke-test`, and `validate-promotion` to pass.
 4. Merge the promotion PR. This is the release authorization.
 5. The resulting push starts the serialized release workflow, which builds and
-   smoke-tests the merged release commit without write credentials.
+   smoke-tests the merged release commit without write credentials, including
+   an archive-driven upgrade from the pinned public baseline.
 6. The final job obtains a short-lived token from the dedicated repository-only
    GitHub App, aligns the remaining release streams, publishes the immutable tag
    and release, and verifies the published checksums.
+7. A published prerelease then runs `v1.4.0-beta.2` through the real production
+   `lg-buddy updates install` path. The canary records sanitized GitHub response
+   evidence for the deterministic mock. Stable promotion remains blocked until
+   this exact prerelease commit has a successful canary.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge
@@ -65,10 +73,14 @@ The workflow:
 3. Generates a versioned identity manifest and packages the release bundle.
 4. Validates the manifest and installs the bundle in an isolated smoke-test root.
 5. Verifies the built and installed binary's exact version, channel, and commit.
-6. Generates and verifies `sha256sums.txt`.
-7. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
-8. Publishes the tag and GitHub release without replacing conflicting assets.
-9. Downloads the published assets and verifies their checksums independently.
+6. Upgrades a pinned real previous archive to the candidate and verifies
+   preserved user state plus replaced owned integration files.
+7. Generates and verifies `sha256sums.txt`.
+8. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
+9. Publishes the tag and GitHub release without replacing conflicting assets.
+10. Downloads the published assets and verifies their checksums independently.
+11. For prereleases, exercises production GitHub discovery, acquisition,
+    confirmation, installation, and final identity from the pinned baseline.
 
 `install.sh` is only an installer. It does not build the runtime.
 
@@ -120,6 +132,19 @@ integrations and verifies that the installed binary matches the candidate.
 This is intentionally a conservative and evolving refusal boundary. It does
 not migrate legacy layouts, declare broad host support, or guarantee that a
 later privileged operation cannot fail.
+
+## Cross-version upgrade baseline
+
+`v1.4.0-beta.2` is the first public updater-capable release and is the pinned
+previous archive for the initial cross-version contract. Its
+`x86_64-unknown-linux-musl` archive SHA-256 is
+`883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32`.
+CI verifies that digest and the full release identity before extracting or
+executing the baseline.
+
+Versions before `v1.4.0-beta.2` do not contain `updates install`. They require
+one normal manual installation of an updater-capable release before assisted
+upgrades become available. Arbitrary historical upgrade support is not implied.
 
 ## Nix source selection
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -345,6 +345,23 @@ The initial and candidate checks are deliberately non-mutating. Orchestration
 tests for their consumers must separately prove that a refusal prevents release
 client, confirmation, sudo, and installer effects.
 
+The cross-version bundle smoke test adds the real release boundary that a
+same-bundle reinstall cannot cover. It verifies the pinned public
+`v1.4.0-beta.2` digest and identity before extraction, installs it into an
+isolated root and home, populates non-default settings and native credentials,
+and upgrades to an explicit candidate archive. It checks initial and candidate
+refusals before network, sudo, or mutation, then verifies preserved user state,
+candidate-owned file replacement, service action order, and final identity.
+
+After a prerelease is public, `production-prerelease-canary` installs the same
+baseline and drives its real `updates install` command through a PTY against
+GitHub. The canary records a sanitized release list, release-by-tag response,
+tag ref, and asset redirects as a workflow artifact. Signed redirect queries
+and URL userinfo are never retained. The observed beta.2 release-list fields
+also live in `crates/lg-buddy/testdata/github/` and are replayed by the normal
+offline Rust suite. A successful canary on the exact prerelease commit is a
+stable-promotion prerequisite.
+
 ## Current Practical Gaps
 
 The most important remaining gaps are:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,6 +247,10 @@ bundle, reruns preflight from the candidate, invokes `install.sh --upgrade`,
 and verifies the installed release identity. It does not accept channel or
 version arguments, downgrade, migrate legacy installations, or run unattended.
 
+`v1.4.0-beta.2` is the first release that contains `updates install`. Older
+installations require one normal manual installation of an updater-capable
+release before this assisted path is available.
+
 `--notify` sends a desktop notification through the running user service. When
 supported by the desktop, the notification includes actions to open the release
 or disable future automatic notifications. LG Buddy does not repeatedly notify

--- a/scripts/record_github_release_responses.py
+++ b/scripts/record_github_release_responses.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+"""Record sanitized GitHub release responses for deterministic update mocks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+API_VERSION = "2026-03-10"
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+def sanitize_url(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    host = parsed.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urllib.parse.urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+
+def sanitize_location(value: str) -> dict[str, Any]:
+    parsed = urllib.parse.urlsplit(value)
+    return {
+        "scheme": parsed.scheme,
+        "host": parsed.hostname,
+        "port": parsed.port,
+        "path": parsed.path,
+        "query_present": bool(parsed.query),
+        "fragment_present": bool(parsed.fragment),
+    }
+
+
+def project_asset(asset: dict[str, Any]) -> dict[str, Any]:
+    projected = {
+        field: asset.get(field)
+        for field in (
+            "id",
+            "name",
+            "state",
+            "size",
+            "digest",
+            "url",
+            "browser_download_url",
+        )
+    }
+    for field in ("url", "browser_download_url"):
+        if isinstance(projected[field], str):
+            projected[field] = sanitize_url(projected[field])
+    return projected
+
+
+def project_release(release: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tag_name": release.get("tag_name"),
+        "html_url": sanitize_url(release["html_url"]),
+        "draft": release.get("draft"),
+        "prerelease": release.get("prerelease"),
+        "assets": [project_asset(asset) for asset in release.get("assets", [])],
+    }
+
+
+def project_git_object(response: dict[str, Any]) -> dict[str, Any]:
+    object_data = response.get("object", {})
+    return {
+        "object": {
+            "type": object_data.get("type"),
+            "sha": object_data.get("sha"),
+        }
+    }
+
+
+class GitHubRecorder:
+    def __init__(self, *, api_root: str, token: str | None) -> None:
+        self.api_root = api_root.rstrip("/")
+        self.token = token
+        self.opener = urllib.request.build_opener(NoRedirect)
+
+    def request(self, url: str, *, accept: str) -> tuple[int, Any, dict[str, str]]:
+        headers = {
+            "Accept": accept,
+            "User-Agent": "lg-buddy-release-response-recorder",
+            "X-GitHub-Api-Version": API_VERSION,
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            response = self.opener.open(request, timeout=30)
+        except urllib.error.HTTPError as error:
+            response = error
+        body = response.read()
+        response_headers = {key.lower(): value for key, value in response.headers.items()}
+        parsed: Any = None
+        if body:
+            content_type = response_headers.get("content-type", "")
+            if "json" in content_type:
+                parsed = json.loads(body)
+            else:
+                parsed = {"bytes": len(body)}
+        return response.status, parsed, response_headers
+
+    def api_json(self, path: str) -> tuple[Any, dict[str, Any]]:
+        status, body, headers = self.request(
+            f"{self.api_root}/{path.lstrip('/')}",
+            accept="application/vnd.github+json",
+        )
+        if status != 200:
+            raise RuntimeError(f"GitHub API request for {path} returned {status}")
+        return body, {
+            "status": status,
+            "etag": headers.get("etag"),
+            "content_type": headers.get("content-type"),
+        }
+
+    def asset_redirect(self, asset: dict[str, Any]) -> dict[str, Any]:
+        status, _, headers = self.request(
+            str(asset["url"]),
+            accept="application/octet-stream",
+        )
+        location = headers.get("location")
+        return {
+            "asset": project_asset(asset),
+            "response": {
+                "status": status,
+                "content_type": headers.get("content-type"),
+                "content_length": headers.get("content-length"),
+                "location": sanitize_location(location) if location else None,
+            },
+        }
+
+
+def record_responses(
+    *, recorder: GitHubRecorder, repository: str, tag: str, target: str
+) -> dict[str, Any]:
+    encoded_repository = "/".join(
+        urllib.parse.quote(part, safe="") for part in repository.split("/")
+    )
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    releases, releases_response = recorder.api_json(
+        f"repos/{encoded_repository}/releases?per_page=20"
+    )
+    release, release_response = recorder.api_json(
+        f"repos/{encoded_repository}/releases/tags/{encoded_tag}"
+    )
+    tag_ref, tag_ref_response = recorder.api_json(
+        f"repos/{encoded_repository}/git/ref/tags/{encoded_tag}"
+    )
+
+    version = tag.removeprefix("v")
+    expected_assets = {
+        f"lg-buddy-{version}-{target}.tar.gz",
+        "sha256sums.txt",
+    }
+    selected_assets = [
+        asset for asset in release.get("assets", []) if asset.get("name") in expected_assets
+    ]
+    if {asset.get("name") for asset in selected_assets} != expected_assets:
+        raise RuntimeError(f"release {tag} does not expose the expected upgrade assets")
+
+    annotated_tag = None
+    if tag_ref.get("object", {}).get("type") == "tag":
+        tag_sha = urllib.parse.quote(str(tag_ref["object"]["sha"]), safe="")
+        tag_object, tag_object_response = recorder.api_json(
+            f"repos/{encoded_repository}/git/tags/{tag_sha}"
+        )
+        annotated_tag = {
+            "response": tag_object_response,
+            "body": project_git_object(tag_object),
+        }
+
+    return {
+        "schema_version": 1,
+        "repository": repository,
+        "tag": tag,
+        "release_list": {
+            "response": releases_response,
+            "body": [project_release(item) for item in releases],
+        },
+        "release_by_tag": {
+            "response": release_response,
+            "body": project_release(release),
+        },
+        "tag_ref": {
+            "response": tag_ref_response,
+            "body": project_git_object(tag_ref),
+        },
+        "annotated_tag": annotated_tag,
+        "asset_redirects": [
+            recorder.asset_redirect(asset) for asset in selected_assets
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--target", default="x86_64-unknown-linux-musl")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--api-root", default="https://api.github.com")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    observation = record_responses(
+        recorder=GitHubRecorder(api_root=args.api_root, token=token),
+        repository=args.repository,
+        tag=args.tag,
+        target=args.target,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(observation, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Recorded sanitized GitHub responses in {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test-cross-version-upgrade.sh
+++ b/scripts/test-cross-version-upgrade.sh
@@ -1,0 +1,445 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+usage() {
+    cat <<EOF
+Usage: $0 \
+  --previous-archive <path> --previous-sha256 <digest> \
+  --previous-tag <tag> --previous-version <version> \
+  --previous-channel <channel> --previous-target <target> \
+  --previous-commit <sha> \
+  --candidate-archive <path> --candidate-tag <tag> \
+  --candidate-version <version> --candidate-channel <channel> \
+  --candidate-target <target> --candidate-commit <sha> \
+  [--work-dir <dir>]
+EOF
+    exit 1
+}
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+assert_file() {
+    [ -f "$1" ] || fail "Expected file not found: $1"
+}
+
+assert_executable() {
+    [ -x "$1" ] || fail "Expected executable not found: $1"
+}
+
+validate_archive_paths() {
+    local archive="$1"
+    local entry=""
+
+    while IFS= read -r entry; do
+        case "$entry" in
+            /*) fail "Archive contains an absolute path: $entry" ;;
+        esac
+        if printf '%s\n' "$entry" | grep -Eq '(^|/)\.\.(/|$)'; then
+            fail "Archive contains a parent-directory traversal path: $entry"
+        fi
+    done < <(tar -tzf "$archive")
+}
+
+extract_bundle() {
+    local archive="$1"
+    local destination="$2"
+    local roots=()
+
+    mkdir -p "$destination"
+    tar --no-same-owner -C "$destination" -xzf "$archive"
+    mapfile -t roots < <(find "$destination" -mindepth 1 -maxdepth 1 -type d -print)
+    [ "${#roots[@]}" -eq 1 ] || fail "Release archive must contain exactly one top-level directory: $archive"
+    printf '%s\n' "${roots[0]}"
+}
+
+tree_digest() {
+    local install_root="$1"
+    local user_home="$2"
+
+    tar \
+        --sort=name \
+        --mtime='@0' \
+        --owner=0 \
+        --group=0 \
+        --numeric-owner \
+        -C "$(dirname "$install_root")" \
+        -cf - "$(basename "$install_root")" \
+        -C "$(dirname "$user_home")" \
+        "$(basename "$user_home")" |
+        sha256sum | awk '{print $1}'
+}
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+PREVIOUS_ARCHIVE=""
+PREVIOUS_SHA256=""
+PREVIOUS_TAG=""
+PREVIOUS_VERSION=""
+PREVIOUS_CHANNEL=""
+PREVIOUS_TARGET=""
+PREVIOUS_COMMIT=""
+CANDIDATE_ARCHIVE=""
+CANDIDATE_TAG=""
+CANDIDATE_VERSION=""
+CANDIDATE_CHANNEL=""
+CANDIDATE_TARGET=""
+CANDIDATE_COMMIT=""
+WORK_DIR=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --previous-archive) PREVIOUS_ARCHIVE="${2:-}"; shift 2 ;;
+        --previous-sha256) PREVIOUS_SHA256="${2:-}"; shift 2 ;;
+        --previous-tag) PREVIOUS_TAG="${2:-}"; shift 2 ;;
+        --previous-version) PREVIOUS_VERSION="${2:-}"; shift 2 ;;
+        --previous-channel) PREVIOUS_CHANNEL="${2:-}"; shift 2 ;;
+        --previous-target) PREVIOUS_TARGET="${2:-}"; shift 2 ;;
+        --previous-commit) PREVIOUS_COMMIT="${2:-}"; shift 2 ;;
+        --candidate-archive) CANDIDATE_ARCHIVE="${2:-}"; shift 2 ;;
+        --candidate-tag) CANDIDATE_TAG="${2:-}"; shift 2 ;;
+        --candidate-version) CANDIDATE_VERSION="${2:-}"; shift 2 ;;
+        --candidate-channel) CANDIDATE_CHANNEL="${2:-}"; shift 2 ;;
+        --candidate-target) CANDIDATE_TARGET="${2:-}"; shift 2 ;;
+        --candidate-commit) CANDIDATE_COMMIT="${2:-}"; shift 2 ;;
+        --work-dir) WORK_DIR="${2:-}"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+for required in \
+    PREVIOUS_ARCHIVE PREVIOUS_SHA256 PREVIOUS_TAG PREVIOUS_VERSION \
+    PREVIOUS_CHANNEL PREVIOUS_TARGET PREVIOUS_COMMIT CANDIDATE_ARCHIVE \
+    CANDIDATE_TAG CANDIDATE_VERSION CANDIDATE_CHANNEL CANDIDATE_TARGET \
+    CANDIDATE_COMMIT
+do
+    [ -n "${!required}" ] || usage
+done
+
+assert_file "$PREVIOUS_ARCHIVE"
+assert_file "$CANDIDATE_ARCHIVE"
+printf '%s\n' "$PREVIOUS_SHA256" | grep -Eq '^[0-9a-f]{64}$' || fail "Previous archive SHA-256 must be 64 lowercase hexadecimal characters."
+command -v strace >/dev/null || fail "strace is required for the no-network refusal control."
+
+ACTUAL_PREVIOUS_SHA256="$(sha256sum "$PREVIOUS_ARCHIVE" | awk '{print $1}')"
+[ "$ACTUAL_PREVIOUS_SHA256" = "$PREVIOUS_SHA256" ] || fail "Previous archive digest is $ACTUAL_PREVIOUS_SHA256, expected $PREVIOUS_SHA256."
+
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$PREVIOUS_ARCHIVE" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$CANDIDATE_ARCHIVE" \
+    --expected-release-tag "$CANDIDATE_TAG" \
+    --expected-version "$CANDIDATE_VERSION" \
+    --expected-channel "$CANDIDATE_CHANNEL" \
+    --expected-target "$CANDIDATE_TARGET" \
+    --expected-commit "$CANDIDATE_COMMIT"
+
+PYTHONPATH="$SCRIPT_DIR" python3 - "$PREVIOUS_VERSION" "$CANDIDATE_VERSION" <<'PY'
+import sys
+from release_promotion import SemVer
+
+previous = SemVer.parse(sys.argv[1])
+candidate = SemVer.parse(sys.argv[2])
+if candidate <= previous:
+    raise SystemExit(
+        f"candidate version {sys.argv[2]} must advance previous version {sys.argv[1]}"
+    )
+PY
+
+validate_archive_paths "$PREVIOUS_ARCHIVE"
+validate_archive_paths "$CANDIDATE_ARCHIVE"
+
+CLEANUP_WORK_DIR=0
+if [ -z "$WORK_DIR" ]; then
+    WORK_DIR="$(mktemp -d)"
+    CLEANUP_WORK_DIR=1
+else
+    mkdir -p "$WORK_DIR"
+fi
+
+cleanup() {
+    if [ "$CLEANUP_WORK_DIR" -eq 1 ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+PREVIOUS_BUNDLE="$(extract_bundle "$PREVIOUS_ARCHIVE" "$WORK_DIR/previous")"
+CANDIDATE_BUNDLE="$(extract_bundle "$CANDIDATE_ARCHIVE" "$WORK_DIR/candidate")"
+assert_executable "$PREVIOUS_BUNDLE/install.sh"
+assert_executable "$PREVIOUS_BUNDLE/lg-buddy"
+assert_executable "$CANDIDATE_BUNDLE/install.sh"
+assert_executable "$CANDIDATE_BUNDLE/lg-buddy"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$PREVIOUS_BUNDLE/release-manifest.json" \
+    --binary "$PREVIOUS_BUNDLE/lg-buddy" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$CANDIDATE_BUNDLE/release-manifest.json" \
+    --binary "$CANDIDATE_BUNDLE/lg-buddy" \
+    --expected-release-tag "$CANDIDATE_TAG" \
+    --expected-version "$CANDIDATE_VERSION" \
+    --expected-channel "$CANDIDATE_CHANNEL" \
+    --expected-target "$CANDIDATE_TARGET" \
+    --expected-commit "$CANDIDATE_COMMIT"
+
+INSTALL_ROOT="$WORK_DIR/root"
+HOME_DIR="$WORK_DIR/home"
+XDG_CONFIG_HOME="$HOME_DIR/.config"
+mkdir -p "$INSTALL_ROOT" "$HOME_DIR/Desktop"
+
+export HOME="$HOME_DIR"
+export XDG_CONFIG_HOME
+export LG_BUDDY_INSTALL_ROOT="$INSTALL_ROOT"
+export LG_BUDDY_SUDO_CMD="none"
+export LG_BUDDY_NONINTERACTIVE="1"
+export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+export LG_BUDDY_SKIP_PIP_INSTALL="1"
+export LG_BUDDY_TV_IP="192.168.50.20"
+export LG_BUDDY_TV_MAC="02:00:00:00:00:20"
+export LG_BUDDY_INPUT="HDMI_3"
+export LG_BUDDY_SCREEN_BACKEND="auto"
+export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+export PIP_DISABLE_PIP_VERSION_CHECK="1"
+export PIP_NO_PYTHON_VERSION_WARNING="1"
+
+(
+    cd "$PREVIOUS_BUNDLE"
+    ./install.sh
+)
+
+CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
+INSTALLED_BINARY="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_POINTER="$INSTALL_ROOT/usr/lib/lg-buddy/config-path"
+SYSTEM_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service"
+LIFECYCLE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service"
+TMPFILES_CONFIG="$INSTALL_ROOT/etc/tmpfiles.d/lg_buddy.conf"
+SYSTEM_SERVICE_OVERRIDE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service.d/config.conf"
+LIFECYCLE_SERVICE_OVERRIDE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service.d/config.conf"
+NM_LIFECYCLE_HOOK="$INSTALL_ROOT/etc/NetworkManager/dispatcher.d/pre-down.d/LG_Buddy_lifecycle"
+SYSTEM_DESKTOP_ENTRY="$INSTALL_ROOT/usr/share/applications/LG_Buddy_Brightness.desktop"
+USER_DESKTOP_ENTRY="$HOME_DIR/Desktop/LG_Buddy_Brightness.desktop"
+USER_SCREEN_SERVICE="$HOME_DIR/.config/systemd/user/LG_Buddy_screen.service"
+USER_SCREEN_OVERRIDE="$HOME_DIR/.config/systemd/user/LG_Buddy_screen.service.d/config.conf"
+USER_UPDATE_SERVICE="$HOME_DIR/.config/systemd/user/LG_Buddy_update_check.service"
+USER_UPDATE_TIMER="$HOME_DIR/.config/systemd/user/LG_Buddy_update_check.timer"
+USER_UPDATE_OVERRIDE="$HOME_DIR/.config/systemd/user/LG_Buddy_update_check.service.d/config.conf"
+NATIVE_TOKEN_FILE="$XDG_CONFIG_HOME/lg-buddy/tvs/primary/access-token.json"
+VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/cross-version-native-marker"
+
+for installed_path in \
+    "$CONFIG_FILE" "$INSTALLED_BINARY" "$INSTALLED_POINTER" "$SYSTEM_SERVICE" \
+    "$LIFECYCLE_SERVICE" "$TMPFILES_CONFIG" "$NM_LIFECYCLE_HOOK" \
+    "$SYSTEM_DESKTOP_ENTRY" "$USER_DESKTOP_ENTRY" "$USER_SCREEN_SERVICE" \
+    "$USER_UPDATE_SERVICE" "$USER_UPDATE_TIMER"
+do
+    assert_file "$installed_path"
+done
+
+export LG_BUDDY_CONFIG="$CONFIG_FILE"
+"$INSTALLED_BINARY" settings set screen.backend gnome
+"$INSTALLED_BINARY" settings set screen.idle_timeout 900
+"$INSTALLED_BINARY" settings set screen.restore_policy aggressive
+"$INSTALLED_BINARY" settings set screen.idle_blank disabled
+"$INSTALLED_BINARY" settings set system.sleep_wake_policy disabled
+"$INSTALLED_BINARY" settings set tv.ip 192.168.50.21
+"$INSTALLED_BINARY" settings set tv.mac 02:00:00:00:00:21
+"$INSTALLED_BINARY" settings set tv.input HDMI_4
+"$INSTALLED_BINARY" settings set updates.auto_check disabled
+"$INSTALLED_BINARY" settings set updates.channel prerelease
+sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+
+mkdir -p "$(dirname "$NATIVE_TOKEN_FILE")"
+printf '%s\n' '{"access_token":"cross-version-native-token"}' >"$NATIVE_TOKEN_FILE"
+chmod 600 "$NATIVE_TOKEN_FILE"
+touch "$VENV_MARKER"
+
+CONFIG_SNAPSHOT="$WORK_DIR/config.snapshot"
+POINTER_SNAPSHOT="$WORK_DIR/config-pointer.snapshot"
+TOKEN_SNAPSHOT="$WORK_DIR/access-token.snapshot"
+cp "$CONFIG_FILE" "$CONFIG_SNAPSHOT"
+cp "$INSTALLED_POINTER" "$POINTER_SNAPSHOT"
+cp "$NATIVE_TOKEN_FILE" "$TOKEN_SNAPSHOT"
+
+BASELINE_PREFLIGHT_OUTPUT="$WORK_DIR/compatible-baseline-preflight.output"
+"$PREVIOUS_BUNDLE/lg-buddy" upgrade-preflight "$PREVIOUS_BUNDLE" >"$BASELINE_PREFLIGHT_OUTPUT"
+grep -F -x -q 'upgrade preflight: compatible' "$BASELINE_PREFLIGHT_OUTPUT"
+
+CANDIDATE_PREFLIGHT_OUTPUT="$WORK_DIR/compatible-candidate-preflight.output"
+"$CANDIDATE_BUNDLE/lg-buddy" upgrade-preflight "$CANDIDATE_BUNDLE" >"$CANDIDATE_PREFLIGHT_OUTPUT"
+grep -F -x -q 'upgrade preflight: compatible' "$CANDIDATE_PREFLIGHT_OUTPUT"
+
+INSTALLER_STUB_DIR="$WORK_DIR/installer-stubs"
+SUDO_MARKER="$WORK_DIR/sudo-invoked"
+SUDO_SPY="$INSTALLER_STUB_DIR/sudo-spy"
+REFUSAL_OUTPUT="$WORK_DIR/initial-preflight-refusal.output"
+NETWORK_TRACE="$WORK_DIR/initial-preflight-network.trace"
+mkdir -p "$INSTALLER_STUB_DIR"
+cat >"$SUDO_SPY" <<'EOF'
+#!/bin/sh
+: >"${LG_BUDDY_SUDO_MARKER:?}"
+exit 97
+EOF
+chmod 755 "$SUDO_SPY"
+
+mv "$SYSTEM_SERVICE" "$SYSTEM_SERVICE.incompatible"
+REFUSAL_TREE_BEFORE="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+REFUSAL_STATUS=0
+if (
+    LG_BUDDY_SUDO_CMD="$SUDO_SPY" \
+    LG_BUDDY_SUDO_MARKER="$SUDO_MARKER" \
+    strace -f -qq -e trace=network -o "$NETWORK_TRACE" \
+        "$INSTALLED_BINARY" updates install >"$REFUSAL_OUTPUT" 2>&1
+); then
+    fail "Incompatible previous installation unexpectedly passed the initial preflight."
+else
+    REFUSAL_STATUS=$?
+fi
+[ "$REFUSAL_STATUS" -eq 1 ] || fail "Initial preflight refusal returned status $REFUSAL_STATUS instead of 1."
+grep -F -q 'upgrade preflight: refused' "$REFUSAL_OUTPUT"
+grep -F -q "$SYSTEM_SERVICE" "$REFUSAL_OUTPUT"
+[ ! -e "$SUDO_MARKER" ] || fail "Initial preflight refusal invoked sudo."
+if grep -E -q 'AF_INET|AF_INET6' "$NETWORK_TRACE"; then
+    fail "Initial preflight refusal attempted network access."
+fi
+REFUSAL_TREE_AFTER="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+[ "$REFUSAL_TREE_BEFORE" = "$REFUSAL_TREE_AFTER" ] || fail "Initial preflight refusal mutated the installation or user state."
+mv "$SYSTEM_SERVICE.incompatible" "$SYSTEM_SERVICE"
+
+CANDIDATE_REFUSAL_OUTPUT="$WORK_DIR/candidate-preflight-refusal.output"
+CANDIDATE_NETWORK_TRACE="$WORK_DIR/candidate-preflight-network.trace"
+CANDIDATE_SERVICE="$CANDIDATE_BUNDLE/systemd/LG_Buddy.service"
+mv "$CANDIDATE_SERVICE" "$CANDIDATE_SERVICE.incompatible"
+CANDIDATE_REFUSAL_TREE_BEFORE="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+if (
+    cd "$CANDIDATE_BUNDLE"
+    LG_BUDDY_SUDO_CMD="$SUDO_SPY" \
+    LG_BUDDY_SUDO_MARKER="$SUDO_MARKER" \
+    strace -f -qq -e trace=network -o "$CANDIDATE_NETWORK_TRACE" \
+        ./install.sh --upgrade >"$CANDIDATE_REFUSAL_OUTPUT" 2>&1
+); then
+    fail "Malformed candidate unexpectedly passed its preflight."
+fi
+grep -F -q 'upgrade preflight: refused' "$CANDIDATE_REFUSAL_OUTPUT"
+grep -F -q "$CANDIDATE_SERVICE" "$CANDIDATE_REFUSAL_OUTPUT"
+[ ! -e "$SUDO_MARKER" ] || fail "Candidate preflight refusal invoked sudo."
+if grep -E -q 'AF_INET|AF_INET6' "$CANDIDATE_NETWORK_TRACE"; then
+    fail "Candidate preflight refusal attempted network access."
+fi
+CANDIDATE_REFUSAL_TREE_AFTER="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+[ "$CANDIDATE_REFUSAL_TREE_BEFORE" = "$CANDIDATE_REFUSAL_TREE_AFTER" ] || fail "Candidate preflight refusal mutated the installation or user state."
+mv "$CANDIDATE_SERVICE.incompatible" "$CANDIDATE_SERVICE"
+
+for stale_target in \
+    "$INSTALLED_BINARY" "$SYSTEM_SERVICE" "$LIFECYCLE_SERVICE" \
+    "$TMPFILES_CONFIG" "$NM_LIFECYCLE_HOOK" "$SYSTEM_DESKTOP_ENTRY" \
+    "$USER_DESKTOP_ENTRY" "$USER_SCREEN_SERVICE" "$USER_UPDATE_SERVICE" \
+    "$USER_UPDATE_TIMER"
+do
+    printf 'stale previous-version asset\n' >"$stale_target"
+done
+chmod 755 "$INSTALLED_BINARY" "$NM_LIFECYCLE_HOOK"
+
+SERVICE_ACTION_LOG="$WORK_DIR/service-actions.log"
+EXPECTED_SERVICE_ACTION_LOG="$WORK_DIR/expected-service-actions.log"
+UPGRADE_OUTPUT="$WORK_DIR/cross-version-upgrade.output"
+cat >"$INSTALLER_STUB_DIR/systemctl" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'systemctl %s\n' "$*" >>"${LG_BUDDY_SERVICE_ACTION_LOG:?}"
+case "$*" in
+    is-system-running|"--user is-system-running") printf 'running\n' ;;
+esac
+EOF
+cat >"$INSTALLER_STUB_DIR/systemd-tmpfiles" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'tmpfiles %s\n' "$*" >>"${LG_BUDDY_SERVICE_ACTION_LOG:?}"
+EOF
+chmod 755 "$INSTALLER_STUB_DIR/systemctl" "$INSTALLER_STUB_DIR/systemd-tmpfiles"
+
+(
+    export PATH="$INSTALLER_STUB_DIR:$PATH"
+    export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
+    export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
+    cd "$CANDIDATE_BUNDLE"
+    ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
+)
+
+grep -F -q 'Upgrade complete!' "$UPGRADE_OUTPUT"
+cat >"$EXPECTED_SERVICE_ACTION_LOG" <<EOF
+systemctl is-system-running
+systemctl --user is-system-running
+tmpfiles --create $TMPFILES_CONFIG
+systemctl daemon-reload
+systemctl enable LG_Buddy.service
+systemctl enable LG_Buddy_lifecycle.service
+systemctl restart LG_Buddy_lifecycle.service
+systemctl --user daemon-reload
+systemctl --user enable LG_Buddy_screen.service
+systemctl --user restart LG_Buddy_screen.service
+systemctl --user disable --now LG_Buddy_update_check.timer
+EOF
+cmp -s "$EXPECTED_SERVICE_ACTION_LOG" "$SERVICE_ACTION_LOG" || {
+    diff -u "$EXPECTED_SERVICE_ACTION_LOG" "$SERVICE_ACTION_LOG" || true
+    fail "Cross-version upgrade service actions did not match the defined order."
+}
+
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || fail "Cross-version upgrade changed the user configuration."
+cmp -s "$POINTER_SNAPSHOT" "$INSTALLED_POINTER" || fail "Cross-version upgrade changed the installed config pointer."
+cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Cross-version upgrade changed the native credential."
+[ -e "$VENV_MARKER" ] || fail "Cross-version native upgrade recreated the Python environment."
+
+cmp -s "$CANDIDATE_BUNDLE/lg-buddy" "$INSTALLED_BINARY"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy.service" "$SYSTEM_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_lifecycle.service" "$LIFECYCLE_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/lg_buddy.conf" "$TMPFILES_CONFIG"
+cmp -s "$CANDIDATE_BUNDLE/LG_Buddy_Brightness.desktop" "$SYSTEM_DESKTOP_ENTRY"
+cmp -s "$CANDIDATE_BUNDLE/LG_Buddy_Brightness.desktop" "$USER_DESKTOP_ENTRY"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_screen.service" "$USER_SCREEN_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_update_check.service" "$USER_UPDATE_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_update_check.timer" "$USER_UPDATE_TIMER"
+grep -F -q 'exec /usr/bin/lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
+for override in \
+    "$SYSTEM_SERVICE_OVERRIDE" "$LIFECYCLE_SERVICE_OVERRIDE" \
+    "$USER_SCREEN_OVERRIDE" "$USER_UPDATE_OVERRIDE"
+do
+    assert_file "$override"
+    grep -F -q "LG_BUDDY_CONFIG=$CONFIG_FILE" "$override"
+done
+
+grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
+grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
+grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
+grep -q '^screen_idle_blank=disabled$' "$CONFIG_FILE"
+grep -q '^system_sleep_wake_policy=disabled$' "$CONFIG_FILE"
+grep -q '^tvs_primary_ip=192.168.50.21$' "$CONFIG_FILE"
+grep -q '^tvs_primary_mac=02:00:00:00:00:21$' "$CONFIG_FILE"
+grep -q '^tvs_primary_input=HDMI_4$' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+grep -q '^updates_auto_check=disabled$' "$CONFIG_FILE"
+grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
+
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$CANDIDATE_BUNDLE/release-manifest.json" \
+    --binary "$INSTALLED_BINARY" \
+    --expected-release-tag "$CANDIDATE_TAG" \
+    --expected-version "$CANDIDATE_VERSION" \
+    --expected-channel "$CANDIDATE_CHANNEL" \
+    --expected-target "$CANDIDATE_TARGET" \
+    --expected-commit "$CANDIDATE_COMMIT"
+
+echo "Cross-version upgrade smoke test passed: $PREVIOUS_VERSION -> $CANDIDATE_VERSION"

--- a/scripts/test-production-upgrade-canary.sh
+++ b/scripts/test-production-upgrade-canary.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+usage() {
+    cat <<EOF
+Usage: $0 \
+  --previous-archive <path> --previous-sha256 <digest> \
+  --previous-tag <tag> --previous-version <version> \
+  --previous-channel <channel> --previous-target <target> \
+  --previous-commit <sha> \
+  --expected-tag <tag> --expected-version <version> \
+  --expected-channel <channel> --expected-target <target> \
+  --expected-commit <sha> [--work-dir <dir>]
+EOF
+    exit 1
+}
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+validate_archive_paths() {
+    local archive="$1"
+    local entry=""
+
+    while IFS= read -r entry; do
+        case "$entry" in
+            /*) fail "Archive contains an absolute path: $entry" ;;
+        esac
+        if printf '%s\n' "$entry" | grep -Eq '(^|/)\.\.(/|$)'; then
+            fail "Archive contains a parent-directory traversal path: $entry"
+        fi
+    done < <(tar -tzf "$archive")
+}
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+PREVIOUS_ARCHIVE=""
+PREVIOUS_SHA256=""
+PREVIOUS_TAG=""
+PREVIOUS_VERSION=""
+PREVIOUS_CHANNEL=""
+PREVIOUS_TARGET=""
+PREVIOUS_COMMIT=""
+EXPECTED_TAG=""
+EXPECTED_VERSION=""
+EXPECTED_CHANNEL=""
+EXPECTED_TARGET=""
+EXPECTED_COMMIT=""
+WORK_DIR=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --previous-archive) PREVIOUS_ARCHIVE="${2:-}"; shift 2 ;;
+        --previous-sha256) PREVIOUS_SHA256="${2:-}"; shift 2 ;;
+        --previous-tag) PREVIOUS_TAG="${2:-}"; shift 2 ;;
+        --previous-version) PREVIOUS_VERSION="${2:-}"; shift 2 ;;
+        --previous-channel) PREVIOUS_CHANNEL="${2:-}"; shift 2 ;;
+        --previous-target) PREVIOUS_TARGET="${2:-}"; shift 2 ;;
+        --previous-commit) PREVIOUS_COMMIT="${2:-}"; shift 2 ;;
+        --expected-tag) EXPECTED_TAG="${2:-}"; shift 2 ;;
+        --expected-version) EXPECTED_VERSION="${2:-}"; shift 2 ;;
+        --expected-channel) EXPECTED_CHANNEL="${2:-}"; shift 2 ;;
+        --expected-target) EXPECTED_TARGET="${2:-}"; shift 2 ;;
+        --expected-commit) EXPECTED_COMMIT="${2:-}"; shift 2 ;;
+        --work-dir) WORK_DIR="${2:-}"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+for required in \
+    PREVIOUS_ARCHIVE PREVIOUS_SHA256 PREVIOUS_TAG PREVIOUS_VERSION \
+    PREVIOUS_CHANNEL PREVIOUS_TARGET PREVIOUS_COMMIT EXPECTED_TAG \
+    EXPECTED_VERSION EXPECTED_CHANNEL EXPECTED_TARGET EXPECTED_COMMIT
+do
+    [ -n "${!required}" ] || usage
+done
+
+[ -f "$PREVIOUS_ARCHIVE" ] || fail "Previous archive not found: $PREVIOUS_ARCHIVE"
+[ "$EXPECTED_TARGET" = "$PREVIOUS_TARGET" ] || fail "Production canary target $EXPECTED_TARGET does not match baseline target $PREVIOUS_TARGET."
+printf '%s\n' "$PREVIOUS_SHA256" | grep -Eq '^[0-9a-f]{64}$' || fail "Previous archive SHA-256 must be 64 lowercase hexadecimal characters."
+command -v script >/dev/null || fail "The util-linux script command is required for the confirmation PTY."
+
+ACTUAL_PREVIOUS_SHA256="$(sha256sum "$PREVIOUS_ARCHIVE" | awk '{print $1}')"
+[ "$ACTUAL_PREVIOUS_SHA256" = "$PREVIOUS_SHA256" ] || fail "Previous archive digest is $ACTUAL_PREVIOUS_SHA256, expected $PREVIOUS_SHA256."
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$PREVIOUS_ARCHIVE" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+PYTHONPATH="$SCRIPT_DIR" python3 - "$PREVIOUS_VERSION" "$EXPECTED_VERSION" <<'PY'
+import sys
+from release_promotion import SemVer
+
+if SemVer.parse(sys.argv[2]) <= SemVer.parse(sys.argv[1]):
+    raise SystemExit(
+        f"expected candidate {sys.argv[2]} must advance baseline {sys.argv[1]}"
+    )
+PY
+validate_archive_paths "$PREVIOUS_ARCHIVE"
+
+CLEANUP_WORK_DIR=0
+if [ -z "$WORK_DIR" ]; then
+    WORK_DIR="$(mktemp -d)"
+    CLEANUP_WORK_DIR=1
+else
+    mkdir -p "$WORK_DIR"
+fi
+
+cleanup() {
+    if [ "$CLEANUP_WORK_DIR" -eq 1 ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+EXTRACT_DIR="$WORK_DIR/previous"
+mkdir -p "$EXTRACT_DIR"
+tar --no-same-owner -C "$EXTRACT_DIR" -xzf "$PREVIOUS_ARCHIVE"
+mapfile -t PREVIOUS_ROOTS < <(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d -print)
+[ "${#PREVIOUS_ROOTS[@]}" -eq 1 ] || fail "Previous archive must contain exactly one top-level directory."
+PREVIOUS_BUNDLE="${PREVIOUS_ROOTS[0]}"
+[ -x "$PREVIOUS_BUNDLE/install.sh" ] || fail "Previous installer is not executable."
+[ -x "$PREVIOUS_BUNDLE/lg-buddy" ] || fail "Previous binary is not executable."
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$PREVIOUS_BUNDLE/release-manifest.json" \
+    --binary "$PREVIOUS_BUNDLE/lg-buddy" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+
+INSTALL_ROOT="$WORK_DIR/root"
+HOME_DIR="$WORK_DIR/home"
+XDG_CONFIG_HOME="$HOME_DIR/.config"
+XDG_CACHE_HOME="$HOME_DIR/.cache"
+mkdir -p "$INSTALL_ROOT" "$HOME_DIR/Desktop" "$XDG_CACHE_HOME"
+
+export HOME="$HOME_DIR"
+export XDG_CONFIG_HOME
+export XDG_CACHE_HOME
+export LG_BUDDY_INSTALL_ROOT="$INSTALL_ROOT"
+export LG_BUDDY_SUDO_CMD="none"
+export LG_BUDDY_NONINTERACTIVE="1"
+export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+export LG_BUDDY_SKIP_PIP_INSTALL="1"
+export LG_BUDDY_TV_IP="192.168.60.20"
+export LG_BUDDY_TV_MAC="02:00:00:00:00:60"
+export LG_BUDDY_INPUT="HDMI_3"
+export LG_BUDDY_SCREEN_BACKEND="auto"
+export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+export PIP_DISABLE_PIP_VERSION_CHECK="1"
+export PIP_NO_PYTHON_VERSION_WARNING="1"
+
+(
+    cd "$PREVIOUS_BUNDLE"
+    ./install.sh
+)
+
+CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
+INSTALLED_BINARY="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_POINTER="$INSTALL_ROOT/usr/lib/lg-buddy/config-path"
+NATIVE_TOKEN_FILE="$XDG_CONFIG_HOME/lg-buddy/tvs/primary/access-token.json"
+VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/production-canary-native-marker"
+[ -x "$INSTALLED_BINARY" ] || fail "Baseline binary was not installed."
+[ -f "$CONFIG_FILE" ] || fail "Baseline config was not installed."
+[ -f "$INSTALLED_POINTER" ] || fail "Baseline config pointer was not installed."
+
+export LG_BUDDY_CONFIG="$CONFIG_FILE"
+"$INSTALLED_BINARY" settings set screen.backend gnome
+"$INSTALLED_BINARY" settings set screen.idle_blank disabled
+"$INSTALLED_BINARY" settings set updates.auto_check disabled
+"$INSTALLED_BINARY" settings set updates.channel prerelease
+sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+mkdir -p "$(dirname "$NATIVE_TOKEN_FILE")"
+printf '%s\n' '{"access_token":"production-canary-native-token"}' >"$NATIVE_TOKEN_FILE"
+chmod 600 "$NATIVE_TOKEN_FILE"
+touch "$VENV_MARKER"
+
+CONFIG_SNAPSHOT="$WORK_DIR/config.snapshot"
+POINTER_SNAPSHOT="$WORK_DIR/config-pointer.snapshot"
+TOKEN_SNAPSHOT="$WORK_DIR/access-token.snapshot"
+cp "$CONFIG_FILE" "$CONFIG_SNAPSHOT"
+cp "$INSTALLED_POINTER" "$POINTER_SNAPSHOT"
+cp "$NATIVE_TOKEN_FILE" "$TOKEN_SNAPSHOT"
+
+CANARY_OUTPUT="$WORK_DIR/production-upgrade-canary.output"
+CANARY_COMMAND="$(printf '%q' "$INSTALLED_BINARY") updates install"
+printf 'yes\n' | script -qefc "$CANARY_COMMAND" /dev/null >"$CANARY_OUTPUT"
+
+grep -F -q "Current: $PREVIOUS_VERSION ($PREVIOUS_CHANNEL, commit $PREVIOUS_COMMIT)" "$CANARY_OUTPUT"
+grep -F -q "Target: $EXPECTED_VERSION ($EXPECTED_CHANNEL, commit $EXPECTED_COMMIT)" "$CANARY_OUTPUT"
+grep -F -q "Release: https://github.com/Staphylococcus/LG_Buddy/releases/tag/$EXPECTED_TAG" "$CANARY_OUTPUT"
+grep -F -q "Installed: $EXPECTED_VERSION ($EXPECTED_CHANNEL, commit $EXPECTED_COMMIT)" "$CANARY_OUTPUT"
+
+EXPECTED_VERSION_OUTPUT="$(printf 'lg-buddy %s\nversion: %s\nchannel: %s\ncommit: %s' \
+    "$EXPECTED_VERSION" "$EXPECTED_VERSION" "$EXPECTED_CHANNEL" "$EXPECTED_COMMIT")"
+ACTUAL_VERSION_OUTPUT="$("$INSTALLED_BINARY" --version)"
+[ "$ACTUAL_VERSION_OUTPUT" = "$EXPECTED_VERSION_OUTPUT" ] || fail "Installed identity does not match the published canary target."
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || fail "Production upgrade changed the user configuration."
+cmp -s "$POINTER_SNAPSHOT" "$INSTALLED_POINTER" || fail "Production upgrade changed the config pointer."
+cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Production upgrade changed the native credential."
+[ -e "$VENV_MARKER" ] || fail "Production native upgrade recreated the Python environment."
+"$INSTALLED_BINARY" settings get updates.channel | grep -q '^prerelease$'
+
+echo "Production GitHub upgrade canary passed: $PREVIOUS_VERSION -> $EXPECTED_VERSION"

--- a/scripts/test_record_github_release_responses.py
+++ b/scripts/test_record_github_release_responses.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+from record_github_release_responses import (
+    API_VERSION,
+    GitHubRecorder,
+    project_git_object,
+    project_release,
+    sanitize_location,
+)
+
+
+class StubResponse:
+    status = 200
+    headers = {"Content-Type": "application/json"}
+
+    @staticmethod
+    def read() -> bytes:
+        return b"{}"
+
+
+class RecordingOpener:
+    def __init__(self) -> None:
+        self.request = None
+
+    def open(self, request, *, timeout):  # type: ignore[no-untyped-def]
+        self.request = request
+        self.timeout = timeout
+        return StubResponse()
+
+
+class ResponseRecordingTests(unittest.TestCase):
+    def test_request_uses_the_production_github_api_version(self) -> None:
+        recorder = GitHubRecorder(api_root="https://api.github.test", token=None)
+        opener = RecordingOpener()
+        recorder.opener = opener
+
+        recorder.request(
+            "https://api.github.test/releases",
+            accept="application/vnd.github+json",
+        )
+
+        self.assertEqual(API_VERSION, "2026-03-10")
+        self.assertEqual(
+            opener.request.get_header("X-github-api-version"),
+            API_VERSION,
+        )
+
+    def test_location_record_drops_userinfo_query_and_fragment(self) -> None:
+        recorded = sanitize_location(
+            "https://user:secret@example.test:8443/releases/asset?token=secret#fragment"
+        )
+
+        self.assertEqual(
+            recorded,
+            {
+                "scheme": "https",
+                "host": "example.test",
+                "port": 8443,
+                "path": "/releases/asset",
+                "query_present": True,
+                "fragment_present": True,
+            },
+        )
+        self.assertNotIn("secret", repr(recorded))
+
+    def test_release_projection_keeps_only_update_client_fields(self) -> None:
+        projected = project_release(
+            {
+                "tag_name": "v1.4.0-beta.2",
+                "html_url": "https://user:secret@github.test/releases/v1.4.0-beta.2?token=secret",
+                "draft": False,
+                "prerelease": True,
+                "author": {"login": "ignored"},
+                "assets": [
+                    {
+                        "id": 42,
+                        "name": "sha256sums.txt",
+                        "state": "uploaded",
+                        "size": 123,
+                        "digest": "sha256:abc",
+                        "url": "https://user:secret@api.github.test/assets/42?token=secret",
+                        "browser_download_url": "https://github.test/assets/42#secret",
+                        "uploader": {"login": "ignored"},
+                    }
+                ],
+            }
+        )
+
+        self.assertNotIn("author", projected)
+        self.assertNotIn("uploader", projected["assets"][0])
+        self.assertEqual(projected["assets"][0]["id"], 42)
+        self.assertNotIn("secret", repr(projected))
+
+    def test_git_object_projection_keeps_only_tag_peeling_fields(self) -> None:
+        projected = project_git_object(
+            {
+                "ref": "refs/tags/v1.4.0-beta.2",
+                "node_id": "ignored",
+                "object": {
+                    "type": "commit",
+                    "sha": "77c8f46c66b9e385f3d90c15dee33d775639bbeb",
+                    "url": "https://api.github.test/commits/secret",
+                },
+            }
+        )
+
+        self.assertEqual(
+            projected,
+            {
+                "object": {
+                    "type": "commit",
+                    "sha": "77c8f46c66b9e385f3d90c15dee33d775639bbeb",
+                }
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #99

## Summary

- add an archive-driven smoke test from the pinned v1.4.0-beta.2 updater baseline to the candidate bundle, including preservation checks and incompatible-layout refusal controls
- require cross-version coverage in CI and release promotion, then run a production-GitHub canary after prerelease publication
- record sanitized observed GitHub release responses and replay the beta.2 fixture in deterministic update-selection tests
- document the supported upgrade boundary and release evidence

## Validation

- Rust unit suite
- full cross-version smoke in a non-root Debian container
- python3 scripts/test_record_github_release_responses.py
- live beta.2 response recording against the production GitHub API contract
- Bash syntax, ShellCheck, actionlint, and git diff --check

The host-limited Cucumber suite remains 121/122 on NixOS because the installer scenario requires /bin/bash; the archive smoke passed in Debian.