### PR TITLE
Add declarative GTK brightness window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,20 @@ jobs:
           sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib tv::tests::user_scoped_launcher_drops_privileges_to_sudo_user_when_running_as_root -- --exact
           sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib platform_access_token::tests::persist_assigns_requested_owner_when_running_as_root -- --exact
 
+      - name: Install GTK test prerequisites
+        run: sudo apt-get update && sudo apt-get install -y dbus-x11 libglib2.0-bin libgtk-4-dev xdotool xvfb
+
+      - name: Run display-backed GTK test suite
+        run: |
+          cargo build -p lg-buddy-gui
+          dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
+          dbus-run-session -- xvfb-run -a env GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
+
       - name: Run clippy
-        run: cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Validate shell scripts
-        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
+name = "cairo-rs"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df683f1d30b457964673a5541a4603208ef95ab6873d2a55871895cf310f3b56"
+dependencies = [
+ "bitflags",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee548131103ad8f698c6725669647b9c757b3b66992dd6a026037596417bee21"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 9.0.0",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +174,16 @@ checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4ece8474b5f766c63426647e7b4b316b67431ade1036a8313cee24a03ae917"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -202,7 +241,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -354,7 +393,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 2.0.117",
  "synthez",
 ]
 
@@ -417,7 +456,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -450,7 +489,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -472,6 +511,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +536,16 @@ dependencies = [
  "cfg-if",
  "libc",
  "nix",
+]
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
 ]
 
 [[package]]
@@ -590,7 +645,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -620,6 +675,63 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f420376dbee041b2db374ce4573892a36222bb3f6c0c43e24f0d67eae9b646"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5209294ba3775f9b650bf78bfadeba4332089f2329b3e2f6ce0a4957a45bff"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 9.0.0",
+]
+
+[[package]]
+name = "gdk4"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81e2a6c6ecba2aab60633a98df1868b03fa0bfdce8105edc27c1bccf71f0e39"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk4-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk4-sys"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d8f608d8d7d229975c4d0d026f5d3071598c4ddab3c5262b0a31840fec78d13"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps 7.0.8",
 ]
 
 [[package]]
@@ -666,10 +778,83 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 2.0.117",
  "textwrap",
  "thiserror",
  "typed-builder",
+]
+
+[[package]]
+name = "gio"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b399f4650bb52c051f3fdf49a234e8a27ab5725c8cd774556c55eee64b2c0350"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "pin-project-lite",
+ "smallvec",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28739f914c15b87a9856000bed9cbd5b3a8afbca5e982d9a299e1601422cb5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 9.0.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "glib"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b9b8d350db41f690ec1b87109f202782748bbd8ab2f2ede17cb40d29e2838c"
+dependencies = [
+ "bitflags",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9597c68fa7bdf4154a3079642cd21c4dccac0b0bdd2897d82861523bf91e7b9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b38907e67e40dec9b60f858bcada952598719cb512a13eb13d6cdcd16f8295"
+dependencies = [
+ "libc",
+ "system-deps 9.0.0",
 ]
 
 [[package]]
@@ -695,6 +880,127 @@ dependencies = [
  "ignore",
  "walkdir",
 ]
+
+[[package]]
+name = "gobject-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07595c9ba696bd9819cb6a8df39f08078f3dd679508fe052dd558492c2053834"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 9.0.0",
+]
+
+[[package]]
+name = "graphene-rs"
+version = "0.22.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb856b9c558971c3f13ab692358926da710b046932a4e087aedcc35b040d7dff"
+dependencies = [
+ "glib",
+ "graphene-sys",
+]
+
+[[package]]
+name = "graphene-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97842c7543828f98aa5583aa54fcda28aa84fa2b0f8c556142177f7bbb638057"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 9.0.0",
+]
+
+[[package]]
+name = "gsk4"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867be1c5f14dcb8f552c0eff6e9a9b1da5f8b43943e8efc3a63c889d84952ff"
+dependencies = [
+ "cairo-rs",
+ "gdk4",
+ "glib",
+ "graphene-rs",
+ "gsk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gsk4-sys"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b7c7eb2e681ee896646cfb8872b431f24d09f53ba9283289d9b10caa6707088"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk4-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "libc",
+ "pango-sys",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "gtk4"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a0a0466484f64b07b5b8184d43fa46be78eb0b8e04ae4e179af31d770b76d9"
+dependencies = [
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk-pixbuf",
+ "gdk4",
+ "gio",
+ "glib",
+ "graphene-rs",
+ "gsk4",
+ "gtk4-macros",
+ "gtk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gtk4-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac7179400a36a04de039c24206bb841c5596992b907b43b23ee8d5bdc40d00e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "gtk4-sys"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f954786af0b1984425c4446b77f5ff6594346181316be3f850caab1c6f01"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "gsk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps 7.0.8",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -853,6 +1159,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +1230,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "lg-buddy-gui"
+version = "1.4.0"
+dependencies = [
+ "gtk4",
+ "lg-buddy",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -958,6 +1282,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1014,6 +1347,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "pango"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2022dbbd82e1c42bd950a6f1df9b98c796e725dce5ec275e03cbf9772e4efa"
+dependencies = [
+ "gio",
+ "glib",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.22.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca02d64761b74d56cdd4b437db6d73dc95e6c0d40f27e1c707952c0f09052948"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 9.0.0",
+]
+
+[[package]]
 name = "peg"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,7 +1419,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1074,9 +1430,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "potential_utf"
@@ -1085,6 +1441,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1160,7 +1525,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1286,7 +1651,7 @@ checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1322,7 +1687,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1336,6 +1701,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
 ]
 
 [[package]]
@@ -1392,7 +1766,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1431,6 +1805,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,7 +1823,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1447,7 +1832,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d8a928f38f1bc873f28e0d2ba8298ad65374a6ac2241dabd297271531a736cd"
 dependencies = [
- "syn",
+ "syn 2.0.117",
  "synthez-codegen",
  "synthez-core",
 ]
@@ -1458,7 +1843,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb83b8df4238e11746984dfb3819b155cd270de0e25847f45abad56b3671047"
 dependencies = [
- "syn",
+ "syn 2.0.117",
  "synthez-core",
 ]
 
@@ -1471,7 +1856,33 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sealed",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0dae2cbca1f0ff93795713cfe0a4c02f760e3c0b8ae2ab4ec4045808ff429f"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
 ]
 
 [[package]]
@@ -1489,6 +1900,12 @@ dependencies = [
  "filetime",
  "libc",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "terminal_size"
@@ -1528,7 +1945,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1559,8 +1976,59 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "toml"
+version = "1.1.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tungstenite"
@@ -1598,7 +2066,7 @@ checksum = "076a02dc54dd46795c2e9c8282ed40bcfb1e22747e955de9389a1de28190fb26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1682,6 +2150,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -1878,6 +2352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,7 +2394,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1932,7 +2415,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1972,7 +2455,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["crates/lg-buddy"]
+members = ["crates/lg-buddy", "crates/lg-buddy-gui"]
 resolver = "2"

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "lg-buddy-gui"
+version = "1.4.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+gtk = { package = "gtk4", version = "0.11.4", features = ["v4_10"] }
+lg-buddy = { path = "../lg-buddy" }
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "lg-buddy-gui"
+path = "src/main.rs"

--- a/crates/lg-buddy-gui/src/brightness.rs
+++ b/crates/lg-buddy-gui/src/brightness.rs
@@ -1,0 +1,114 @@
+use gtk::prelude::*;
+use lg_buddy::presentation::brightness::{BrightnessPresentation, BrightnessStatus};
+
+pub(crate) fn present(
+    application: &gtk::Application,
+    presentation: &BrightnessPresentation,
+) -> gtk::Window {
+    if let Some(window) = application.windows().into_iter().next() {
+        window.present();
+        return window;
+    }
+
+    let window = build_window(application, presentation);
+    window.present();
+    window.upcast()
+}
+
+fn build_window(
+    application: &gtk::Application,
+    presentation: &BrightnessPresentation,
+) -> gtk::ApplicationWindow {
+    let content = gtk::Box::builder()
+        .orientation(gtk::Orientation::Vertical)
+        .spacing(16)
+        .margin_top(24)
+        .margin_bottom(24)
+        .margin_start(24)
+        .margin_end(24)
+        .build();
+
+    let heading = gtk::Label::builder()
+        .label(presentation.heading())
+        .xalign(0.0)
+        .accessible_role(gtk::AccessibleRole::Heading)
+        .build();
+    heading.add_css_class("title-2");
+    content.append(&heading);
+
+    match presentation.status() {
+        BrightnessStatus::Loading { message } => {
+            let loading = gtk::Box::builder()
+                .orientation(gtk::Orientation::Horizontal)
+                .spacing(12)
+                .build();
+            let spinner = gtk::Spinner::builder()
+                .spinning(true)
+                .accessible_role(gtk::AccessibleRole::Status)
+                .build();
+            spinner.update_property(&[
+                gtk::accessible::Property::Label(message),
+                gtk::accessible::Property::Description(
+                    "LG Buddy is waiting for the current TV brightness.",
+                ),
+            ]);
+            let status = gtk::Label::builder()
+                .label(message)
+                .wrap(true)
+                .xalign(0.0)
+                .build();
+
+            loading.append(&spinner);
+            loading.append(&status);
+            content.append(&loading);
+        }
+    }
+
+    gtk::ApplicationWindow::builder()
+        .application(application)
+        .title(presentation.title())
+        .default_width(360)
+        .child(&content)
+        .build()
+}
+
+#[cfg(test)]
+pub(crate) fn assert_loading_window(window: &gtk::Window, presentation: &BrightnessPresentation) {
+    assert!(window.is_visible());
+    assert_eq!(window.title().as_deref(), Some(presentation.title()));
+
+    let content = window
+        .child()
+        .expect("brightness window should have content")
+        .downcast::<gtk::Box>()
+        .expect("brightness window content should be a box");
+    let heading = content
+        .first_child()
+        .expect("brightness window should have a heading")
+        .downcast::<gtk::Label>()
+        .expect("brightness heading should be a label");
+    assert_eq!(heading.label(), presentation.heading());
+    assert_eq!(heading.accessible_role(), gtk::AccessibleRole::Heading);
+
+    let loading = heading
+        .next_sibling()
+        .expect("brightness window should have loading content")
+        .downcast::<gtk::Box>()
+        .expect("brightness loading content should be a box");
+    let spinner = loading
+        .first_child()
+        .expect("brightness loading content should have a spinner")
+        .downcast::<gtk::Spinner>()
+        .expect("brightness loading indicator should be a spinner");
+    assert!(spinner.is_spinning());
+    assert_eq!(spinner.accessible_role(), gtk::AccessibleRole::Status);
+
+    let status = spinner
+        .next_sibling()
+        .expect("brightness loading content should have a status label")
+        .downcast::<gtk::Label>()
+        .expect("brightness loading status should be a label");
+    let BrightnessStatus::Loading { message } = presentation.status();
+    assert_eq!(status.label(), message.as_str());
+    assert_eq!(status.accessible_role(), gtk::AccessibleRole::Label);
+}

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1,0 +1,169 @@
+mod brightness;
+
+use std::fmt;
+
+use gtk::glib;
+use gtk::prelude::*;
+use lg_buddy::presentation::brightness::BrightnessPresentation;
+
+pub const APPLICATION_ID: &str = "io.github.staphylococcus.LGBuddy";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuiCommand {
+    Brightness,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GuiParseError {
+    MissingCommand,
+    UnknownCommand(String),
+    UnexpectedArguments(Vec<String>),
+}
+
+impl fmt::Display for GuiParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingCommand => write!(f, "missing command; expected `brightness`"),
+            Self::UnknownCommand(command) => write!(f, "unknown command `{command}`"),
+            Self::UnexpectedArguments(arguments) => {
+                write!(f, "unexpected arguments: {}", arguments.join(" "))
+            }
+        }
+    }
+}
+
+pub fn parse_args<I, S>(args: I) -> Result<GuiCommand, GuiParseError>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut args = args.into_iter();
+    let command = match args.next() {
+        Some(command) if command.as_ref() == "brightness" => GuiCommand::Brightness,
+        Some(command) => return Err(GuiParseError::UnknownCommand(command.as_ref().to_string())),
+        None => return Err(GuiParseError::MissingCommand),
+    };
+
+    let unexpected: Vec<String> = args.map(|argument| argument.as_ref().to_string()).collect();
+    if !unexpected.is_empty() {
+        return Err(GuiParseError::UnexpectedArguments(unexpected));
+    }
+
+    Ok(command)
+}
+
+pub fn help(program: &str) -> String {
+    format!("Usage: {program} brightness\n")
+}
+
+pub fn run(command: GuiCommand) -> glib::ExitCode {
+    match command {
+        GuiCommand::Brightness => run_brightness_application(),
+    }
+}
+
+fn run_brightness_application() -> glib::ExitCode {
+    let application = gtk::Application::builder()
+        .application_id(APPLICATION_ID)
+        .build();
+    install_application_actions(&application);
+    connect_brightness_application(&application, BrightnessPresentation::loading());
+    application.run_with_args(&["lg-buddy-gui"])
+}
+
+fn install_application_actions(application: &gtk::Application) {
+    let quit = gtk::gio::SimpleAction::new("quit", None);
+    quit.connect_activate({
+        let application = application.clone();
+        move |_, _| application.quit()
+    });
+    application.add_action(&quit);
+    application.set_accels_for_action("app.quit", &["<Primary>q"]);
+}
+
+fn connect_brightness_application(
+    application: &gtk::Application,
+    presentation: BrightnessPresentation,
+) {
+    application.connect_activate(move |application| {
+        brightness::present(application, &presentation);
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::{Cell, RefCell};
+    use std::rc::Rc;
+
+    use gtk::glib;
+    use gtk::prelude::*;
+    use lg_buddy::presentation::brightness::BrightnessPresentation;
+
+    use super::{connect_brightness_application, help, parse_args, GuiCommand, GuiParseError};
+
+    #[test]
+    fn parses_the_brightness_command() {
+        assert_eq!(parse_args(["brightness"]), Ok(GuiCommand::Brightness));
+        assert_eq!(
+            parse_args(std::iter::empty::<&str>()),
+            Err(GuiParseError::MissingCommand)
+        );
+        assert_eq!(
+            parse_args(["settings"]),
+            Err(GuiParseError::UnknownCommand("settings".to_string()))
+        );
+        assert_eq!(
+            parse_args(["brightness", "extra"]),
+            Err(GuiParseError::UnexpectedArguments(
+                vec!["extra".to_string()]
+            ))
+        );
+        assert_eq!(help("lg-buddy-gui"), "Usage: lg-buddy-gui brightness\n");
+    }
+
+    #[test]
+    fn display_backed_application_presents_one_loading_window_and_closes() {
+        let presentation = BrightnessPresentation::loading();
+        let application_id = format!(
+            "io.github.staphylococcus.LGBuddy.Test{}",
+            std::process::id()
+        );
+        let application = gtk::Application::builder()
+            .application_id(application_id)
+            .build();
+        connect_brightness_application(&application, presentation.clone());
+
+        let activation_count = Rc::new(Cell::new(0));
+        let first_window = Rc::new(RefCell::new(None));
+
+        application.connect_activate({
+            let activation_count = Rc::clone(&activation_count);
+            let first_window = Rc::clone(&first_window);
+            move |application| {
+                let current_count = activation_count.get() + 1;
+                activation_count.set(current_count);
+
+                let windows = application.windows();
+                assert_eq!(windows.len(), 1);
+                let window = windows[0].clone();
+                super::brightness::assert_loading_window(&window, &presentation);
+
+                if current_count == 1 {
+                    first_window.replace(Some(window));
+                    let application = application.clone();
+                    glib::idle_add_local_once(move || application.activate());
+                } else {
+                    assert_eq!(first_window.borrow().as_ref(), Some(&window));
+                    window.close();
+                    application.quit();
+                }
+            }
+        });
+
+        let exit_code = application.run_with_args(&["lg-buddy-gui-test"]);
+
+        assert_eq!(exit_code, glib::ExitCode::SUCCESS);
+        assert_eq!(activation_count.get(), 2);
+        assert!(application.windows().is_empty());
+    }
+}

--- a/crates/lg-buddy-gui/src/main.rs
+++ b/crates/lg-buddy-gui/src/main.rs
@@ -1,0 +1,18 @@
+use gtk::glib;
+use lg_buddy_gui::{help, parse_args, run, GuiCommand};
+
+fn main() -> glib::ExitCode {
+    let program = std::env::args()
+        .next()
+        .unwrap_or_else(|| "lg-buddy-gui".to_string());
+
+    match parse_args(std::env::args().skip(1)) {
+        Ok(GuiCommand::Brightness) => run(GuiCommand::Brightness),
+        Err(err) => {
+            eprintln!("LG Buddy GUI: {err}");
+            eprintln!();
+            eprint!("{}", help(&program));
+            glib::ExitCode::FAILURE
+        }
+    }
+}

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod lifecycle;
 pub mod notifications;
 pub mod platform_access_token;
 pub mod policy;
+pub mod presentation;
 pub mod release_bundle;
 pub mod runtime_phase;
 pub mod screen;

--- a/crates/lg-buddy/src/presentation/brightness.rs
+++ b/crates/lg-buddy/src/presentation/brightness.rs
@@ -1,0 +1,54 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrightnessPresentation {
+    title: String,
+    heading: String,
+    status: BrightnessStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BrightnessStatus {
+    Loading { message: String },
+}
+
+impl BrightnessPresentation {
+    pub fn loading() -> Self {
+        Self {
+            title: "LG TV Brightness".to_string(),
+            heading: "OLED Pixel Brightness".to_string(),
+            status: BrightnessStatus::Loading {
+                message: "Loading current brightness…".to_string(),
+            },
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn heading(&self) -> &str {
+        &self.heading
+    }
+
+    pub fn status(&self) -> &BrightnessStatus {
+        &self.status
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BrightnessPresentation, BrightnessStatus};
+
+    #[test]
+    fn loading_presentation_declares_the_initial_brightness_screen() {
+        let presentation = BrightnessPresentation::loading();
+
+        assert_eq!(presentation.title(), "LG TV Brightness");
+        assert_eq!(presentation.heading(), "OLED Pixel Brightness");
+        assert_eq!(
+            presentation.status(),
+            &BrightnessStatus::Loading {
+                message: "Loading current brightness…".to_string(),
+            }
+        );
+    }
+}

--- a/crates/lg-buddy/src/presentation/mod.rs
+++ b/crates/lg-buddy/src/presentation/mod.rs
@@ -1,0 +1,1 @@
+pub mod brightness;

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -7,13 +7,20 @@ It is not a product roadmap. It is a map of what exists today and how the main p
 For the top-level system, desktop, and service event paths that enter the
 runtime, see [Runtime event handler map](runtime-event-handler-map.md).
 
+For the application-owned presentation contract and GTK renderer boundary,
+including the target beyond the initial loading shell, see
+[GUI target architecture](gui-target-architecture.md). The architecture below
+describes the current implementation.
+
 ## Repository Shape
 
-The repository now has one runtime implementation and one setup surface:
+The repository has one application/runtime crate, one GUI frontend crate, and
+one setup surface:
 
 - Rust runtime workspace
   - `Cargo.toml`
   - `crates/lg-buddy/`
+  - `crates/lg-buddy-gui/`
 - shell-based setup surface
   - `configure.sh`
   - `install.sh`
@@ -21,7 +28,9 @@ The repository now has one runtime implementation and one setup surface:
   - `bin/LG_Buddy_Common`
   - `systemd/`
 
-The Rust runtime owns operational behavior. The remaining shell layer exists for configuration, installation, and removal.
+The Rust application owns operational behavior and toolkit-neutral presentation
+state. The GTK crate renders that state. The remaining shell layer exists for
+configuration, installation, and removal.
 
 ## High-Level Runtime Shape
 
@@ -88,8 +97,10 @@ The main runtime consumers are:
 - desktop environment and session integrations, including GNOME, `swayidle`,
   and Linux input activity sources
 - TTY users invoking the CLI directly
-- frontend surfaces, currently the zenity brightness dialog, which delegate
-  back through the CLI/API command surface
+- the installed Zenity brightness dialog, which delegates back through the
+  CLI/API command surface
+- the standalone `lg-buddy-gui brightness` GTK loading shell, which currently
+  renders application-owned presentation state without TV operations
 
 ```mermaid
 flowchart LR
@@ -112,6 +123,7 @@ flowchart LR
 
     subgraph Frontend["Frontend"]
         ZENITY["zenity brightness dialog<br/>interactive prompt"]
+        GTK["lg-buddy-gui<br/>brightness loading shell"]
     end
 
     subgraph Rust["Rust Runtime"]
@@ -126,6 +138,7 @@ flowchart LR
         PHASE["runtime_phase.rs<br/>machine sleep phase provider"]
         CONFIG["config.rs<br/>config.env parsing"]
         STATE["state.rs<br/>runtime markers"]
+        PRESENTATION["presentation/brightness.rs<br/>toolkit-neutral Loading state"]
 
         subgraph SessionSubsystem["Session Integration Subsystem"]
             BACKEND["backend.rs<br/>backend selection"]
@@ -173,6 +186,7 @@ flowchart LR
     NM --> MAIN
     TERMINAL --> MAIN
     ZENITY --> MAIN
+    PRESENTATION --> GTK
     MAIN --> COMMANDS
     COMMANDS --> EVENTS
     COMMANDS --> NMGATE

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,6 +9,13 @@ Compiling the Rust runtime requires:
 - a Rust toolchain with `cargo`
 - a working C toolchain
 
+Compiling and testing the GTK frontend additionally requires:
+
+- GTK 4.10 or newer development files
+- `pkg-config`
+- a graphical session or virtual display for renderer tests
+- `xdotool` for the executable launch smoke test
+
 Running the interactive installer, exercising the legacy TV fallback, and
 testing release bundles also requires:
 
@@ -43,6 +50,21 @@ Build the runtime from source with:
 ```bash
 cargo build --release -p lg-buddy
 ```
+
+Build the GTK frontend from source with:
+
+```bash
+cargo build -p lg-buddy-gui
+```
+
+Run its current brightness shell with:
+
+```bash
+cargo run -p lg-buddy-gui -- brightness
+```
+
+The resulting `lg-buddy-gui` binary is a development artifact in the current
+GUI slice. Installer and release-bundle integration are tracked separately.
 
 Official release builds inject version identity into the binary:
 
@@ -83,7 +105,9 @@ Useful checks during development:
 ```bash
 cargo test -p lg-buddy --lib
 cargo test -p lg-buddy --test cucumber
-cargo clippy -p lg-buddy --all-targets --all-features -- -D warnings
+dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
+dbus-run-session -- xvfb-run -a env GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 python3 scripts/test_release_promotion.py
 python3 scripts/test_record_github_release_responses.py
@@ -186,6 +210,7 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/commands.rs` | Runtime command entrypoints and dependency assembly |
 | `crates/lg-buddy/src/events.rs` | Canonical runtime event vocabulary |
 | `crates/lg-buddy/src/policy.rs` | Policy outcome, action, no-action, diagnostic, and state-transition types |
+| `crates/lg-buddy/src/presentation/` | Toolkit-neutral GUI presentation declarations owned by the application |
 | `crates/lg-buddy/src/screen.rs` | Session screen blank/restore policy |
 | `crates/lg-buddy/src/lifecycle.rs` | Startup, shutdown, system sleep, and system resume policy |
 | `crates/lg-buddy/src/runtime_phase.rs` | Runtime sleep-phase provider abstraction |
@@ -201,6 +226,7 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/tv.rs` | TV transport boundary and facade |
 | `crates/lg-buddy/src/web_os/` | Native webOS client, profile-bound TV adapter, domain operations, and test support |
 | `crates/lg-buddy/src/wol.rs` | Native Wake-on-LAN support |
+| `crates/lg-buddy-gui/` | GTK 4 executable, application lifecycle, and thin presentation renderer |
 | `configure.sh` | Interactive configuration tool |
 | `install.sh` | Installer for an existing binary |
 | `uninstall.sh` | Uninstaller |
@@ -220,6 +246,7 @@ the branch contract and recovery process, see
 | `docs/architecture-overview.md` | Runtime architecture |
 | `docs/defaults-and-configuration.md` | Product defaults and persistent configuration guidance |
 | `docs/gamepad-subsystem.md` | Gamepad activity architecture and adapter guidance |
+| `docs/gui-target-architecture.md` | Target declarative application contract and GTK renderer boundary |
 | `docs/runtime-event-handler-map.md` | Top-level system, desktop, and runtime event handler map |
 | `docs/session-backend-model.md` | Session backend semantics and capability model |
 | `docs/testing-strategy.md` | Test strategy and scope |

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -1,0 +1,557 @@
+# LG Buddy GUI Target Architecture
+
+This document defines the target frontend architecture for the first-party
+Linux GUI. It anchors the brightness MVP in
+[#127](https://github.com/Staphylococcus/LG_Buddy/issues/127) and the later GUI
+increments under
+[#22](https://github.com/Staphylococcus/LG_Buddy/issues/22).
+
+This is a target-state document, not a description of the current Zenity
+implementation. For the architecture that exists today, see
+[Architecture overview](architecture-overview.md).
+
+## Decisions
+
+1. GTK 4 is the first-party renderer.
+2. The application owns one typed, toolkit-neutral declaration for each
+   screen and accepts semantic user intents in return.
+3. The GTK layer contains no business logic or consequential effects.
+4. The GUI calls the Rust application in-process. It does not communicate
+   through CLI output, a daemon, HTTP, or a serialized UI protocol.
+5. CLI and service paths remain headless and do not link GTK.
+6. GTK uses standard controls, system typography, system colors, native
+   focus behavior, and accessibility semantics with minimal custom styling.
+7. The declaration vocabulary stays small and specific to LG Buddy. It is not
+   a general-purpose widget toolkit.
+
+The central distinction is between declaring what the user can currently see
+and do, and deciding what those actions mean. The application owns both the
+declaration and the meaning. GTK only realizes the declaration using native
+widgets and translates widget events back into semantic intents.
+
+## Migration Baseline
+
+The current `brightness` prompt path in `commands.rs` is a useful behavioral
+baseline, but not the target boundary:
+
+| Current implementation | Target state |
+| --- | --- |
+| `BrightnessUi` exposes one blocking prompt and an error dialog | The application publishes state and accepts intents over time |
+| `ZenityBrightnessUi` shells out to `zenity` | GTK renders typed application declarations |
+| `CurrentExeBrightnessCli` shells back into `lg-buddy brightness get/set` | The GUI process calls an in-process brightness application operation |
+| The prompt wrapper owns reachability, read fallback, notifications, and orchestration together | Those decisions live in an explicit application flow behind the presentation contract |
+| Tests fake the prompt, nested CLI, ping, and notification collaborators | Application tests drive state and operations directly; renderer tests consume presentation fixtures |
+| Cucumber substitutes a Zenity executable | A thin display-backed smoke covers the real GTK launch boundary |
+
+The migration should preserve observable product behavior unless the MVP issue
+explicitly changes it. It should not preserve the subprocess structure merely
+because current tests encode that structure.
+
+## Target Boundary
+
+```mermaid
+flowchart LR
+    ENTRY["Desktop entry or GUI launcher"] --> COMPOSE["lg-buddy-gui<br/>composition root"]
+
+    subgraph Frontend["GTK frontend"]
+        RENDER["GTK renderer<br/>widgets, focus, layout, accessibility"]
+    end
+
+    subgraph Contract["Application-owned presentation contract"]
+        VIEW["Typed presentation state"]
+        INTENT["Semantic user intents"]
+    end
+
+    subgraph Application["LG Buddy application"]
+        FLOW["Brightness flow<br/>state transitions and effect decisions"]
+        OPS["Brightness operations<br/>config, TV access, notifications"]
+    end
+
+    subgraph Domain["Existing domain and adapters"]
+        TV["TvDevice picture API"]
+        WEBOS["Selected TV adapter"]
+    end
+
+    FLOW --> VIEW --> RENDER
+    RENDER --> INTENT --> FLOW
+    FLOW --> OPS --> TV --> WEBOS
+    COMPOSE --> RENDER
+    COMPOSE --> FLOW
+```
+
+The arrows define the dependency direction:
+
+- presentation types belong to the application, not GTK
+- GTK depends on those types
+- application and domain code do not depend on GTK
+- GTK does not call TV, config, settings, notification, or service modules
+- the composition root may construct both sides but contains no product
+  decisions
+
+## Target Repository Shape
+
+The smallest useful compile-time boundary is a separate GUI binary crate:
+
+```text
+crates/lg-buddy/
+  src/
+    presentation/
+      mod.rs
+      brightness.rs
+    ...existing application, domain, and adapter modules...
+
+crates/lg-buddy-gui/
+  Cargo.toml
+  src/
+    lib.rs
+    main.rs
+    brightness.rs
+```
+
+`crates/lg-buddy` remains the GTK-free library and CLI/service binary. It owns
+the presentation contracts, state transitions, dependency construction, and
+operations. Its normal tests must continue to build on a host without GTK
+development packages.
+
+`crates/lg-buddy-gui` owns the GTK application, windows, widgets, renderer, and
+main-loop bridge. It depends on `lg-buddy` and GTK, never the reverse. The GUI
+crate should consume one public application entrypoint rather than assembling
+TV or configuration dependencies itself.
+
+The installed graphical executable is `lg-buddy-gui`. The desktop entry launches
+that executable directly. The user-facing `lg-buddy brightness` command may
+locate and launch it for compatibility, while `lg-buddy brightness get` and
+`lg-buddy brightness set` remain direct headless commands. That launcher handoff
+does not become the frontend/backend contract: once `lg-buddy-gui` starts, GTK
+and the application communicate only through in-process Rust types.
+
+This split also keeps GTK runtime linkage out of systemd services and the
+headless CLI. Release bundles and packages must ship the GUI executable and
+declare its real GTK runtime dependencies separately from the existing CLI
+binary.
+
+The headless binary may retain its current static musl release target. The GTK
+binary is a separate dynamically linked Linux artifact built against the
+oldest supported GNU/GTK baseline. The release bundle must identify and verify
+both artifacts; the GUI must not force the service and CLI binary to adopt its
+linkage model. The exact minimum GTK and GNU ABI versions are release and
+packaging decisions validated on supported distribution baselines.
+
+## Presentation Contract
+
+### Screen-specific declarations
+
+The contract starts with concrete screen models. The brightness MVP should not
+begin with a generic tree of rows, widgets, properties, callbacks, or stringly
+typed component names.
+
+A representative contract shape is:
+
+```rust
+pub struct BrightnessPresentation {
+    pub title: String,
+    pub status: BrightnessStatus,
+    pub control: Option<BrightnessControl>,
+    pub primary_action: ActionPresentation,
+    pub cancel_action: ActionPresentation,
+}
+
+pub struct BrightnessControl {
+    pub label: String,
+    pub current: OledBrightness,
+    pub proposed: OledBrightness,
+    pub minimum: u8,
+    pub maximum: u8,
+    pub step: u8,
+    pub enabled: bool,
+}
+
+pub enum BrightnessStatus {
+    Loading,
+    Ready,
+    Applying,
+    Failed(UserFacingError),
+}
+
+pub struct ActionPresentation {
+    pub label: String,
+    pub enabled: bool,
+    pub intent: BrightnessIntent,
+}
+
+pub struct UserFacingError {
+    pub summary: String,
+    pub detail: Option<String>,
+}
+```
+
+This is semantic data, not a GTK widget tree:
+
+- `BrightnessControl` means “let the user propose a bounded brightness value,”
+  not “construct this exact slider with these pixels.”
+- each action declares its intent and availability without choosing a GTK
+  widget hierarchy or asking the renderer to infer what a label means.
+- `BrightnessStatus` tells the renderer what state exists without exposing a
+  transport error or asking the renderer to infer policy.
+- copy is plain text. GTK markup and widget-specific properties do not cross
+  the boundary.
+
+The renderer chooses the standard GTK representation for each semantic role.
+Shared presentation primitives should be extracted only after another screen
+needs the same semantics. Similar appearance alone is not enough reason to
+create a generic abstraction.
+
+### Semantic intents
+
+GTK returns only intents that express what the user requested:
+
+```rust
+pub enum BrightnessIntent {
+    Propose(OledBrightness),
+    Apply,
+    Retry,
+    Cancel,
+}
+```
+
+The renderer does not turn `Apply` into a TV call, decide whether retry is
+allowed, or close the window because a callback happened to succeed. The
+application handles the intent and publishes the next presentation or an
+explicit close outcome.
+
+Window-close requests map to `Cancel`. Programmatic widget changes must not
+create accidental user intents. The GTK adapter may suppress signal feedback
+while applying a presentation; that is rendering mechanics, not business
+logic.
+
+### Application outcomes
+
+The application publishes a closed set of outcomes to the host:
+
+```rust
+pub enum BrightnessFrontendUpdate {
+    Present(BrightnessPresentation),
+    Close,
+}
+```
+
+The contract is internal and typed. It is not serialized or independently
+versioned. The backend and frontend change atomically in the workspace, and
+the Rust compiler enforces contract compatibility.
+
+If a later requirement needs an external process boundary, that is a separate
+architecture decision. It must not be anticipated by adding identifiers,
+schema versions, JSON, or transport errors to this contract.
+
+## Application Ownership
+
+The brightness application flow owns:
+
+- configuration loading and validation
+- construction of the selected TV client
+- reachability policy, if retained
+- reading and validating the current brightness
+- fallback or recovery behavior when the read fails
+- the proposed value and whether Apply is available
+- the loading, ready, applying, failed, and completed transitions
+- prevention of duplicate or stale operations
+- cancellation semantics
+- error normalization and recovery actions
+- the TV write and its postcondition behavior
+- success or failure notifications
+- diagnostics and exit status
+
+The GTK layer owns only:
+
+- selecting standard GTK widgets for the declared semantic roles
+- widget creation, placement, sizing, and responsive layout
+- rendering application-provided text and state
+- focus order, keyboard accelerators, and mnemonic wiring
+- accessibility roles, labels, descriptions, and relationships
+- routing widget signals to semantic intents
+- presenting or closing the window when instructed
+- respecting system font, scale, color, and theme settings
+
+GTK callbacks must not:
+
+- parse configuration or command output
+- construct a TV client or call `TvDevice`
+- perform a ping or other reachability check
+- validate, clamp, or silently replace a brightness value
+- decide when an action is enabled
+- translate transport failures into user messages
+- retry, notify, persist, log product outcomes, or control services
+- branch on domain errors to choose the next workflow state
+
+Simple renderer assertions that protect toolkit invariants are allowed. For
+example, receiving an invalid declared range should fail a renderer test rather
+than be repaired with a second set of product rules.
+
+## Brightness Flow
+
+The application flow is an explicit state machine even if its implementation
+remains small:
+
+| Current state | Input | Application responsibility | Next presentation |
+| --- | --- | --- | --- |
+| Opening | application start | begin the current-value operation | Loading |
+| Loading | read succeeds | store current and proposed value | Ready |
+| Loading | read fails | apply the defined recovery or fallback policy | Ready or Failed |
+| Ready | `Propose(value)` | validate and store the proposal | Ready |
+| Ready | `Apply` | capture the proposal and start one write | Applying |
+| Applying | write succeeds | record success and complete notification policy | Close or completed state |
+| Applying | write fails | normalize the failure and expose recovery | Failed |
+| Failed | `Retry` | retry the application-defined operation | Loading or Applying |
+| Any open state | `Cancel` | cancel or detach safely without writing new state | Close |
+
+The exact current product behavior should be preserved while moving it behind
+this boundary unless #127 explicitly changes it. In particular, cancellation
+must not write TV state, and `brightness get` and `brightness set` retain their
+existing CLI contracts. Existing reachability, read-fallback, and notification
+behavior must be treated as application policy during migration, never copied
+into GTK.
+
+An operation result is accepted only for the operation instance that is still
+current. A late completion after cancel, retry, or shutdown cannot reopen the
+window, overwrite a newer proposal, or report success for the wrong request.
+
+## Main Loop And Blocking Work
+
+GTK objects stay on the GTK main thread. TV discovery, connection, pairing,
+reads, writes, subprocess compatibility calls, and network checks never run in
+a GTK signal callback or otherwise block the main loop. This follows GTK's
+[threading model](https://docs.gtk.org/gtk4/section-threading.html).
+
+The target event path is:
+
+1. A GTK signal is translated into a `BrightnessIntent`.
+2. The application accepts or rejects the intent from its current state.
+3. Any blocking application effect runs on a worker owned by the application
+   host.
+4. Its typed completion returns to the application state machine.
+5. The application publishes a new `BrightnessFrontendUpdate`.
+6. The GTK main loop renders that update.
+
+The chosen channel or executor is an implementation detail. It must provide a
+bounded, shutdown-safe path and must not leak GLib or GTK types into
+`crates/lg-buddy`. Only one brightness effect is in flight at a time. The
+application remains authoritative even when the renderer has already disabled
+a button.
+
+## GTK Rendering Rules
+
+The MVP should look like a normal GTK utility rather than introduce an LG
+Buddy-specific widget language or theme.
+
+| Declared meaning | GTK responsibility |
+| --- | --- |
+| Screen title | Application window title and visible heading where appropriate |
+| Brightness percentage | Standard bounded adjustment control with a visible value |
+| Loading or applying | Standard busy indication and insensitive affected controls |
+| Primary action | Standard button using the declared label and enabled state |
+| Cancel | Standard secondary action and window-close behavior |
+| Failure | Standard inline error/status presentation with declared recovery action |
+
+Renderer rules:
+
+- use GTK widgets before custom widgets
+- use natural sizing and standard spacing rather than fixed pixel layouts
+- preserve visible labels and logical focus order
+- make the full flow keyboard-operable
+- expose accessible names, descriptions, values, and relationships
+- do not encode state using color alone
+- follow the active system theme and scaling
+- avoid custom CSS unless a concrete GTK limitation requires it
+- keep platform chrome, focus visuals, animation, and control behavior under
+  GTK ownership
+
+The minimum GTK API level must be selected from the oldest supported Linux
+distribution baseline, not from the newest API available on a development
+machine. Raising that baseline belongs with packaging validation.
+
+## Error, Cancellation, And Shutdown Semantics
+
+Domain and adapter errors remain typed inside the application. Before a failure
+crosses the presentation boundary, the application converts it into safe,
+actionable text and declares which recovery intents are available. The
+renderer never displays debug representations or searches error strings.
+
+Secrets, access tokens, and unredacted protocol payloads must not enter a
+presentation type. Detailed diagnostics may be logged through the existing
+application diagnostics path, while the presentation receives only the detail
+needed by the user.
+
+Closing the window emits `Cancel`; it is not permission for the renderer to
+kill a worker or assume that an operation was undone. The application decides
+whether a pending operation can be cancelled, must be detached, or has already
+completed. Shutdown closes intent/update channels cleanly, ignores obsolete
+completions, and never leaves a GTK callback waiting for a worker.
+
+Failure to initialize GTK or connect to a graphical session is a launcher
+failure. It should produce a concise diagnostic and nonzero exit status without
+changing the headless CLI behavior.
+
+## Contract Testing Strategy
+
+The GUI follows the repository's three-layer
+[testing strategy](testing-strategy.md). The majority of behavior remains
+testable without GTK.
+
+### 1. Module behavior: application presentation and state
+
+Pure or narrowly injected tests in `crates/lg-buddy` cover:
+
+- the initial Loading declaration
+- successful current-value loading
+- the defined read-failure recovery or fallback
+- proposal changes and Apply availability
+- invalid values being rejected before presentation
+- Apply producing exactly one operation
+- duplicate Apply being ignored while busy
+- success, write failure, retry, and cancellation transitions
+- late operation completions being ignored
+- safe user-facing error normalization
+- GTK-free construction and equality of every presentation state
+
+These tests assert semantic state and emitted effects, not widget classes,
+pixels, screenshots, or callback order.
+
+### 2. Module interoperability: application operations and renderer contract
+
+Application integration tests use injected brightness operations and the
+existing TV test boundaries to prove that intents reach the real application
+path without invoking the CLI as a subprocess. They cover configuration,
+selected TV adapters, pairing/recovery, current-value reads, writes,
+notifications, and representative failures at the abstraction that owns each
+behavior.
+
+The GTK crate has a reusable renderer contract suite. It feeds representative
+`BrightnessPresentation` fixtures into the renderer and observes the semantic
+surface:
+
+- the expected controls, labels, values, status, and enabled states exist
+- focus order and keyboard activation are correct
+- accessible roles, names, values, and descriptions are present
+- widget signals emit exactly the corresponding `BrightnessIntent`
+- applying a new presentation does not emit accidental intents
+- busy, failure, retry, scaling, and light/dark theme states remain usable
+
+Renderer tests use application-owned fixtures; they do not rebuild the state
+machine in a GTK fake. A display-backed CI lane may provide the GTK environment,
+but TV and network dependencies remain mocked at their existing boundaries.
+
+### 3. User needs: thin graphical journey
+
+A small acceptance layer proves only the user-visible boundary:
+
+- the desktop entry opens the brightness window without a terminal
+- the current value becomes visible
+- changing and applying a value reaches the application once
+- cancellation performs no write
+- an unreachable TV or failed write leaves actionable feedback
+- the window remains responsive during blocking TV work
+
+Release-bundle smoke proves that both executables, the desktop entry, and the
+required GTK runtime dependencies are present. It should not duplicate the
+application state-machine matrix.
+
+Screenshots may support design review, but they are not the primary contract:
+system themes, fonts, and rendering legitimately vary. Automated assertions
+should prefer semantic controls, accessibility state, and user intents.
+
+Real TV testing remains targeted. It is required only when a change claims
+different visible TV behavior or when the existing mock contract is unclear;
+ordinary renderer work must not require hardware.
+
+### Contract matrix
+
+| Contract | Owner | Primary proof |
+| --- | --- | --- |
+| Presentation and intent semantics | `lg-buddy` application | GTK-free module tests |
+| State transitions and effect decisions | `lg-buddy` application | Pure/injected state-machine tests |
+| TV operation behavior | Existing TV domain and adapters | Existing unit, protocol, and characterization tests |
+| Application-to-operation wiring | `lg-buddy` application | Integration tests with injected dependencies |
+| Semantic declaration to GTK mapping | `lg-buddy-gui` renderer | Reusable renderer contract suite |
+| Desktop launch and runtime dependencies | Packaging/release surface | Display-backed bundle smoke |
+| Visible TV outcome | Product boundary | Selected acceptance and hardware checks |
+
+No test should need to mock a contract below the layer under test when a
+shared repository harness already represents that boundary.
+
+## Implementation Method
+
+The MVP moves toward the target in independently reviewable, observable
+slices. Implementation details remain acceptance criteria within the slice
+that first needs them:
+
+1. [#140](https://github.com/Staphylococcus/LG_Buddy/issues/140) opens the GTK
+   window from an application-owned Loading declaration and establishes the
+   crate, renderer, lifecycle, and display-backed test boundaries.
+2. [#141](https://github.com/Staphylococcus/LG_Buddy/issues/141) retrieves and
+   displays the current brightness, establishing backend-to-frontend state
+   flow and the non-blocking operation boundary.
+3. [#142](https://github.com/Staphylococcus/LG_Buddy/issues/142) lets the user
+   apply brightness, establishing semantic intents and frontend-to-backend
+   state flow.
+4. [#143](https://github.com/Staphylococcus/LG_Buddy/issues/143) routes the
+   existing desktop and interactive CLI touchpoints to the GTK window.
+5. [#144](https://github.com/Staphylococcus/LG_Buddy/issues/144) integrates the
+   GUI with install, upgrade, and removal behavior.
+6. [#145](https://github.com/Staphylococcus/LG_Buddy/issues/145) ships the GUI
+   in release bundles and adds installed-artifact smoke coverage.
+
+Each slice must leave the existing `brightness get`, `brightness set`, service,
+and compatibility paths green. The Zenity implementation remains available in
+the v1.5.0 slice; removing it is tracked separately by
+[#130](https://github.com/Staphylococcus/LG_Buddy/issues/130).
+
+## Evolution Rules
+
+Later GUI areas follow the same method:
+
+- add a screen-specific application declaration and semantic intents
+- keep navigation and multi-step workflow state in the application
+- reuse domain operations rather than CLI strings
+- add GTK-free contract/state tests first
+- implement GTK mapping and its renderer contract tests second
+- extract a shared semantic presentation type only after genuine reuse appears
+- change the application contract and every renderer atomically
+
+A frontend change that requires GTK to understand config keys, TV transports,
+service commands, update rules, or migration policy indicates that the
+application contract is missing a semantic state or intent. Fix the contract
+instead of teaching the renderer the rule.
+
+## Non-goals
+
+- a general-purpose declarative UI framework
+- a serialized UI schema or runtime-loaded screen definition
+- a custom theme, widget set, or design system
+- a local daemon or frontend protocol
+- moving existing domain or policy behavior into GUI code
+- replacing the CLI or service entrypoints
+- implementing settings, pairing, diagnostics, or first-run setup in the
+  brightness MVP
+- removing Zenity in the MVP
+
+GTK templates or builder files may be used internally by the GTK renderer.
+They are renderer implementation details and do not replace the
+application-owned presentation contract.
+
+## MVP Architectural Acceptance
+
+The brightness MVP satisfies this architecture when:
+
+- the core crate compiles and tests without GTK
+- the GTK crate imports application presentation types but the core imports no
+  GTK or GLib types
+- GTK callbacks emit semantic intents and perform no TV, config, notification,
+  service, validation, or workflow work
+- blocking operations cannot stall the GTK main loop
+- presentation states and transitions have complete GTK-free coverage
+- the GTK renderer passes the shared semantic, keyboard, accessibility,
+  scaling, and theme contract
+- the desktop entry launches the GUI and the bundle supplies its runtime
+  dependencies
+- CLI, headless service behavior, and the retained Zenity compatibility path
+  remain unchanged

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -172,6 +172,11 @@ So cucumber sits on top of the first two layers:
 
 ## Applying The Strategy To This Repo
 
+The GTK frontend applies these same layers without moving application
+behavior into GUI tests. Its presentation contract, renderer boundary, and
+test split are defined in
+[GUI target architecture](gui-target-architecture.md).
+
 ### Rust runtime core
 
 Primary concern:

--- a/scripts/test-gui-launch.sh
+++ b/scripts/test-gui-launch.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+GUI_BINARY="${1:-./target/debug/lg-buddy-gui}"
+APPLICATION_ID="io.github.staphylococcus.LGBuddy"
+WINDOW_TITLE="LG TV Brightness"
+GUI_PID=""
+WINDOW_IDS=()
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "$GUI_PID" ] && kill -0 "$GUI_PID" 2>/dev/null; then
+        kill "$GUI_PID"
+        wait "$GUI_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+[ -x "$GUI_BINARY" ] || fail "GUI binary is not executable: $GUI_BINARY"
+[ -n "${DISPLAY:-}" ] || fail "DISPLAY is required for the GUI launch smoke test."
+[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || fail "A D-Bus session is required for the GUI launch smoke test."
+command -v gapplication >/dev/null || fail "gapplication is required for the GUI launch smoke test."
+command -v xdotool >/dev/null || fail "xdotool is required for the GUI launch smoke test."
+
+GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+    "$GUI_BINARY" brightness &
+GUI_PID=$!
+
+for ((attempt = 0; attempt < 300; attempt++)); do
+    if ! kill -0 "$GUI_PID" 2>/dev/null; then
+        status=0
+        wait "$GUI_PID" || status=$?
+        fail "GUI process exited before presenting a window with status $status."
+    fi
+
+    mapfile -t WINDOW_IDS < <(
+        xdotool search --onlyvisible --name "^${WINDOW_TITLE}$" 2>/dev/null || true
+    )
+    [ "${#WINDOW_IDS[@]}" -le 1 ] || fail "GUI presented duplicate brightness windows."
+    [ "${#WINDOW_IDS[@]}" -eq 0 ] || break
+    sleep 0.1
+done
+
+[ "${#WINDOW_IDS[@]}" -eq 1 ] || fail "GUI did not present the brightness window."
+
+GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+    "$GUI_BINARY" brightness
+mapfile -t WINDOW_IDS < <(
+    xdotool search --onlyvisible --name "^${WINDOW_TITLE}$" 2>/dev/null || true
+)
+[ "${#WINDOW_IDS[@]}" -eq 1 ] || fail "Reactivation did not preserve one brightness window."
+
+gapplication action "$APPLICATION_ID" quit
+wait "$GUI_PID"
+GUI_PID=""


### PR DESCRIPTION
## Summary

- establish the toolkit-neutral GUI contract and dedicated GTK 4 executable crate
- render the application-owned brightness Loading state in one accessible, single-instance window
- add real-binary and renderer lifecycle coverage under an isolated D-Bus/Xvfb display
- keep the existing CLI, services, TV operations, desktop entry, installer, and release bundle unchanged

## Validation

- cargo fmt --all -- --check
- full cargo test -p lg-buddy suite: 740 passed, 1 ignored; 124 Cucumber scenarios passed
- display-backed lg-buddy-gui executable smoke
- cargo test -p lg-buddy-gui -- --test-threads=1
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- shell syntax validation
- git diff --check

Closes #140