### PR TITLE
Route brightness entrypoints to GTK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,9 @@ jobs:
 
       - name: Run display-backed GTK test suite
         run: |
-          cargo build -p lg-buddy-gui
+          cargo build -p lg-buddy -p lg-buddy-gui
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
+          dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy
           dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
 
       - name: Run clippy

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -1,7 +1,9 @@
 use std::env;
+use std::fs;
 use std::io::{self, Write};
 use std::net::Ipv4Addr;
-use std::path::PathBuf;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::process::Output;
 use std::time::Duration;
@@ -25,6 +27,9 @@ use crate::wol::UdpWakeOnLanSender;
 use crate::{BrightnessCommand, MuteCommand, RunError, StartupMode, VolumeCommand};
 
 const SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
+const BRIGHTNESS_GUI_ENV: &str = "LG_BUDDY_GUI";
+const BRIGHTNESS_GUI_EXECUTABLE: &str = "lg-buddy-gui";
+
 trait ReachabilityChecker {
     fn is_reachable(&self, tv_ip: Ipv4Addr) -> io::Result<bool>;
 }
@@ -53,6 +58,17 @@ struct ZenityBrightnessUi {
 
 struct CurrentExeBrightnessCli {
     command_path: PathBuf,
+}
+
+struct InstalledBrightnessGui {
+    current_exe: PathBuf,
+    command_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BrightnessGuiLaunchOutcome {
+    Launched,
+    Missing,
 }
 
 struct BrightnessDialogDeps<'a, R, U, B, N> {
@@ -123,6 +139,132 @@ impl CurrentExeBrightnessCli {
             .output()
             .map_err(RunError::Io)
     }
+}
+
+impl InstalledBrightnessGui {
+    fn from_env() -> Result<Self, RunError> {
+        let current_exe = env::current_exe()?;
+        let command_path = match env::var_os(BRIGHTNESS_GUI_ENV) {
+            Some(value) if value.is_empty() => {
+                return Err(RunError::Policy(format!(
+                    "{BRIGHTNESS_GUI_ENV} is set but empty"
+                )));
+            }
+            Some(value) => PathBuf::from(value),
+            None => current_exe.with_file_name(BRIGHTNESS_GUI_EXECUTABLE),
+        };
+
+        Ok(Self {
+            current_exe,
+            command_path,
+        })
+    }
+
+    #[cfg(test)]
+    fn new(current_exe: impl Into<PathBuf>, command_path: impl Into<PathBuf>) -> Self {
+        Self {
+            current_exe: current_exe.into(),
+            command_path: command_path.into(),
+        }
+    }
+
+    fn launch(&self) -> Result<BrightnessGuiLaunchOutcome, RunError> {
+        match fs::symlink_metadata(&self.command_path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                return Ok(BrightnessGuiLaunchOutcome::Missing);
+            }
+            Err(error) => {
+                return Err(RunError::Policy(format!(
+                    "could not inspect installed brightness GUI at `{}`: {error}",
+                    self.command_path.display()
+                )));
+            }
+        }
+        let metadata = fs::metadata(&self.command_path).map_err(|error| {
+            invalid_brightness_gui(
+                &self.command_path,
+                &format!("its target cannot be inspected: {error}"),
+            )
+        })?;
+
+        if !metadata.is_file() {
+            return Err(invalid_brightness_gui(
+                &self.command_path,
+                "it is not a regular file",
+            ));
+        }
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(invalid_brightness_gui(
+                &self.command_path,
+                "it is not executable",
+            ));
+        }
+
+        let current_metadata = fs::metadata(&self.current_exe).map_err(|error| {
+            RunError::Policy(format!(
+                "could not validate the LG Buddy executable at `{}`: {error}",
+                self.current_exe.display()
+            ))
+        })?;
+        if metadata.dev() == current_metadata.dev() && metadata.ino() == current_metadata.ino() {
+            return Err(invalid_brightness_gui(
+                &self.command_path,
+                "it resolves to the lg-buddy executable and would recursively relaunch itself",
+            ));
+        }
+
+        let output = ProcessCommand::new(&self.command_path)
+            .arg("brightness")
+            .output()
+            .map_err(|error| {
+                RunError::Policy(format!(
+                    "could not launch installed brightness GUI at `{}`: {error}",
+                    self.command_path.display()
+                ))
+            })?;
+
+        if output.status.success() {
+            Ok(BrightnessGuiLaunchOutcome::Launched)
+        } else {
+            Err(RunError::Policy(format!(
+                "installed brightness GUI at `{}` failed: {}",
+                self.command_path.display(),
+                brightness_gui_output_message(&output)
+            )))
+        }
+    }
+}
+
+fn invalid_brightness_gui(path: &Path, reason: &str) -> RunError {
+    RunError::Policy(format!(
+        "invalid brightness GUI installation at `{}`: {reason}",
+        path.display()
+    ))
+}
+
+fn brightness_gui_output_message(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    if !stderr.is_empty() {
+        return stderr
+            .strip_prefix("LG Buddy GUI: ")
+            .unwrap_or(&stderr)
+            .to_string();
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if !stdout.is_empty() {
+        return stdout;
+    }
+
+    format!(
+        "exited with status {}",
+        output
+            .status
+            .code()
+            .map(|code| code.to_string())
+            .unwrap_or_else(|| "terminated by signal".to_string())
+    )
 }
 
 impl BrightnessCli for CurrentExeBrightnessCli {
@@ -339,11 +481,16 @@ pub fn run_brightness<W: Write>(
     writer: &mut W,
     command: BrightnessCommand,
 ) -> Result<(), RunError> {
-    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-
     match command {
         BrightnessCommand::Prompt => {
+            let gui = InstalledBrightnessGui::from_env()?;
+            match gui.launch()? {
+                BrightnessGuiLaunchOutcome::Launched => return Ok(()),
+                BrightnessGuiLaunchOutcome::Missing => {}
+            }
+
+            let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
+            let config = load_config(&config_path).map_err(RunError::Config)?;
             let reachability = PingReachabilityChecker::default();
             let ui = ZenityBrightnessUi::default();
             let brightness_cli = CurrentExeBrightnessCli::from_current_exe()?;
@@ -358,6 +505,8 @@ pub fn run_brightness<W: Write>(
             run_brightness_prompt_with(writer, &config, deps)
         }
         BrightnessCommand::Get | BrightnessCommand::Set(_) => {
+            let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
+            let config = load_config(&config_path).map_err(RunError::Config)?;
             let tv_client = build_tv_client(
                 &config_path,
                 config.tv_ip,
@@ -731,7 +880,8 @@ mod tests {
 
     use super::{
         run_brightness_command_with, run_brightness_prompt_with, BrightnessCli,
-        BrightnessDialogDeps, BrightnessUi, ReachabilityChecker,
+        BrightnessDialogDeps, BrightnessGuiLaunchOutcome, BrightnessUi, InstalledBrightnessGui,
+        ReachabilityChecker,
     };
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenIdleBlankPolicy, ScreenRestorePolicy,
@@ -749,17 +899,19 @@ mod tests {
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
     use crate::{BrightnessCommand, RunError, StartupMode};
     use std::cell::RefCell;
+    use std::env;
     use std::ffi::CString;
     use std::fs;
     use std::io;
     use std::net::Ipv4Addr;
     #[cfg(unix)]
     use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::symlink;
     use std::path::{Path, PathBuf};
     use std::process;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    use support::MockBscpylgtv;
+    use support::{ExecutableScript, MockBscpylgtv};
 
     #[cfg(unix)]
     fn set_modified_time(path: &Path, modified: SystemTime) {
@@ -1522,6 +1674,112 @@ mod tests {
             vec![FakeBrightnessCliCall::Get, FakeBrightnessCliCall::Set(65),]
         );
         assert!(rendered(&output).contains("Set OLED pixel brightness to 65%."));
+    }
+
+    #[test]
+    fn installed_brightness_gui_launches_only_the_brightness_command() {
+        let gui = ExecutableScript::new(
+            "brightness-gui-launch",
+            "lg-buddy-gui",
+            "#!/bin/sh\n[ \"$#\" -eq 1 ] && [ \"$1\" = \"brightness\" ]\n",
+        );
+        let launcher = InstalledBrightnessGui::new(
+            env::current_exe().expect("current executable"),
+            gui.path(),
+        );
+
+        assert_eq!(
+            launcher.launch().expect("GUI launch should succeed"),
+            BrightnessGuiLaunchOutcome::Launched
+        );
+    }
+
+    #[test]
+    fn missing_installed_brightness_gui_allows_compatibility_fallback() {
+        let anchor =
+            ExecutableScript::new("brightness-gui-missing", "anchor", "#!/bin/sh\nexit 0\n");
+        let launcher = InstalledBrightnessGui::new(
+            env::current_exe().expect("current executable"),
+            anchor.path().with_file_name("missing-lg-buddy-gui"),
+        );
+
+        assert_eq!(
+            launcher.launch().expect("missing GUI should be recognized"),
+            BrightnessGuiLaunchOutcome::Missing
+        );
+    }
+
+    #[test]
+    fn failed_installed_brightness_gui_is_reported_without_fallback() {
+        let gui = ExecutableScript::new(
+            "brightness-gui-failure",
+            "lg-buddy-gui",
+            "#!/bin/sh\nprintf 'LG Buddy GUI: initialization failed\\n' >&2\nexit 23\n",
+        );
+        let launcher = InstalledBrightnessGui::new(
+            env::current_exe().expect("current executable"),
+            gui.path(),
+        );
+
+        let error = launcher
+            .launch()
+            .expect_err("failed GUI must not become a missing-GUI fallback");
+
+        assert!(error.to_string().contains("initialization failed"));
+        assert!(!error.to_string().contains("exited with status"));
+    }
+
+    #[test]
+    fn invalid_installed_brightness_gui_is_rejected() {
+        let anchor =
+            ExecutableScript::new("brightness-gui-invalid", "anchor", "#!/bin/sh\nexit 0\n");
+        let launcher = InstalledBrightnessGui::new(
+            env::current_exe().expect("current executable"),
+            anchor.path().parent().expect("anchor parent"),
+        );
+
+        let error = launcher
+            .launch()
+            .expect_err("directory must not be treated as a GUI executable");
+
+        assert!(error
+            .to_string()
+            .contains("invalid brightness GUI installation"));
+        assert!(error.to_string().contains("not a regular file"));
+    }
+
+    #[test]
+    fn dangling_installed_brightness_gui_is_invalid_instead_of_missing() {
+        let anchor =
+            ExecutableScript::new("brightness-gui-dangling", "anchor", "#!/bin/sh\nexit 0\n");
+        let gui_path = anchor.path().with_file_name("lg-buddy-gui");
+        symlink(anchor.path().with_file_name("missing-target"), &gui_path)
+            .expect("create dangling GUI symlink");
+        let launcher =
+            InstalledBrightnessGui::new(env::current_exe().expect("current executable"), gui_path);
+
+        let error = launcher
+            .launch()
+            .expect_err("dangling GUI installation must not use compatibility fallback");
+
+        assert!(error
+            .to_string()
+            .contains("invalid brightness GUI installation"));
+        assert!(error.to_string().contains("target cannot be inspected"));
+    }
+
+    #[test]
+    fn brightness_gui_cannot_resolve_to_the_cli_executable() {
+        let current_exe = env::current_exe().expect("current executable");
+        let launcher = InstalledBrightnessGui::new(&current_exe, &current_exe);
+
+        let error = launcher
+            .launch()
+            .expect_err("recursive GUI launch must be rejected");
+
+        assert!(error
+            .to_string()
+            .contains("would recursively relaunch itself"));
     }
 
     #[test]

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -153,6 +153,21 @@ fn brightness_dialog_returns(world: &mut LgBuddyWorld, value: u8) {
     world.install_brightness_ui_stub(Some(value));
 }
 
+#[given("the GTK brightness GUI is unavailable")]
+fn gtk_brightness_gui_is_unavailable(world: &mut LgBuddyWorld) {
+    world.make_brightness_gui_unavailable();
+}
+
+#[given("a working GTK brightness GUI")]
+fn working_gtk_brightness_gui(world: &mut LgBuddyWorld) {
+    world.install_brightness_gui_stub(0);
+}
+
+#[given(regex = r#"the GTK brightness GUI exits with status (\d+)"#)]
+fn failing_gtk_brightness_gui(world: &mut LgBuddyWorld, status: i32) {
+    world.install_brightness_gui_stub(status);
+}
+
 #[given("the brightness dialog is cancelled")]
 fn brightness_dialog_is_cancelled(world: &mut LgBuddyWorld) {
     world.install_brightness_ui_stub(None);
@@ -161,6 +176,21 @@ fn brightness_dialog_is_cancelled(world: &mut LgBuddyWorld) {
 #[given("the brightness error dialog is available")]
 fn brightness_error_dialog_is_available(world: &mut LgBuddyWorld) {
     world.install_brightness_ui_stub(None);
+}
+
+#[then(regex = r#"the GTK brightness GUI received "([^"]+)""#)]
+fn gtk_brightness_gui_received(world: &mut LgBuddyWorld, arguments: String) {
+    world.assert_brightness_gui_received(&arguments);
+}
+
+#[then("the GTK brightness GUI was not launched")]
+fn gtk_brightness_gui_not_launched(world: &mut LgBuddyWorld) {
+    world.assert_brightness_gui_not_launched();
+}
+
+#[then("the brightness compatibility dialog was not opened")]
+fn brightness_compatibility_dialog_not_opened(world: &mut LgBuddyWorld) {
+    world.assert_brightness_ui_not_opened();
 }
 
 #[given("the TV screen is blanked")]

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -23,6 +23,8 @@ pub struct LgBuddyWorld {
     nm_online: Option<MockNmOnline>,
     swayidle: Option<MockSwayidle>,
     path_scripts: Vec<ExecutableScript>,
+    brightness_gui_calls_path: Option<PathBuf>,
+    brightness_ui_calls_path: Option<PathBuf>,
     config_snapshot: Option<String>,
     systemctl_log_path: Option<PathBuf>,
     command_result: Option<CommandExecution>,
@@ -52,6 +54,8 @@ impl fmt::Debug for LgBuddyWorld {
             .field("nm_online", &self.nm_online.is_some())
             .field("swayidle", &self.swayidle.is_some())
             .field("path_scripts", &self.path_scripts.len())
+            .field("brightness_gui_calls_path", &self.brightness_gui_calls_path)
+            .field("brightness_ui_calls_path", &self.brightness_ui_calls_path)
             .field("config_snapshot", &self.config_snapshot.is_some())
             .field("systemctl_log_path", &self.systemctl_log_path)
             .field("command_result", &self.command_result)
@@ -433,15 +437,86 @@ exit 1\n",
     pub fn install_brightness_ui_stub(&mut self, selection: Option<u8>) {
         self.ensure_mock_session_bus_idle_monitor()
             .set_notifications_available(true);
+        let log_owner =
+            ExecutableScript::new("cucumber-zenity-log", "log-owner", "#!/bin/sh\nexit 0\n");
+        let calls_path = log_owner.path().with_extension("calls");
         let body = match selection {
             Some(value) => format!(
-                "#!/bin/sh\nif [ \"$1\" = \"--scale\" ]; then\n  printf '%s\\n' '{value}'\n  exit 0\nfi\nif [ \"$1\" = \"--error\" ]; then\n  exit 0\nfi\nexit 1\n"
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"--scale\" ]; then\n  printf '%s\\n' '{value}'\n  exit 0\nfi\nif [ \"$1\" = \"--error\" ]; then\n  exit 0\nfi\nexit 1\n",
+                calls_path.display()
             ),
-            None => "#!/bin/sh\nif [ \"$1\" = \"--scale\" ]; then\n  exit 1\nfi\nif [ \"$1\" = \"--error\" ]; then\n  exit 0\nfi\nexit 1\n".to_string(),
+            None => format!(
+                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"--scale\" ]; then\n  exit 1\nfi\nif [ \"$1\" = \"--error\" ]; then\n  exit 0\nfi\nexit 1\n",
+                calls_path.display()
+            ),
         };
         let script = ExecutableScript::new("cucumber-zenity", "mock-zenity", &body);
         self.ensure_env().set("LG_BUDDY_ZENITY", script.path());
+        self.brightness_ui_calls_path = Some(calls_path);
+        self.path_scripts.push(log_owner);
         self.path_scripts.push(script);
+    }
+
+    pub fn make_brightness_gui_unavailable(&mut self) {
+        let anchor = ExecutableScript::new(
+            "cucumber-missing-brightness-gui",
+            "anchor",
+            "#!/bin/sh\nexit 0\n",
+        );
+        let missing_path = anchor.path().with_file_name("missing-lg-buddy-gui");
+        self.ensure_env().set("LG_BUDDY_GUI", missing_path);
+        self.path_scripts.push(anchor);
+    }
+
+    pub fn install_brightness_gui_stub(&mut self, exit_status: i32) {
+        let log_owner = ExecutableScript::new(
+            "cucumber-brightness-gui-log",
+            "log-owner",
+            "#!/bin/sh\nexit 0\n",
+        );
+        let calls_path = log_owner.path().with_extension("calls");
+        let body = format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nexit {exit_status}\n",
+            calls_path.display()
+        );
+        let script = ExecutableScript::new("cucumber-brightness-gui", "lg-buddy-gui", &body);
+        self.ensure_env().set("LG_BUDDY_GUI", script.path());
+        self.brightness_gui_calls_path = Some(calls_path);
+        self.path_scripts.push(log_owner);
+        self.path_scripts.push(script);
+    }
+
+    pub fn assert_brightness_gui_received(&self, arguments: &str) {
+        let calls_path = self
+            .brightness_gui_calls_path
+            .as_ref()
+            .expect("brightness GUI stub should be installed");
+        assert_eq!(
+            fs::read_to_string(calls_path).expect("read brightness GUI calls"),
+            format!("{arguments}\n")
+        );
+    }
+
+    pub fn assert_brightness_gui_not_launched(&self) {
+        let calls_path = self
+            .brightness_gui_calls_path
+            .as_ref()
+            .expect("brightness GUI stub should be installed");
+        assert!(
+            !calls_path.exists(),
+            "brightness GUI was unexpectedly launched"
+        );
+    }
+
+    pub fn assert_brightness_ui_not_opened(&self) {
+        let calls_path = self
+            .brightness_ui_calls_path
+            .as_ref()
+            .expect("brightness compatibility UI stub should be installed");
+        assert!(
+            !calls_path.exists(),
+            "brightness compatibility dialog was unexpectedly opened"
+        );
     }
 
     pub fn install_gnome_shell_stub(&mut self) {

--- a/crates/lg-buddy/tests/features/brightness.feature
+++ b/crates/lg-buddy/tests/features/brightness.feature
@@ -1,11 +1,31 @@
 Feature: Brightness
   LG Buddy should provide a manual OLED brightness control for the configured TV.
 
-  Scenario: Brightness sets the TV OLED brightness when the TV is reachable
+  Scenario: Brightness launches the GTK window through the stable command
+    Given a working GTK brightness GUI
+    And the brightness error dialog is available
+    When I run the command "brightness"
+    Then the command succeeds
+    And the GTK brightness GUI received "brightness"
+    And the brightness compatibility dialog was not opened
+
+  Scenario: A failed GTK launch does not open the compatibility dialog
+    Given the GTK brightness GUI exits with status 23
+    And the brightness error dialog is available
+    When I run the command "brightness"
+    Then the command fails
+    And the command exits with status 1
+    And stderr contains "installed brightness GUI"
+    And stderr contains "exited with status 23"
+    And the GTK brightness GUI received "brightness"
+    And the brightness compatibility dialog was not opened
+
+  Scenario: Missing GTK GUI falls back to the brightness compatibility dialog
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client
     And the TV backlight is 72
     And the TV is reachable over ping
+    And the GTK brightness GUI is unavailable
     And the brightness dialog returns 65
     When I run the command "brightness"
     Then the command succeeds
@@ -19,6 +39,7 @@ Feature: Brightness
     And a mock TV client
     And the TV backlight is 44
     And the TV is reachable over ping
+    And the GTK brightness GUI is unavailable
     And the brightness dialog is cancelled
     When I run the command "brightness"
     Then the command succeeds
@@ -30,9 +51,11 @@ Feature: Brightness
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client
     And the TV backlight is 58
+    And a working GTK brightness GUI
     When I run the command "brightness get"
     Then the command succeeds
     And stdout is "58"
+    And the GTK brightness GUI was not launched
     And the TV client received "get_picture_settings"
     And the TV client did not receive "set_settings"
 
@@ -40,9 +63,11 @@ Feature: Brightness
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client
     And the TV backlight is 44
+    And a working GTK brightness GUI
     When I run the command "brightness set 66"
     Then the command succeeds
     And stdout contains "Set OLED pixel brightness to 66%."
+    And the GTK brightness GUI was not launched
     And the TV client received "set_settings"
     And the TV brightness is 66
 
@@ -63,6 +88,7 @@ Feature: Brightness
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client
     And the TV is unreachable over ping
+    And the GTK brightness GUI is unavailable
     And the brightness error dialog is available
     When I run the command "brightness"
     Then the command fails

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -15,6 +15,23 @@ use support::{
 };
 
 #[test]
+fn brightness_desktop_entry_uses_the_stable_headless_launcher() {
+    let desktop_entry = fs::read_to_string(
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("LG_Buddy_Brightness.desktop"),
+    )
+    .expect("read brightness desktop entry");
+    let lines = desktop_entry.lines().collect::<Vec<_>>();
+
+    assert!(lines.contains(&"Exec=/usr/bin/lg-buddy brightness"));
+    assert!(lines.contains(&"Terminal=false"));
+    assert!(!lines
+        .iter()
+        .any(|line| line.starts_with("Exec=") && line.contains("lg-buddy-gui")));
+}
+
+#[test]
 fn run_screen_off_loads_config_and_uses_session_runtime_override() {
     let mock = MockBscpylgtv::new("entrypoint-screen-off-tv");
     mock.set_input("HDMI_2");

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -98,11 +98,11 @@ The main runtime consumers are:
 - desktop environment and session integrations, including GNOME, `swayidle`,
   and Linux input activity sources
 - TTY users invoking the CLI directly
-- the installed Zenity brightness dialog, which delegates back through the
-  CLI/API command surface
-- the standalone `lg-buddy-gui brightness` GTK window, which asynchronously
-  reads and writes OLED brightness and renders application-owned Loading,
-  Ready, Applying, or Failed presentation state
+- the stable `lg-buddy brightness` launcher, which opens the matching installed
+  GTK executable and uses Zenity only when that executable is absent
+- the `lg-buddy-gui brightness` GTK window, which asynchronously reads and
+  writes OLED brightness and renders application-owned Loading, Ready,
+  Applying, or Failed presentation state
 
 ```mermaid
 flowchart LR
@@ -188,6 +188,8 @@ flowchart LR
     LOGINDADAPTER -->|"RuntimeEvent"| EVENTS
     NM --> MAIN
     TERMINAL --> MAIN
+    MAIN -->|"brightness launcher"| GTK
+    MAIN -.->|"GUI absent"| ZENITY
     ZENITY --> MAIN
     GTK -->|"Propose / Apply / Retry / Cancel intents"| BRIGHTNESS
     BRIGHTNESS --> PRESENTATION
@@ -459,16 +461,19 @@ owns an operational cache under the user cache directory for GitHub ETag,
 latest release metadata, and last-notified release state used by the observable
 update notification policy; that cache is not user configuration and is not
 part of the settings API.
-The `brightness get` and `brightness set` commands use the TV picture
+The `brightness` command locates `lg-buddy-gui` beside the running CLI and
+launches its `brightness` entrypoint. Only an absent GUI executable selects the
+temporary Zenity compatibility flow; an invalid installation or failed GUI
+process is returned directly without a second prompt. The `brightness get` and
+`brightness set` commands never enter that launcher and use the TV picture
 abstraction in `tv.rs` for typed OLED brightness validation and live TV
 read/write operations. The interactive Zenity brightness dialog delegates its
-TV operations back through those CLI commands. The GTK brightness window uses
-the same typed picture read/write capabilities directly through the core
-brightness application flow. Workers keep blocking TV operations off the GTK
-main loop; the application permits one write at a time, and opaque operation
-identity prevents late results from replacing newer or closed presentation
-state. Successful GTK writes retain the existing brightness success
-notification.
+TV operations back through those direct CLI commands. The GTK brightness window
+uses the same typed picture capabilities through the core brightness
+application flow. Workers keep blocking TV operations off the GTK main loop;
+the application permits one write at a time, and opaque operation identity
+prevents late results from replacing newer or closed presentation state.
+Successful GTK writes retain the existing brightness success notification.
 The `volume` family uses the TV audio abstraction for typed volume and mute
 operations. Setting or stepping volume explicitly unmutes after the volume
 operation; mute toggle reads the current state before writing its inverse.
@@ -896,6 +901,8 @@ Important environment overrides:
   - force backend selection
 - `LG_BUDDY_BSCPYLGTV_COMMAND`
   - override TV command path
+- `LG_BUDDY_GUI`
+  - override the matching `lg-buddy-gui` path for relocation and tests
 - `LG_BUDDY_SYSTEM_RUNTIME_DIR`
   - override system state directory
 - `LG_BUDDY_SESSION_RUNTIME_DIR`

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,6 +64,12 @@ Run its current brightness window with:
 cargo run -p lg-buddy-gui -- brightness
 ```
 
+After building both workspace binaries, the stable launcher can be exercised
+with `cargo run -p lg-buddy -- brightness`; it resolves `lg-buddy-gui` beside
+the running CLI executable. `LG_BUDDY_GUI` overrides that companion path for
+relocation and subprocess tests. Only a missing path selects the temporary
+Zenity compatibility flow.
+
 The resulting `lg-buddy-gui` binary is a development artifact in the current
 GUI slice. Installer and release-bundle integration are tracked separately.
 
@@ -107,6 +113,7 @@ Useful checks during development:
 cargo test -p lg-buddy --lib
 cargo test -p lg-buddy --test cucumber
 dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
+dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy
 dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
 cargo clippy --workspace --all-targets --all-features -- -D warnings
 bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -120,12 +120,16 @@ application-owned. It depends on `lg-buddy`, GTK, and libadwaita, never the
 reverse. The GUI crate should consume one public application entrypoint rather
 than assembling TV or configuration dependencies itself.
 
-The installed graphical executable is `lg-buddy-gui`. The desktop entry launches
-that executable directly. The user-facing `lg-buddy brightness` command may
-locate and launch it for compatibility, while `lg-buddy brightness get` and
-`lg-buddy brightness set` remain direct headless commands. That launcher handoff
-does not become the frontend/backend contract: once `lg-buddy-gui` starts, GTK
-and the application communicate only through in-process Rust types.
+The installed graphical executable is `lg-buddy-gui`. The desktop entry keeps
+the stable `lg-buddy brightness` command surface, which locates the matching GUI
+beside the running CLI executable and launches `lg-buddy-gui brightness`.
+`lg-buddy brightness get` and `lg-buddy brightness set` remain direct headless
+commands and never inspect or launch the GUI. During the compatibility window,
+an absent GUI executable falls back to the retained Zenity flow. A present but
+invalid GUI installation, or a GUI process that starts and fails, is reported
+without opening Zenity or performing a second TV operation. That launcher
+handoff does not become the frontend/backend contract: once `lg-buddy-gui`
+starts, GTK and the application communicate only through in-process Rust types.
 
 This split also keeps GTK runtime linkage out of systemd services and the
 headless CLI. Release bundles and packages must ship the GUI executable and

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -39,8 +39,10 @@ syntax.
   is pending.
 - `screen off` blanks the TV output while remembering that LG Buddy blanked it.
 - `screen on` restores the output according to the configured restore policy.
-- `brightness` opens the desktop brightness dialog. `brightness get` and
-  `brightness set <0-100>` read or change OLED brightness directly.
+- `brightness` opens the GTK brightness window. If the GUI executable is absent
+  from a transitional installation, LG Buddy uses the retained Zenity dialog.
+  `brightness get` and `brightness set <0-100>` remain headless and read or
+  change OLED brightness directly.
 - `volume` prints the current level, `mute` when muted, or `unknown` when the TV
   does not expose a numeric level. `volume <0-100>`, `volume up`, and `volume
   down` change the volume and unmute the TV. `volume mute [on|off]` toggles or


### PR DESCRIPTION
Closes #143

## Summary

- route the stable `lg-buddy brightness` command and desktop entry to the installed GTK brightness window
- retain Zenity only as an explicit missing-GUI compatibility fallback while keeping `brightness get` and `brightness set` headless
- cover launcher arguments, failure boundaries, desktop wiring, and the real display-backed entrypoint; align architecture and user documentation

## Validation

- `cargo test -p lg-buddy` (including 126 Cucumber scenarios)
- `cargo test -p lg-buddy-gui`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- display-backed launcher smoke through `target/debug/lg-buddy`