### PR TITLE
Prepare v1.4.0-beta.3 upgrade canary release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.4.0-beta.2"
+version = "1.4.0-beta.3"
 dependencies = [
  "base64",
  "cucumber",

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.4.0-beta.2"
+version = "1.4.0-beta.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- advance the LG Buddy crate and lockfile version to `1.4.0-beta.3`
- prepare the prerelease that will exercise the complete beta.2 → beta.3 production upgrade canary and immutable draft-first publication path

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings`
- `cargo test -p lg-buddy --lib` — 732 passed, 1 ignored manual hardware test
- `python3 scripts/test_release_promotion.py` — 20 passed
- `python3 scripts/test_release_bundle_manifest.py` — 17 passed
- injected release identity reports version `1.4.0-beta.3`, channel `prerelease`, and the expected commit
- `git diff --check`

After this merges into `dev`, release publication requires the separate reviewed `dev` → `prerelease` promotion PR. Related to #91 and #99.