### PR TITLE
Prepare v1.4.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -890,7 +890,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.4.0-beta.3"
+version = "1.4.0"
 dependencies = [
  "base64",
  "cucumber",

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.4.0-beta.3"
+version = "1.4.0"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- set the lg-buddy crate version to stable 1.4.0
- keep Cargo.lock aligned with the manifest

## Validation

- release-promotion contract tests: 20 passed
- cargo metadata resolves lg-buddy 1.4.0
- git diff --check

After this reaches dev, the stable release is promoted directly from dev to main. Public beta.3 already has the required successful production upgrade canary.