### PR TITLE
Use newest published release for update discovery

### DIFF
--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -24,7 +24,6 @@ const GITHUB_CONNECT_TIMEOUT_SECONDS: u64 = 5;
 const GITHUB_REQUEST_TIMEOUT_SECONDS: u64 = 20;
 const MAX_GITHUB_RESPONSE_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_GITHUB_ERROR_BYTES: u64 = 16 * 1024;
-const PRERELEASE_PAGE_SIZE: u8 = 20;
 const CACHE_DIR_NAME: &str = "lg-buddy";
 const UPDATE_CHECK_CACHE_FILE_NAME: &str = "update-check.json";
 
@@ -903,21 +902,21 @@ enum GitHubReleaseResponse {
 #[derive(Debug, Clone, Copy)]
 enum ReleaseEndpoint {
     LatestStable,
-    ReleasesList { per_page: u8 },
+    LatestPublished,
 }
 
 impl ReleaseEndpoint {
     fn url(self, base: &str) -> String {
         match self {
             Self::LatestStable => format!("{base}/latest"),
-            Self::ReleasesList { per_page } => format!("{base}?per_page={per_page}"),
+            Self::LatestPublished => format!("{base}?per_page=1"),
         }
     }
 
     fn label(self) -> &'static str {
         match self {
             Self::LatestStable => "latest",
-            Self::ReleasesList { .. } => "releases",
+            Self::LatestPublished => "releases",
         }
     }
 }
@@ -1379,9 +1378,7 @@ fn fetch_latest_release<C: GitHubReleasesClient>(
             })
         }
         UpdateChannel::Prerelease => {
-            let endpoint = ReleaseEndpoint::ReleasesList {
-                per_page: PRERELEASE_PAGE_SIZE,
-            };
+            let endpoint = ReleaseEndpoint::LatestPublished;
             let response = client.get(endpoint, &user_agent, cached_etag)?;
 
             latest_from_response(channel, response, cache, now_unix_seconds, |body| {
@@ -1393,8 +1390,8 @@ fn fetch_latest_release<C: GitHubReleasesClient>(
 
                 releases
                     .into_iter()
-                    .filter_map(|release| release_info_from_api_release(release, channel))
-                    .max_by(|left, right| left.version.cmp(&right.version))
+                    .next()
+                    .and_then(|release| release_info_from_api_release(release, channel))
                     .ok_or(UpdatesError::NoMatchingRelease { channel })
             })
         }
@@ -1510,7 +1507,7 @@ mod tests {
         UpdateChannel, UpdateCheckCache, UpdateNotificationDecision, UpdateNotificationPolicyInput,
         UpdateNotificationReason, UpdateNotificationSkipReason, UpdateSettings, UpdatesCommand,
         UpdatesDeferredFailure, UpdatesError, UpdatesRunContext, UreqGitHubReleasesClient,
-        MAX_GITHUB_RESPONSE_BYTES, PRERELEASE_PAGE_SIZE,
+        MAX_GITHUB_RESPONSE_BYTES,
     };
     use crate::session_notifications::{
         UpdateNotificationError, UpdateNotificationHandoff, UpdateNotificationOutcome,
@@ -1725,18 +1722,14 @@ mod tests {
     fn channel_response(channel: UpdateChannel) -> String {
         match channel {
             UpdateChannel::Stable => stable_release("v1.1.1"),
-            UpdateChannel::Prerelease => format!(
-                "[{},{}]",
-                stable_release("v1.1.1"),
-                prerelease("v1.2.0-beta.1")
-            ),
+            UpdateChannel::Prerelease => format!("[{}]", prerelease("v1.2.0-beta.1")),
         }
     }
 
     fn channel_endpoint(channel: UpdateChannel) -> &'static str {
         match channel {
             UpdateChannel::Stable => "https://api.example.test/releases/latest",
-            UpdateChannel::Prerelease => "https://api.example.test/releases?per_page=20",
+            UpdateChannel::Prerelease => "https://api.example.test/releases?per_page=1",
         }
     }
 
@@ -2223,7 +2216,7 @@ mod tests {
             let length = stream.read(&mut buffer).expect("read request");
             let request = String::from_utf8_lossy(&buffer[..length]);
 
-            assert!(request.starts_with("GET /releases?per_page=20 "));
+            assert!(request.starts_with("GET /releases?per_page=1 "));
             assert!(request.contains("If-None-Match: \"cached-etag\""));
 
             stream
@@ -2242,9 +2235,7 @@ mod tests {
 
         let response = client
             .get(
-                ReleaseEndpoint::ReleasesList {
-                    per_page: PRERELEASE_PAGE_SIZE,
-                },
+                ReleaseEndpoint::LatestPublished,
                 "lg-buddy/1.1.0-alpha.0",
                 Some("\"cached-etag\""),
             )
@@ -2467,7 +2458,7 @@ mod tests {
         assert_eq!(
             client.requests_with_etags(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.2.0-beta.1".to_string(),
                 Some("\"prerelease-etag\"".to_string())
             )]
@@ -2660,11 +2651,8 @@ mod tests {
 
     #[test]
     fn background_update_check_uses_configured_prerelease_channel() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            stable_release("v1.1.0"),
-            prerelease("v1.2.0-beta.1")
-        ))]);
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.2.0-beta.1")))]);
         let notifier = RecordingNotifier::default();
         let cache_store = MemoryUpdateCacheStore::default();
         let update_settings = StaticUpdateSettings::enabled(UpdateChannel::Prerelease);
@@ -2689,7 +2677,7 @@ mod tests {
         assert_eq!(
             client.requests(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.1.0".to_string()
             )]
         );
@@ -3042,11 +3030,8 @@ mod tests {
 
     #[test]
     fn manual_update_check_uses_saved_prerelease_channel_when_auto_check_is_disabled() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            stable_release("v1.1.0"),
-            prerelease("v1.2.0-beta.1")
-        ))]);
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.2.0-beta.1")))]);
         let notifier = RecordingNotifier::default();
         let cache_store = MemoryUpdateCacheStore::default();
         let update_settings = StaticUpdateSettings::disabled(UpdateChannel::Prerelease);
@@ -3070,7 +3055,7 @@ mod tests {
         assert_eq!(
             client.requests(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.1.0".to_string()
             )]
         );
@@ -3078,11 +3063,8 @@ mod tests {
 
     #[test]
     fn install_discovery_uses_saved_channel_and_ignores_automatic_check_gate() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            stable_release("v1.1.0"),
-            prerelease("v1.2.0-beta.1")
-        ))]);
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.2.0-beta.1")))]);
         let update_settings = StaticUpdateSettings::disabled(UpdateChannel::Prerelease);
 
         let release = discover_install_candidate_with(
@@ -3097,7 +3079,7 @@ mod tests {
         assert_eq!(
             client.requests(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.1.0".to_string()
             )]
         );
@@ -3592,14 +3574,9 @@ mod tests {
     }
 
     #[test]
-    fn prerelease_channel_includes_stable_releases_and_picks_highest_semver() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{},{},{}]",
-            draft_prerelease("v1.3.0-beta.1"),
-            stable_release("v1.2.0"),
-            prerelease("release-0.6"),
-            prerelease("v1.2.0-beta.2")
-        ))]);
+    fn prerelease_channel_accepts_the_newest_published_stable_release() {
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", stable_release("v1.2.0")))]);
 
         let result = check_updates(
             UpdateChannel::Prerelease,
@@ -3616,15 +3593,9 @@ mod tests {
     }
 
     #[test]
-    fn prerelease_channel_uses_semver_ordering_across_release_stages() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{},{},{},{}]",
-            stable_release("v1.2.0"),
-            prerelease("v1.2.0-rc.1"),
-            prerelease("v1.3.0-alpha.1"),
-            prerelease("v1.2.0-beta.1"),
-            prerelease("v1.2.0-alpha.1")
-        ))]);
+    fn prerelease_channel_accepts_the_newest_published_prerelease() {
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.3.0-alpha.1")))]);
 
         let result = check_updates(
             UpdateChannel::Prerelease,
@@ -3726,25 +3697,27 @@ mod tests {
 
     #[test]
     fn missing_release_candidate_for_prerelease_channel_is_reported() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            prerelease("release-0.6"),
-            draft_prerelease("v1.2.0-beta.1")
-        ))]);
+        for response in [
+            "[]".to_string(),
+            format!("[{}]", prerelease("release-0.6")),
+            format!("[{}]", draft_prerelease("v1.2.0-beta.1")),
+        ] {
+            let client = MockGitHubReleasesClient::new(vec![Ok(response)]);
 
-        let err = check_updates(
-            UpdateChannel::Prerelease,
-            version_info("1.1.0-beta.1", ReleaseChannel::Prerelease),
-            &client,
-        )
-        .expect_err("missing prerelease candidate should fail update check");
+            let err = check_updates(
+                UpdateChannel::Prerelease,
+                version_info("1.1.0-beta.1", ReleaseChannel::Prerelease),
+                &client,
+            )
+            .expect_err("missing prerelease candidate should fail update check");
 
-        assert!(matches!(
-            err,
-            UpdatesError::NoMatchingRelease {
-                channel: UpdateChannel::Prerelease
-            }
-        ));
+            assert!(matches!(
+                err,
+                UpdatesError::NoMatchingRelease {
+                    channel: UpdateChannel::Prerelease
+                }
+            ));
+        }
     }
 
     #[test]

--- a/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
+++ b/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
@@ -24,19 +24,5 @@
         "browser_download_url": "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/sha256sums.txt"
       }
     ]
-  },
-  {
-    "tag_name": "v1.4.0-beta.1",
-    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.4.0-beta.1",
-    "draft": false,
-    "prerelease": true,
-    "assets": []
-  },
-  {
-    "tag_name": "v1.3.0",
-    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.3.0",
-    "draft": false,
-    "prerelease": false,
-    "assets": []
   }
 ]

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -38,6 +38,11 @@ Required promotion checks prove that:
 - a stable promotion has a successful production upgrade canary on the exact
   prerelease commit
 
+Requiring every candidate to advance both release-channel heads keeps release
+publication globally monotonic. The newest published release is therefore also
+the highest semantic version and prerelease-channel clients do not scan release
+history to determine ordering.
+
 The tag, binary, archive, and GitHub release all use the Cargo package version.
 There is no separate version input.
 
@@ -55,9 +60,10 @@ There is no separate version input.
    verifies its complete asset set, and publishes it. Repository release
    immutability then locks the tag and assets.
 7. A published prerelease then runs `v1.4.0-beta.2` through the real production
-   `lg-buddy updates install` path. The canary records sanitized GitHub response
-   evidence for the deterministic mock. Stable promotion remains blocked until
-   this exact prerelease commit has a successful canary.
+   `lg-buddy updates install` path. The newly installed candidate performs a
+   cold-cache production update check, and the canary records sanitized GitHub
+   response evidence for the deterministic mock. Stable promotion remains
+   blocked until this exact prerelease commit has a successful canary.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -355,11 +355,13 @@ candidate-owned file replacement, service action order, and final identity.
 
 After a prerelease is public, `production-prerelease-canary` installs the same
 baseline and drives its real `updates install` command through a PTY against
-GitHub. The canary records a sanitized release list, release-by-tag response,
-tag ref, and asset redirects as a workflow artifact. Signed redirect queries
-and URL userinfo are never retained. The observed beta.2 release-list fields
-also live in `crates/lg-buddy/testdata/github/` and are replayed by the normal
-offline Rust suite. A successful canary on the exact prerelease commit is a
+GitHub. It then clears the update cache and proves that the newly installed
+candidate sees itself as GitHub's newest published release. The canary records
+that sanitized newest-release response, the release-by-tag response, tag ref,
+and asset redirects as a workflow artifact. Signed redirect queries and URL
+userinfo are never retained. The observed beta.2 newest-release fields also
+live in `crates/lg-buddy/testdata/github/` and are replayed by the normal offline
+Rust suite. A successful canary on the exact prerelease commit is a
 stable-promotion prerequisite.
 
 ## Current Practical Gaps

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -236,8 +236,9 @@ lg-buddy updates install
 
 The saved `updates.channel` setting controls every check, regardless of the
 installed binary's own release channel. `stable` checks stable releases only;
-`prerelease` considers both stable and prerelease releases and selects the
-highest semantic version.
+`prerelease` accepts GitHub's newest published stable or prerelease. Release
+promotion requires every version to advance both release-channel heads, so the
+newest published release is also the highest semantic version.
 
 `updates install` is an assisted, foreground upgrade. It checks whether the
 current host and installation are safely upgradeable before discovery, shows

--- a/scripts/record_github_release_responses.py
+++ b/scripts/record_github_release_responses.py
@@ -103,7 +103,9 @@ class GitHubRecorder:
         except urllib.error.HTTPError as error:
             response = error
         body = response.read()
-        response_headers = {key.lower(): value for key, value in response.headers.items()}
+        response_headers = {
+            key.lower(): value for key, value in response.headers.items()
+        }
         parsed: Any = None
         if body:
             content_type = response_headers.get("content-type", "")
@@ -151,8 +153,15 @@ def record_responses(
     )
     encoded_tag = urllib.parse.quote(tag, safe="")
     releases, releases_response = recorder.api_json(
-        f"repos/{encoded_repository}/releases?per_page=20"
+        f"repos/{encoded_repository}/releases?per_page=1"
     )
+    latest_release = (
+        releases[0] if isinstance(releases, list) and len(releases) == 1 else None
+    )
+    if not isinstance(latest_release, dict) or latest_release.get("tag_name") != tag:
+        raise RuntimeError(
+            f"newly published release {tag} is not GitHub's newest release"
+        )
     release, release_response = recorder.api_json(
         f"repos/{encoded_repository}/releases/tags/{encoded_tag}"
     )
@@ -166,7 +175,9 @@ def record_responses(
         "sha256sums.txt",
     }
     selected_assets = [
-        asset for asset in release.get("assets", []) if asset.get("name") in expected_assets
+        asset
+        for asset in release.get("assets", [])
+        if asset.get("name") in expected_assets
     ]
     if {asset.get("name") for asset in selected_assets} != expected_assets:
         raise RuntimeError(f"release {tag} does not expose the expected upgrade assets")

--- a/scripts/test-production-upgrade-canary.sh
+++ b/scripts/test-production-upgrade-canary.sh
@@ -209,4 +209,18 @@ cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Production upgrade change
 [ -e "$VENV_MARKER" ] || fail "Production native upgrade recreated the Python environment."
 "$INSTALLED_BINARY" settings get updates.channel | grep -q '^prerelease$'
 
+CANDIDATE_CHECK_OUTPUT="$WORK_DIR/candidate-update-check.output"
+UPDATE_CACHE_FILE="$XDG_CACHE_HOME/lg-buddy/update-check.json"
+rm -f "$UPDATE_CACHE_FILE"
+"$INSTALLED_BINARY" updates check >"$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "status: up to date" "$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "current: $EXPECTED_VERSION ($EXPECTED_CHANNEL)" "$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "latest: $EXPECTED_VERSION ($EXPECTED_CHANNEL)" "$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "url: https://github.com/Staphylococcus/LG_Buddy/releases/tag/$EXPECTED_TAG" "$CANDIDATE_CHECK_OUTPUT"
+{
+    echo
+    echo "Published candidate update check:"
+    cat "$CANDIDATE_CHECK_OUTPUT"
+} >>"$CANARY_OUTPUT"
+
 echo "Production GitHub upgrade canary passed: $PREVIOUS_VERSION -> $EXPECTED_VERSION"

--- a/scripts/test_record_github_release_responses.py
+++ b/scripts/test_record_github_release_responses.py
@@ -9,6 +9,7 @@ from record_github_release_responses import (
     GitHubRecorder,
     project_git_object,
     project_release,
+    record_responses,
     sanitize_location,
 )
 
@@ -30,6 +31,57 @@ class RecordingOpener:
         self.request = request
         self.timeout = timeout
         return StubResponse()
+
+
+class FixtureRecorder:
+    def __init__(self, latest_tag: str = "v1.4.0-beta.2") -> None:
+        self.latest_tag = latest_tag
+        self.paths: list[str] = []
+        self.release = {
+            "tag_name": "v1.4.0-beta.2",
+            "html_url": "https://github.test/releases/tag/v1.4.0-beta.2",
+            "draft": False,
+            "prerelease": True,
+            "assets": [
+                {
+                    "id": 1,
+                    "name": "lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz",
+                    "state": "uploaded",
+                    "size": 100,
+                    "digest": "sha256:archive",
+                    "url": "https://api.github.test/assets/1",
+                    "browser_download_url": "https://github.test/assets/1",
+                },
+                {
+                    "id": 2,
+                    "name": "sha256sums.txt",
+                    "state": "uploaded",
+                    "size": 10,
+                    "digest": "sha256:checksums",
+                    "url": "https://api.github.test/assets/2",
+                    "browser_download_url": "https://github.test/assets/2",
+                },
+            ],
+        }
+
+    def api_json(self, path: str):  # type: ignore[no-untyped-def]
+        self.paths.append(path)
+        if path.endswith("releases?per_page=1"):
+            return [{**self.release, "tag_name": self.latest_tag}], {"status": 200}
+        if "/releases/tags/" in path:
+            return self.release, {"status": 200}
+        if "/git/ref/tags/" in path:
+            return {
+                "object": {
+                    "type": "commit",
+                    "sha": "a" * 40,
+                }
+            }, {"status": 200}
+        raise AssertionError(f"unexpected API path: {path}")
+
+    @staticmethod
+    def asset_redirect(asset):  # type: ignore[no-untyped-def]
+        return {"asset": asset, "response": {"status": 302}}
 
 
 class ResponseRecordingTests(unittest.TestCase):
@@ -116,6 +168,47 @@ class ResponseRecordingTests(unittest.TestCase):
                     "sha": "77c8f46c66b9e385f3d90c15dee33d775639bbeb",
                 }
             },
+        )
+
+    def test_recorder_captures_only_githubs_newest_release(self) -> None:
+        recorder = FixtureRecorder()
+
+        recorded = record_responses(
+            recorder=recorder,
+            repository="Staphylococcus/LG_Buddy",
+            tag="v1.4.0-beta.2",
+            target="x86_64-unknown-linux-musl",
+        )
+
+        self.assertEqual(
+            recorder.paths[0],
+            "repos/Staphylococcus/LG_Buddy/releases?per_page=1",
+        )
+        self.assertEqual(len(recorded["release_list"]["body"]), 1)
+        self.assertEqual(
+            recorded["release_list"]["body"][0]["tag_name"],
+            "v1.4.0-beta.2",
+        )
+
+    def test_recorder_refuses_when_candidate_is_not_githubs_newest_release(
+        self,
+    ) -> None:
+        recorder = FixtureRecorder(latest_tag="v1.4.0-beta.1")
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "newly published release v1.4.0-beta.2 is not GitHub's newest release",
+        ):
+            record_responses(
+                recorder=recorder,
+                repository="Staphylococcus/LG_Buddy",
+                tag="v1.4.0-beta.2",
+                target="x86_64-unknown-linux-musl",
+            )
+
+        self.assertEqual(
+            recorder.paths,
+            ["repos/Staphylococcus/LG_Buddy/releases?per_page=1"],
         )
 
 


### PR DESCRIPTION
## Summary

- make prerelease-channel discovery consume GitHub’s single newest published release instead of scanning release history for maximum SemVer
- rely on the existing strictly monotonic release-promotion contract and document that authority
- align the observed beta.2 fixture and response recorder with the one-release request, refusing canary evidence when the candidate is not newest
- make the production canary clear its cache and exercise the newly installed candidate’s own update discovery

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo test -p lg-buddy --lib` — 732 passed, 1 ignored manual hardware test
- `python3 scripts/test_record_github_release_responses.py` — 6 passed
- `python3 scripts/test_release_promotion.py` — 20 passed
- Ruff lint and format checks
- ShellCheck and Bash syntax
- live sanitized beta.2 response recording through `/releases?per_page=1`
- `git diff --check`

Related to #91.