### PR TITLE
Harden immutable release publication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py
 
+      - name: Validate release publication contract
+        run: python3 scripts/test_publish_release_assets.py
+
       - name: Validate release bundle manifest contract
         run: python3 scripts/test_release_bundle_manifest.py
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,6 +162,12 @@ Run the focused manifest contract tests with:
 python3 scripts/test_release_bundle_manifest.py
 ```
 
+Run the mock-backed draft publication and retry contract tests with:
+
+```bash
+python3 scripts/test_publish_release_assets.py
+```
+
 Dry-run the GitHub release publish step with:
 
 ```bash

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,8 +51,9 @@ There is no separate version input.
    smoke-tests the merged release commit without write credentials, including
    an archive-driven upgrade from the pinned public baseline.
 6. The final job obtains a short-lived token from the dedicated repository-only
-   GitHub App, aligns the remaining release streams, publishes the immutable tag
-   and release, and verifies the published checksums.
+   GitHub App, aligns the remaining release streams, creates or resumes a draft,
+   verifies its complete asset set, and publishes it. Repository release
+   immutability then locks the tag and assets.
 7. A published prerelease then runs `v1.4.0-beta.2` through the real production
    `lg-buddy updates install` path. The canary records sanitized GitHub response
    evidence for the deterministic mock. Stable promotion remains blocked until
@@ -60,8 +61,17 @@ There is no separate version input.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge
-release run can be rerun safely, but an existing tag or asset is accepted only
-when it is byte-for-byte consistent with the merged release commit.
+release run can be rerun safely: an incomplete draft remains private and is
+resumed only when its tag, classification, and existing assets match the merged
+release commit. A published release is accepted only when its expected asset set
+is complete and byte-for-byte identical.
+
+Repository release immutability must remain enabled. GitHub applies it only when
+a draft is published, so the publisher uploads and verifies every expected asset
+before making the release visible. Each stored asset must report the expected
+name, uploaded state, byte size, and server-computed SHA-256 digest. Unexpected
+draft assets block publication; published releases are verification-only and are
+never repaired in place.
 
 ## What the release workflow validates
 
@@ -77,7 +87,8 @@ The workflow:
    preserved user state plus replaced owned integration files.
 7. Generates and verifies `sha256sums.txt`.
 8. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
-9. Publishes the tag and GitHub release without replacing conflicting assets.
+9. Stages the exact release assets privately, then publishes them together under
+   the repository's immutable-release policy.
 10. Downloads the published assets and verifies their checksums independently.
 11. For prereleases, exercises production GitHub discovery, acquisition,
     confirmation, installation, and final identity from the pinned baseline.

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 usage() {
     echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
@@ -121,33 +121,138 @@ if [ "${#RELEASE_FLAGS[@]}" -gt 0 ]; then
     EXPECTED_PRERELEASE="true"
 fi
 
+RELEASE_IS_DRAFT="true"
 if gh release view "$TAG" >/dev/null 2>&1; then
     RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
-        echo "Existing release $TAG is still a draft."
-        exit 1
-    }
+    RELEASE_IS_DRAFT="$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)"
+    case "$RELEASE_IS_DRAFT" in
+        true|false) ;;
+        *)
+            echo "Existing release $TAG returned an invalid draft state."
+            exit 1
+            ;;
+    esac
     [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
         echo "Existing release $TAG has the wrong prerelease classification."
         exit 1
     }
 else
-    gh release create "$TAG" --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
+    gh release create "$TAG" --draft --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
 fi
 
+EXPECTED_ASSETS=("${ARCHIVES[@]}" "$CHECKSUM_FILE")
+EXPECTED_ASSET_NAMES=()
 
-for asset in "${ARCHIVES[@]}" "$CHECKSUM_FILE"; do
+asset_name_is_expected() {
+    local candidate="$1"
+    local expected=""
+
+    for expected in "${EXPECTED_ASSET_NAMES[@]}"; do
+        [ "$candidate" != "$expected" ] || return 0
+    done
+    return 1
+}
+
+for asset in "${EXPECTED_ASSETS[@]}"; do
     asset_name="$(basename "$asset")"
-    if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -F -x -q "$asset_name"; then
-        compare_dir="$(mktemp -d)"
-        gh release download "$TAG" --pattern "$asset_name" --dir "$compare_dir"
-        if ! cmp -s "$asset" "$compare_dir/$asset_name"; then
-            echo "Existing release asset differs from the candidate: $asset_name"
-            rm -rf "$compare_dir"
+    ! asset_name_is_expected "$asset_name" || {
+        echo "Release assets must have unique file names: $asset_name"
+        exit 1
+    }
+    EXPECTED_ASSET_NAMES+=("$asset_name")
+done
+
+RELEASE_ASSET_NAMES="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+while IFS= read -r asset_name; do
+    [ -z "$asset_name" ] || asset_name_is_expected "$asset_name" || {
+        echo "Release $TAG contains unexpected asset: $asset_name"
+        exit 1
+    }
+done <<< "$RELEASE_ASSET_NAMES"
+
+for asset in "${EXPECTED_ASSETS[@]}"; do
+    asset_name="$(basename "$asset")"
+    if ! grep -F -x -q -- "$asset_name" <<< "$RELEASE_ASSET_NAMES"; then
+        [ "$RELEASE_IS_DRAFT" = "true" ] || {
+            echo "Published release $TAG is missing required asset: $asset_name"
             exit 1
-        fi
-        rm -rf "$compare_dir"
-    else
+        }
         gh release upload "$TAG" "$asset"
     fi
 done
+
+RELEASE_ASSETS="$(gh release view "$TAG" --json assets)"
+REMOTE_ASSET_COUNT="$(printf '%s' "$RELEASE_ASSETS" | jq '.assets | length')"
+[ "$REMOTE_ASSET_COUNT" -eq "${#EXPECTED_ASSET_NAMES[@]}" ] || {
+    echo "Release $TAG contains $REMOTE_ASSET_COUNT assets, expected ${#EXPECTED_ASSET_NAMES[@]}."
+    exit 1
+}
+
+for asset in "${EXPECTED_ASSETS[@]}"; do
+    asset_name="$(basename "$asset")"
+    MATCHING_ASSET_COUNT="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq --arg name "$asset_name" '[.assets[] | select(.name == $name)] | length'
+    )"
+    [ "$MATCHING_ASSET_COUNT" -eq 1 ] || {
+        echo "Release $TAG must contain exactly one asset named $asset_name."
+        exit 1
+    }
+
+    REMOTE_ASSET_STATE="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .state'
+    )"
+    [ "$REMOTE_ASSET_STATE" = "uploaded" ] || {
+        echo "Release asset $asset_name is not fully uploaded."
+        exit 1
+    }
+
+    LOCAL_ASSET_SIZE="$(wc -c < "$asset" | tr -d '[:space:]')"
+    REMOTE_ASSET_SIZE="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .size'
+    )"
+    [ "$REMOTE_ASSET_SIZE" = "$LOCAL_ASSET_SIZE" ] || {
+        echo "Release asset $asset_name has size $REMOTE_ASSET_SIZE, expected $LOCAL_ASSET_SIZE."
+        exit 1
+    }
+
+    LOCAL_ASSET_DIGEST="sha256:$(sha256sum "$asset" | cut -d ' ' -f 1)"
+    REMOTE_ASSET_DIGEST="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest'
+    )"
+    [ "$REMOTE_ASSET_DIGEST" = "$LOCAL_ASSET_DIGEST" ] || {
+        echo "Release asset $asset_name has digest $REMOTE_ASSET_DIGEST, expected $LOCAL_ASSET_DIGEST."
+        exit 1
+    }
+done
+
+if [ "$RELEASE_IS_DRAFT" = "true" ]; then
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
+        echo "Release $TAG was published before asset verification completed."
+        exit 1
+    }
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+        echo "Release $TAG changed prerelease classification before publication."
+        exit 1
+    }
+
+    gh release edit "$TAG" \
+        --draft=false \
+        --prerelease="$EXPECTED_PRERELEASE" \
+        --title "$TITLE" \
+        --notes "$NOTES"
+
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
+        echo "Release $TAG remained a draft after publication."
+        exit 1
+    }
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+        echo "Published release $TAG has the wrong prerelease classification."
+        exit 1
+    }
+fi

--- a/scripts/test_publish_release_assets.py
+++ b/scripts/test_publish_release_assets.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from release_bundle_manifest import MANIFEST_NAME, ReleaseIdentity, render_manifest
+
+
+VERSION = "9.8.7-beta.1"
+TAG = f"v{VERSION}"
+TARGET = "x86_64-unknown-linux-musl"
+
+
+FAKE_GH = r"""#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+state_path = Path(os.environ["FAKE_GH_STATE"])
+asset_dir = Path(os.environ["FAKE_GH_ASSETS"])
+log_path = Path(os.environ["FAKE_GH_LOG"])
+args = sys.argv[1:]
+
+with log_path.open("a", encoding="utf-8") as log:
+    log.write(json.dumps(args) + "\n")
+
+state = json.loads(state_path.read_text(encoding="utf-8"))
+
+def save():
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+if len(args) < 3 or args[0] != "release":
+    sys.exit("unsupported fake gh invocation")
+
+command = args[1]
+tag = args[2]
+rest = args[3:]
+
+if command == "view":
+    if not state["exists"]:
+        sys.exit(1)
+    if "--json" not in rest:
+        sys.exit(0)
+    fields = rest[rest.index("--json") + 1]
+    if fields == "assets":
+        if "--jq" in rest:
+            print("\n".join(sorted(state["assets"])))
+        else:
+            assets = []
+            for name in sorted(state["assets"]):
+                content = (asset_dir / name).read_bytes()
+                assets.append({
+                    "name": name,
+                    "state": "uploaded",
+                    "size": len(content),
+                    "digest": f"sha256:{hashlib.sha256(content).hexdigest()}",
+                })
+            print(json.dumps({"assets": assets}))
+    else:
+        print(json.dumps({
+            "isDraft": state["draft"],
+            "isPrerelease": state["prerelease"],
+        }))
+    sys.exit(0)
+
+if command == "create":
+    if state["exists"]:
+        sys.exit("release already exists")
+    state.update({
+        "exists": True,
+        "draft": "--draft" in rest,
+        "prerelease": "--prerelease" in rest,
+        "assets": [],
+    })
+    save()
+    sys.exit(0)
+
+if not state["exists"]:
+    sys.exit("release does not exist")
+
+if command == "upload":
+    source = Path(rest[0])
+    if os.environ.get("FAKE_GH_FAIL_UPLOAD") == source.name:
+        sys.exit("injected upload failure")
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    if os.environ.get("FAKE_GH_CORRUPT_UPLOAD") == source.name:
+        content = bytearray(source.read_bytes())
+        content[0] ^= 1
+        (asset_dir / source.name).write_bytes(content)
+    else:
+        shutil.copyfile(source, asset_dir / source.name)
+    if source.name not in state["assets"]:
+        state["assets"].append(source.name)
+    save()
+    sys.exit(0)
+
+if command == "download":
+    pattern = rest[rest.index("--pattern") + 1]
+    destination = Path(rest[rest.index("--dir") + 1])
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(asset_dir / pattern, destination / pattern)
+    sys.exit(0)
+
+if command == "edit":
+    for argument in rest:
+        if argument.startswith("--draft="):
+            state["draft"] = argument.split("=", 1)[1] == "true"
+        elif argument.startswith("--prerelease="):
+            state["prerelease"] = argument.split("=", 1)[1] == "true"
+    save()
+    sys.exit(0)
+
+sys.exit("unsupported fake gh release command")
+"""
+
+
+class PublishReleaseAssetsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.repository = self.root / "repository"
+        self.repository.mkdir()
+        self.dist = self.repository / "dist"
+        self.dist.mkdir()
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+        self.remote_assets = self.root / "remote-assets"
+        self.state_path = self.root / "state.json"
+        self.log_path = self.root / "gh-calls.jsonl"
+
+        self.git("init", "--quiet")
+        self.git("config", "user.name", "Release test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        (self.repository / "marker").write_text("release\n", encoding="utf-8")
+        self.git("add", "marker")
+        self.git("commit", "--quiet", "-m", "release")
+        self.commit = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("tag", TAG)
+
+        identity = ReleaseIdentity(
+            release_tag=TAG,
+            version=VERSION,
+            channel="prerelease",
+            target=TARGET,
+            commit=self.commit,
+        )
+        bundle_name = f"lg-buddy-{VERSION}-{TARGET}"
+        self.archive = self.dist / f"{bundle_name}.tar.gz"
+        manifest = render_manifest(identity)
+        with tarfile.open(self.archive, mode="w:gz") as bundle:
+            info = tarfile.TarInfo(f"{bundle_name}/{MANIFEST_NAME}")
+            info.size = len(manifest)
+            bundle.addfile(info, io.BytesIO(manifest))
+
+        digest = hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        self.checksums = self.dist / "sha256sums.txt"
+        self.checksums.write_text(
+            f"{digest}  {self.archive.name}\n", encoding="utf-8"
+        )
+
+        fake_gh = self.fake_bin / "gh"
+        fake_gh.write_text(FAKE_GH, encoding="utf-8")
+        fake_gh.chmod(0o755)
+        self.write_state()
+
+        self.environment = os.environ.copy()
+        self.environment.update(
+            {
+                "PATH": f"{self.fake_bin}:{self.environment['PATH']}",
+                "FAKE_GH_STATE": str(self.state_path),
+                "FAKE_GH_ASSETS": str(self.remote_assets),
+                "FAKE_GH_LOG": str(self.log_path),
+            }
+        )
+        self.publisher = Path(__file__).with_name("publish-release-assets.sh")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repository,
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+
+    def write_state(
+        self,
+        *,
+        exists: bool = False,
+        draft: bool = True,
+        prerelease: bool = True,
+        assets: dict[str, bytes] | None = None,
+    ) -> None:
+        asset_values = assets or {}
+        self.remote_assets.mkdir(parents=True, exist_ok=True)
+        for name, content in asset_values.items():
+            (self.remote_assets / name).write_bytes(content)
+        self.state_path.write_text(
+            json.dumps(
+                {
+                    "exists": exists,
+                    "draft": draft,
+                    "prerelease": prerelease,
+                    "assets": list(asset_values),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def run_publisher(
+        self,
+        *,
+        fail_upload: str | None = None,
+        corrupt_upload: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        environment = self.environment.copy()
+        if fail_upload is not None:
+            environment["FAKE_GH_FAIL_UPLOAD"] = fail_upload
+        if corrupt_upload is not None:
+            environment["FAKE_GH_CORRUPT_UPLOAD"] = corrupt_upload
+        return subprocess.run(
+            [
+                "bash",
+                self.publisher,
+                "--dist-dir",
+                self.dist,
+                "--tag",
+                TAG,
+                "--commit",
+                self.commit,
+            ],
+            cwd=self.repository,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    def state(self) -> dict[str, object]:
+        return json.loads(self.state_path.read_text(encoding="utf-8"))
+
+    def calls(self) -> list[list[str]]:
+        if not self.log_path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in self.log_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def mutations(self, command: str) -> list[list[str]]:
+        return [call for call in self.calls() if call[:2] == ["release", command]]
+
+    def complete_assets(self) -> dict[str, bytes]:
+        return {
+            self.archive.name: self.archive.read_bytes(),
+            self.checksums.name: self.checksums.read_bytes(),
+        }
+
+    def test_new_release_is_published_only_after_assets_are_uploaded(self) -> None:
+        result = self.run_publisher()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(set(self.state()["assets"]), set(self.complete_assets()))
+        self.assertFalse(self.state()["draft"])
+        create = self.mutations("create")
+        uploads = self.mutations("upload")
+        edit = self.mutations("edit")
+        self.assertEqual(len(create), 1)
+        self.assertIn("--draft", create[0])
+        self.assertEqual(len(uploads), 2)
+        self.assertEqual(len(edit), 1)
+        self.assertIn("--draft=false", edit[0])
+        self.assertLess(self.calls().index(create[0]), self.calls().index(uploads[0]))
+        self.assertLess(self.calls().index(uploads[-1]), self.calls().index(edit[0]))
+
+    def test_retry_resumes_a_partially_uploaded_draft(self) -> None:
+        first = self.run_publisher(fail_upload=self.checksums.name)
+        self.assertNotEqual(first.returncode, 0)
+        self.assertTrue(self.state()["draft"])
+
+        second = self.run_publisher()
+
+        self.assertEqual(second.returncode, 0, second.stdout)
+        self.assertFalse(self.state()["draft"])
+        self.assertEqual(len(self.mutations("create")), 1)
+        archive_uploads = [
+            call for call in self.mutations("upload") if call[-1] == str(self.archive)
+        ]
+        self.assertEqual(len(archive_uploads), 1)
+        self.assertEqual(len(self.mutations("edit")), 1)
+
+    def test_unexpected_draft_asset_blocks_publication_without_mutation(self) -> None:
+        self.write_state(exists=True, assets={"unexpected.txt": b"unexpected"})
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains unexpected asset", result.stdout)
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_published_release_missing_asset_is_not_modified(self) -> None:
+        self.write_state(
+            exists=True,
+            draft=False,
+            assets={self.archive.name: self.archive.read_bytes()},
+        )
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is missing required asset", result.stdout)
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_mismatched_draft_asset_blocks_publication(self) -> None:
+        self.write_state(
+            exists=True,
+            assets={self.archive.name: b"different archive"},
+        )
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"Release asset {self.archive.name} has size", result.stdout)
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_successful_but_corrupted_upload_blocks_publication(self) -> None:
+        result = self.run_publisher(corrupt_upload=self.checksums.name)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"Release asset {self.checksums.name} has digest", result.stdout)
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_complete_published_release_is_verification_only(self) -> None:
+        self.write_state(exists=True, draft=False, assets=self.complete_assets())
+
+        result = self.run_publisher()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -60,7 +60,7 @@ class RepositoryFixture:
         self.git("switch", "dev")
         self.write_version(version, lock_version)
         self.git("add", ".")
-        self.git("commit", "-m", f"prepare {version}")
+        self.git("commit", "--allow-empty", "-m", f"prepare {version}")
         return self.git("rev-parse", "HEAD")
 
     def validate(self, target: str, head_sha: str) -> dict[str, object]:
@@ -160,6 +160,28 @@ class PromotionTests(unittest.TestCase):
         head = self.repository.candidate("1.4.0-beta.1", "1.3.0")
         with self.assertRaisesRegex(PromotionError, "does not match Cargo.lock"):
             self.repository.validate("prerelease", head)
+
+    def test_stable_version_must_strictly_advance_main(self) -> None:
+        for version in ("1.3.0", "1.2.9"):
+            with self.subTest(version=version):
+                head = self.repository.candidate(version)
+                with self.assertRaisesRegex(
+                    PromotionError, f"candidate {version} must advance main from 1.3.0"
+                ):
+                    self.repository.validate("main", head)
+
+    def test_prerelease_version_must_strictly_advance_prerelease(self) -> None:
+        current = self.repository.candidate("1.4.0-beta.2")
+        self.repository.git("branch", "-f", "prerelease", current)
+
+        for version in ("1.4.0-beta.2", "1.4.0-beta.1"):
+            with self.subTest(version=version):
+                head = self.repository.candidate(version)
+                with self.assertRaisesRegex(
+                    PromotionError,
+                    f"candidate {version} must advance prerelease from 1.4.0-beta.2",
+                ):
+                    self.repository.validate("prerelease", head)
 
     def test_stale_target_is_rejected(self) -> None:
         head = self.repository.candidate("1.4.0-beta.1")


### PR DESCRIPTION
## Summary

- create or resume a private draft and publish only after its complete asset set is verified
- require GitHub-reported upload state, size, and SHA-256 digest to match every local asset
- add mock-backed interruption, corruption, conflict, and verification-only coverage
- lock the strictly increasing release-version invariant with regression tests

## Validation

- `python3 scripts/test_release_promotion.py`
- `python3 scripts/test_publish_release_assets.py`
- `python3 scripts/test_release_bundle_manifest.py`
- `python3 scripts/test_record_github_release_responses.py`
- shell syntax, ShellCheck, actionlint, and `git diff --check`