### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -22,7 +22,7 @@ jobs:
           components: clippy
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -88,7 +88,7 @@ jobs:
           targets: x86_64-unknown-linux-musl
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -49,14 +49,14 @@ jobs:
           }
 
       - name: Check out trusted promotion validator
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,14 +29,14 @@ jobs:
 
     steps:
       - name: Check out merged release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Check out merged release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate.outputs.head_sha }}
           persist-credentials: false
@@ -80,7 +80,7 @@ jobs:
           targets: x86_64-unknown-linux-musl
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -142,7 +142,7 @@ jobs:
           sha256sum -c sha256sums.txt
 
       - name: Upload workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lg-buddy-release-${{ needs.validate.outputs.tag }}
           path: |
@@ -161,14 +161,14 @@ jobs:
 
     steps:
       - name: Check out merged release commit
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -186,7 +186,7 @@ jobs:
               --base-sha "${{ needs.validate.outputs.base_sha }}"
 
       - name: Download verified release bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: lg-buddy-release-${{ needs.validate.outputs.tag }}
           path: dist
@@ -198,7 +198,7 @@ jobs:
         id: release-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
         with:
-          app-id: ${{ vars.RELEASE_PROMOTION_APP_ID }}
+          client-id: ${{ vars.RELEASE_PROMOTION_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PROMOTION_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: LG_Buddy
@@ -274,13 +274,13 @@ jobs:
 
     steps:
       - name: Check out published prerelease
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ needs.validate.outputs.head_sha }}
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -323,7 +323,7 @@ jobs:
 
       - name: Upload canary evidence for the offline mock
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: production-upgrade-canary-${{ needs.validate.outputs.tag }}
           path: |


### PR DESCRIPTION
## Summary

- update checkout and setup-python to their Node 24 majors
- update artifact upload/download actions to their first Node 24 majors
- replace the deprecated GitHub App `app-id` input with `client-id`
- configure `RELEASE_PROMOTION_APP_CLIENT_ID` with the existing release App client ID

The numeric `RELEASE_PROMOTION_APP_ID` variable remains available for governance APIs that require the App ID.

## Validation

- `nix shell nixpkgs#actionlint --command actionlint`
- `git diff --check`
- verified each selected action declares the Node 24 runtime
- verified the replacement repository variable against the registered GitHub App settings