### PR TITLE
Promote v1.4.0-beta.3 prerelease

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
 
 permissions:
+  checks: read
   contents: read
 
 jobs:
@@ -38,7 +39,7 @@ jobs:
         run: cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
 
       - name: Validate shell scripts
-        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
+        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py
@@ -46,9 +47,33 @@ jobs:
       - name: Validate release bundle manifest contract
         run: python3 scripts/test_release_bundle_manifest.py
 
+      - name: Validate GitHub response recorder
+        run: python3 scripts/test_record_github_release_responses.py
+
+      - name: Require successful production prerelease canary for stable promotion
+        if: github.event_name == 'pull_request' && github.base_ref == 'main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prerelease_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/prerelease" --jq .object.sha)"
+          [ "$prerelease_sha" != "${{ github.event.pull_request.base.sha }}" ] || {
+              echo "Stable promotion requires a distinct prerelease candidate."
+              exit 1
+          }
+          matching_checks="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$prerelease_sha/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "production-prerelease-canary" and .status == "completed" and .conclusion == "success" and .app.slug == "github-actions")] | length')"
+          [ "$matching_checks" -gt 0 ] || {
+              echo "No successful production-prerelease canary exists for $prerelease_sha."
+              exit 1
+          }
+
   bundle-smoke-test:
     runs-on: ubuntu-latest
     needs: verify
+    env:
+      SMOKE_VERSION: 1.4.0-beta.2.ci
 
     steps:
       - name: Check out repository
@@ -65,29 +90,53 @@ jobs:
           python-version: "3.x"
 
       - name: Install smoke-test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y musl-tools zenity
+        run: sudo apt-get update && sudo apt-get install -y musl-tools strace zenity
 
       - name: Build lg-buddy release binary
         env:
           LG_BUDDY_BUILD_COMMIT: ${{ github.sha }}
-          LG_BUDDY_RELEASE_VERSION: 0.0.0-ci.smoke
+          LG_BUDDY_RELEASE_VERSION: ${{ env.SMOKE_VERSION }}
         run: cargo build --release -p lg-buddy --target x86_64-unknown-linux-musl
 
       - name: Create release bundle
         run: |
           umask 0002
-          ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version 0.0.0-ci.smoke --output-dir dist
+          ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --version "$SMOKE_VERSION" --output-dir dist
 
       - name: Smoke test release bundle
         run: |
           ./scripts/test-release-bundle.sh \
               --skip-pip-install \
-              --archive dist/lg-buddy-0.0.0-ci.smoke-x86_64-unknown-linux-musl.tar.gz \
-              --expected-tag v0.0.0-ci.smoke \
-              --expected-version 0.0.0-ci.smoke \
+              --archive "dist/lg-buddy-${SMOKE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+              --expected-tag "v${SMOKE_VERSION}" \
+              --expected-version "$SMOKE_VERSION" \
               --expected-channel prerelease \
               --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ github.sha }}"
+
+      - name: Download pinned cross-version baseline
+        run: |
+          curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --output "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Smoke test cross-version upgrade
+        run: |
+          ./scripts/test-cross-version-upgrade.sh \
+              --previous-archive "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              --previous-sha256 883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32 \
+              --previous-tag v1.4.0-beta.2 \
+              --previous-version 1.4.0-beta.2 \
+              --previous-channel prerelease \
+              --previous-target x86_64-unknown-linux-musl \
+              --previous-commit 77c8f46c66b9e385f3d90c15dee33d775639bbeb \
+              --candidate-archive "dist/lg-buddy-${SMOKE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+              --candidate-tag "v${SMOKE_VERSION}" \
+              --candidate-version "$SMOKE_VERSION" \
+              --candidate-channel prerelease \
+              --candidate-target x86_64-unknown-linux-musl \
+              --candidate-commit "${{ github.sha }}"
 
       - name: Generate checksums
         run: |
@@ -102,4 +151,4 @@ jobs:
       - name: Dry-run publish release assets
         env:
           GH_RELEASE_DRY_RUN: "1"
-        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag v0.0.0-ci.smoke --commit "${{ github.sha }}"
+        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag "v${SMOKE_VERSION}" --commit "${{ github.sha }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py
 
+      - name: Validate release publication contract
+        run: python3 scripts/test_publish_release_assets.py
+
       - name: Validate release bundle manifest contract
         run: python3 scripts/test_release_bundle_manifest.py
 

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -12,6 +12,7 @@ on:
       - ready_for_review
 
 permissions:
+  checks: read
   contents: read
   pull-requests: read
 
@@ -95,3 +96,23 @@ jobs:
               [ "$CHANNEL" = "stable" ] || expected_prerelease="true"
               [ "$(printf '%s' "$release_state" | jq -r .isPrerelease)" = "$expected_prerelease" ]
           fi
+
+      - name: Require production prerelease upgrade canary
+        if: github.event.pull_request.base.ref == 'main'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAIN_SHA: ${{ steps.contract.outputs.main_sha }}
+          PRERELEASE_SHA: ${{ steps.contract.outputs.prerelease_sha }}
+        run: |
+          [ "$PRERELEASE_SHA" != "$MAIN_SHA" ] || {
+              echo "Stable promotion requires a distinct prerelease candidate."
+              exit 1
+          }
+          matching_checks="$(gh api \
+              -H 'Accept: application/vnd.github+json' \
+              "repos/$GITHUB_REPOSITORY/commits/$PRERELEASE_SHA/check-runs?per_page=100" \
+              --jq '[.check_runs[] | select(.name == "production-prerelease-canary" and .status == "completed" and .conclusion == "success" and .app.slug == "github-actions")] | length')"
+          [ "$matching_checks" -gt 0 ] || {
+              echo "No successful production-prerelease canary exists for $PRERELEASE_SHA."
+              exit 1
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install release prerequisites
-        run: sudo apt-get update && sudo apt-get install -y musl-tools zenity
+        run: sudo apt-get update && sudo apt-get install -y musl-tools strace zenity
 
       - name: Build lg-buddy
         env:
@@ -106,6 +106,30 @@ jobs:
               --expected-channel "${{ needs.validate.outputs.channel }}" \
               --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Download pinned cross-version baseline
+        run: |
+          curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --output "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Smoke test cross-version upgrade
+        run: |
+          ./scripts/test-cross-version-upgrade.sh \
+              --previous-archive "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              --previous-sha256 883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32 \
+              --previous-tag v1.4.0-beta.2 \
+              --previous-version 1.4.0-beta.2 \
+              --previous-channel prerelease \
+              --previous-target x86_64-unknown-linux-musl \
+              --previous-commit 77c8f46c66b9e385f3d90c15dee33d775639bbeb \
+              --candidate-archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
+              --candidate-tag "${{ needs.validate.outputs.tag }}" \
+              --candidate-version "${{ needs.validate.outputs.version }}" \
+              --candidate-channel "${{ needs.validate.outputs.channel }}" \
+              --candidate-target x86_64-unknown-linux-musl \
+              --candidate-commit "${{ needs.validate.outputs.head_sha }}"
 
       - name: Generate checksums
         run: |
@@ -239,3 +263,71 @@ jobs:
           verify_dir="$(mktemp -d)"
           gh release download "$RELEASE_TAG" --dir "$verify_dir"
           (cd "$verify_dir" && sha256sum -c sha256sums.txt)
+
+  production-prerelease-canary:
+    name: production-prerelease-canary
+    if: needs.validate.outputs.publish == 'true' && needs.validate.outputs.channel == 'prerelease'
+    runs-on: ubuntu-latest
+    needs:
+      - validate
+      - publish
+
+    steps:
+      - name: Check out published prerelease
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.head_sha }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Install canary prerequisites
+        run: sudo apt-get update && sudo apt-get install -y python3-venv util-linux zenity
+
+      - name: Download pinned updater-capable baseline
+        run: |
+          curl --fail --silent --show-error --location \
+              --proto '=https' --tlsv1.2 \
+              --output "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz
+
+      - name: Exercise production GitHub upgrade path
+        run: |
+          ./scripts/test-production-upgrade-canary.sh \
+              --work-dir "$RUNNER_TEMP/production-canary" \
+              --previous-archive "$RUNNER_TEMP/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz" \
+              --previous-sha256 883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32 \
+              --previous-tag v1.4.0-beta.2 \
+              --previous-version 1.4.0-beta.2 \
+              --previous-channel prerelease \
+              --previous-target x86_64-unknown-linux-musl \
+              --previous-commit 77c8f46c66b9e385f3d90c15dee33d775639bbeb \
+              --expected-tag "${{ needs.validate.outputs.tag }}" \
+              --expected-version "${{ needs.validate.outputs.version }}" \
+              --expected-channel prerelease \
+              --expected-target x86_64-unknown-linux-musl \
+              --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Record sanitized production GitHub responses
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/record_github_release_responses.py \
+              --repository "$GITHUB_REPOSITORY" \
+              --tag "${{ needs.validate.outputs.tag }}" \
+              --output "$RUNNER_TEMP/production-canary/github-responses.json"
+
+      - name: Upload canary evidence for the offline mock
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: production-upgrade-canary-${{ needs.validate.outputs.tag }}
+          path: |
+            ${{ runner.temp }}/production-canary/production-upgrade-canary.output
+            ${{ runner.temp }}/production-canary/github-responses.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.4.0-beta.2"
+version = "1.4.0-beta.3"
 dependencies = [
  "base64",
  "cucumber",

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ and then runs the verified bundle's upgrade installer. Upgrade mode preserves
 configuration and credentials and does not repeat setup or pairing;
 incompatible and legacy layouts are refused rather than migrated.
 
+`v1.4.0-beta.2` is the first release with `updates install`; older versions
+need one normal manual release-bundle installation before assisted upgrades are
+available.
+
 The shell installer targets conventional Linux installations with mutable
 system locations. First-class NixOS packaging is tracked in
 [issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.4.0-beta.2"
+version = "1.4.0-beta.3"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -2324,6 +2324,44 @@ mod tests {
     }
 
     #[test]
+    fn observed_beta_2_response_is_replayed_as_the_upgrade_baseline() {
+        // Reduced to the fields consumed by GitHubRelease from the production
+        // response recorded in https://github.com/Staphylococcus/LG_Buddy/issues/99.
+        let body = include_str!("../testdata/github/releases-v1.4.0-beta.2.json");
+        let client = MockGitHubReleasesClient::new(vec![Ok(body.to_string())]);
+        let release = discover_install_candidate_with(
+            version_info("1.4.0-beta.1", ReleaseChannel::Prerelease),
+            &client,
+            &StaticUpdateSettings::enabled(UpdateChannel::Prerelease),
+        )
+        .expect("observed prerelease response should select beta.2");
+
+        assert_eq!(release.version(), &Version::parse("1.4.0-beta.2").unwrap());
+        assert_eq!(release.channel(), UpdateChannel::Prerelease);
+        assert_eq!(release.tag_name(), "v1.4.0-beta.2");
+        assert_eq!(release.assets().len(), 2);
+        let archive = &release.assets()[0];
+        assert_eq!(archive.id(), 539980839);
+        assert_eq!(archive.size(), 3_051_471);
+        assert_eq!(
+            archive.digest(),
+            Some("sha256:883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32")
+        );
+        assert_eq!(
+            archive.api_url(),
+            "https://api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/539980839"
+        );
+        assert_eq!(
+            archive.download_url(),
+            "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz"
+        );
+        let checksums = &release.assets()[1];
+        assert_eq!(checksums.id(), 539980872);
+        assert_eq!(checksums.name(), "sha256sums.txt");
+        assert_eq!(checksums.size(), 123);
+    }
+
+    #[test]
     fn ureq_client_rejects_oversized_release_metadata() {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind local test server");
         let address = listener.local_addr().expect("read local test address");

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -24,7 +24,6 @@ const GITHUB_CONNECT_TIMEOUT_SECONDS: u64 = 5;
 const GITHUB_REQUEST_TIMEOUT_SECONDS: u64 = 20;
 const MAX_GITHUB_RESPONSE_BYTES: u64 = 2 * 1024 * 1024;
 const MAX_GITHUB_ERROR_BYTES: u64 = 16 * 1024;
-const PRERELEASE_PAGE_SIZE: u8 = 20;
 const CACHE_DIR_NAME: &str = "lg-buddy";
 const UPDATE_CHECK_CACHE_FILE_NAME: &str = "update-check.json";
 
@@ -903,21 +902,21 @@ enum GitHubReleaseResponse {
 #[derive(Debug, Clone, Copy)]
 enum ReleaseEndpoint {
     LatestStable,
-    ReleasesList { per_page: u8 },
+    LatestPublished,
 }
 
 impl ReleaseEndpoint {
     fn url(self, base: &str) -> String {
         match self {
             Self::LatestStable => format!("{base}/latest"),
-            Self::ReleasesList { per_page } => format!("{base}?per_page={per_page}"),
+            Self::LatestPublished => format!("{base}?per_page=1"),
         }
     }
 
     fn label(self) -> &'static str {
         match self {
             Self::LatestStable => "latest",
-            Self::ReleasesList { .. } => "releases",
+            Self::LatestPublished => "releases",
         }
     }
 }
@@ -1379,9 +1378,7 @@ fn fetch_latest_release<C: GitHubReleasesClient>(
             })
         }
         UpdateChannel::Prerelease => {
-            let endpoint = ReleaseEndpoint::ReleasesList {
-                per_page: PRERELEASE_PAGE_SIZE,
-            };
+            let endpoint = ReleaseEndpoint::LatestPublished;
             let response = client.get(endpoint, &user_agent, cached_etag)?;
 
             latest_from_response(channel, response, cache, now_unix_seconds, |body| {
@@ -1393,8 +1390,8 @@ fn fetch_latest_release<C: GitHubReleasesClient>(
 
                 releases
                     .into_iter()
-                    .filter_map(|release| release_info_from_api_release(release, channel))
-                    .max_by(|left, right| left.version.cmp(&right.version))
+                    .next()
+                    .and_then(|release| release_info_from_api_release(release, channel))
                     .ok_or(UpdatesError::NoMatchingRelease { channel })
             })
         }
@@ -1510,7 +1507,7 @@ mod tests {
         UpdateChannel, UpdateCheckCache, UpdateNotificationDecision, UpdateNotificationPolicyInput,
         UpdateNotificationReason, UpdateNotificationSkipReason, UpdateSettings, UpdatesCommand,
         UpdatesDeferredFailure, UpdatesError, UpdatesRunContext, UreqGitHubReleasesClient,
-        MAX_GITHUB_RESPONSE_BYTES, PRERELEASE_PAGE_SIZE,
+        MAX_GITHUB_RESPONSE_BYTES,
     };
     use crate::session_notifications::{
         UpdateNotificationError, UpdateNotificationHandoff, UpdateNotificationOutcome,
@@ -1725,18 +1722,14 @@ mod tests {
     fn channel_response(channel: UpdateChannel) -> String {
         match channel {
             UpdateChannel::Stable => stable_release("v1.1.1"),
-            UpdateChannel::Prerelease => format!(
-                "[{},{}]",
-                stable_release("v1.1.1"),
-                prerelease("v1.2.0-beta.1")
-            ),
+            UpdateChannel::Prerelease => format!("[{}]", prerelease("v1.2.0-beta.1")),
         }
     }
 
     fn channel_endpoint(channel: UpdateChannel) -> &'static str {
         match channel {
             UpdateChannel::Stable => "https://api.example.test/releases/latest",
-            UpdateChannel::Prerelease => "https://api.example.test/releases?per_page=20",
+            UpdateChannel::Prerelease => "https://api.example.test/releases?per_page=1",
         }
     }
 
@@ -2223,7 +2216,7 @@ mod tests {
             let length = stream.read(&mut buffer).expect("read request");
             let request = String::from_utf8_lossy(&buffer[..length]);
 
-            assert!(request.starts_with("GET /releases?per_page=20 "));
+            assert!(request.starts_with("GET /releases?per_page=1 "));
             assert!(request.contains("If-None-Match: \"cached-etag\""));
 
             stream
@@ -2242,9 +2235,7 @@ mod tests {
 
         let response = client
             .get(
-                ReleaseEndpoint::ReleasesList {
-                    per_page: PRERELEASE_PAGE_SIZE,
-                },
+                ReleaseEndpoint::LatestPublished,
                 "lg-buddy/1.1.0-alpha.0",
                 Some("\"cached-etag\""),
             )
@@ -2467,7 +2458,7 @@ mod tests {
         assert_eq!(
             client.requests_with_etags(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.2.0-beta.1".to_string(),
                 Some("\"prerelease-etag\"".to_string())
             )]
@@ -2660,11 +2651,8 @@ mod tests {
 
     #[test]
     fn background_update_check_uses_configured_prerelease_channel() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            stable_release("v1.1.0"),
-            prerelease("v1.2.0-beta.1")
-        ))]);
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.2.0-beta.1")))]);
         let notifier = RecordingNotifier::default();
         let cache_store = MemoryUpdateCacheStore::default();
         let update_settings = StaticUpdateSettings::enabled(UpdateChannel::Prerelease);
@@ -2689,7 +2677,7 @@ mod tests {
         assert_eq!(
             client.requests(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.1.0".to_string()
             )]
         );
@@ -3042,11 +3030,8 @@ mod tests {
 
     #[test]
     fn manual_update_check_uses_saved_prerelease_channel_when_auto_check_is_disabled() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            stable_release("v1.1.0"),
-            prerelease("v1.2.0-beta.1")
-        ))]);
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.2.0-beta.1")))]);
         let notifier = RecordingNotifier::default();
         let cache_store = MemoryUpdateCacheStore::default();
         let update_settings = StaticUpdateSettings::disabled(UpdateChannel::Prerelease);
@@ -3070,7 +3055,7 @@ mod tests {
         assert_eq!(
             client.requests(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.1.0".to_string()
             )]
         );
@@ -3078,11 +3063,8 @@ mod tests {
 
     #[test]
     fn install_discovery_uses_saved_channel_and_ignores_automatic_check_gate() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            stable_release("v1.1.0"),
-            prerelease("v1.2.0-beta.1")
-        ))]);
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.2.0-beta.1")))]);
         let update_settings = StaticUpdateSettings::disabled(UpdateChannel::Prerelease);
 
         let release = discover_install_candidate_with(
@@ -3097,7 +3079,7 @@ mod tests {
         assert_eq!(
             client.requests(),
             vec![(
-                "https://api.example.test/releases?per_page=20".to_string(),
+                "https://api.example.test/releases?per_page=1".to_string(),
                 "lg-buddy/1.1.0".to_string()
             )]
         );
@@ -3592,14 +3574,9 @@ mod tests {
     }
 
     #[test]
-    fn prerelease_channel_includes_stable_releases_and_picks_highest_semver() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{},{},{}]",
-            draft_prerelease("v1.3.0-beta.1"),
-            stable_release("v1.2.0"),
-            prerelease("release-0.6"),
-            prerelease("v1.2.0-beta.2")
-        ))]);
+    fn prerelease_channel_accepts_the_newest_published_stable_release() {
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", stable_release("v1.2.0")))]);
 
         let result = check_updates(
             UpdateChannel::Prerelease,
@@ -3616,15 +3593,9 @@ mod tests {
     }
 
     #[test]
-    fn prerelease_channel_uses_semver_ordering_across_release_stages() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{},{},{},{}]",
-            stable_release("v1.2.0"),
-            prerelease("v1.2.0-rc.1"),
-            prerelease("v1.3.0-alpha.1"),
-            prerelease("v1.2.0-beta.1"),
-            prerelease("v1.2.0-alpha.1")
-        ))]);
+    fn prerelease_channel_accepts_the_newest_published_prerelease() {
+        let client =
+            MockGitHubReleasesClient::new(vec![Ok(format!("[{}]", prerelease("v1.3.0-alpha.1")))]);
 
         let result = check_updates(
             UpdateChannel::Prerelease,
@@ -3726,25 +3697,27 @@ mod tests {
 
     #[test]
     fn missing_release_candidate_for_prerelease_channel_is_reported() {
-        let client = MockGitHubReleasesClient::new(vec![Ok(format!(
-            "[{},{}]",
-            prerelease("release-0.6"),
-            draft_prerelease("v1.2.0-beta.1")
-        ))]);
+        for response in [
+            "[]".to_string(),
+            format!("[{}]", prerelease("release-0.6")),
+            format!("[{}]", draft_prerelease("v1.2.0-beta.1")),
+        ] {
+            let client = MockGitHubReleasesClient::new(vec![Ok(response)]);
 
-        let err = check_updates(
-            UpdateChannel::Prerelease,
-            version_info("1.1.0-beta.1", ReleaseChannel::Prerelease),
-            &client,
-        )
-        .expect_err("missing prerelease candidate should fail update check");
+            let err = check_updates(
+                UpdateChannel::Prerelease,
+                version_info("1.1.0-beta.1", ReleaseChannel::Prerelease),
+                &client,
+            )
+            .expect_err("missing prerelease candidate should fail update check");
 
-        assert!(matches!(
-            err,
-            UpdatesError::NoMatchingRelease {
-                channel: UpdateChannel::Prerelease
-            }
-        ));
+            assert!(matches!(
+                err,
+                UpdatesError::NoMatchingRelease {
+                    channel: UpdateChannel::Prerelease
+                }
+            ));
+        }
     }
 
     #[test]

--- a/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
+++ b/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
@@ -1,0 +1,42 @@
+[
+  {
+    "tag_name": "v1.4.0-beta.2",
+    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.4.0-beta.2",
+    "draft": false,
+    "prerelease": true,
+    "assets": [
+      {
+        "id": 539980839,
+        "name": "lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz",
+        "state": "uploaded",
+        "size": 3051471,
+        "digest": "sha256:883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32",
+        "url": "https://api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/539980839",
+        "browser_download_url": "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz"
+      },
+      {
+        "id": 539980872,
+        "name": "sha256sums.txt",
+        "state": "uploaded",
+        "size": 123,
+        "digest": "sha256:581c539163fc8477b464d05c598fdcb19f654c83b124c9986665b1a531093dd1",
+        "url": "https://api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/539980872",
+        "browser_download_url": "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/sha256sums.txt"
+      }
+    ]
+  },
+  {
+    "tag_name": "v1.4.0-beta.1",
+    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.4.0-beta.1",
+    "draft": false,
+    "prerelease": true,
+    "assets": []
+  },
+  {
+    "tag_name": "v1.3.0",
+    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.3.0",
+    "draft": false,
+    "prerelease": false,
+    "assets": []
+  }
+]

--- a/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
+++ b/crates/lg-buddy/testdata/github/releases-v1.4.0-beta.2.json
@@ -24,19 +24,5 @@
         "browser_download_url": "https://github.com/Staphylococcus/LG_Buddy/releases/download/v1.4.0-beta.2/sha256sums.txt"
       }
     ]
-  },
-  {
-    "tag_name": "v1.4.0-beta.1",
-    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.4.0-beta.1",
-    "draft": false,
-    "prerelease": true,
-    "assets": []
-  },
-  {
-    "tag_name": "v1.3.0",
-    "html_url": "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.3.0",
-    "draft": false,
-    "prerelease": false,
-    "assets": []
   }
 ]

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,6 +162,12 @@ Run the focused manifest contract tests with:
 python3 scripts/test_release_bundle_manifest.py
 ```
 
+Run the mock-backed draft publication and retry contract tests with:
+
+```bash
+python3 scripts/test_publish_release_assets.py
+```
+
 Dry-run the GitHub release publish step with:
 
 ```bash

--- a/docs/development.md
+++ b/docs/development.md
@@ -84,8 +84,9 @@ Useful checks during development:
 cargo test -p lg-buddy --lib
 cargo test -p lg-buddy --test cucumber
 cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
-bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/publish-release-assets.sh
+bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 python3 scripts/test_release_promotion.py
+python3 scripts/test_record_github_release_responses.py
 ```
 
 Optional hardware smoke for gamepad activity:
@@ -136,6 +137,25 @@ root and exercises upgrade refusal, preservation, Python repair, owned-file
 replacement, service ordering, installed identity, lifecycle topology, and
 uninstall cleanup without mutating the host installation.
 
+Run the cross-version smoke with explicit previous and candidate archives:
+
+```bash
+./scripts/test-cross-version-upgrade.sh \
+  --previous-archive /path/to/previous.tar.gz \
+  --previous-sha256 <pinned-digest> \
+  --previous-tag <tag> --previous-version <version> \
+  --previous-channel <channel> --previous-target <target> \
+  --previous-commit <sha> \
+  --candidate-archive /path/to/candidate.tar.gz \
+  --candidate-tag <tag> --candidate-version <version> \
+  --candidate-channel <channel> --candidate-target <target> \
+  --candidate-commit <sha>
+```
+
+The production upgrade canary is CI-only because it requires the candidate to
+already be published. It records sanitized GitHub responses as a workflow
+artifact so the observed production shapes can be replayed offline.
+
 Run the focused manifest contract tests with:
 
 ```bash
@@ -181,6 +201,9 @@ the branch contract and recovery process, see
 | `scripts/release_bundle_manifest.py` | Release-bundle identity manifest creator and validator |
 | `scripts/build-release-bundle.sh` | Release bundle builder |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |
+| `scripts/test-cross-version-upgrade.sh` | Pinned previous-to-candidate archive upgrade smoke test |
+| `scripts/test-production-upgrade-canary.sh` | Post-publication production GitHub upgrade canary |
+| `scripts/record_github_release_responses.py` | Sanitized production response recorder for offline mocks |
 | `scripts/publish-release-assets.sh` | GitHub release publish helper |
 | `scripts/release_promotion.py` | Promotion version, branch, and tag validator |
 | `.github/workflows/ci.yml` | CI validation workflow |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -38,6 +38,11 @@ Required promotion checks prove that:
 - a stable promotion has a successful production upgrade canary on the exact
   prerelease commit
 
+Requiring every candidate to advance both release-channel heads keeps release
+publication globally monotonic. The newest published release is therefore also
+the highest semantic version and prerelease-channel clients do not scan release
+history to determine ordering.
+
 The tag, binary, archive, and GitHub release all use the Cargo package version.
 There is no separate version input.
 
@@ -55,9 +60,10 @@ There is no separate version input.
    verifies its complete asset set, and publishes it. Repository release
    immutability then locks the tag and assets.
 7. A published prerelease then runs `v1.4.0-beta.2` through the real production
-   `lg-buddy updates install` path. The canary records sanitized GitHub response
-   evidence for the deterministic mock. Stable promotion remains blocked until
-   this exact prerelease commit has a successful canary.
+   `lg-buddy updates install` path. The newly installed candidate performs a
+   cold-cache production update check, and the canary records sanitized GitHub
+   response evidence for the deterministic mock. Stable promotion remains
+   blocked until this exact prerelease commit has a successful canary.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -51,8 +51,9 @@ There is no separate version input.
    smoke-tests the merged release commit without write credentials, including
    an archive-driven upgrade from the pinned public baseline.
 6. The final job obtains a short-lived token from the dedicated repository-only
-   GitHub App, aligns the remaining release streams, publishes the immutable tag
-   and release, and verifies the published checksums.
+   GitHub App, aligns the remaining release streams, creates or resumes a draft,
+   verifies its complete asset set, and publishes it. Repository release
+   immutability then locks the tag and assets.
 7. A published prerelease then runs `v1.4.0-beta.2` through the real production
    `lg-buddy updates install` path. The canary records sanitized GitHub response
    evidence for the deterministic mock. Stable promotion remains blocked until
@@ -60,8 +61,17 @@ There is no separate version input.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge
-release run can be rerun safely, but an existing tag or asset is accepted only
-when it is byte-for-byte consistent with the merged release commit.
+release run can be rerun safely: an incomplete draft remains private and is
+resumed only when its tag, classification, and existing assets match the merged
+release commit. A published release is accepted only when its expected asset set
+is complete and byte-for-byte identical.
+
+Repository release immutability must remain enabled. GitHub applies it only when
+a draft is published, so the publisher uploads and verifies every expected asset
+before making the release visible. Each stored asset must report the expected
+name, uploaded state, byte size, and server-computed SHA-256 digest. Unexpected
+draft assets block publication; published releases are verification-only and are
+never repaired in place.
 
 ## What the release workflow validates
 
@@ -77,7 +87,8 @@ The workflow:
    preserved user state plus replaced owned integration files.
 7. Generates and verifies `sha256sums.txt`.
 8. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
-9. Publishes the tag and GitHub release without replacing conflicting assets.
+9. Stages the exact release assets privately, then publishes them together under
+   the repository's immutable-release policy.
 10. Downloads the published assets and verifies their checksums independently.
 11. For prereleases, exercises production GitHub discovery, acquisition,
     confirmation, installation, and final identity from the pinned baseline.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -33,7 +33,10 @@ Required promotion checks prove that:
 - the version advances both existing release-channel heads
 - the persistent branches have not moved or diverged before merge
 - the derived `v<crate-version>` tag is absent before merge
-- normal CI and the release-bundle smoke test pass
+- normal CI and the release-bundle smoke test pass; the bundle smoke includes a
+  pinned cross-version upgrade from `v1.4.0-beta.2`
+- a stable promotion has a successful production upgrade canary on the exact
+  prerelease commit
 
 The tag, binary, archive, and GitHub release all use the Cargo package version.
 There is no separate version input.
@@ -45,10 +48,15 @@ There is no separate version input.
 3. Wait for `verify`, `bundle-smoke-test`, and `validate-promotion` to pass.
 4. Merge the promotion PR. This is the release authorization.
 5. The resulting push starts the serialized release workflow, which builds and
-   smoke-tests the merged release commit without write credentials.
+   smoke-tests the merged release commit without write credentials, including
+   an archive-driven upgrade from the pinned public baseline.
 6. The final job obtains a short-lived token from the dedicated repository-only
    GitHub App, aligns the remaining release streams, publishes the immutable tag
    and release, and verifies the published checksums.
+7. A published prerelease then runs `v1.4.0-beta.2` through the real production
+   `lg-buddy updates install` path. The canary records sanitized GitHub response
+   evidence for the deterministic mock. Stable promotion remains blocked until
+   this exact prerelease commit has a successful canary.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge
@@ -65,10 +73,14 @@ The workflow:
 3. Generates a versioned identity manifest and packages the release bundle.
 4. Validates the manifest and installs the bundle in an isolated smoke-test root.
 5. Verifies the built and installed binary's exact version, channel, and commit.
-6. Generates and verifies `sha256sums.txt`.
-7. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
-8. Publishes the tag and GitHub release without replacing conflicting assets.
-9. Downloads the published assets and verifies their checksums independently.
+6. Upgrades a pinned real previous archive to the candidate and verifies
+   preserved user state plus replaced owned integration files.
+7. Generates and verifies `sha256sums.txt`.
+8. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
+9. Publishes the tag and GitHub release without replacing conflicting assets.
+10. Downloads the published assets and verifies their checksums independently.
+11. For prereleases, exercises production GitHub discovery, acquisition,
+    confirmation, installation, and final identity from the pinned baseline.
 
 `install.sh` is only an installer. It does not build the runtime.
 
@@ -120,6 +132,19 @@ integrations and verifies that the installed binary matches the candidate.
 This is intentionally a conservative and evolving refusal boundary. It does
 not migrate legacy layouts, declare broad host support, or guarantee that a
 later privileged operation cannot fail.
+
+## Cross-version upgrade baseline
+
+`v1.4.0-beta.2` is the first public updater-capable release and is the pinned
+previous archive for the initial cross-version contract. Its
+`x86_64-unknown-linux-musl` archive SHA-256 is
+`883e6cb869cbe60988a195acac2e15864d904797edfefbb7d90052eff9a17d32`.
+CI verifies that digest and the full release identity before extracting or
+executing the baseline.
+
+Versions before `v1.4.0-beta.2` do not contain `updates install`. They require
+one normal manual installation of an updater-capable release before assisted
+upgrades become available. Arbitrary historical upgrade support is not implied.
 
 ## Nix source selection
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -345,6 +345,23 @@ The initial and candidate checks are deliberately non-mutating. Orchestration
 tests for their consumers must separately prove that a refusal prevents release
 client, confirmation, sudo, and installer effects.
 
+The cross-version bundle smoke test adds the real release boundary that a
+same-bundle reinstall cannot cover. It verifies the pinned public
+`v1.4.0-beta.2` digest and identity before extraction, installs it into an
+isolated root and home, populates non-default settings and native credentials,
+and upgrades to an explicit candidate archive. It checks initial and candidate
+refusals before network, sudo, or mutation, then verifies preserved user state,
+candidate-owned file replacement, service action order, and final identity.
+
+After a prerelease is public, `production-prerelease-canary` installs the same
+baseline and drives its real `updates install` command through a PTY against
+GitHub. The canary records a sanitized release list, release-by-tag response,
+tag ref, and asset redirects as a workflow artifact. Signed redirect queries
+and URL userinfo are never retained. The observed beta.2 release-list fields
+also live in `crates/lg-buddy/testdata/github/` and are replayed by the normal
+offline Rust suite. A successful canary on the exact prerelease commit is a
+stable-promotion prerequisite.
+
 ## Current Practical Gaps
 
 The most important remaining gaps are:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -355,11 +355,13 @@ candidate-owned file replacement, service action order, and final identity.
 
 After a prerelease is public, `production-prerelease-canary` installs the same
 baseline and drives its real `updates install` command through a PTY against
-GitHub. The canary records a sanitized release list, release-by-tag response,
-tag ref, and asset redirects as a workflow artifact. Signed redirect queries
-and URL userinfo are never retained. The observed beta.2 release-list fields
-also live in `crates/lg-buddy/testdata/github/` and are replayed by the normal
-offline Rust suite. A successful canary on the exact prerelease commit is a
+GitHub. It then clears the update cache and proves that the newly installed
+candidate sees itself as GitHub's newest published release. The canary records
+that sanitized newest-release response, the release-by-tag response, tag ref,
+and asset redirects as a workflow artifact. Signed redirect queries and URL
+userinfo are never retained. The observed beta.2 newest-release fields also
+live in `crates/lg-buddy/testdata/github/` and are replayed by the normal offline
+Rust suite. A successful canary on the exact prerelease commit is a
 stable-promotion prerequisite.
 
 ## Current Practical Gaps

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -236,8 +236,9 @@ lg-buddy updates install
 
 The saved `updates.channel` setting controls every check, regardless of the
 installed binary's own release channel. `stable` checks stable releases only;
-`prerelease` considers both stable and prerelease releases and selects the
-highest semantic version.
+`prerelease` accepts GitHub's newest published stable or prerelease. Release
+promotion requires every version to advance both release-channel heads, so the
+newest published release is also the highest semantic version.
 
 `updates install` is an assisted, foreground upgrade. It checks whether the
 current host and installation are safely upgradeable before discovery, shows

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -247,6 +247,10 @@ bundle, reruns preflight from the candidate, invokes `install.sh --upgrade`,
 and verifies the installed release identity. It does not accept channel or
 version arguments, downgrade, migrate legacy installations, or run unattended.
 
+`v1.4.0-beta.2` is the first release that contains `updates install`. Older
+installations require one normal manual installation of an updater-capable
+release before this assisted path is available.
+
 `--notify` sends a desktop notification through the running user service. When
 supported by the desktop, the notification includes actions to open the release
 or disable future automatic notifications. LG Buddy does not repeatedly notify

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 usage() {
     echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
@@ -121,33 +121,138 @@ if [ "${#RELEASE_FLAGS[@]}" -gt 0 ]; then
     EXPECTED_PRERELEASE="true"
 fi
 
+RELEASE_IS_DRAFT="true"
 if gh release view "$TAG" >/dev/null 2>&1; then
     RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
-        echo "Existing release $TAG is still a draft."
-        exit 1
-    }
+    RELEASE_IS_DRAFT="$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)"
+    case "$RELEASE_IS_DRAFT" in
+        true|false) ;;
+        *)
+            echo "Existing release $TAG returned an invalid draft state."
+            exit 1
+            ;;
+    esac
     [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
         echo "Existing release $TAG has the wrong prerelease classification."
         exit 1
     }
 else
-    gh release create "$TAG" --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
+    gh release create "$TAG" --draft --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
 fi
 
+EXPECTED_ASSETS=("${ARCHIVES[@]}" "$CHECKSUM_FILE")
+EXPECTED_ASSET_NAMES=()
 
-for asset in "${ARCHIVES[@]}" "$CHECKSUM_FILE"; do
+asset_name_is_expected() {
+    local candidate="$1"
+    local expected=""
+
+    for expected in "${EXPECTED_ASSET_NAMES[@]}"; do
+        [ "$candidate" != "$expected" ] || return 0
+    done
+    return 1
+}
+
+for asset in "${EXPECTED_ASSETS[@]}"; do
     asset_name="$(basename "$asset")"
-    if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -F -x -q "$asset_name"; then
-        compare_dir="$(mktemp -d)"
-        gh release download "$TAG" --pattern "$asset_name" --dir "$compare_dir"
-        if ! cmp -s "$asset" "$compare_dir/$asset_name"; then
-            echo "Existing release asset differs from the candidate: $asset_name"
-            rm -rf "$compare_dir"
+    ! asset_name_is_expected "$asset_name" || {
+        echo "Release assets must have unique file names: $asset_name"
+        exit 1
+    }
+    EXPECTED_ASSET_NAMES+=("$asset_name")
+done
+
+RELEASE_ASSET_NAMES="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+while IFS= read -r asset_name; do
+    [ -z "$asset_name" ] || asset_name_is_expected "$asset_name" || {
+        echo "Release $TAG contains unexpected asset: $asset_name"
+        exit 1
+    }
+done <<< "$RELEASE_ASSET_NAMES"
+
+for asset in "${EXPECTED_ASSETS[@]}"; do
+    asset_name="$(basename "$asset")"
+    if ! grep -F -x -q -- "$asset_name" <<< "$RELEASE_ASSET_NAMES"; then
+        [ "$RELEASE_IS_DRAFT" = "true" ] || {
+            echo "Published release $TAG is missing required asset: $asset_name"
             exit 1
-        fi
-        rm -rf "$compare_dir"
-    else
+        }
         gh release upload "$TAG" "$asset"
     fi
 done
+
+RELEASE_ASSETS="$(gh release view "$TAG" --json assets)"
+REMOTE_ASSET_COUNT="$(printf '%s' "$RELEASE_ASSETS" | jq '.assets | length')"
+[ "$REMOTE_ASSET_COUNT" -eq "${#EXPECTED_ASSET_NAMES[@]}" ] || {
+    echo "Release $TAG contains $REMOTE_ASSET_COUNT assets, expected ${#EXPECTED_ASSET_NAMES[@]}."
+    exit 1
+}
+
+for asset in "${EXPECTED_ASSETS[@]}"; do
+    asset_name="$(basename "$asset")"
+    MATCHING_ASSET_COUNT="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq --arg name "$asset_name" '[.assets[] | select(.name == $name)] | length'
+    )"
+    [ "$MATCHING_ASSET_COUNT" -eq 1 ] || {
+        echo "Release $TAG must contain exactly one asset named $asset_name."
+        exit 1
+    }
+
+    REMOTE_ASSET_STATE="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .state'
+    )"
+    [ "$REMOTE_ASSET_STATE" = "uploaded" ] || {
+        echo "Release asset $asset_name is not fully uploaded."
+        exit 1
+    }
+
+    LOCAL_ASSET_SIZE="$(wc -c < "$asset" | tr -d '[:space:]')"
+    REMOTE_ASSET_SIZE="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .size'
+    )"
+    [ "$REMOTE_ASSET_SIZE" = "$LOCAL_ASSET_SIZE" ] || {
+        echo "Release asset $asset_name has size $REMOTE_ASSET_SIZE, expected $LOCAL_ASSET_SIZE."
+        exit 1
+    }
+
+    LOCAL_ASSET_DIGEST="sha256:$(sha256sum "$asset" | cut -d ' ' -f 1)"
+    REMOTE_ASSET_DIGEST="$(
+        printf '%s' "$RELEASE_ASSETS" |
+            jq -r --arg name "$asset_name" '.assets[] | select(.name == $name) | .digest'
+    )"
+    [ "$REMOTE_ASSET_DIGEST" = "$LOCAL_ASSET_DIGEST" ] || {
+        echo "Release asset $asset_name has digest $REMOTE_ASSET_DIGEST, expected $LOCAL_ASSET_DIGEST."
+        exit 1
+    }
+done
+
+if [ "$RELEASE_IS_DRAFT" = "true" ]; then
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
+        echo "Release $TAG was published before asset verification completed."
+        exit 1
+    }
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+        echo "Release $TAG changed prerelease classification before publication."
+        exit 1
+    }
+
+    gh release edit "$TAG" \
+        --draft=false \
+        --prerelease="$EXPECTED_PRERELEASE" \
+        --title "$TITLE" \
+        --notes "$NOTES"
+
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
+        echo "Release $TAG remained a draft after publication."
+        exit 1
+    }
+    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+        echo "Published release $TAG has the wrong prerelease classification."
+        exit 1
+    }
+fi

--- a/scripts/record_github_release_responses.py
+++ b/scripts/record_github_release_responses.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+"""Record sanitized GitHub release responses for deterministic update mocks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+API_VERSION = "2026-03-10"
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+def sanitize_url(value: str) -> str:
+    parsed = urllib.parse.urlsplit(value)
+    host = parsed.hostname or ""
+    if ":" in host:
+        host = f"[{host}]"
+    if parsed.port is not None:
+        host = f"{host}:{parsed.port}"
+    return urllib.parse.urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+
+def sanitize_location(value: str) -> dict[str, Any]:
+    parsed = urllib.parse.urlsplit(value)
+    return {
+        "scheme": parsed.scheme,
+        "host": parsed.hostname,
+        "port": parsed.port,
+        "path": parsed.path,
+        "query_present": bool(parsed.query),
+        "fragment_present": bool(parsed.fragment),
+    }
+
+
+def project_asset(asset: dict[str, Any]) -> dict[str, Any]:
+    projected = {
+        field: asset.get(field)
+        for field in (
+            "id",
+            "name",
+            "state",
+            "size",
+            "digest",
+            "url",
+            "browser_download_url",
+        )
+    }
+    for field in ("url", "browser_download_url"):
+        if isinstance(projected[field], str):
+            projected[field] = sanitize_url(projected[field])
+    return projected
+
+
+def project_release(release: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "tag_name": release.get("tag_name"),
+        "html_url": sanitize_url(release["html_url"]),
+        "draft": release.get("draft"),
+        "prerelease": release.get("prerelease"),
+        "assets": [project_asset(asset) for asset in release.get("assets", [])],
+    }
+
+
+def project_git_object(response: dict[str, Any]) -> dict[str, Any]:
+    object_data = response.get("object", {})
+    return {
+        "object": {
+            "type": object_data.get("type"),
+            "sha": object_data.get("sha"),
+        }
+    }
+
+
+class GitHubRecorder:
+    def __init__(self, *, api_root: str, token: str | None) -> None:
+        self.api_root = api_root.rstrip("/")
+        self.token = token
+        self.opener = urllib.request.build_opener(NoRedirect)
+
+    def request(self, url: str, *, accept: str) -> tuple[int, Any, dict[str, str]]:
+        headers = {
+            "Accept": accept,
+            "User-Agent": "lg-buddy-release-response-recorder",
+            "X-GitHub-Api-Version": API_VERSION,
+        }
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        request = urllib.request.Request(url, headers=headers)
+        try:
+            response = self.opener.open(request, timeout=30)
+        except urllib.error.HTTPError as error:
+            response = error
+        body = response.read()
+        response_headers = {key.lower(): value for key, value in response.headers.items()}
+        parsed: Any = None
+        if body:
+            content_type = response_headers.get("content-type", "")
+            if "json" in content_type:
+                parsed = json.loads(body)
+            else:
+                parsed = {"bytes": len(body)}
+        return response.status, parsed, response_headers
+
+    def api_json(self, path: str) -> tuple[Any, dict[str, Any]]:
+        status, body, headers = self.request(
+            f"{self.api_root}/{path.lstrip('/')}",
+            accept="application/vnd.github+json",
+        )
+        if status != 200:
+            raise RuntimeError(f"GitHub API request for {path} returned {status}")
+        return body, {
+            "status": status,
+            "etag": headers.get("etag"),
+            "content_type": headers.get("content-type"),
+        }
+
+    def asset_redirect(self, asset: dict[str, Any]) -> dict[str, Any]:
+        status, _, headers = self.request(
+            str(asset["url"]),
+            accept="application/octet-stream",
+        )
+        location = headers.get("location")
+        return {
+            "asset": project_asset(asset),
+            "response": {
+                "status": status,
+                "content_type": headers.get("content-type"),
+                "content_length": headers.get("content-length"),
+                "location": sanitize_location(location) if location else None,
+            },
+        }
+
+
+def record_responses(
+    *, recorder: GitHubRecorder, repository: str, tag: str, target: str
+) -> dict[str, Any]:
+    encoded_repository = "/".join(
+        urllib.parse.quote(part, safe="") for part in repository.split("/")
+    )
+    encoded_tag = urllib.parse.quote(tag, safe="")
+    releases, releases_response = recorder.api_json(
+        f"repos/{encoded_repository}/releases?per_page=20"
+    )
+    release, release_response = recorder.api_json(
+        f"repos/{encoded_repository}/releases/tags/{encoded_tag}"
+    )
+    tag_ref, tag_ref_response = recorder.api_json(
+        f"repos/{encoded_repository}/git/ref/tags/{encoded_tag}"
+    )
+
+    version = tag.removeprefix("v")
+    expected_assets = {
+        f"lg-buddy-{version}-{target}.tar.gz",
+        "sha256sums.txt",
+    }
+    selected_assets = [
+        asset for asset in release.get("assets", []) if asset.get("name") in expected_assets
+    ]
+    if {asset.get("name") for asset in selected_assets} != expected_assets:
+        raise RuntimeError(f"release {tag} does not expose the expected upgrade assets")
+
+    annotated_tag = None
+    if tag_ref.get("object", {}).get("type") == "tag":
+        tag_sha = urllib.parse.quote(str(tag_ref["object"]["sha"]), safe="")
+        tag_object, tag_object_response = recorder.api_json(
+            f"repos/{encoded_repository}/git/tags/{tag_sha}"
+        )
+        annotated_tag = {
+            "response": tag_object_response,
+            "body": project_git_object(tag_object),
+        }
+
+    return {
+        "schema_version": 1,
+        "repository": repository,
+        "tag": tag,
+        "release_list": {
+            "response": releases_response,
+            "body": [project_release(item) for item in releases],
+        },
+        "release_by_tag": {
+            "response": release_response,
+            "body": project_release(release),
+        },
+        "tag_ref": {
+            "response": tag_ref_response,
+            "body": project_git_object(tag_ref),
+        },
+        "annotated_tag": annotated_tag,
+        "asset_redirects": [
+            recorder.asset_redirect(asset) for asset in selected_assets
+        ],
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--target", default="x86_64-unknown-linux-musl")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--api-root", default="https://api.github.com")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    observation = record_responses(
+        recorder=GitHubRecorder(api_root=args.api_root, token=token),
+        repository=args.repository,
+        tag=args.tag,
+        target=args.target,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(observation, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(f"Recorded sanitized GitHub responses in {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/record_github_release_responses.py
+++ b/scripts/record_github_release_responses.py
@@ -103,7 +103,9 @@ class GitHubRecorder:
         except urllib.error.HTTPError as error:
             response = error
         body = response.read()
-        response_headers = {key.lower(): value for key, value in response.headers.items()}
+        response_headers = {
+            key.lower(): value for key, value in response.headers.items()
+        }
         parsed: Any = None
         if body:
             content_type = response_headers.get("content-type", "")
@@ -151,8 +153,15 @@ def record_responses(
     )
     encoded_tag = urllib.parse.quote(tag, safe="")
     releases, releases_response = recorder.api_json(
-        f"repos/{encoded_repository}/releases?per_page=20"
+        f"repos/{encoded_repository}/releases?per_page=1"
     )
+    latest_release = (
+        releases[0] if isinstance(releases, list) and len(releases) == 1 else None
+    )
+    if not isinstance(latest_release, dict) or latest_release.get("tag_name") != tag:
+        raise RuntimeError(
+            f"newly published release {tag} is not GitHub's newest release"
+        )
     release, release_response = recorder.api_json(
         f"repos/{encoded_repository}/releases/tags/{encoded_tag}"
     )
@@ -166,7 +175,9 @@ def record_responses(
         "sha256sums.txt",
     }
     selected_assets = [
-        asset for asset in release.get("assets", []) if asset.get("name") in expected_assets
+        asset
+        for asset in release.get("assets", [])
+        if asset.get("name") in expected_assets
     ]
     if {asset.get("name") for asset in selected_assets} != expected_assets:
         raise RuntimeError(f"release {tag} does not expose the expected upgrade assets")

--- a/scripts/test-cross-version-upgrade.sh
+++ b/scripts/test-cross-version-upgrade.sh
@@ -1,0 +1,445 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+usage() {
+    cat <<EOF
+Usage: $0 \
+  --previous-archive <path> --previous-sha256 <digest> \
+  --previous-tag <tag> --previous-version <version> \
+  --previous-channel <channel> --previous-target <target> \
+  --previous-commit <sha> \
+  --candidate-archive <path> --candidate-tag <tag> \
+  --candidate-version <version> --candidate-channel <channel> \
+  --candidate-target <target> --candidate-commit <sha> \
+  [--work-dir <dir>]
+EOF
+    exit 1
+}
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+assert_file() {
+    [ -f "$1" ] || fail "Expected file not found: $1"
+}
+
+assert_executable() {
+    [ -x "$1" ] || fail "Expected executable not found: $1"
+}
+
+validate_archive_paths() {
+    local archive="$1"
+    local entry=""
+
+    while IFS= read -r entry; do
+        case "$entry" in
+            /*) fail "Archive contains an absolute path: $entry" ;;
+        esac
+        if printf '%s\n' "$entry" | grep -Eq '(^|/)\.\.(/|$)'; then
+            fail "Archive contains a parent-directory traversal path: $entry"
+        fi
+    done < <(tar -tzf "$archive")
+}
+
+extract_bundle() {
+    local archive="$1"
+    local destination="$2"
+    local roots=()
+
+    mkdir -p "$destination"
+    tar --no-same-owner -C "$destination" -xzf "$archive"
+    mapfile -t roots < <(find "$destination" -mindepth 1 -maxdepth 1 -type d -print)
+    [ "${#roots[@]}" -eq 1 ] || fail "Release archive must contain exactly one top-level directory: $archive"
+    printf '%s\n' "${roots[0]}"
+}
+
+tree_digest() {
+    local install_root="$1"
+    local user_home="$2"
+
+    tar \
+        --sort=name \
+        --mtime='@0' \
+        --owner=0 \
+        --group=0 \
+        --numeric-owner \
+        -C "$(dirname "$install_root")" \
+        -cf - "$(basename "$install_root")" \
+        -C "$(dirname "$user_home")" \
+        "$(basename "$user_home")" |
+        sha256sum | awk '{print $1}'
+}
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+PREVIOUS_ARCHIVE=""
+PREVIOUS_SHA256=""
+PREVIOUS_TAG=""
+PREVIOUS_VERSION=""
+PREVIOUS_CHANNEL=""
+PREVIOUS_TARGET=""
+PREVIOUS_COMMIT=""
+CANDIDATE_ARCHIVE=""
+CANDIDATE_TAG=""
+CANDIDATE_VERSION=""
+CANDIDATE_CHANNEL=""
+CANDIDATE_TARGET=""
+CANDIDATE_COMMIT=""
+WORK_DIR=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --previous-archive) PREVIOUS_ARCHIVE="${2:-}"; shift 2 ;;
+        --previous-sha256) PREVIOUS_SHA256="${2:-}"; shift 2 ;;
+        --previous-tag) PREVIOUS_TAG="${2:-}"; shift 2 ;;
+        --previous-version) PREVIOUS_VERSION="${2:-}"; shift 2 ;;
+        --previous-channel) PREVIOUS_CHANNEL="${2:-}"; shift 2 ;;
+        --previous-target) PREVIOUS_TARGET="${2:-}"; shift 2 ;;
+        --previous-commit) PREVIOUS_COMMIT="${2:-}"; shift 2 ;;
+        --candidate-archive) CANDIDATE_ARCHIVE="${2:-}"; shift 2 ;;
+        --candidate-tag) CANDIDATE_TAG="${2:-}"; shift 2 ;;
+        --candidate-version) CANDIDATE_VERSION="${2:-}"; shift 2 ;;
+        --candidate-channel) CANDIDATE_CHANNEL="${2:-}"; shift 2 ;;
+        --candidate-target) CANDIDATE_TARGET="${2:-}"; shift 2 ;;
+        --candidate-commit) CANDIDATE_COMMIT="${2:-}"; shift 2 ;;
+        --work-dir) WORK_DIR="${2:-}"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+for required in \
+    PREVIOUS_ARCHIVE PREVIOUS_SHA256 PREVIOUS_TAG PREVIOUS_VERSION \
+    PREVIOUS_CHANNEL PREVIOUS_TARGET PREVIOUS_COMMIT CANDIDATE_ARCHIVE \
+    CANDIDATE_TAG CANDIDATE_VERSION CANDIDATE_CHANNEL CANDIDATE_TARGET \
+    CANDIDATE_COMMIT
+do
+    [ -n "${!required}" ] || usage
+done
+
+assert_file "$PREVIOUS_ARCHIVE"
+assert_file "$CANDIDATE_ARCHIVE"
+printf '%s\n' "$PREVIOUS_SHA256" | grep -Eq '^[0-9a-f]{64}$' || fail "Previous archive SHA-256 must be 64 lowercase hexadecimal characters."
+command -v strace >/dev/null || fail "strace is required for the no-network refusal control."
+
+ACTUAL_PREVIOUS_SHA256="$(sha256sum "$PREVIOUS_ARCHIVE" | awk '{print $1}')"
+[ "$ACTUAL_PREVIOUS_SHA256" = "$PREVIOUS_SHA256" ] || fail "Previous archive digest is $ACTUAL_PREVIOUS_SHA256, expected $PREVIOUS_SHA256."
+
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$PREVIOUS_ARCHIVE" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$CANDIDATE_ARCHIVE" \
+    --expected-release-tag "$CANDIDATE_TAG" \
+    --expected-version "$CANDIDATE_VERSION" \
+    --expected-channel "$CANDIDATE_CHANNEL" \
+    --expected-target "$CANDIDATE_TARGET" \
+    --expected-commit "$CANDIDATE_COMMIT"
+
+PYTHONPATH="$SCRIPT_DIR" python3 - "$PREVIOUS_VERSION" "$CANDIDATE_VERSION" <<'PY'
+import sys
+from release_promotion import SemVer
+
+previous = SemVer.parse(sys.argv[1])
+candidate = SemVer.parse(sys.argv[2])
+if candidate <= previous:
+    raise SystemExit(
+        f"candidate version {sys.argv[2]} must advance previous version {sys.argv[1]}"
+    )
+PY
+
+validate_archive_paths "$PREVIOUS_ARCHIVE"
+validate_archive_paths "$CANDIDATE_ARCHIVE"
+
+CLEANUP_WORK_DIR=0
+if [ -z "$WORK_DIR" ]; then
+    WORK_DIR="$(mktemp -d)"
+    CLEANUP_WORK_DIR=1
+else
+    mkdir -p "$WORK_DIR"
+fi
+
+cleanup() {
+    if [ "$CLEANUP_WORK_DIR" -eq 1 ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+PREVIOUS_BUNDLE="$(extract_bundle "$PREVIOUS_ARCHIVE" "$WORK_DIR/previous")"
+CANDIDATE_BUNDLE="$(extract_bundle "$CANDIDATE_ARCHIVE" "$WORK_DIR/candidate")"
+assert_executable "$PREVIOUS_BUNDLE/install.sh"
+assert_executable "$PREVIOUS_BUNDLE/lg-buddy"
+assert_executable "$CANDIDATE_BUNDLE/install.sh"
+assert_executable "$CANDIDATE_BUNDLE/lg-buddy"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$PREVIOUS_BUNDLE/release-manifest.json" \
+    --binary "$PREVIOUS_BUNDLE/lg-buddy" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$CANDIDATE_BUNDLE/release-manifest.json" \
+    --binary "$CANDIDATE_BUNDLE/lg-buddy" \
+    --expected-release-tag "$CANDIDATE_TAG" \
+    --expected-version "$CANDIDATE_VERSION" \
+    --expected-channel "$CANDIDATE_CHANNEL" \
+    --expected-target "$CANDIDATE_TARGET" \
+    --expected-commit "$CANDIDATE_COMMIT"
+
+INSTALL_ROOT="$WORK_DIR/root"
+HOME_DIR="$WORK_DIR/home"
+XDG_CONFIG_HOME="$HOME_DIR/.config"
+mkdir -p "$INSTALL_ROOT" "$HOME_DIR/Desktop"
+
+export HOME="$HOME_DIR"
+export XDG_CONFIG_HOME
+export LG_BUDDY_INSTALL_ROOT="$INSTALL_ROOT"
+export LG_BUDDY_SUDO_CMD="none"
+export LG_BUDDY_NONINTERACTIVE="1"
+export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+export LG_BUDDY_SKIP_PIP_INSTALL="1"
+export LG_BUDDY_TV_IP="192.168.50.20"
+export LG_BUDDY_TV_MAC="02:00:00:00:00:20"
+export LG_BUDDY_INPUT="HDMI_3"
+export LG_BUDDY_SCREEN_BACKEND="auto"
+export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+export PIP_DISABLE_PIP_VERSION_CHECK="1"
+export PIP_NO_PYTHON_VERSION_WARNING="1"
+
+(
+    cd "$PREVIOUS_BUNDLE"
+    ./install.sh
+)
+
+CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
+INSTALLED_BINARY="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_POINTER="$INSTALL_ROOT/usr/lib/lg-buddy/config-path"
+SYSTEM_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service"
+LIFECYCLE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service"
+TMPFILES_CONFIG="$INSTALL_ROOT/etc/tmpfiles.d/lg_buddy.conf"
+SYSTEM_SERVICE_OVERRIDE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service.d/config.conf"
+LIFECYCLE_SERVICE_OVERRIDE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service.d/config.conf"
+NM_LIFECYCLE_HOOK="$INSTALL_ROOT/etc/NetworkManager/dispatcher.d/pre-down.d/LG_Buddy_lifecycle"
+SYSTEM_DESKTOP_ENTRY="$INSTALL_ROOT/usr/share/applications/LG_Buddy_Brightness.desktop"
+USER_DESKTOP_ENTRY="$HOME_DIR/Desktop/LG_Buddy_Brightness.desktop"
+USER_SCREEN_SERVICE="$HOME_DIR/.config/systemd/user/LG_Buddy_screen.service"
+USER_SCREEN_OVERRIDE="$HOME_DIR/.config/systemd/user/LG_Buddy_screen.service.d/config.conf"
+USER_UPDATE_SERVICE="$HOME_DIR/.config/systemd/user/LG_Buddy_update_check.service"
+USER_UPDATE_TIMER="$HOME_DIR/.config/systemd/user/LG_Buddy_update_check.timer"
+USER_UPDATE_OVERRIDE="$HOME_DIR/.config/systemd/user/LG_Buddy_update_check.service.d/config.conf"
+NATIVE_TOKEN_FILE="$XDG_CONFIG_HOME/lg-buddy/tvs/primary/access-token.json"
+VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/cross-version-native-marker"
+
+for installed_path in \
+    "$CONFIG_FILE" "$INSTALLED_BINARY" "$INSTALLED_POINTER" "$SYSTEM_SERVICE" \
+    "$LIFECYCLE_SERVICE" "$TMPFILES_CONFIG" "$NM_LIFECYCLE_HOOK" \
+    "$SYSTEM_DESKTOP_ENTRY" "$USER_DESKTOP_ENTRY" "$USER_SCREEN_SERVICE" \
+    "$USER_UPDATE_SERVICE" "$USER_UPDATE_TIMER"
+do
+    assert_file "$installed_path"
+done
+
+export LG_BUDDY_CONFIG="$CONFIG_FILE"
+"$INSTALLED_BINARY" settings set screen.backend gnome
+"$INSTALLED_BINARY" settings set screen.idle_timeout 900
+"$INSTALLED_BINARY" settings set screen.restore_policy aggressive
+"$INSTALLED_BINARY" settings set screen.idle_blank disabled
+"$INSTALLED_BINARY" settings set system.sleep_wake_policy disabled
+"$INSTALLED_BINARY" settings set tv.ip 192.168.50.21
+"$INSTALLED_BINARY" settings set tv.mac 02:00:00:00:00:21
+"$INSTALLED_BINARY" settings set tv.input HDMI_4
+"$INSTALLED_BINARY" settings set updates.auto_check disabled
+"$INSTALLED_BINARY" settings set updates.channel prerelease
+sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+
+mkdir -p "$(dirname "$NATIVE_TOKEN_FILE")"
+printf '%s\n' '{"access_token":"cross-version-native-token"}' >"$NATIVE_TOKEN_FILE"
+chmod 600 "$NATIVE_TOKEN_FILE"
+touch "$VENV_MARKER"
+
+CONFIG_SNAPSHOT="$WORK_DIR/config.snapshot"
+POINTER_SNAPSHOT="$WORK_DIR/config-pointer.snapshot"
+TOKEN_SNAPSHOT="$WORK_DIR/access-token.snapshot"
+cp "$CONFIG_FILE" "$CONFIG_SNAPSHOT"
+cp "$INSTALLED_POINTER" "$POINTER_SNAPSHOT"
+cp "$NATIVE_TOKEN_FILE" "$TOKEN_SNAPSHOT"
+
+BASELINE_PREFLIGHT_OUTPUT="$WORK_DIR/compatible-baseline-preflight.output"
+"$PREVIOUS_BUNDLE/lg-buddy" upgrade-preflight "$PREVIOUS_BUNDLE" >"$BASELINE_PREFLIGHT_OUTPUT"
+grep -F -x -q 'upgrade preflight: compatible' "$BASELINE_PREFLIGHT_OUTPUT"
+
+CANDIDATE_PREFLIGHT_OUTPUT="$WORK_DIR/compatible-candidate-preflight.output"
+"$CANDIDATE_BUNDLE/lg-buddy" upgrade-preflight "$CANDIDATE_BUNDLE" >"$CANDIDATE_PREFLIGHT_OUTPUT"
+grep -F -x -q 'upgrade preflight: compatible' "$CANDIDATE_PREFLIGHT_OUTPUT"
+
+INSTALLER_STUB_DIR="$WORK_DIR/installer-stubs"
+SUDO_MARKER="$WORK_DIR/sudo-invoked"
+SUDO_SPY="$INSTALLER_STUB_DIR/sudo-spy"
+REFUSAL_OUTPUT="$WORK_DIR/initial-preflight-refusal.output"
+NETWORK_TRACE="$WORK_DIR/initial-preflight-network.trace"
+mkdir -p "$INSTALLER_STUB_DIR"
+cat >"$SUDO_SPY" <<'EOF'
+#!/bin/sh
+: >"${LG_BUDDY_SUDO_MARKER:?}"
+exit 97
+EOF
+chmod 755 "$SUDO_SPY"
+
+mv "$SYSTEM_SERVICE" "$SYSTEM_SERVICE.incompatible"
+REFUSAL_TREE_BEFORE="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+REFUSAL_STATUS=0
+if (
+    LG_BUDDY_SUDO_CMD="$SUDO_SPY" \
+    LG_BUDDY_SUDO_MARKER="$SUDO_MARKER" \
+    strace -f -qq -e trace=network -o "$NETWORK_TRACE" \
+        "$INSTALLED_BINARY" updates install >"$REFUSAL_OUTPUT" 2>&1
+); then
+    fail "Incompatible previous installation unexpectedly passed the initial preflight."
+else
+    REFUSAL_STATUS=$?
+fi
+[ "$REFUSAL_STATUS" -eq 1 ] || fail "Initial preflight refusal returned status $REFUSAL_STATUS instead of 1."
+grep -F -q 'upgrade preflight: refused' "$REFUSAL_OUTPUT"
+grep -F -q "$SYSTEM_SERVICE" "$REFUSAL_OUTPUT"
+[ ! -e "$SUDO_MARKER" ] || fail "Initial preflight refusal invoked sudo."
+if grep -E -q 'AF_INET|AF_INET6' "$NETWORK_TRACE"; then
+    fail "Initial preflight refusal attempted network access."
+fi
+REFUSAL_TREE_AFTER="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+[ "$REFUSAL_TREE_BEFORE" = "$REFUSAL_TREE_AFTER" ] || fail "Initial preflight refusal mutated the installation or user state."
+mv "$SYSTEM_SERVICE.incompatible" "$SYSTEM_SERVICE"
+
+CANDIDATE_REFUSAL_OUTPUT="$WORK_DIR/candidate-preflight-refusal.output"
+CANDIDATE_NETWORK_TRACE="$WORK_DIR/candidate-preflight-network.trace"
+CANDIDATE_SERVICE="$CANDIDATE_BUNDLE/systemd/LG_Buddy.service"
+mv "$CANDIDATE_SERVICE" "$CANDIDATE_SERVICE.incompatible"
+CANDIDATE_REFUSAL_TREE_BEFORE="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+if (
+    cd "$CANDIDATE_BUNDLE"
+    LG_BUDDY_SUDO_CMD="$SUDO_SPY" \
+    LG_BUDDY_SUDO_MARKER="$SUDO_MARKER" \
+    strace -f -qq -e trace=network -o "$CANDIDATE_NETWORK_TRACE" \
+        ./install.sh --upgrade >"$CANDIDATE_REFUSAL_OUTPUT" 2>&1
+); then
+    fail "Malformed candidate unexpectedly passed its preflight."
+fi
+grep -F -q 'upgrade preflight: refused' "$CANDIDATE_REFUSAL_OUTPUT"
+grep -F -q "$CANDIDATE_SERVICE" "$CANDIDATE_REFUSAL_OUTPUT"
+[ ! -e "$SUDO_MARKER" ] || fail "Candidate preflight refusal invoked sudo."
+if grep -E -q 'AF_INET|AF_INET6' "$CANDIDATE_NETWORK_TRACE"; then
+    fail "Candidate preflight refusal attempted network access."
+fi
+CANDIDATE_REFUSAL_TREE_AFTER="$(tree_digest "$INSTALL_ROOT" "$HOME_DIR")"
+[ "$CANDIDATE_REFUSAL_TREE_BEFORE" = "$CANDIDATE_REFUSAL_TREE_AFTER" ] || fail "Candidate preflight refusal mutated the installation or user state."
+mv "$CANDIDATE_SERVICE.incompatible" "$CANDIDATE_SERVICE"
+
+for stale_target in \
+    "$INSTALLED_BINARY" "$SYSTEM_SERVICE" "$LIFECYCLE_SERVICE" \
+    "$TMPFILES_CONFIG" "$NM_LIFECYCLE_HOOK" "$SYSTEM_DESKTOP_ENTRY" \
+    "$USER_DESKTOP_ENTRY" "$USER_SCREEN_SERVICE" "$USER_UPDATE_SERVICE" \
+    "$USER_UPDATE_TIMER"
+do
+    printf 'stale previous-version asset\n' >"$stale_target"
+done
+chmod 755 "$INSTALLED_BINARY" "$NM_LIFECYCLE_HOOK"
+
+SERVICE_ACTION_LOG="$WORK_DIR/service-actions.log"
+EXPECTED_SERVICE_ACTION_LOG="$WORK_DIR/expected-service-actions.log"
+UPGRADE_OUTPUT="$WORK_DIR/cross-version-upgrade.output"
+cat >"$INSTALLER_STUB_DIR/systemctl" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'systemctl %s\n' "$*" >>"${LG_BUDDY_SERVICE_ACTION_LOG:?}"
+case "$*" in
+    is-system-running|"--user is-system-running") printf 'running\n' ;;
+esac
+EOF
+cat >"$INSTALLER_STUB_DIR/systemd-tmpfiles" <<'EOF'
+#!/bin/sh
+set -eu
+printf 'tmpfiles %s\n' "$*" >>"${LG_BUDDY_SERVICE_ACTION_LOG:?}"
+EOF
+chmod 755 "$INSTALLER_STUB_DIR/systemctl" "$INSTALLER_STUB_DIR/systemd-tmpfiles"
+
+(
+    export PATH="$INSTALLER_STUB_DIR:$PATH"
+    export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
+    export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
+    cd "$CANDIDATE_BUNDLE"
+    ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
+)
+
+grep -F -q 'Upgrade complete!' "$UPGRADE_OUTPUT"
+cat >"$EXPECTED_SERVICE_ACTION_LOG" <<EOF
+systemctl is-system-running
+systemctl --user is-system-running
+tmpfiles --create $TMPFILES_CONFIG
+systemctl daemon-reload
+systemctl enable LG_Buddy.service
+systemctl enable LG_Buddy_lifecycle.service
+systemctl restart LG_Buddy_lifecycle.service
+systemctl --user daemon-reload
+systemctl --user enable LG_Buddy_screen.service
+systemctl --user restart LG_Buddy_screen.service
+systemctl --user disable --now LG_Buddy_update_check.timer
+EOF
+cmp -s "$EXPECTED_SERVICE_ACTION_LOG" "$SERVICE_ACTION_LOG" || {
+    diff -u "$EXPECTED_SERVICE_ACTION_LOG" "$SERVICE_ACTION_LOG" || true
+    fail "Cross-version upgrade service actions did not match the defined order."
+}
+
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || fail "Cross-version upgrade changed the user configuration."
+cmp -s "$POINTER_SNAPSHOT" "$INSTALLED_POINTER" || fail "Cross-version upgrade changed the installed config pointer."
+cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Cross-version upgrade changed the native credential."
+[ -e "$VENV_MARKER" ] || fail "Cross-version native upgrade recreated the Python environment."
+
+cmp -s "$CANDIDATE_BUNDLE/lg-buddy" "$INSTALLED_BINARY"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy.service" "$SYSTEM_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_lifecycle.service" "$LIFECYCLE_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/lg_buddy.conf" "$TMPFILES_CONFIG"
+cmp -s "$CANDIDATE_BUNDLE/LG_Buddy_Brightness.desktop" "$SYSTEM_DESKTOP_ENTRY"
+cmp -s "$CANDIDATE_BUNDLE/LG_Buddy_Brightness.desktop" "$USER_DESKTOP_ENTRY"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_screen.service" "$USER_SCREEN_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_update_check.service" "$USER_UPDATE_SERVICE"
+cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_update_check.timer" "$USER_UPDATE_TIMER"
+grep -F -q 'exec /usr/bin/lg-buddy nm-pre-down' "$NM_LIFECYCLE_HOOK"
+for override in \
+    "$SYSTEM_SERVICE_OVERRIDE" "$LIFECYCLE_SERVICE_OVERRIDE" \
+    "$USER_SCREEN_OVERRIDE" "$USER_UPDATE_OVERRIDE"
+do
+    assert_file "$override"
+    grep -F -q "LG_BUDDY_CONFIG=$CONFIG_FILE" "$override"
+done
+
+grep -q '^screen_backend=gnome$' "$CONFIG_FILE"
+grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
+grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
+grep -q '^screen_idle_blank=disabled$' "$CONFIG_FILE"
+grep -q '^system_sleep_wake_policy=disabled$' "$CONFIG_FILE"
+grep -q '^tvs_primary_ip=192.168.50.21$' "$CONFIG_FILE"
+grep -q '^tvs_primary_mac=02:00:00:00:00:21$' "$CONFIG_FILE"
+grep -q '^tvs_primary_input=HDMI_4$' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+grep -q '^updates_auto_check=disabled$' "$CONFIG_FILE"
+grep -q '^updates_channel=prerelease$' "$CONFIG_FILE"
+
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$CANDIDATE_BUNDLE/release-manifest.json" \
+    --binary "$INSTALLED_BINARY" \
+    --expected-release-tag "$CANDIDATE_TAG" \
+    --expected-version "$CANDIDATE_VERSION" \
+    --expected-channel "$CANDIDATE_CHANNEL" \
+    --expected-target "$CANDIDATE_TARGET" \
+    --expected-commit "$CANDIDATE_COMMIT"
+
+echo "Cross-version upgrade smoke test passed: $PREVIOUS_VERSION -> $CANDIDATE_VERSION"

--- a/scripts/test-production-upgrade-canary.sh
+++ b/scripts/test-production-upgrade-canary.sh
@@ -1,0 +1,212 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+usage() {
+    cat <<EOF
+Usage: $0 \
+  --previous-archive <path> --previous-sha256 <digest> \
+  --previous-tag <tag> --previous-version <version> \
+  --previous-channel <channel> --previous-target <target> \
+  --previous-commit <sha> \
+  --expected-tag <tag> --expected-version <version> \
+  --expected-channel <channel> --expected-target <target> \
+  --expected-commit <sha> [--work-dir <dir>]
+EOF
+    exit 1
+}
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+validate_archive_paths() {
+    local archive="$1"
+    local entry=""
+
+    while IFS= read -r entry; do
+        case "$entry" in
+            /*) fail "Archive contains an absolute path: $entry" ;;
+        esac
+        if printf '%s\n' "$entry" | grep -Eq '(^|/)\.\.(/|$)'; then
+            fail "Archive contains a parent-directory traversal path: $entry"
+        fi
+    done < <(tar -tzf "$archive")
+}
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+PREVIOUS_ARCHIVE=""
+PREVIOUS_SHA256=""
+PREVIOUS_TAG=""
+PREVIOUS_VERSION=""
+PREVIOUS_CHANNEL=""
+PREVIOUS_TARGET=""
+PREVIOUS_COMMIT=""
+EXPECTED_TAG=""
+EXPECTED_VERSION=""
+EXPECTED_CHANNEL=""
+EXPECTED_TARGET=""
+EXPECTED_COMMIT=""
+WORK_DIR=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --previous-archive) PREVIOUS_ARCHIVE="${2:-}"; shift 2 ;;
+        --previous-sha256) PREVIOUS_SHA256="${2:-}"; shift 2 ;;
+        --previous-tag) PREVIOUS_TAG="${2:-}"; shift 2 ;;
+        --previous-version) PREVIOUS_VERSION="${2:-}"; shift 2 ;;
+        --previous-channel) PREVIOUS_CHANNEL="${2:-}"; shift 2 ;;
+        --previous-target) PREVIOUS_TARGET="${2:-}"; shift 2 ;;
+        --previous-commit) PREVIOUS_COMMIT="${2:-}"; shift 2 ;;
+        --expected-tag) EXPECTED_TAG="${2:-}"; shift 2 ;;
+        --expected-version) EXPECTED_VERSION="${2:-}"; shift 2 ;;
+        --expected-channel) EXPECTED_CHANNEL="${2:-}"; shift 2 ;;
+        --expected-target) EXPECTED_TARGET="${2:-}"; shift 2 ;;
+        --expected-commit) EXPECTED_COMMIT="${2:-}"; shift 2 ;;
+        --work-dir) WORK_DIR="${2:-}"; shift 2 ;;
+        *) usage ;;
+    esac
+done
+
+for required in \
+    PREVIOUS_ARCHIVE PREVIOUS_SHA256 PREVIOUS_TAG PREVIOUS_VERSION \
+    PREVIOUS_CHANNEL PREVIOUS_TARGET PREVIOUS_COMMIT EXPECTED_TAG \
+    EXPECTED_VERSION EXPECTED_CHANNEL EXPECTED_TARGET EXPECTED_COMMIT
+do
+    [ -n "${!required}" ] || usage
+done
+
+[ -f "$PREVIOUS_ARCHIVE" ] || fail "Previous archive not found: $PREVIOUS_ARCHIVE"
+[ "$EXPECTED_TARGET" = "$PREVIOUS_TARGET" ] || fail "Production canary target $EXPECTED_TARGET does not match baseline target $PREVIOUS_TARGET."
+printf '%s\n' "$PREVIOUS_SHA256" | grep -Eq '^[0-9a-f]{64}$' || fail "Previous archive SHA-256 must be 64 lowercase hexadecimal characters."
+command -v script >/dev/null || fail "The util-linux script command is required for the confirmation PTY."
+
+ACTUAL_PREVIOUS_SHA256="$(sha256sum "$PREVIOUS_ARCHIVE" | awk '{print $1}')"
+[ "$ACTUAL_PREVIOUS_SHA256" = "$PREVIOUS_SHA256" ] || fail "Previous archive digest is $ACTUAL_PREVIOUS_SHA256, expected $PREVIOUS_SHA256."
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --archive "$PREVIOUS_ARCHIVE" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+PYTHONPATH="$SCRIPT_DIR" python3 - "$PREVIOUS_VERSION" "$EXPECTED_VERSION" <<'PY'
+import sys
+from release_promotion import SemVer
+
+if SemVer.parse(sys.argv[2]) <= SemVer.parse(sys.argv[1]):
+    raise SystemExit(
+        f"expected candidate {sys.argv[2]} must advance baseline {sys.argv[1]}"
+    )
+PY
+validate_archive_paths "$PREVIOUS_ARCHIVE"
+
+CLEANUP_WORK_DIR=0
+if [ -z "$WORK_DIR" ]; then
+    WORK_DIR="$(mktemp -d)"
+    CLEANUP_WORK_DIR=1
+else
+    mkdir -p "$WORK_DIR"
+fi
+
+cleanup() {
+    if [ "$CLEANUP_WORK_DIR" -eq 1 ]; then
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+EXTRACT_DIR="$WORK_DIR/previous"
+mkdir -p "$EXTRACT_DIR"
+tar --no-same-owner -C "$EXTRACT_DIR" -xzf "$PREVIOUS_ARCHIVE"
+mapfile -t PREVIOUS_ROOTS < <(find "$EXTRACT_DIR" -mindepth 1 -maxdepth 1 -type d -print)
+[ "${#PREVIOUS_ROOTS[@]}" -eq 1 ] || fail "Previous archive must contain exactly one top-level directory."
+PREVIOUS_BUNDLE="${PREVIOUS_ROOTS[0]}"
+[ -x "$PREVIOUS_BUNDLE/install.sh" ] || fail "Previous installer is not executable."
+[ -x "$PREVIOUS_BUNDLE/lg-buddy" ] || fail "Previous binary is not executable."
+python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
+    --manifest "$PREVIOUS_BUNDLE/release-manifest.json" \
+    --binary "$PREVIOUS_BUNDLE/lg-buddy" \
+    --expected-release-tag "$PREVIOUS_TAG" \
+    --expected-version "$PREVIOUS_VERSION" \
+    --expected-channel "$PREVIOUS_CHANNEL" \
+    --expected-target "$PREVIOUS_TARGET" \
+    --expected-commit "$PREVIOUS_COMMIT"
+
+INSTALL_ROOT="$WORK_DIR/root"
+HOME_DIR="$WORK_DIR/home"
+XDG_CONFIG_HOME="$HOME_DIR/.config"
+XDG_CACHE_HOME="$HOME_DIR/.cache"
+mkdir -p "$INSTALL_ROOT" "$HOME_DIR/Desktop" "$XDG_CACHE_HOME"
+
+export HOME="$HOME_DIR"
+export XDG_CONFIG_HOME
+export XDG_CACHE_HOME
+export LG_BUDDY_INSTALL_ROOT="$INSTALL_ROOT"
+export LG_BUDDY_SUDO_CMD="none"
+export LG_BUDDY_NONINTERACTIVE="1"
+export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+export LG_BUDDY_SKIP_PIP_INSTALL="1"
+export LG_BUDDY_TV_IP="192.168.60.20"
+export LG_BUDDY_TV_MAC="02:00:00:00:00:60"
+export LG_BUDDY_INPUT="HDMI_3"
+export LG_BUDDY_SCREEN_BACKEND="auto"
+export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+export PIP_DISABLE_PIP_VERSION_CHECK="1"
+export PIP_NO_PYTHON_VERSION_WARNING="1"
+
+(
+    cd "$PREVIOUS_BUNDLE"
+    ./install.sh
+)
+
+CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
+INSTALLED_BINARY="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_POINTER="$INSTALL_ROOT/usr/lib/lg-buddy/config-path"
+NATIVE_TOKEN_FILE="$XDG_CONFIG_HOME/lg-buddy/tvs/primary/access-token.json"
+VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/production-canary-native-marker"
+[ -x "$INSTALLED_BINARY" ] || fail "Baseline binary was not installed."
+[ -f "$CONFIG_FILE" ] || fail "Baseline config was not installed."
+[ -f "$INSTALLED_POINTER" ] || fail "Baseline config pointer was not installed."
+
+export LG_BUDDY_CONFIG="$CONFIG_FILE"
+"$INSTALLED_BINARY" settings set screen.backend gnome
+"$INSTALLED_BINARY" settings set screen.idle_blank disabled
+"$INSTALLED_BINARY" settings set updates.auto_check disabled
+"$INSTALLED_BINARY" settings set updates.channel prerelease
+sed -i 's/^tvs_primary_platform=bscpylgtv$/tvs_primary_platform=lg_webos/' "$CONFIG_FILE"
+grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
+mkdir -p "$(dirname "$NATIVE_TOKEN_FILE")"
+printf '%s\n' '{"access_token":"production-canary-native-token"}' >"$NATIVE_TOKEN_FILE"
+chmod 600 "$NATIVE_TOKEN_FILE"
+touch "$VENV_MARKER"
+
+CONFIG_SNAPSHOT="$WORK_DIR/config.snapshot"
+POINTER_SNAPSHOT="$WORK_DIR/config-pointer.snapshot"
+TOKEN_SNAPSHOT="$WORK_DIR/access-token.snapshot"
+cp "$CONFIG_FILE" "$CONFIG_SNAPSHOT"
+cp "$INSTALLED_POINTER" "$POINTER_SNAPSHOT"
+cp "$NATIVE_TOKEN_FILE" "$TOKEN_SNAPSHOT"
+
+CANARY_OUTPUT="$WORK_DIR/production-upgrade-canary.output"
+CANARY_COMMAND="$(printf '%q' "$INSTALLED_BINARY") updates install"
+printf 'yes\n' | script -qefc "$CANARY_COMMAND" /dev/null >"$CANARY_OUTPUT"
+
+grep -F -q "Current: $PREVIOUS_VERSION ($PREVIOUS_CHANNEL, commit $PREVIOUS_COMMIT)" "$CANARY_OUTPUT"
+grep -F -q "Target: $EXPECTED_VERSION ($EXPECTED_CHANNEL, commit $EXPECTED_COMMIT)" "$CANARY_OUTPUT"
+grep -F -q "Release: https://github.com/Staphylococcus/LG_Buddy/releases/tag/$EXPECTED_TAG" "$CANARY_OUTPUT"
+grep -F -q "Installed: $EXPECTED_VERSION ($EXPECTED_CHANNEL, commit $EXPECTED_COMMIT)" "$CANARY_OUTPUT"
+
+EXPECTED_VERSION_OUTPUT="$(printf 'lg-buddy %s\nversion: %s\nchannel: %s\ncommit: %s' \
+    "$EXPECTED_VERSION" "$EXPECTED_VERSION" "$EXPECTED_CHANNEL" "$EXPECTED_COMMIT")"
+ACTUAL_VERSION_OUTPUT="$("$INSTALLED_BINARY" --version)"
+[ "$ACTUAL_VERSION_OUTPUT" = "$EXPECTED_VERSION_OUTPUT" ] || fail "Installed identity does not match the published canary target."
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || fail "Production upgrade changed the user configuration."
+cmp -s "$POINTER_SNAPSHOT" "$INSTALLED_POINTER" || fail "Production upgrade changed the config pointer."
+cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Production upgrade changed the native credential."
+[ -e "$VENV_MARKER" ] || fail "Production native upgrade recreated the Python environment."
+"$INSTALLED_BINARY" settings get updates.channel | grep -q '^prerelease$'
+
+echo "Production GitHub upgrade canary passed: $PREVIOUS_VERSION -> $EXPECTED_VERSION"

--- a/scripts/test-production-upgrade-canary.sh
+++ b/scripts/test-production-upgrade-canary.sh
@@ -209,4 +209,18 @@ cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Production upgrade change
 [ -e "$VENV_MARKER" ] || fail "Production native upgrade recreated the Python environment."
 "$INSTALLED_BINARY" settings get updates.channel | grep -q '^prerelease$'
 
+CANDIDATE_CHECK_OUTPUT="$WORK_DIR/candidate-update-check.output"
+UPDATE_CACHE_FILE="$XDG_CACHE_HOME/lg-buddy/update-check.json"
+rm -f "$UPDATE_CACHE_FILE"
+"$INSTALLED_BINARY" updates check >"$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "status: up to date" "$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "current: $EXPECTED_VERSION ($EXPECTED_CHANNEL)" "$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "latest: $EXPECTED_VERSION ($EXPECTED_CHANNEL)" "$CANDIDATE_CHECK_OUTPUT"
+grep -F -q "url: https://github.com/Staphylococcus/LG_Buddy/releases/tag/$EXPECTED_TAG" "$CANDIDATE_CHECK_OUTPUT"
+{
+    echo
+    echo "Published candidate update check:"
+    cat "$CANDIDATE_CHECK_OUTPUT"
+} >>"$CANARY_OUTPUT"
+
 echo "Production GitHub upgrade canary passed: $PREVIOUS_VERSION -> $EXPECTED_VERSION"

--- a/scripts/test_publish_release_assets.py
+++ b/scripts/test_publish_release_assets.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import shutil
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+from release_bundle_manifest import MANIFEST_NAME, ReleaseIdentity, render_manifest
+
+
+VERSION = "9.8.7-beta.1"
+TAG = f"v{VERSION}"
+TARGET = "x86_64-unknown-linux-musl"
+
+
+FAKE_GH = r"""#!/usr/bin/env python3
+import hashlib
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+state_path = Path(os.environ["FAKE_GH_STATE"])
+asset_dir = Path(os.environ["FAKE_GH_ASSETS"])
+log_path = Path(os.environ["FAKE_GH_LOG"])
+args = sys.argv[1:]
+
+with log_path.open("a", encoding="utf-8") as log:
+    log.write(json.dumps(args) + "\n")
+
+state = json.loads(state_path.read_text(encoding="utf-8"))
+
+def save():
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+
+if len(args) < 3 or args[0] != "release":
+    sys.exit("unsupported fake gh invocation")
+
+command = args[1]
+tag = args[2]
+rest = args[3:]
+
+if command == "view":
+    if not state["exists"]:
+        sys.exit(1)
+    if "--json" not in rest:
+        sys.exit(0)
+    fields = rest[rest.index("--json") + 1]
+    if fields == "assets":
+        if "--jq" in rest:
+            print("\n".join(sorted(state["assets"])))
+        else:
+            assets = []
+            for name in sorted(state["assets"]):
+                content = (asset_dir / name).read_bytes()
+                assets.append({
+                    "name": name,
+                    "state": "uploaded",
+                    "size": len(content),
+                    "digest": f"sha256:{hashlib.sha256(content).hexdigest()}",
+                })
+            print(json.dumps({"assets": assets}))
+    else:
+        print(json.dumps({
+            "isDraft": state["draft"],
+            "isPrerelease": state["prerelease"],
+        }))
+    sys.exit(0)
+
+if command == "create":
+    if state["exists"]:
+        sys.exit("release already exists")
+    state.update({
+        "exists": True,
+        "draft": "--draft" in rest,
+        "prerelease": "--prerelease" in rest,
+        "assets": [],
+    })
+    save()
+    sys.exit(0)
+
+if not state["exists"]:
+    sys.exit("release does not exist")
+
+if command == "upload":
+    source = Path(rest[0])
+    if os.environ.get("FAKE_GH_FAIL_UPLOAD") == source.name:
+        sys.exit("injected upload failure")
+    asset_dir.mkdir(parents=True, exist_ok=True)
+    if os.environ.get("FAKE_GH_CORRUPT_UPLOAD") == source.name:
+        content = bytearray(source.read_bytes())
+        content[0] ^= 1
+        (asset_dir / source.name).write_bytes(content)
+    else:
+        shutil.copyfile(source, asset_dir / source.name)
+    if source.name not in state["assets"]:
+        state["assets"].append(source.name)
+    save()
+    sys.exit(0)
+
+if command == "download":
+    pattern = rest[rest.index("--pattern") + 1]
+    destination = Path(rest[rest.index("--dir") + 1])
+    destination.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(asset_dir / pattern, destination / pattern)
+    sys.exit(0)
+
+if command == "edit":
+    for argument in rest:
+        if argument.startswith("--draft="):
+            state["draft"] = argument.split("=", 1)[1] == "true"
+        elif argument.startswith("--prerelease="):
+            state["prerelease"] = argument.split("=", 1)[1] == "true"
+    save()
+    sys.exit(0)
+
+sys.exit("unsupported fake gh release command")
+"""
+
+
+class PublishReleaseAssetsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary_directory.name)
+        self.repository = self.root / "repository"
+        self.repository.mkdir()
+        self.dist = self.repository / "dist"
+        self.dist.mkdir()
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+        self.remote_assets = self.root / "remote-assets"
+        self.state_path = self.root / "state.json"
+        self.log_path = self.root / "gh-calls.jsonl"
+
+        self.git("init", "--quiet")
+        self.git("config", "user.name", "Release test")
+        self.git("config", "user.email", "release-test@example.invalid")
+        (self.repository / "marker").write_text("release\n", encoding="utf-8")
+        self.git("add", "marker")
+        self.git("commit", "--quiet", "-m", "release")
+        self.commit = self.git("rev-parse", "HEAD").stdout.strip()
+        self.git("tag", TAG)
+
+        identity = ReleaseIdentity(
+            release_tag=TAG,
+            version=VERSION,
+            channel="prerelease",
+            target=TARGET,
+            commit=self.commit,
+        )
+        bundle_name = f"lg-buddy-{VERSION}-{TARGET}"
+        self.archive = self.dist / f"{bundle_name}.tar.gz"
+        manifest = render_manifest(identity)
+        with tarfile.open(self.archive, mode="w:gz") as bundle:
+            info = tarfile.TarInfo(f"{bundle_name}/{MANIFEST_NAME}")
+            info.size = len(manifest)
+            bundle.addfile(info, io.BytesIO(manifest))
+
+        digest = hashlib.sha256(self.archive.read_bytes()).hexdigest()
+        self.checksums = self.dist / "sha256sums.txt"
+        self.checksums.write_text(
+            f"{digest}  {self.archive.name}\n", encoding="utf-8"
+        )
+
+        fake_gh = self.fake_bin / "gh"
+        fake_gh.write_text(FAKE_GH, encoding="utf-8")
+        fake_gh.chmod(0o755)
+        self.write_state()
+
+        self.environment = os.environ.copy()
+        self.environment.update(
+            {
+                "PATH": f"{self.fake_bin}:{self.environment['PATH']}",
+                "FAKE_GH_STATE": str(self.state_path),
+                "FAKE_GH_ASSETS": str(self.remote_assets),
+                "FAKE_GH_LOG": str(self.log_path),
+            }
+        )
+        self.publisher = Path(__file__).with_name("publish-release-assets.sh")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["git", *args],
+            cwd=self.repository,
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+
+    def write_state(
+        self,
+        *,
+        exists: bool = False,
+        draft: bool = True,
+        prerelease: bool = True,
+        assets: dict[str, bytes] | None = None,
+    ) -> None:
+        asset_values = assets or {}
+        self.remote_assets.mkdir(parents=True, exist_ok=True)
+        for name, content in asset_values.items():
+            (self.remote_assets / name).write_bytes(content)
+        self.state_path.write_text(
+            json.dumps(
+                {
+                    "exists": exists,
+                    "draft": draft,
+                    "prerelease": prerelease,
+                    "assets": list(asset_values),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def run_publisher(
+        self,
+        *,
+        fail_upload: str | None = None,
+        corrupt_upload: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        environment = self.environment.copy()
+        if fail_upload is not None:
+            environment["FAKE_GH_FAIL_UPLOAD"] = fail_upload
+        if corrupt_upload is not None:
+            environment["FAKE_GH_CORRUPT_UPLOAD"] = corrupt_upload
+        return subprocess.run(
+            [
+                "bash",
+                self.publisher,
+                "--dist-dir",
+                self.dist,
+                "--tag",
+                TAG,
+                "--commit",
+                self.commit,
+            ],
+            cwd=self.repository,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+
+    def state(self) -> dict[str, object]:
+        return json.loads(self.state_path.read_text(encoding="utf-8"))
+
+    def calls(self) -> list[list[str]]:
+        if not self.log_path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in self.log_path.read_text(encoding="utf-8").splitlines()
+        ]
+
+    def mutations(self, command: str) -> list[list[str]]:
+        return [call for call in self.calls() if call[:2] == ["release", command]]
+
+    def complete_assets(self) -> dict[str, bytes]:
+        return {
+            self.archive.name: self.archive.read_bytes(),
+            self.checksums.name: self.checksums.read_bytes(),
+        }
+
+    def test_new_release_is_published_only_after_assets_are_uploaded(self) -> None:
+        result = self.run_publisher()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(set(self.state()["assets"]), set(self.complete_assets()))
+        self.assertFalse(self.state()["draft"])
+        create = self.mutations("create")
+        uploads = self.mutations("upload")
+        edit = self.mutations("edit")
+        self.assertEqual(len(create), 1)
+        self.assertIn("--draft", create[0])
+        self.assertEqual(len(uploads), 2)
+        self.assertEqual(len(edit), 1)
+        self.assertIn("--draft=false", edit[0])
+        self.assertLess(self.calls().index(create[0]), self.calls().index(uploads[0]))
+        self.assertLess(self.calls().index(uploads[-1]), self.calls().index(edit[0]))
+
+    def test_retry_resumes_a_partially_uploaded_draft(self) -> None:
+        first = self.run_publisher(fail_upload=self.checksums.name)
+        self.assertNotEqual(first.returncode, 0)
+        self.assertTrue(self.state()["draft"])
+
+        second = self.run_publisher()
+
+        self.assertEqual(second.returncode, 0, second.stdout)
+        self.assertFalse(self.state()["draft"])
+        self.assertEqual(len(self.mutations("create")), 1)
+        archive_uploads = [
+            call for call in self.mutations("upload") if call[-1] == str(self.archive)
+        ]
+        self.assertEqual(len(archive_uploads), 1)
+        self.assertEqual(len(self.mutations("edit")), 1)
+
+    def test_unexpected_draft_asset_blocks_publication_without_mutation(self) -> None:
+        self.write_state(exists=True, assets={"unexpected.txt": b"unexpected"})
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("contains unexpected asset", result.stdout)
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_published_release_missing_asset_is_not_modified(self) -> None:
+        self.write_state(
+            exists=True,
+            draft=False,
+            assets={self.archive.name: self.archive.read_bytes()},
+        )
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is missing required asset", result.stdout)
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_mismatched_draft_asset_blocks_publication(self) -> None:
+        self.write_state(
+            exists=True,
+            assets={self.archive.name: b"different archive"},
+        )
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"Release asset {self.archive.name} has size", result.stdout)
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_successful_but_corrupted_upload_blocks_publication(self) -> None:
+        result = self.run_publisher(corrupt_upload=self.checksums.name)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(f"Release asset {self.checksums.name} has digest", result.stdout)
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_complete_published_release_is_verification_only(self) -> None:
+        self.write_state(exists=True, draft=False, assets=self.complete_assets())
+
+        result = self.run_publisher()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_record_github_release_responses.py
+++ b/scripts/test_record_github_release_responses.py
@@ -9,6 +9,7 @@ from record_github_release_responses import (
     GitHubRecorder,
     project_git_object,
     project_release,
+    record_responses,
     sanitize_location,
 )
 
@@ -30,6 +31,57 @@ class RecordingOpener:
         self.request = request
         self.timeout = timeout
         return StubResponse()
+
+
+class FixtureRecorder:
+    def __init__(self, latest_tag: str = "v1.4.0-beta.2") -> None:
+        self.latest_tag = latest_tag
+        self.paths: list[str] = []
+        self.release = {
+            "tag_name": "v1.4.0-beta.2",
+            "html_url": "https://github.test/releases/tag/v1.4.0-beta.2",
+            "draft": False,
+            "prerelease": True,
+            "assets": [
+                {
+                    "id": 1,
+                    "name": "lg-buddy-1.4.0-beta.2-x86_64-unknown-linux-musl.tar.gz",
+                    "state": "uploaded",
+                    "size": 100,
+                    "digest": "sha256:archive",
+                    "url": "https://api.github.test/assets/1",
+                    "browser_download_url": "https://github.test/assets/1",
+                },
+                {
+                    "id": 2,
+                    "name": "sha256sums.txt",
+                    "state": "uploaded",
+                    "size": 10,
+                    "digest": "sha256:checksums",
+                    "url": "https://api.github.test/assets/2",
+                    "browser_download_url": "https://github.test/assets/2",
+                },
+            ],
+        }
+
+    def api_json(self, path: str):  # type: ignore[no-untyped-def]
+        self.paths.append(path)
+        if path.endswith("releases?per_page=1"):
+            return [{**self.release, "tag_name": self.latest_tag}], {"status": 200}
+        if "/releases/tags/" in path:
+            return self.release, {"status": 200}
+        if "/git/ref/tags/" in path:
+            return {
+                "object": {
+                    "type": "commit",
+                    "sha": "a" * 40,
+                }
+            }, {"status": 200}
+        raise AssertionError(f"unexpected API path: {path}")
+
+    @staticmethod
+    def asset_redirect(asset):  # type: ignore[no-untyped-def]
+        return {"asset": asset, "response": {"status": 302}}
 
 
 class ResponseRecordingTests(unittest.TestCase):
@@ -116,6 +168,47 @@ class ResponseRecordingTests(unittest.TestCase):
                     "sha": "77c8f46c66b9e385f3d90c15dee33d775639bbeb",
                 }
             },
+        )
+
+    def test_recorder_captures_only_githubs_newest_release(self) -> None:
+        recorder = FixtureRecorder()
+
+        recorded = record_responses(
+            recorder=recorder,
+            repository="Staphylococcus/LG_Buddy",
+            tag="v1.4.0-beta.2",
+            target="x86_64-unknown-linux-musl",
+        )
+
+        self.assertEqual(
+            recorder.paths[0],
+            "repos/Staphylococcus/LG_Buddy/releases?per_page=1",
+        )
+        self.assertEqual(len(recorded["release_list"]["body"]), 1)
+        self.assertEqual(
+            recorded["release_list"]["body"][0]["tag_name"],
+            "v1.4.0-beta.2",
+        )
+
+    def test_recorder_refuses_when_candidate_is_not_githubs_newest_release(
+        self,
+    ) -> None:
+        recorder = FixtureRecorder(latest_tag="v1.4.0-beta.1")
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "newly published release v1.4.0-beta.2 is not GitHub's newest release",
+        ):
+            record_responses(
+                recorder=recorder,
+                repository="Staphylococcus/LG_Buddy",
+                tag="v1.4.0-beta.2",
+                target="x86_64-unknown-linux-musl",
+            )
+
+        self.assertEqual(
+            recorder.paths,
+            ["repos/Staphylococcus/LG_Buddy/releases?per_page=1"],
         )
 
 

--- a/scripts/test_record_github_release_responses.py
+++ b/scripts/test_record_github_release_responses.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import unittest
+
+from record_github_release_responses import (
+    API_VERSION,
+    GitHubRecorder,
+    project_git_object,
+    project_release,
+    sanitize_location,
+)
+
+
+class StubResponse:
+    status = 200
+    headers = {"Content-Type": "application/json"}
+
+    @staticmethod
+    def read() -> bytes:
+        return b"{}"
+
+
+class RecordingOpener:
+    def __init__(self) -> None:
+        self.request = None
+
+    def open(self, request, *, timeout):  # type: ignore[no-untyped-def]
+        self.request = request
+        self.timeout = timeout
+        return StubResponse()
+
+
+class ResponseRecordingTests(unittest.TestCase):
+    def test_request_uses_the_production_github_api_version(self) -> None:
+        recorder = GitHubRecorder(api_root="https://api.github.test", token=None)
+        opener = RecordingOpener()
+        recorder.opener = opener
+
+        recorder.request(
+            "https://api.github.test/releases",
+            accept="application/vnd.github+json",
+        )
+
+        self.assertEqual(API_VERSION, "2026-03-10")
+        self.assertEqual(
+            opener.request.get_header("X-github-api-version"),
+            API_VERSION,
+        )
+
+    def test_location_record_drops_userinfo_query_and_fragment(self) -> None:
+        recorded = sanitize_location(
+            "https://user:secret@example.test:8443/releases/asset?token=secret#fragment"
+        )
+
+        self.assertEqual(
+            recorded,
+            {
+                "scheme": "https",
+                "host": "example.test",
+                "port": 8443,
+                "path": "/releases/asset",
+                "query_present": True,
+                "fragment_present": True,
+            },
+        )
+        self.assertNotIn("secret", repr(recorded))
+
+    def test_release_projection_keeps_only_update_client_fields(self) -> None:
+        projected = project_release(
+            {
+                "tag_name": "v1.4.0-beta.2",
+                "html_url": "https://user:secret@github.test/releases/v1.4.0-beta.2?token=secret",
+                "draft": False,
+                "prerelease": True,
+                "author": {"login": "ignored"},
+                "assets": [
+                    {
+                        "id": 42,
+                        "name": "sha256sums.txt",
+                        "state": "uploaded",
+                        "size": 123,
+                        "digest": "sha256:abc",
+                        "url": "https://user:secret@api.github.test/assets/42?token=secret",
+                        "browser_download_url": "https://github.test/assets/42#secret",
+                        "uploader": {"login": "ignored"},
+                    }
+                ],
+            }
+        )
+
+        self.assertNotIn("author", projected)
+        self.assertNotIn("uploader", projected["assets"][0])
+        self.assertEqual(projected["assets"][0]["id"], 42)
+        self.assertNotIn("secret", repr(projected))
+
+    def test_git_object_projection_keeps_only_tag_peeling_fields(self) -> None:
+        projected = project_git_object(
+            {
+                "ref": "refs/tags/v1.4.0-beta.2",
+                "node_id": "ignored",
+                "object": {
+                    "type": "commit",
+                    "sha": "77c8f46c66b9e385f3d90c15dee33d775639bbeb",
+                    "url": "https://api.github.test/commits/secret",
+                },
+            }
+        )
+
+        self.assertEqual(
+            projected,
+            {
+                "object": {
+                    "type": "commit",
+                    "sha": "77c8f46c66b9e385f3d90c15dee33d775639bbeb",
+                }
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -60,7 +60,7 @@ class RepositoryFixture:
         self.git("switch", "dev")
         self.write_version(version, lock_version)
         self.git("add", ".")
-        self.git("commit", "-m", f"prepare {version}")
+        self.git("commit", "--allow-empty", "-m", f"prepare {version}")
         return self.git("rev-parse", "HEAD")
 
     def validate(self, target: str, head_sha: str) -> dict[str, object]:
@@ -160,6 +160,28 @@ class PromotionTests(unittest.TestCase):
         head = self.repository.candidate("1.4.0-beta.1", "1.3.0")
         with self.assertRaisesRegex(PromotionError, "does not match Cargo.lock"):
             self.repository.validate("prerelease", head)
+
+    def test_stable_version_must_strictly_advance_main(self) -> None:
+        for version in ("1.3.0", "1.2.9"):
+            with self.subTest(version=version):
+                head = self.repository.candidate(version)
+                with self.assertRaisesRegex(
+                    PromotionError, f"candidate {version} must advance main from 1.3.0"
+                ):
+                    self.repository.validate("main", head)
+
+    def test_prerelease_version_must_strictly_advance_prerelease(self) -> None:
+        current = self.repository.candidate("1.4.0-beta.2")
+        self.repository.git("branch", "-f", "prerelease", current)
+
+        for version in ("1.4.0-beta.2", "1.4.0-beta.1"):
+            with self.subTest(version=version):
+                head = self.repository.candidate(version)
+                with self.assertRaisesRegex(
+                    PromotionError,
+                    f"candidate {version} must advance prerelease from 1.4.0-beta.2",
+                ):
+                    self.repository.validate("prerelease", head)
 
     def test_stale_target_is_rejected(self) -> None:
         head = self.repository.candidate("1.4.0-beta.1")


### PR DESCRIPTION
## Release authorization

Merge `dev` at `60a7904b02f469447c921e7d3ede63df237ba455` into `prerelease` as `v1.4.0-beta.3`.

This promotion carries the completed release-bundle upgrade path, cross-version smoke gate, immutable draft-first publication, and newest-release discovery contract. Merging this PR authorizes publication; there is no separate label or publish action.

## Post-merge proof

The release workflow must:

- build and validate the exact merged prerelease commit
- perform the pinned beta.2 → beta.3 archive upgrade smoke
- publish the complete draft under the repository immutable-release policy
- independently download and verify the published checksums
- exercise beta.2 → beta.3 through production GitHub
- cold-cache the installed beta.3 updater and prove it sees itself as newest
- record sanitized GitHub responses for the deterministic mock

Related to #91 and #99.