### PR TITLE
Install, upgrade, and remove the GTK brightness GUI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,20 +36,21 @@ jobs:
           sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib platform_access_token::tests::persist_assigns_requested_owner_when_running_as_root -- --exact
 
       - name: Install GTK test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev xdotool xvfb
+        run: sudo apt-get update && sudo apt-get install -y dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev xdotool xvfb zenity
 
       - name: Run display-backed GTK test suite
         run: |
           cargo build -p lg-buddy -p lg-buddy-gui
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy
+          dbus-run-session -- xvfb-run -a bash ./scripts/test-installed-gui.sh ./target/debug/lg-buddy ./target/debug/lg-buddy-gui
           dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
 
       - name: Run clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Validate shell scripts
-        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+        run: bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 
       - name: Validate release promotion contract
         run: python3 scripts/test_release_promotion.py

--- a/README.md
+++ b/README.md
@@ -45,15 +45,18 @@ selection and troubleshooting. Protocol and event details are documented in the
 Fresh installation selects the native `lg_webos` control path, which does not
 require Python. Native-only packages can omit the Python client, `venv`, and
 `pip`. The release-bundle installer still provisions `bscpylgtv` as an explicit
-compatibility fallback and installs the brightness dialog, so it checks for
-Python 3 with a `venv` that provisions `pip`, plus `zenity`. `swayidle` is needed
-only by an existing explicit selection or as the deprecated compatibility
-fallback.
+compatibility fallback, so it checks for Python 3 with a `venv` that provisions
+`pip`, plus `zenity`. The GTK brightness window requires GTK 4.10 or newer and
+libadwaita 1; the installer verifies that the GUI executable can load and has
+the same release identity as the runtime before changing the installation.
+Zenity remains the compatibility fallback when the GUI executable is absent.
+`swayidle` is needed only by an existing explicit selection or as the deprecated
+compatibility fallback.
 
 ### Debian, Ubuntu, and Pop!_OS
 
 ```bash
-sudo apt install python3-venv python3-pip zenity
+sudo apt install python3-venv python3-pip zenity libgtk-4-1 libadwaita-1-0
 # Deprecated compatibility fallback only:
 sudo apt install swayidle
 ```
@@ -61,7 +64,7 @@ sudo apt install swayidle
 ### Fedora
 
 ```bash
-sudo dnf install python3 python3-pip python3-virtualenv zenity
+sudo dnf install python3 python3-pip python3-virtualenv zenity gtk4 libadwaita
 # Deprecated compatibility fallback only:
 sudo dnf install swayidle
 ```
@@ -69,7 +72,7 @@ sudo dnf install swayidle
 ### Arch Linux
 
 ```bash
-sudo pacman -S python python-pip python-virtualenv zenity
+sudo pacman -S python python-pip python-virtualenv zenity gtk4 libadwaita
 # Deprecated compatibility fallback only:
 sudo pacman -S swayidle
 ```

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -21,6 +21,7 @@ pub const APPLICATION_ID: &str = "io.github.staphylococcus.LGBuddy";
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuiCommand {
     Brightness,
+    Version,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -50,6 +51,7 @@ where
     let mut args = args.into_iter();
     let command = match args.next() {
         Some(command) if command.as_ref() == "brightness" => GuiCommand::Brightness,
+        Some(command) if matches!(command.as_ref(), "--version" | "-V") => GuiCommand::Version,
         Some(command) => return Err(GuiParseError::UnknownCommand(command.as_ref().to_string())),
         None => return Err(GuiParseError::MissingCommand),
     };
@@ -63,12 +65,16 @@ where
 }
 
 pub fn help(program: &str) -> String {
-    format!("Usage: {program} brightness\n")
+    format!("Usage: {program} brightness\n       {program} --version\n")
 }
 
 pub fn run(command: GuiCommand) -> glib::ExitCode {
     match command {
         GuiCommand::Brightness => run_brightness_application(),
+        GuiCommand::Version => {
+            print!("{}", lg_buddy::version::version_text());
+            glib::ExitCode::SUCCESS
+        }
     }
 }
 
@@ -348,6 +354,8 @@ mod tests {
     #[test]
     fn parses_the_brightness_command() {
         assert_eq!(parse_args(["brightness"]), Ok(GuiCommand::Brightness));
+        assert_eq!(parse_args(["--version"]), Ok(GuiCommand::Version));
+        assert_eq!(parse_args(["-V"]), Ok(GuiCommand::Version));
         assert_eq!(
             parse_args(std::iter::empty::<&str>()),
             Err(GuiParseError::MissingCommand)
@@ -362,7 +370,10 @@ mod tests {
                 vec!["extra".to_string()]
             ))
         );
-        assert_eq!(help("lg-buddy-gui"), "Usage: lg-buddy-gui brightness\n");
+        assert_eq!(
+            help("lg-buddy-gui"),
+            "Usage: lg-buddy-gui brightness\n       lg-buddy-gui --version\n"
+        );
     }
 
     #[test]

--- a/crates/lg-buddy-gui/src/main.rs
+++ b/crates/lg-buddy-gui/src/main.rs
@@ -1,5 +1,5 @@
 use gtk::glib;
-use lg_buddy_gui::{help, parse_args, run, GuiCommand};
+use lg_buddy_gui::{help, parse_args, run};
 
 fn main() -> glib::ExitCode {
     let program = std::env::args()
@@ -7,7 +7,7 @@ fn main() -> glib::ExitCode {
         .unwrap_or_else(|| "lg-buddy-gui".to_string());
 
     match parse_args(std::env::args().skip(1)) {
-        Ok(GuiCommand::Brightness) => run(GuiCommand::Brightness),
+        Ok(command) => run(command),
         Err(err) => {
             eprintln!("LG Buddy GUI: {err}");
             eprintln!();

--- a/crates/lg-buddy/src/upgrade_preflight.rs
+++ b/crates/lg-buddy/src/upgrade_preflight.rs
@@ -110,6 +110,11 @@ const SYSTEM_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[
     ),
 ];
 
+const OPTIONAL_SYSTEM_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[requirement(
+    "/usr/bin/lg-buddy-gui",
+    InstallerPathPolicy::ReplaceExecutable,
+)];
+
 const PYTHON_REPAIR_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[requirement(
     "/usr/bin/LG_Buddy_PIP",
     InstallerPathPolicy::RecursiveClear,
@@ -173,6 +178,7 @@ const CANDIDATE_PATH_REQUIREMENTS: &[InstallerPathRequirement] = &[
     requirement("release-manifest.json", InstallerPathPolicy::ReadableInput),
     requirement("install.sh", InstallerPathPolicy::ExecutableInput),
     requirement("lg-buddy", InstallerPathPolicy::ExecutableInput),
+    requirement("lg-buddy-gui", InstallerPathPolicy::ExecutableInput),
     requirement(
         "LG_Buddy_Brightness.desktop",
         InstallerPathPolicy::ReadableInput,
@@ -633,6 +639,15 @@ fn evaluate_installed_state(
             Some(system_trust),
             requirement.policy,
             check,
+        );
+    }
+    for requirement in OPTIONAL_SYSTEM_PATH_REQUIREMENTS {
+        checker.check_optional_requirement(
+            &facts.layout.system_path(requirement.path),
+            facts.system_owner_uid,
+            Some(system_trust),
+            requirement.policy,
+            "installed-layout",
         );
     }
     if repair_python {
@@ -1499,6 +1514,29 @@ mod tests {
     }
 
     #[test]
+    fn installed_gui_is_optional_for_first_upgrade_but_validated_when_present() {
+        let fixture = InstalledFixture::new("optional-installed-gui");
+        let gui = fixture.facts.layout.system_path("/usr/bin/lg-buddy-gui");
+
+        let missing = evaluate_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        assert!(missing.compatible(), "{}", missing.render());
+
+        write_file(&gui, true);
+        let installed = evaluate_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        assert!(installed.compatible(), "{}", installed.render());
+
+        fs::remove_file(&gui).unwrap();
+        symlink(fixture.facts.layout.installed_executable(), &gui).unwrap();
+        let unsafe_installation = evaluate_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        assert_failure(
+            &unsafe_installation,
+            "installed-layout",
+            &gui,
+            "found Symlink",
+        );
+    }
+
+    #[test]
     fn python_environment_safety_is_required_only_when_repair_is_requested() {
         let fixture = InstalledFixture::new("conditional-python-repair");
         let filesystem = RootOwnedFilesystem(OsFilesystemFacts);
@@ -1722,6 +1760,7 @@ mod tests {
         for (label, path, mode) in [
             ("writable-manifest", "release-manifest.json", 0o660),
             ("writable-installer", "install.sh", 0o770),
+            ("writable-gui", "lg-buddy-gui", 0o770),
             ("writable-input-directory", "systemd", 0o770),
         ] {
             let fixture = InstalledFixture::new(label);
@@ -2252,10 +2291,14 @@ mod tests {
 
     #[test]
     fn candidate_preflight_requires_owner_usable_executable_modes() {
-        for (label, mode) in [("unreadable-installer", 0o100), ("other-executable", 0o401)] {
+        for (label, path, mode) in [
+            ("unreadable-installer", "install.sh", 0o100),
+            ("other-executable", "install.sh", 0o401),
+            ("non-executable-gui", "lg-buddy-gui", 0o400),
+        ] {
             let fixture = InstalledFixture::new(label);
-            let installer = fixture.candidate_root.join("install.sh");
-            set_mode(&installer, mode);
+            let executable = fixture.candidate_root.join(path);
+            set_mode(&executable, mode);
 
             let report = evaluate_candidate_preflight(
                 &OsFilesystemFacts,
@@ -2266,7 +2309,7 @@ mod tests {
             assert_failure(
                 &report,
                 "candidate-layout",
-                &installer,
+                &executable,
                 "not readable and executable by its owner",
             );
         }

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -525,9 +525,13 @@ mutation targets, and special files in owned config state are refused.
 After a bundle has been verified, its candidate binary can run the second
 preflight. That pass rechecks the installed state, proves it is executing the
 candidate from the supplied bundle root, and checks the candidate manifest,
-installer, runtime, desktop entry, and systemd assets before any privileged
-mutation. Candidate inputs must be owner-usable and not writable by another
-user. The external ancestor chain must remain root- or user-owned and cannot be
+installer, runtime, GUI executable, desktop entry, and systemd assets before
+any privileged mutation. The first GUI upgrade permits the installed GUI to be
+absent; once present, it must satisfy the same safe executable-replacement
+policy as the runtime. Candidate inputs must be owner-usable and not writable
+by another user. The installer also runs both candidates' non-graphical version
+paths and requires exact release identity agreement before mutation. The
+external ancestor chain must remain root- or user-owned and cannot be
 shared-writable unless sticky-directory semantics protect its trusted child.
 Configuration and pairing scripts are deliberately excluded because the
 non-interactive upgrade mode preserves existing configuration and credentials

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ cargo build --release -p lg-buddy
 Build the GTK frontend from source with:
 
 ```bash
-cargo build -p lg-buddy-gui
+cargo build --release -p lg-buddy-gui
 ```
 
 Run its current brightness window with:
@@ -70,8 +70,8 @@ the running CLI executable. `LG_BUDDY_GUI` overrides that companion path for
 relocation and subprocess tests. Only a missing path selects the temporary
 Zenity compatibility flow.
 
-The resulting `lg-buddy-gui` binary is a development artifact in the current
-GUI slice. Installer and release-bundle integration are tracked separately.
+The local installer accepts the GUI and runtime as separate build artifacts.
+Shipping both artifacts in official release bundles is tracked separately.
 
 Official release builds inject version identity into the binary:
 
@@ -91,12 +91,14 @@ The resulting binary will be at:
 
 ## Install a Locally Built Binary
 
-`install.sh` is installer-only. It does not build the runtime.
+`install.sh` is installer-only. It does not build the runtime or GUI.
 
-To install a binary you built yourself:
+To install binaries you built yourself:
 
 ```bash
-./install.sh --runtime-binary ./target/release/lg-buddy
+./install.sh \
+  --runtime-binary ./target/release/lg-buddy \
+  --gui-binary ./target/release/lg-buddy-gui
 ```
 
 To install from a release bundle instead, extract the archive and run:
@@ -114,9 +116,10 @@ cargo test -p lg-buddy --lib
 cargo test -p lg-buddy --test cucumber
 dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
 dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy
+dbus-run-session -- xvfb-run -a bash ./scripts/test-installed-gui.sh ./target/debug/lg-buddy ./target/debug/lg-buddy-gui
 dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
 cargo clippy --workspace --all-targets --all-features -- -D warnings
-bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-release-bundle.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
 python3 scripts/test_release_promotion.py
 python3 scripts/test_record_github_release_responses.py
 ```
@@ -237,10 +240,11 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/wol.rs` | Native Wake-on-LAN support |
 | `crates/lg-buddy-gui/` | GTK 4/libadwaita executable, application lifecycle, and thin presentation renderer |
 | `configure.sh` | Interactive configuration tool |
-| `install.sh` | Installer for an existing binary |
+| `install.sh` | Installer for existing runtime and GUI binaries |
 | `uninstall.sh` | Uninstaller |
 | `scripts/release_bundle_manifest.py` | Release-bundle identity manifest creator and validator |
 | `scripts/build-release-bundle.sh` | Release bundle builder |
+| `scripts/test-installed-gui.sh` | Installed GTK launcher and removal smoke test |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |
 | `scripts/test-cross-version-upgrade.sh` | Pinned previous-to-candidate archive upgrade smoke test |
 | `scripts/test-production-upgrade-canary.sh` | Post-publication production GitHub upgrade canary |

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -458,9 +458,12 @@ A small acceptance layer proves only the user-visible boundary:
 - an unreachable TV or failed write leaves actionable feedback
 - the window remains responsive during blocking TV work
 
-Release-bundle smoke proves that both executables, the desktop entry, and the
-required GTK runtime dependencies are present. It should not duplicate the
-application state-machine matrix.
+Installed-GUI smoke proves that both executables and the desktop entry are
+installed together, the stable launcher opens the window without a terminal,
+and removal preserves user state. Release-bundle smoke separately proves that
+the distributed archive contains both executables and declares the required
+GTK runtime dependencies. Neither layer should duplicate the application
+state-machine matrix.
 
 Screenshots may support design review, but they are not the primary contract:
 system themes, fonts, and rendering legitimately vary. Automated assertions
@@ -505,7 +508,7 @@ that first needs them:
 5. [#144](https://github.com/Staphylococcus/LG_Buddy/issues/144) integrates the
    GUI with install, upgrade, and removal behavior.
 6. [#145](https://github.com/Staphylococcus/LG_Buddy/issues/145) ships the GUI
-   in release bundles and adds installed-artifact smoke coverage.
+   in release bundles and adds release-artifact smoke coverage.
 
 Each slice must leave the existing `brightness get`, `brightness set`, service,
 and compatibility paths green. The Zenity implementation remains available in

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -103,7 +103,7 @@ The workflow:
 11. For prereleases, exercises production GitHub discovery, acquisition,
     confirmation, installation, and final identity from the pinned baseline.
 
-`install.sh` is only an installer. It does not build the runtime.
+`install.sh` is only an installer. It does not build the runtime or GUI.
 
 ## Release bundle identity
 
@@ -198,10 +198,13 @@ An incompatible or legacy layout is refused rather than migrated. If a failure
 occurs after installation writes begin, correct the reported cause and rerun the
 same verified bundle with `--upgrade`.
 
-## Installing a locally built binary
+## Installing locally built binaries
 
-If you build `lg-buddy` yourself, install it by passing the binary path explicitly:
+If you build `lg-buddy` and `lg-buddy-gui` yourself, install them by passing both
+binary paths explicitly:
 
 ```bash
-./install.sh --runtime-binary ./target/release/lg-buddy
+./install.sh \
+  --runtime-binary ./target/release/lg-buddy \
+  --gui-binary ./target/release/lg-buddy-gui
 ```

--- a/install.sh
+++ b/install.sh
@@ -11,23 +11,27 @@ NONINTERACTIVE="${LG_BUDDY_NONINTERACTIVE:-0}"
 SKIP_SYSTEMD_ACTIONS="${LG_BUDDY_SKIP_SYSTEMD_ACTIONS:-0}"
 SKIP_PIP_INSTALL="${LG_BUDDY_SKIP_PIP_INSTALL:-0}"
 DEFAULT_RUNTIME_BINARY="$SCRIPT_DIR/lg-buddy"
+DEFAULT_GUI_BINARY="$SCRIPT_DIR/lg-buddy-gui"
 RUNTIME_BINARY="$DEFAULT_RUNTIME_BINARY"
+GUI_BINARY="$DEFAULT_GUI_BINARY"
 RUNTIME_BINARY_OVERRIDDEN=0
+GUI_BINARY_OVERRIDDEN=0
 UPGRADE_MODE=0
 MUTATION_STARTED=0
 UPGRADE_COMPLETED=0
 
 usage() {
     cat <<EOF
-Usage: $0 [--upgrade] [--runtime-binary /path/to/lg-buddy]
+Usage: $0 [--upgrade] [--runtime-binary /path/to/lg-buddy] [--gui-binary /path/to/lg-buddy-gui]
 
-Install LG Buddy from an existing runtime binary.
+Install LG Buddy from existing runtime and GUI binaries.
 
 Options:
   --upgrade         Upgrade an existing compatible release-bundle installation
 
 Defaults:
   --runtime-binary defaults to ./lg-buddy next to install.sh
+  --gui-binary defaults to ./lg-buddy-gui next to install.sh
 EOF
     exit 1
 }
@@ -38,6 +42,12 @@ while [ "$#" -gt 0 ]; do
             RUNTIME_BINARY="${2:-}"
             [ -n "$RUNTIME_BINARY" ] || usage
             RUNTIME_BINARY_OVERRIDDEN=1
+            shift 2
+            ;;
+        --gui-binary)
+            GUI_BINARY="${2:-}"
+            [ -n "$GUI_BINARY" ] || usage
+            GUI_BINARY_OVERRIDDEN=1
             shift 2
             ;;
         --upgrade)
@@ -54,8 +64,8 @@ while [ "$#" -gt 0 ]; do
     esac
 done
 
-if [ "$UPGRADE_MODE" -eq 1 ] && [ "$RUNTIME_BINARY_OVERRIDDEN" -eq 1 ]; then
-    echo "Error: --upgrade uses the verified lg-buddy binary from this release bundle."
+if [ "$UPGRADE_MODE" -eq 1 ] && { [ "$RUNTIME_BINARY_OVERRIDDEN" -eq 1 ] || [ "$GUI_BINARY_OVERRIDDEN" -eq 1 ]; }; then
+    echo "Error: --upgrade uses the verified lg-buddy and lg-buddy-gui binaries from this release bundle."
     exit 1
 fi
 
@@ -113,6 +123,7 @@ run_privileged() {
 
 SYSTEM_BIN_DIR="$(prefix_path "/usr/bin")"
 RUNTIME_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy"
+GUI_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy-gui"
 VENV_DIR="${SYSTEM_BIN_DIR}/LG_Buddy_PIP"
 SYSTEM_LIB_DIR="$(prefix_path "/usr/lib/lg-buddy")"
 CONFIG_POINTER_PATH="${SYSTEM_LIB_DIR}/config-path"
@@ -239,6 +250,54 @@ resolve_runtime_binary() {
     echo "Using lg-buddy runtime binary: $RUNTIME_BINARY"
 }
 
+resolve_gui_binary() {
+    if [ -L "$GUI_BINARY" ]; then
+        echo "LG Buddy GUI binary must be a regular file, not a symbolic link: $GUI_BINARY"
+        exit 1
+    fi
+
+    if [ ! -f "$GUI_BINARY" ]; then
+        echo "LG Buddy GUI binary not found at: $GUI_BINARY"
+        echo "Build lg-buddy-gui separately first, or use an official release bundle."
+        exit 1
+    fi
+
+    if [ ! -r "$GUI_BINARY" ] || [ ! -x "$GUI_BINARY" ]; then
+        echo "LG Buddy GUI binary is not readable and executable: $GUI_BINARY"
+        echo "Provide a regular executable lg-buddy-gui binary."
+        exit 1
+    fi
+
+    if find "$GUI_BINARY" -prune -perm /022 | grep -q .; then
+        echo "LG Buddy GUI binary is writable by its group or by other users: $GUI_BINARY"
+        echo "Remove unsafe write permissions before installing."
+        exit 1
+    fi
+
+    if [ "$GUI_BINARY" -ef "$RUNTIME_BINARY" ]; then
+        echo "LG Buddy GUI binary resolves to the lg-buddy runtime binary: $GUI_BINARY"
+        exit 1
+    fi
+
+    echo "Using lg-buddy GUI binary: $GUI_BINARY"
+}
+
+validate_candidate_binary_identity() {
+    if ! CANDIDATE_VERSION_OUTPUT="$("$RUNTIME_BINARY" --version)"; then
+        echo "LG Buddy runtime binary could not report its version identity: $RUNTIME_BINARY"
+        exit 1
+    fi
+    if ! GUI_VERSION_OUTPUT="$("$GUI_BINARY" --version)"; then
+        echo "LG Buddy GUI binary could not report its version identity: $GUI_BINARY"
+        echo "Ensure GTK 4.10 or newer and libadwaita 1 runtime libraries are installed."
+        exit 1
+    fi
+    if [ "$GUI_VERSION_OUTPUT" != "$CANDIDATE_VERSION_OUTPUT" ]; then
+        echo "LG Buddy GUI candidate identity does not match the runtime candidate."
+        exit 1
+    fi
+}
+
 install_missing_prerequisites() {
     if [ ${#MISSING_PKGS[@]} -eq 0 ]; then
         echo "All prerequisites satisfied."
@@ -329,8 +388,6 @@ load_upgrade_configuration() {
     SYSTEM_SLEEP_WAKE_POLICY="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get system.sleep_wake_policy)"
     UPDATE_AUTO_CHECK="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get updates.auto_check)"
     UPDATE_CHANNEL="$(LG_BUDDY_CONFIG="$CONFIG_FILE" "$RUNTIME_BINARY" settings get updates.channel)"
-    CANDIDATE_VERSION_OUTPUT="$("$RUNTIME_BINARY" --version)"
-
     echo "Using existing configuration file at $CONFIG_FILE"
     echo "Preserving update channel: $UPDATE_CHANNEL"
 }
@@ -379,6 +436,8 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
     echo ""
     echo "Running candidate upgrade preflight..."
     "$RUNTIME_BINARY" upgrade-preflight "$SCRIPT_DIR"
+    resolve_gui_binary
+    validate_candidate_binary_identity
     load_upgrade_configuration
 
     if [ "$TV_PLATFORM" = "lg_webos" ]; then
@@ -391,16 +450,18 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
         require_python_repair_prerequisites
     fi
 else
+    resolve_gui_binary
+    validate_candidate_binary_identity
     check_fresh_install_prerequisites
 
 # CONFIGURE FRESH INSTALLATION
 echo ""
 echo "Running configuration script..."
-# Make sure configure.sh is executable
-if [ ! -x "$SCRIPT_DIR/configure.sh" ]; then
-    chmod +x "$SCRIPT_DIR/configure.sh"
+if [ ! -r "$SCRIPT_DIR/configure.sh" ]; then
+    echo "Configuration script is not readable: $SCRIPT_DIR/configure.sh"
+    exit 1
 fi
-LG_BUDDY_RUNTIME_BINARY="$RUNTIME_BINARY" "$SCRIPT_DIR/configure.sh"
+LG_BUDDY_RUNTIME_BINARY="$RUNTIME_BINARY" bash "$SCRIPT_DIR/configure.sh"
 CONFIG_FILE="$(bash "$SCRIPT_DIR/bin/LG_Buddy_Common" --user-config-path)"
 SCREEN_IDLE_BLANK="$(sed -n 's/^screen_idle_blank=//p' "$CONFIG_FILE" | tail -n1)"
 case "$SCREEN_IDLE_BLANK" in
@@ -514,6 +575,7 @@ fi
 MUTATION_STARTED=1
 echo "Installing Rust runtime and support files..."
 run_privileged install -m 755 "$RUNTIME_BINARY" "$RUNTIME_INSTALL_PATH"
+run_privileged install -m 755 "$GUI_BINARY" "$GUI_INSTALL_PATH"
 if [ "$UPGRADE_MODE" -eq 0 ]; then
     run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Startup"
     run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Shutdown"
@@ -621,6 +683,15 @@ if [ "$SYSTEM_SLEEP_WAKE_POLICY" = "enabled" ]; then
     echo "System sleep/wake TV control enabled via LG_Buddy_lifecycle.service and NetworkManager pre-down gate."
 else
     echo "System sleep/wake TV control disabled by config. Lifecycle integration is installed and will no-op until re-enabled."
+fi
+
+INSTALLED_GUI_VERSION_OUTPUT="$("$GUI_INSTALL_PATH" --version)"
+if ! cmp -s "$GUI_BINARY" "$GUI_INSTALL_PATH" || [ "$INSTALLED_GUI_VERSION_OUTPUT" != "$CANDIDATE_VERSION_OUTPUT" ]; then
+    echo "Installed GUI identity does not match the verified candidate." >&2
+    if [ "$UPGRADE_MODE" -eq 1 ]; then
+        echo "Rerun this verified bundle with --upgrade to repair the partial installation." >&2
+    fi
+    exit 1
 fi
 
 if [ "$UPGRADE_MODE" -eq 1 ]; then

--- a/scripts/test-cross-version-upgrade.sh
+++ b/scripts/test-cross-version-upgrade.sh
@@ -31,6 +31,32 @@ assert_executable() {
     [ -x "$1" ] || fail "Expected executable not found: $1"
 }
 
+install_gui_candidate_fixture() {
+    local bundle_root="$1"
+    local gui_binary="$bundle_root/lg-buddy-gui"
+
+    # #144 covers installer upgrades before #145 adds the real GUI to release
+    # archives and their manifest.
+    [ ! -e "$gui_binary" ] || return 0
+    cat >"$gui_binary" <<'EOF'
+#!/bin/sh
+set -eu
+
+case "${1:-}" in
+    --version|-V)
+        [ "$#" -eq 1 ] || exit 2
+        exec "$(dirname "$0")/lg-buddy" --version
+        ;;
+    brightness)
+        [ "$#" -eq 1 ] || exit 2
+        exit 0
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod 755 "$gui_binary"
+}
+
 validate_archive_paths() {
     local archive="$1"
     local entry=""
@@ -194,6 +220,8 @@ python3 "$SCRIPT_DIR/release_bundle_manifest.py" validate \
     --expected-channel "$CANDIDATE_CHANNEL" \
     --expected-target "$CANDIDATE_TARGET" \
     --expected-commit "$CANDIDATE_COMMIT"
+install_gui_candidate_fixture "$CANDIDATE_BUNDLE"
+assert_executable "$CANDIDATE_BUNDLE/lg-buddy-gui"
 
 INSTALL_ROOT="$WORK_DIR/root"
 HOME_DIR="$WORK_DIR/home"
@@ -218,11 +246,12 @@ export PIP_NO_PYTHON_VERSION_WARNING="1"
 
 (
     cd "$PREVIOUS_BUNDLE"
-    ./install.sh
+    bash ./install.sh
 )
 
 CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
 INSTALLED_BINARY="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_GUI="$INSTALL_ROOT/usr/bin/lg-buddy-gui"
 INSTALLED_POINTER="$INSTALL_ROOT/usr/lib/lg-buddy/config-path"
 SYSTEM_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy.service"
 LIFECYCLE_SERVICE="$INSTALL_ROOT/etc/systemd/system/LG_Buddy_lifecycle.service"
@@ -330,7 +359,7 @@ if (
     LG_BUDDY_SUDO_CMD="$SUDO_SPY" \
     LG_BUDDY_SUDO_MARKER="$SUDO_MARKER" \
     strace -f -qq -e trace=network -o "$CANDIDATE_NETWORK_TRACE" \
-        ./install.sh --upgrade >"$CANDIDATE_REFUSAL_OUTPUT" 2>&1
+        bash ./install.sh --upgrade >"$CANDIDATE_REFUSAL_OUTPUT" 2>&1
 ); then
     fail "Malformed candidate unexpectedly passed its preflight."
 fi
@@ -377,7 +406,7 @@ chmod 755 "$INSTALLER_STUB_DIR/systemctl" "$INSTALLER_STUB_DIR/systemd-tmpfiles"
     export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
     cd "$CANDIDATE_BUNDLE"
-    ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
+    bash ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
 )
 
 grep -F -q 'Upgrade complete!' "$UPGRADE_OUTPUT"
@@ -405,6 +434,10 @@ cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN_FILE" || fail "Cross-version upgrade cha
 [ -e "$VENV_MARKER" ] || fail "Cross-version native upgrade recreated the Python environment."
 
 cmp -s "$CANDIDATE_BUNDLE/lg-buddy" "$INSTALLED_BINARY"
+assert_executable "$INSTALLED_GUI"
+[ "$(stat -c '%a' "$INSTALLED_GUI")" = "755" ] || fail "Installed GUI mode is not 755."
+cmp -s "$CANDIDATE_BUNDLE/lg-buddy-gui" "$INSTALLED_GUI"
+[ "$("$INSTALLED_GUI" --version)" = "$("$INSTALLED_BINARY" --version)" ] || fail "Installed GUI identity does not match the runtime."
 cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy.service" "$SYSTEM_SERVICE"
 cmp -s "$CANDIDATE_BUNDLE/systemd/LG_Buddy_lifecycle.service" "$LIFECYCLE_SERVICE"
 cmp -s "$CANDIDATE_BUNDLE/systemd/lg_buddy.conf" "$TMPFILES_CONFIG"

--- a/scripts/test-installed-gui.sh
+++ b/scripts/test-installed-gui.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPOSITORY_ROOT="$(dirname "$SCRIPT_DIR")"
+RUNTIME_BINARY="${1:-$REPOSITORY_ROOT/target/debug/lg-buddy}"
+GUI_BINARY="${2:-$REPOSITORY_ROOT/target/debug/lg-buddy-gui}"
+WORK_DIR="$(mktemp -d)"
+INSTALL_ROOT="$WORK_DIR/root"
+HOME_DIR="$WORK_DIR/home"
+
+fail() {
+    echo "$1" >&2
+    exit 1
+}
+
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+[ "$(id -u)" -ne 0 ] || fail "Installed GUI smoke must run as a regular user."
+[ -x "$RUNTIME_BINARY" ] || fail "Runtime binary is not executable: $RUNTIME_BINARY"
+[ -x "$GUI_BINARY" ] || fail "GUI binary is not executable: $GUI_BINARY"
+[ -n "${DISPLAY:-}" ] || fail "DISPLAY is required for the installed GUI smoke test."
+[ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || fail "A D-Bus session is required for the installed GUI smoke test."
+
+RUNTIME_BINARY="$(realpath "$RUNTIME_BINARY")"
+GUI_BINARY="$(realpath "$GUI_BINARY")"
+mkdir -p "$INSTALL_ROOT" "$HOME_DIR/Desktop"
+
+export HOME="$HOME_DIR"
+export XDG_CONFIG_HOME="$HOME_DIR/.config"
+export LG_BUDDY_INSTALL_ROOT="$INSTALL_ROOT"
+export LG_BUDDY_SUDO_CMD="none"
+export LG_BUDDY_NONINTERACTIVE="1"
+export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+export LG_BUDDY_SKIP_PIP_INSTALL="1"
+export LG_BUDDY_TV_IP="192.0.2.10"
+export LG_BUDDY_TV_MAC="02:00:00:00:00:10"
+export LG_BUDDY_INPUT="HDMI_1"
+export LG_BUDDY_TV_PLATFORM="bscpylgtv"
+export LG_BUDDY_SCREEN_BACKEND="auto"
+export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+
+bash "$REPOSITORY_ROOT/install.sh" \
+    --runtime-binary "$RUNTIME_BINARY" \
+    --gui-binary "$GUI_BINARY"
+
+INSTALLED_RUNTIME="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_GUI="$INSTALL_ROOT/usr/bin/lg-buddy-gui"
+DESKTOP_ENTRY="$INSTALL_ROOT/usr/share/applications/LG_Buddy_Brightness.desktop"
+CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
+NATIVE_TOKEN="$XDG_CONFIG_HOME/lg-buddy/tvs/primary/access-token.json"
+
+[ -x "$INSTALLED_RUNTIME" ] || fail "Installed runtime is missing."
+[ -x "$INSTALLED_GUI" ] || fail "Installed GUI is missing."
+[ "$(stat -c '%a' "$INSTALLED_GUI")" = "755" ] || fail "Installed GUI mode is not 755."
+[ "$(stat -c '%u' "$INSTALLED_GUI")" = "$(id -u)" ] || fail "Installed GUI has the wrong owner."
+cmp -s "$RUNTIME_BINARY" "$INSTALLED_RUNTIME" || fail "Installed runtime bytes differ from the candidate."
+cmp -s "$GUI_BINARY" "$INSTALLED_GUI" || fail "Installed GUI bytes differ from the candidate."
+grep -F -x -q 'Exec=/usr/bin/lg-buddy brightness' "$DESKTOP_ENTRY" || fail "Desktop entry does not use the stable brightness launcher."
+grep -F -x -q 'Terminal=false' "$DESKTOP_ENTRY" || fail "Desktop entry would open a terminal."
+
+export LG_BUDDY_CONFIG="$CONFIG_FILE"
+bash "$SCRIPT_DIR/test-gui-launch.sh" "$INSTALLED_RUNTIME"
+
+mkdir -p "$(dirname "$NATIVE_TOKEN")"
+printf '%s\n' '{"access_token":"installed-gui-smoke-token"}' >"$NATIVE_TOKEN"
+chmod 600 "$NATIVE_TOKEN"
+CONFIG_SNAPSHOT="$WORK_DIR/config.snapshot"
+TOKEN_SNAPSHOT="$WORK_DIR/token.snapshot"
+cp "$CONFIG_FILE" "$CONFIG_SNAPSHOT"
+cp "$NATIVE_TOKEN" "$TOKEN_SNAPSHOT"
+
+unset LG_BUDDY_REMOVE_CONFIG
+bash "$REPOSITORY_ROOT/uninstall.sh"
+
+[ ! -e "$INSTALLED_RUNTIME" ] || fail "Uninstall left the runtime installed."
+[ ! -e "$INSTALLED_GUI" ] || fail "Uninstall left the GUI installed."
+[ ! -e "$DESKTOP_ENTRY" ] || fail "Uninstall left the desktop entry installed."
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE" || fail "Uninstall changed the user configuration."
+cmp -s "$TOKEN_SNAPSHOT" "$NATIVE_TOKEN" || fail "Uninstall changed the native credential."

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -29,6 +29,18 @@ assert_mode() {
     fi
 }
 
+assert_owner_uid() {
+    local path="$1"
+    local expected="$2"
+    local actual=""
+
+    actual="$(stat -c '%u' "$path")"
+    if [ "$actual" != "$expected" ]; then
+        echo "Expected owner UID $expected for $path, got $actual"
+        exit 1
+    fi
+}
+
 assert_executable() {
     local path="$1"
 
@@ -36,6 +48,32 @@ assert_executable() {
         echo "Expected executable not found: $path"
         exit 1
     fi
+}
+
+install_gui_candidate_fixture() {
+    local bundle_root="$1"
+    local gui_binary="$bundle_root/lg-buddy-gui"
+
+    # #144 tests the installer contract before #145 adds the real GUI to
+    # release archives and their manifest.
+    [ ! -e "$gui_binary" ] || return 0
+    cat >"$gui_binary" <<'EOF'
+#!/bin/sh
+set -eu
+
+case "${1:-}" in
+    --version|-V)
+        [ "$#" -eq 1 ] || exit 2
+        exec "$(dirname "$0")/lg-buddy" --version
+        ;;
+    brightness)
+        [ "$#" -eq 1 ] || exit 2
+        exit 0
+        ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod 755 "$gui_binary"
 }
 
 assert_hidden_compatibility_alias() {
@@ -342,6 +380,73 @@ printf '%s\n' "$VERSION_OUTPUT" | grep -q "^version: "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^channel: "
 printf '%s\n' "$VERSION_OUTPUT" | grep -q "^commit: "
 
+install_gui_candidate_fixture "$BUNDLE_DIR"
+assert_executable "$BUNDLE_DIR/lg-buddy-gui"
+
+PAYLOAD_REFUSAL_ROOT="$WORK_DIR/payload-refusal-root"
+PAYLOAD_REFUSAL_HOME="$WORK_DIR/payload-refusal-home"
+PAYLOAD_REFUSAL_SUDO_MARKER="$WORK_DIR/payload-refusal-sudo"
+PAYLOAD_REFUSAL_SUDO="$WORK_DIR/payload-refusal-sudo-spy"
+MISSING_GUI_OUTPUT="$WORK_DIR/missing-gui-refusal.output"
+UNSAFE_GUI_OUTPUT="$WORK_DIR/unsafe-gui-refusal.output"
+GUI_FIXTURE_SNAPSHOT="$WORK_DIR/lg-buddy-gui.fixture"
+mkdir -p "$PAYLOAD_REFUSAL_ROOT" "$PAYLOAD_REFUSAL_HOME"
+cat >"$PAYLOAD_REFUSAL_SUDO" <<'EOF'
+#!/bin/sh
+: >"${LG_BUDDY_PAYLOAD_REFUSAL_SUDO_MARKER:?}"
+exit 97
+EOF
+chmod 755 "$PAYLOAD_REFUSAL_SUDO"
+mv "$BUNDLE_DIR/lg-buddy-gui" "$GUI_FIXTURE_SNAPSHOT"
+if (
+    export HOME="$PAYLOAD_REFUSAL_HOME"
+    export XDG_CONFIG_HOME="$PAYLOAD_REFUSAL_HOME/.config"
+    export LG_BUDDY_INSTALL_ROOT="$PAYLOAD_REFUSAL_ROOT"
+    export LG_BUDDY_SUDO_CMD="$PAYLOAD_REFUSAL_SUDO"
+    export LG_BUDDY_PAYLOAD_REFUSAL_SUDO_MARKER="$PAYLOAD_REFUSAL_SUDO_MARKER"
+    export LG_BUDDY_NONINTERACTIVE="1"
+    cd "$BUNDLE_DIR"
+    bash ./install.sh >"$MISSING_GUI_OUTPUT" 2>&1
+); then
+    echo "Fresh install unexpectedly accepted a missing GUI candidate."
+    exit 1
+fi
+mv "$GUI_FIXTURE_SNAPSHOT" "$BUNDLE_DIR/lg-buddy-gui"
+grep -F -q 'LG Buddy GUI binary not found' "$MISSING_GUI_OUTPUT"
+[ ! -e "$PAYLOAD_REFUSAL_SUDO_MARKER" ] || {
+    echo "Missing GUI candidate requested sudo."
+    exit 1
+}
+[ -z "$(find "$PAYLOAD_REFUSAL_ROOT" -mindepth 1 -print -quit)" ] || {
+    echo "Missing GUI candidate mutated the installation root."
+    exit 1
+}
+
+chmod 775 "$BUNDLE_DIR/lg-buddy-gui"
+if (
+    export HOME="$PAYLOAD_REFUSAL_HOME"
+    export XDG_CONFIG_HOME="$PAYLOAD_REFUSAL_HOME/.config"
+    export LG_BUDDY_INSTALL_ROOT="$PAYLOAD_REFUSAL_ROOT"
+    export LG_BUDDY_SUDO_CMD="$PAYLOAD_REFUSAL_SUDO"
+    export LG_BUDDY_PAYLOAD_REFUSAL_SUDO_MARKER="$PAYLOAD_REFUSAL_SUDO_MARKER"
+    export LG_BUDDY_NONINTERACTIVE="1"
+    cd "$BUNDLE_DIR"
+    bash ./install.sh >"$UNSAFE_GUI_OUTPUT" 2>&1
+); then
+    echo "Fresh install unexpectedly accepted an unsafe GUI candidate."
+    exit 1
+fi
+chmod 755 "$BUNDLE_DIR/lg-buddy-gui"
+grep -F -q 'GUI binary is writable by its group or by other users' "$UNSAFE_GUI_OUTPUT"
+[ ! -e "$PAYLOAD_REFUSAL_SUDO_MARKER" ] || {
+    echo "Unsafe GUI candidate requested sudo."
+    exit 1
+}
+[ -z "$(find "$PAYLOAD_REFUSAL_ROOT" -mindepth 1 -print -quit)" ] || {
+    echo "Unsafe GUI candidate mutated the installation root."
+    exit 1
+}
+
 FRESH_CONFIG_HOME="$WORK_DIR/fresh-config-home"
 FRESH_CONFIG_OUTPUT="$WORK_DIR/fresh-config.output"
 FRESH_NATIVE_RUNTIME="$WORK_DIR/fresh-native-runtime"
@@ -380,7 +485,7 @@ mkdir -p "$FRESH_CONFIG_HOME"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
     printf '%s\n' \
         '192.0.2.10' 'aa:bb:cc:dd:ee:ff' '2' '' 'Y' '1' '300' '1' 'Y' \
-        | "$BUNDLE_DIR/configure.sh" >"$FRESH_CONFIG_OUTPUT" 2>&1
+        | bash "$BUNDLE_DIR/configure.sh" >"$FRESH_CONFIG_OUTPUT" 2>&1
 )
 grep -F -q 'TV Platform:         lg_webos' "$FRESH_CONFIG_OUTPUT"
 grep -F -q 'pairing required; accept the prompt on the TV' "$FRESH_CONFIG_OUTPUT"
@@ -417,11 +522,12 @@ fi
 
 (
     cd "$BUNDLE_DIR"
-    ./install.sh
+    bash ./install.sh
 )
 
 CONFIG_FILE="$XDG_CONFIG_HOME/lg-buddy/config.env"
 INSTALLED_BINARY="$INSTALL_ROOT/usr/bin/lg-buddy"
+INSTALLED_GUI="$INSTALL_ROOT/usr/bin/lg-buddy-gui"
 INSTALLED_VENV_PIP="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/bin/pip"
 INSTALLED_BSCPYLGTV="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/bin/bscpylgtvcommand"
 STALE_VENV_MARKER="$INSTALL_ROOT/usr/bin/LG_Buddy_PIP/lib/python-old/site-packages/stale-marker"
@@ -447,6 +553,14 @@ export LG_BUDDY_CONFIG="$CONFIG_FILE"
 
 assert_file "$CONFIG_FILE"
 assert_executable "$INSTALLED_BINARY"
+assert_executable "$INSTALLED_GUI"
+assert_mode "$INSTALLED_GUI" 755
+assert_owner_uid "$INSTALLED_GUI" "$(id -u)"
+cmp -s "$BUNDLE_DIR/lg-buddy-gui" "$INSTALLED_GUI"
+[ "$("$INSTALLED_GUI" --version)" = "$VERSION_OUTPUT" ] || {
+    echo "Installed GUI identity did not match the runtime candidate."
+    exit 1
+}
 assert_executable "$INSTALLED_VENV_PIP"
 assert_file "$INSTALLED_POINTER"
 assert_lifecycle_topology_installed
@@ -494,7 +608,7 @@ LEGACY_MISSING_CONFIGURE_OUTPUT="$WORK_DIR/legacy-missing-configure.output"
 (
     unset LG_BUDDY_TV_PLATFORM
     cd "$BUNDLE_DIR"
-    ./configure.sh >"$LEGACY_MISSING_CONFIGURE_OUTPUT" 2>&1
+    bash ./configure.sh >"$LEGACY_MISSING_CONFIGURE_OUTPUT" 2>&1
 )
 grep -F -q 'TV Platform:         bscpylgtv' "$LEGACY_MISSING_CONFIGURE_OUTPUT"
 grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
@@ -549,7 +663,7 @@ LEGACY_CONFIGURE_OUTPUT="$WORK_DIR/legacy-configure.output"
     export LG_BUDDY_TV_MAC="11:22:33:44:55:66"
     export LG_BUDDY_INPUT="HDMI_3"
     cd "$BUNDLE_DIR"
-    ./configure.sh >"$LEGACY_CONFIGURE_OUTPUT" 2>&1
+    bash ./configure.sh >"$LEGACY_CONFIGURE_OUTPUT" 2>&1
 )
 
 grep -F -q 'Warning: swayidle is a deprecated compatibility backend planned for removal in LG Buddy 2.0.0' "$LEGACY_CONFIGURE_OUTPUT"
@@ -579,7 +693,7 @@ do
     cp "$CONFIG_FILE" "$INVALID_PLATFORM_CONFIG"
     if (
         cd "$BUNDLE_DIR"
-        ./configure.sh >"$INVALID_PLATFORM_OUTPUT" 2>&1
+        bash ./configure.sh >"$INVALID_PLATFORM_OUTPUT" 2>&1
     ); then
         echo "configure.sh unexpectedly accepted invalid TV platform: $invalid_platform_line"
         exit 1
@@ -615,6 +729,7 @@ touch "$NATIVE_VENV_MARKER"
 printf '#!/bin/sh\nprintf "stale installed runtime\\n"\n' >"$INSTALLED_BINARY"
 chmod 755 "$INSTALLED_BINARY"
 for stale_target in \
+    "$INSTALLED_GUI" \
     "$SYSTEM_SERVICE" \
     "$LIFECYCLE_SERVICE" \
     "$TMPFILES_CONFIG" \
@@ -631,6 +746,7 @@ INSTALLER_STUB_DIR="$WORK_DIR/installer-stubs"
 SUDO_MARKER="$WORK_DIR/sudo-invoked"
 SUDO_SPY="$INSTALLER_STUB_DIR/sudo-spy"
 REFUSAL_OUTPUT="$WORK_DIR/upgrade-refusal.output"
+GUI_IDENTITY_REFUSAL_OUTPUT="$WORK_DIR/gui-identity-refusal.output"
 mkdir -p "$INSTALLER_STUB_DIR"
 cat >"$SUDO_SPY" <<'EOF'
 #!/bin/sh
@@ -638,12 +754,41 @@ cat >"$SUDO_SPY" <<'EOF'
 exit 97
 EOF
 chmod 755 "$SUDO_SPY"
+
+GUI_CANDIDATE_SNAPSHOT="$WORK_DIR/lg-buddy-gui.candidate"
+cp -p "$BUNDLE_DIR/lg-buddy-gui" "$GUI_CANDIDATE_SNAPSHOT"
+cat >"$BUNDLE_DIR/lg-buddy-gui" <<'EOF'
+#!/bin/sh
+[ "${1:-}" = "--version" ] || [ "${1:-}" = "-V" ] || exit 2
+printf 'lg-buddy 0.0.0\nversion: 0.0.0\nchannel: dev\ncommit: mismatched\n'
+EOF
+chmod 755 "$BUNDLE_DIR/lg-buddy-gui"
+if (
+    export LG_BUDDY_SUDO_CMD="$SUDO_SPY"
+    export LG_BUDDY_SUDO_MARKER="$SUDO_MARKER"
+    cd "$BUNDLE_DIR"
+    bash ./install.sh --upgrade >"$GUI_IDENTITY_REFUSAL_OUTPUT" 2>&1
+); then
+    echo "Upgrade unexpectedly passed with a mismatched GUI candidate."
+    exit 1
+fi
+mv "$GUI_CANDIDATE_SNAPSHOT" "$BUNDLE_DIR/lg-buddy-gui"
+grep -F -q 'GUI candidate identity does not match the runtime candidate' "$GUI_IDENTITY_REFUSAL_OUTPUT"
+[ ! -e "$SUDO_MARKER" ] || {
+    echo "Mismatched GUI candidate requested sudo."
+    exit 1
+}
+grep -F -q 'stale installed runtime' "$INSTALLED_BINARY"
+grep -F -q 'stale installed integration' "$INSTALLED_GUI"
+cmp -s "$CONFIG_SNAPSHOT" "$CONFIG_FILE"
+cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE"
+
 mv "$SYSTEM_SERVICE" "$SYSTEM_SERVICE.preflight-refusal"
 if (
     export LG_BUDDY_SUDO_CMD="$SUDO_SPY"
     export LG_BUDDY_SUDO_MARKER="$SUDO_MARKER"
     cd "$BUNDLE_DIR"
-    ./install.sh --upgrade >"$REFUSAL_OUTPUT" 2>&1
+    bash ./install.sh --upgrade >"$REFUSAL_OUTPUT" 2>&1
 ); then
     echo "Upgrade unexpectedly passed with a missing installed service."
     exit 1
@@ -705,7 +850,7 @@ if (
     export LG_BUDDY_FAIL_SYSTEM_RELOAD="1"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
     cd "$BUNDLE_DIR"
-    ./install.sh --upgrade >"$PARTIAL_UPGRADE_OUTPUT" 2>&1
+    bash ./install.sh --upgrade >"$PARTIAL_UPGRADE_OUTPUT" 2>&1
 ); then
     echo "Upgrade unexpectedly succeeded after a simulated post-mutation failure."
     exit 1
@@ -742,7 +887,7 @@ if (
     export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
     cd "$BUNDLE_DIR"
-    ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
+    bash ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
 ); then
     :
 else
@@ -798,6 +943,11 @@ cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE" || {
     exit 1
 }
 cmp -s "$BUNDLE_DIR/lg-buddy" "$INSTALLED_BINARY"
+cmp -s "$BUNDLE_DIR/lg-buddy-gui" "$INSTALLED_GUI"
+[ "$("$INSTALLED_GUI" --version)" = "$INSTALLED_VERSION_OUTPUT" ] || {
+    echo "Upgraded GUI identity did not match the runtime candidate."
+    exit 1
+}
 cmp -s "$BUNDLE_DIR/systemd/LG_Buddy.service" "$SYSTEM_SERVICE"
 cmp -s "$BUNDLE_DIR/systemd/LG_Buddy_lifecycle.service" "$LIFECYCLE_SERVICE"
 cmp -s "$BUNDLE_DIR/systemd/lg_buddy.conf" "$TMPFILES_CONFIG"
@@ -828,7 +978,7 @@ touch "$HEALTHY_VENV_MARKER"
 (
     export LG_BUDDY_SKIP_PIP_INSTALL="1"
     cd "$BUNDLE_DIR"
-    ./install.sh --upgrade
+    bash ./install.sh --upgrade
 )
 [ -e "$HEALTHY_VENV_MARKER" ] || {
     echo "Healthy compatibility environment was recreated during upgrade."
@@ -845,7 +995,7 @@ touch "$REPAIR_VENV_MARKER"
 (
     export LG_BUDDY_SKIP_PIP_INSTALL="1"
     cd "$BUNDLE_DIR"
-    ./install.sh --upgrade
+    bash ./install.sh --upgrade
 )
 [ ! -e "$REPAIR_VENV_MARKER" ] || {
     echo "Unhealthy compatibility environment was not repaired."
@@ -857,7 +1007,7 @@ rm -rf "$INSTALL_ROOT/usr/bin/LG_Buddy_PIP"
 (
     export LG_BUDDY_SKIP_PIP_INSTALL="1"
     cd "$BUNDLE_DIR"
-    ./install.sh --upgrade
+    bash ./install.sh --upgrade
 )
 assert_executable "$INSTALLED_VENV_PIP"
 
@@ -868,11 +1018,15 @@ rm -f "$NATIVE_ACCESS_TOKEN_SNAPSHOT"
 export LG_BUDDY_REMOVE_CONFIG="1"
 (
     cd "$BUNDLE_DIR"
-    ./uninstall.sh
+    bash ./uninstall.sh
 )
 
 [ ! -e "$INSTALLED_BINARY" ] || {
     echo "Installed binary still present after uninstall: $INSTALLED_BINARY"
+    exit 1
+}
+[ ! -e "$INSTALLED_GUI" ] || {
+    echo "Installed GUI still present after uninstall: $INSTALLED_GUI"
     exit 1
 }
 [ ! -e "$INSTALLED_VENV_PIP" ] || {
@@ -946,11 +1100,12 @@ mkdir -p "$(dirname "$STALE_VENV_MARKER")"
 touch "$STALE_VENV_MARKER"
 (
     cd "$BUNDLE_DIR"
-    ./install.sh
+    bash ./install.sh
 )
 
 assert_file "$CONFIG_FILE"
 assert_executable "$INSTALLED_BINARY"
+assert_executable "$INSTALLED_GUI"
 [ ! -e "$STALE_VENV_MARKER" ] || {
     echo "Installer left stale virtualenv contents in place: $STALE_VENV_MARKER"
     exit 1
@@ -961,11 +1116,15 @@ grep -q '^system_sleep_wake_policy=disabled$' "$CONFIG_FILE"
 
 (
     cd "$BUNDLE_DIR"
-    ./uninstall.sh
+    bash ./uninstall.sh
 )
 
 [ ! -e "$INSTALLED_BINARY" ] || {
     echo "Installed binary still present after disabled-policy uninstall: $INSTALLED_BINARY"
+    exit 1
+}
+[ ! -e "$INSTALLED_GUI" ] || {
+    echo "Installed GUI still present after disabled-policy uninstall: $INSTALLED_GUI"
     exit 1
 }
 [ ! -e "$LIFECYCLE_SERVICE" ] || {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -28,6 +28,7 @@ run_privileged() {
 
 SYSTEM_BIN_DIR="$(prefix_path "/usr/bin")"
 RUNTIME_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy"
+GUI_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy-gui"
 VENV_DIR="${SYSTEM_BIN_DIR}/LG_Buddy_PIP"
 SYSTEM_LIB_DIR="$(prefix_path "/usr/lib/lg-buddy")"
 COMMON_HELPER_PATH="${SYSTEM_LIB_DIR}/common.sh"
@@ -115,6 +116,7 @@ echo "Done."
 
 echo "Removing scripts"
 run_privileged rm -f "$RUNTIME_INSTALL_PATH"
+run_privileged rm -f "$GUI_INSTALL_PATH"
 run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Startup"
 run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Shutdown"
 run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_On"


### PR DESCRIPTION
## Summary

- validate and install `lg-buddy-gui` alongside the headless runtime for fresh installs and upgrades
- extend upgrade preflight and uninstall behavior while preserving configuration, credentials, and the Zenity compatibility fallback
- add installed-GUI, refusal, upgrade, ownership, mode, launcher, and removal coverage
- document GTK/libadwaita runtime requirements and the two-binary local installation contract

Official release-archive packaging remains in #145.

## Validation

- `cargo test -p lg-buddy --lib -- --test-threads=1`
- `cargo test -p lg-buddy --test cucumber`
- display-backed GUI library and launcher smoke tests
- installed-GUI temporary-root smoke test
- release-bundle and pinned cross-version upgrade smoke tests
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- shell syntax and whitespace checks

Closes #144
