### PR TITLE
Blank the TV when the graphical session locks

### DIFF
--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -911,7 +911,7 @@ mod tests {
     use std::process;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
-    use support::{ExecutableScript, MockBscpylgtv};
+    use support::{find_command_in_path, python3_path, ExecutableScript, MockBscpylgtv};
 
     #[cfg(unix)]
     fn set_modified_time(path: &Path, modified: SystemTime) {
@@ -1678,14 +1678,9 @@ mod tests {
 
     #[test]
     fn installed_brightness_gui_launches_only_the_brightness_command() {
-        let gui = ExecutableScript::new(
-            "brightness-gui-launch",
-            "lg-buddy-gui",
-            "#!/bin/sh\n[ \"$#\" -eq 1 ] && [ \"$1\" = \"brightness\" ]\n",
-        );
         let launcher = InstalledBrightnessGui::new(
             env::current_exe().expect("current executable"),
-            gui.path(),
+            find_command_in_path("test").expect("test executable"),
         );
 
         assert_eq!(
@@ -1711,22 +1706,18 @@ mod tests {
 
     #[test]
     fn failed_installed_brightness_gui_is_reported_without_fallback() {
-        let gui = ExecutableScript::new(
-            "brightness-gui-failure",
-            "lg-buddy-gui",
-            "#!/bin/sh\nprintf 'LG Buddy GUI: initialization failed\\n' >&2\nexit 23\n",
-        );
         let launcher = InstalledBrightnessGui::new(
             env::current_exe().expect("current executable"),
-            gui.path(),
+            python3_path(),
         );
 
         let error = launcher
             .launch()
             .expect_err("failed GUI must not become a missing-GUI fallback");
 
-        assert!(error.to_string().contains("initialization failed"));
-        assert!(!error.to_string().contains("exited with status"));
+        let error = error.to_string();
+        assert!(error.contains("brightness"), "{error}");
+        assert!(!error.contains("exited with status"), "{error}");
     }
 
     #[test]

--- a/crates/lg-buddy/src/release_bundle.rs
+++ b/crates/lg-buddy/src/release_bundle.rs
@@ -1199,7 +1199,7 @@ fn rewind_clone(file: &File) -> Result<File, BundleAcquisitionError> {
 #[derive(Debug)]
 struct StagingDirectory {
     path: PathBuf,
-    _lock: File,
+    lock: File,
     device: u64,
     inode: u64,
 }
@@ -1246,7 +1246,7 @@ impl StagingDirectory {
                     }
                     return Ok(Self {
                         path,
-                        _lock: lock,
+                        lock,
                         device: metadata.dev(),
                         inode: metadata.ino(),
                     });
@@ -1273,6 +1273,7 @@ impl Drop for StagingDirectory {
         }) {
             let _ = fs::remove_dir_all(&self.path);
         }
+        let _ = unsafe { libc::flock(self.lock.as_raw_fd(), libc::LOCK_UN) };
     }
 }
 
@@ -3437,6 +3438,23 @@ mod tests {
         assert!(cache_root.join(LOCK_FILE_NAME).is_file());
         let next = StagingDirectory::create(&cache_root).expect("next staging");
         drop(next);
+        fs::remove_dir_all(dir).expect("remove test directory");
+    }
+
+    #[test]
+    fn staging_drop_unlocks_a_duplicated_descriptor() {
+        let dir = temp_dir("staging-lock-duplicate");
+        let cache_root = dir.join("cache");
+        let staging = StagingDirectory::create(&cache_root).expect("create staging");
+        // A descriptor inherited across fork has the same locking semantics.
+        let duplicate = staging.lock.try_clone().expect("duplicate lock descriptor");
+
+        drop(staging);
+        let next = StagingDirectory::create(&cache_root)
+            .expect("explicit unlock must permit immediate reacquisition");
+
+        drop(next);
+        drop(duplicate);
         fs::remove_dir_all(dir).expect("remove test directory");
     }
 

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -1154,7 +1154,7 @@ fn marker_state(exists: bool) -> &'static str {
 fn is_session_screen_source(source: EventSource) -> bool {
     matches!(
         source,
-        EventSource::DesktopSession | EventSource::AuxiliaryInput
+        EventSource::DesktopSession | EventSource::AuxiliaryInput | EventSource::LinuxLogind
     )
 }
 
@@ -1436,6 +1436,33 @@ mod tests {
     }
 
     #[test]
+    fn logind_lock_uses_the_existing_input_blank_and_marker_policy() {
+        let temp_dir = TestDir::new("screen-outcome-logind-lock");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let mock = MockBscpylgtv::new("screen-outcome-logind-lock-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let mut phase = FixedRuntimePhaseProvider::not_pending();
+        let lifecycle_status = NoopSystemLifecycleStatusProvider;
+
+        let mut output = Vec::new();
+        let outcome = run_screen_off_with_outcome_for_event(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+            RuntimeEvent::new(EventSource::LinuxLogind, RuntimeEventKind::SessionLocked),
+            &mut phase,
+            &lifecycle_status,
+        )
+        .expect("logind lock should use normal session blank policy");
+
+        assert_eq!(outcome.actions.len(), 1);
+        assert_eq!(outcome.actions[0].kind, ActionKind::TvScreenBlank);
+        assert!(marker.exists());
+    }
+
+    #[test]
     fn screen_off_outcome_records_input_mismatch_no_action_and_marker_clear() {
         let temp_dir = TestDir::new("screen-outcome-off-skip");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
@@ -1589,7 +1616,7 @@ mod tests {
     }
 
     #[test]
-    fn session_screen_off_is_ineligible_while_machine_sleep_is_pending() {
+    fn logind_lock_screen_off_is_ineligible_while_machine_sleep_is_pending() {
         let temp_dir = TestDir::new("screen-phase-off-pending");
         let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
         let mock = MockBscpylgtv::new("screen-phase-off-pending-tv");
@@ -1604,7 +1631,7 @@ mod tests {
             &sample_config(HdmiInput::Hdmi2),
             &marker,
             &client,
-            RuntimeEvent::new(EventSource::DesktopSession, RuntimeEventKind::SessionIdle),
+            RuntimeEvent::new(EventSource::LinuxLogind, RuntimeEventKind::SessionLocked),
             &mut phase,
             &lifecycle_status,
         )

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -28,6 +28,9 @@ pub struct InactivityEngine {
     blank_at: Instant,
     phase: InactivityPhase,
     restore_pending: bool,
+    session_locked_since: Option<Instant>,
+    lock_activity_floor: Option<Instant>,
+    latest_independent_activity_at: Option<Instant>,
 }
 
 impl InactivityEngine {
@@ -37,6 +40,9 @@ impl InactivityEngine {
             blank_at: started_at + blank_after,
             phase: InactivityPhase::Unknown,
             restore_pending: false,
+            session_locked_since: None,
+            lock_activity_floor: None,
+            latest_independent_activity_at: None,
         }
     }
 
@@ -46,6 +52,9 @@ impl InactivityEngine {
             blank_at: started_at + blank_after,
             phase: InactivityPhase::Unknown,
             restore_pending: true,
+            session_locked_since: None,
+            lock_activity_floor: None,
+            latest_independent_activity_at: None,
         }
     }
 
@@ -58,12 +67,45 @@ impl InactivityEngine {
         observation: InactivityObservation,
         observed_at: Instant,
     ) -> InactivityDecision {
+        if matches!(
+            observation,
+            InactivityObservation::DesktopActivityObserved
+                | InactivityObservation::UserActivityObserved
+        ) {
+            self.latest_independent_activity_at = Some(
+                self.latest_independent_activity_at
+                    .map_or(observed_at, |latest| latest.max(observed_at)),
+            );
+        }
+
+        if self.session_locked_since.is_some()
+            && matches!(
+                observation,
+                InactivityObservation::ProviderActive | InactivityObservation::WakeRequested
+            )
+        {
+            return InactivityDecision::NoOp;
+        }
+
+        if self.phase == InactivityPhase::Idle
+            && self.lock_activity_floor.is_some_and(|locked_at| {
+                !matches!(
+                    observation,
+                    InactivityObservation::DesktopActivityObserved
+                        | InactivityObservation::UserActivityObserved
+                ) || observed_at <= locked_at
+            })
+        {
+            return InactivityDecision::NoOp;
+        }
+
         self.blank_at = self.blank_at.max(observed_at + self.blank_after);
 
         match self.phase {
             InactivityPhase::Idle => {
                 self.phase = InactivityPhase::Active;
                 self.restore_pending = false;
+                self.lock_activity_floor = None;
                 InactivityDecision::RestoreNow
             }
             InactivityPhase::Unknown => {
@@ -87,7 +129,31 @@ impl InactivityEngine {
         }
 
         self.phase = InactivityPhase::Idle;
+        self.lock_activity_floor = self.session_locked_since;
         InactivityDecision::BlankNow
+    }
+
+    pub fn observe_lock(&mut self, observed_at: Instant) -> InactivityDecision {
+        let locked_at = *self.session_locked_since.get_or_insert(observed_at);
+        if self
+            .latest_independent_activity_at
+            .is_some_and(|activity_at| activity_at > locked_at)
+        {
+            self.lock_activity_floor = None;
+            return InactivityDecision::NoOp;
+        }
+        self.lock_activity_floor = Some(locked_at);
+
+        if self.phase == InactivityPhase::Idle {
+            return InactivityDecision::NoOp;
+        }
+
+        self.phase = InactivityPhase::Idle;
+        InactivityDecision::BlankNow
+    }
+
+    pub fn observe_unlock(&mut self) {
+        self.session_locked_since = None;
     }
 }
 
@@ -261,5 +327,136 @@ mod tests {
             InactivityDecision::BlankNow
         );
         assert_eq!(engine.time_until_blank(started_at), None);
+    }
+
+    #[test]
+    fn lock_blanks_immediately_once_and_activity_can_restore() {
+        let started_at = Instant::now();
+        let mut engine = test_engine(started_at);
+        let locked_at = started_at + Duration::from_secs(1);
+
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::NoOp);
+        assert_eq!(engine.time_until_blank(started_at), None);
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                started_at + Duration::from_secs(2),
+            ),
+            InactivityDecision::RestoreNow
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(7)),
+            InactivityDecision::BlankNow
+        );
+    }
+
+    #[test]
+    fn lock_restore_requires_independent_activity_newer_than_the_lock() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+        let mut engine = test_engine(started_at);
+
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                started_at + Duration::from_millis(900),
+            ),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                started_at + Duration::from_secs(2),
+            ),
+            InactivityDecision::RestoreNow
+        );
+    }
+
+    #[test]
+    fn newer_independent_activity_processed_before_lock_keeps_the_screen_active() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+        let activity_at = started_at + Duration::from_secs(2);
+        let mut engine = test_engine(started_at);
+
+        assert_eq!(
+            engine.observe_activity(InactivityObservation::DesktopActivityObserved, activity_at,),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::NoOp);
+        assert_eq!(
+            engine.time_until_blank(activity_at),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[test]
+    fn provider_unlock_signals_do_not_restore_a_lock_blank() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+        let mut engine = test_engine(started_at);
+
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+        for observation in [
+            InactivityObservation::WakeRequested,
+            InactivityObservation::ProviderActive,
+        ] {
+            assert_eq!(
+                engine.observe_activity(observation, started_at + Duration::from_secs(2)),
+                InactivityDecision::NoOp
+            );
+        }
+
+        engine.observe_unlock();
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::ProviderActive,
+                started_at + Duration::from_secs(3),
+            ),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                started_at + Duration::from_secs(3),
+            ),
+            InactivityDecision::RestoreNow
+        );
+    }
+
+    #[test]
+    fn timeout_while_locked_keeps_the_independent_activity_gate() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+        let mut engine = test_engine(started_at);
+
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                started_at + Duration::from_secs(2),
+            ),
+            InactivityDecision::RestoreNow
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(7)),
+            InactivityDecision::BlankNow
+        );
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::WakeRequested,
+                started_at + Duration::from_secs(8),
+            ),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                started_at + Duration::from_secs(8),
+            ),
+            InactivityDecision::RestoreNow
+        );
     }
 }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -43,7 +43,10 @@ use crate::sources::desktop::gnome::{
 };
 use crate::sources::desktop::wayland::run_wayland_activity_monitor;
 use crate::sources::linux::logind::{
-    acquire_sleep_delay_inhibitor, add_logind_signal_match, map_prepare_for_sleep_signal,
+    acquire_sleep_delay_inhibitor, add_locked_hint_signal_match, add_logind_owner_signal_match,
+    add_logind_signal_match, locked_hint, logind_owner_changed, map_locked_hint_change,
+    map_prepare_for_sleep_signal, resolve_current_graphical_session, resolve_logind_owner,
+    LockedHintChange, LockedHintTracker, LogindSession, LogindSessionError,
 };
 use crate::state::{ScreenOwnershipMarker, StateScope};
 use crate::RunError;
@@ -59,6 +62,7 @@ const GAMEPAD_ACTIVITY_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
 const GAMEPAD_ACTIVITY_SEND_INTERVAL: Duration = Duration::from_millis(500);
 const LOGIND_LIFECYCLE_PROCESS_INTERVAL: Duration = Duration::from_secs(5);
 const LOGIND_LIFECYCLE_TEST_PROCESS_INTERVAL: Duration = Duration::from_millis(50);
+const LOGIND_LOCK_PROCESS_INTERVAL: Duration = Duration::from_millis(100);
 const SESSION_AGENT_BACKEND_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 const GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV: &str = "LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS";
 const LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS_ENV: &str =
@@ -208,6 +212,19 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
                     }
                 }
             }
+            SessionEvent::Lock => {
+                writeln!(
+                    writer,
+                    "LG Buddy Monitor: Session locked; requesting screen blank."
+                )?;
+                let runtime_event = RuntimeEvent::from_session_event(source, event);
+                match self.executor.screen_off(runtime_event) {
+                    Ok(output) => write_command_output(writer, &output)?,
+                    Err(err) => {
+                        writeln!(writer, "LG Buddy Monitor: screen-off action failed. {err}")?
+                    }
+                }
+            }
             SessionEvent::Active | SessionEvent::WakeRequested | SessionEvent::UserActivity => {
                 writeln!(
                     writer,
@@ -251,11 +268,10 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
                     )?,
                 }
             }
-            SessionEvent::Lock | SessionEvent::Unlock => {
+            SessionEvent::Unlock => {
                 writeln!(
                     writer,
-                    "LG Buddy Monitor: Session event `{}` is not handled yet.",
-                    event.as_str()
+                    "LG Buddy Monitor: Session unlocked; no screen restore requested."
                 )?;
             }
         }
@@ -745,6 +761,28 @@ where
     E: SessionActionExecutor,
     S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
 {
+    run_native_session_monitor_with_lock_monitor(
+        writer,
+        dispatcher,
+        backend,
+        spawn_monitor,
+        |sender| Some(spawn_logind_lock_thread(sender)),
+    )
+}
+
+fn run_native_session_monitor_with_lock_monitor<W, E, S, L>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    backend: ScreenBackend,
+    spawn_monitor: S,
+    spawn_lock_monitor: L,
+) -> Result<(), SessionRunnerError>
+where
+    W: Write,
+    E: SessionActionExecutor,
+    S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
+    L: FnOnce(mpsc::Sender<RunnerMessage>) -> Option<LogindLockThread>,
+{
     let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
     let started_at = Instant::now();
     let mut inactivity = if session_screen_ownership_marker_exists(backend)? {
@@ -757,6 +795,7 @@ where
     let latest_inactivity = Arc::new(LatestInactivityObservation::default());
     let monitor_handle = spawn_monitor(sender.clone(), Arc::clone(&latest_inactivity));
     let _gamepad_monitor = spawn_gamepad_activity_thread(sender.clone());
+    let _logind_lock_monitor = spawn_lock_monitor(sender.clone());
     let mut monitor_result = Ok(());
 
     loop {
@@ -809,39 +848,55 @@ where
             }
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Active,
+                source,
                 observed_at,
             } => handle_inactivity_observation(
                 writer,
                 dispatcher,
                 &mut inactivity,
-                EventSource::DesktopSession,
+                source,
                 InactivityObservation::ProviderActive,
                 observed_at,
             )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::WakeRequested,
+                source,
                 observed_at,
             } => handle_inactivity_observation(
                 writer,
                 dispatcher,
                 &mut inactivity,
-                EventSource::DesktopSession,
+                source,
                 InactivityObservation::WakeRequested,
                 observed_at,
             )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::UserActivity,
+                source,
                 observed_at,
             } => handle_inactivity_observation(
                 writer,
                 dispatcher,
                 &mut inactivity,
-                EventSource::DesktopSession,
+                source,
                 InactivityObservation::UserActivityObserved,
                 observed_at,
             )?,
-            RunnerMessage::SessionEvent { event, .. } => {
-                dispatcher.dispatch_event(writer, event)?;
+            RunnerMessage::SessionEvent {
+                event: SessionEvent::Lock,
+                source,
+                observed_at,
+            } => handle_session_lock(writer, dispatcher, &mut inactivity, source, observed_at)?,
+            RunnerMessage::SessionEvent {
+                event: SessionEvent::Unlock,
+                source,
+                ..
+            } => {
+                inactivity.observe_unlock();
+                dispatcher.dispatch_event_from_source(writer, source, SessionEvent::Unlock)?;
+            }
+            RunnerMessage::SessionEvent { event, source, .. } => {
+                dispatcher.dispatch_event_from_source(writer, source, event)?;
             }
             RunnerMessage::Diagnostic(message) => {
                 writeln!(writer, "LG Buddy Monitor: {message}")?;
@@ -988,6 +1043,124 @@ fn spawn_wayland_monitor_thread(
         });
         let _ = sender.send(RunnerMessage::MonitorExited(result));
     })
+}
+
+fn spawn_logind_lock_thread(sender: mpsc::Sender<RunnerMessage>) -> LogindLockThread {
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = Arc::clone(&stop);
+    let handle = thread::spawn(move || {
+        let result = new_system_bus_client()
+            .map_err(Into::into)
+            .and_then(|mut bus| run_logind_lock_monitor_process(&mut bus, &sender, &thread_stop));
+        report_logind_lock_monitor_result(&sender, result);
+    });
+
+    LogindLockThread {
+        stop,
+        handle: Some(handle),
+    }
+}
+
+fn report_logind_lock_monitor_result(
+    sender: &mpsc::Sender<RunnerMessage>,
+    result: Result<(), crate::sources::linux::logind::LogindSessionError>,
+) {
+    if let Err(err) = result {
+        let _ = sender.send(RunnerMessage::Diagnostic(format!(
+            "session lock monitoring unavailable: {err}"
+        )));
+    }
+}
+
+fn run_logind_lock_monitor_process(
+    bus: &mut impl SessionBusClient,
+    sender: &mpsc::Sender<RunnerMessage>,
+    stop: &AtomicBool,
+) -> Result<(), LogindSessionError> {
+    let explicit_session_id = std::env::var("XDG_SESSION_ID").ok();
+    let current_uid = current_effective_uid();
+    add_logind_owner_signal_match(bus)?;
+    let (mut session, owner, initial_locked) =
+        bind_logind_lock_target(bus, explicit_session_id.as_deref(), current_uid)?;
+    let mut logind_owner = Some(owner);
+
+    let mut tracker = LockedHintTracker::default();
+    if !send_locked_hint_event(sender, &mut tracker, initial_locked) {
+        return Ok(());
+    }
+
+    while !stop.load(Ordering::SeqCst) {
+        let Some(signal) = bus.process(LOGIND_LOCK_PROCESS_INTERVAL)? else {
+            continue;
+        };
+
+        if let Some(new_owner) = logind_owner_changed(&signal) {
+            if new_owner.is_none() {
+                logind_owner = None;
+                continue;
+            }
+
+            let (new_session, owner, locked) =
+                bind_logind_lock_target(bus, explicit_session_id.as_deref(), current_uid)?;
+            session = new_session;
+            logind_owner = Some(owner);
+            if !send_locked_hint_event(sender, &mut tracker, locked) {
+                return Ok(());
+            }
+            continue;
+        }
+
+        let Some(logind_owner) = logind_owner.as_deref() else {
+            continue;
+        };
+        let Some(change) = map_locked_hint_change(&signal, &session, logind_owner) else {
+            continue;
+        };
+        let locked = match change {
+            LockedHintChange::Changed(locked) => locked,
+            LockedHintChange::Invalidated => locked_hint(bus, &session)?,
+        };
+        if !send_locked_hint_event(sender, &mut tracker, locked) {
+            return Ok(());
+        }
+    }
+
+    Ok(())
+}
+
+fn bind_logind_lock_target(
+    bus: &mut impl SessionBusClient,
+    explicit_session_id: Option<&str>,
+    current_uid: u32,
+) -> Result<(LogindSession, String, bool), LogindSessionError> {
+    let session = resolve_current_graphical_session(bus, explicit_session_id, current_uid)?;
+    let owner = resolve_logind_owner(bus)?;
+    add_locked_hint_signal_match(bus, &session, &owner)?;
+    let locked = locked_hint(bus, &session)?;
+    Ok((session, owner, locked))
+}
+
+fn send_locked_hint_event(
+    sender: &mpsc::Sender<RunnerMessage>,
+    tracker: &mut LockedHintTracker,
+    locked: bool,
+) -> bool {
+    let Some(event) = tracker.observe(locked) else {
+        return true;
+    };
+
+    sender
+        .send(RunnerMessage::SessionEvent {
+            event,
+            source: EventSource::LinuxLogind,
+            observed_at: Instant::now(),
+        })
+        .is_ok()
+}
+
+fn current_effective_uid() -> u32 {
+    // SAFETY: `geteuid` has no preconditions and does not mutate process state.
+    unsafe { libc::geteuid() }
 }
 
 fn spawn_gamepad_activity_thread(
@@ -1245,6 +1418,7 @@ fn run_gnome_monitor_process(
         if sender
             .send(RunnerMessage::SessionEvent {
                 event,
+                source: EventSource::DesktopSession,
                 observed_at: Instant::now(),
             })
             .is_err()
@@ -1257,6 +1431,7 @@ fn run_gnome_monitor_process(
 enum RunnerMessage {
     SessionEvent {
         event: SessionEvent,
+        source: EventSource,
         observed_at: Instant,
     },
     ActivityObservation {
@@ -1273,6 +1448,21 @@ enum RunnerMessage {
 struct GamepadActivityThread {
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
+}
+
+#[derive(Debug)]
+struct LogindLockThread {
+    stop: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl Drop for LogindLockThread {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 impl Drop for GamepadActivityThread {
@@ -1566,6 +1756,20 @@ fn handle_inactivity_timeout<W: Write, E: SessionActionExecutor>(
     Ok(())
 }
 
+fn handle_session_lock<W: Write, E: SessionActionExecutor>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    inactivity: &mut InactivityEngine,
+    source: EventSource,
+    observed_at: Instant,
+) -> Result<(), SessionRunnerError> {
+    if inactivity.observe_lock(observed_at) == InactivityDecision::BlankNow {
+        dispatcher.dispatch_event_from_source(writer, source, SessionEvent::Lock)?;
+    }
+
+    Ok(())
+}
+
 fn shell_quote(path: &Path) -> String {
     let rendered = path.to_string_lossy();
     let escaped = rendered.replace('\'', "'\"'\"'");
@@ -1601,10 +1805,11 @@ mod tests {
         complete_gamepad_refresh, gamepad_activity_send_due,
         gamepad_device_event_refresh_requested, gamepad_refresh_due, handle_inactivity_observation,
         handle_inactivity_timeout, normalize_idle_timeout_secs, poll_gnome_idle_monitor_once,
-        run_lifecycle_monitor_with_bus, run_native_session_monitor, schedule_gamepad_refresh,
-        shell_quote, GamepadDeviceEventMonitor, GamepadDeviceEventRefresh,
-        GamepadDiagnosticEmitter, LatestInactivityObservation, RunnerMessage,
-        SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
+        report_logind_lock_monitor_result, run_lifecycle_monitor_with_bus,
+        run_logind_lock_monitor_process, run_native_session_monitor_with_lock_monitor,
+        schedule_gamepad_refresh, shell_quote, GamepadDeviceEventMonitor,
+        GamepadDeviceEventRefresh, GamepadDiagnosticEmitter, LatestInactivityObservation,
+        RunnerMessage, SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
         TrustedScreenSaverSignals, GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL,
         GAMEPAD_ACTIVITY_SEND_INTERVAL,
     };
@@ -1620,14 +1825,15 @@ mod tests {
         GNOME_SCREEN_SAVER_INTERFACE, GNOME_SCREEN_SAVER_NAME, GNOME_SCREEN_SAVER_PATH,
     };
     use crate::sources::linux::logind::{
-        LOGIND_MANAGER_INTERFACE, LOGIND_MANAGER_PATH, LOGIND_SERVICE_NAME,
+        LogindSessionError, LOGIND_MANAGER_INTERFACE, LOGIND_MANAGER_PATH, LOGIND_SERVICE_NAME,
+        LOGIND_SESSION_INTERFACE,
     };
     use crate::RunError;
     use std::collections::VecDeque;
     use std::fs;
     use std::io;
     use std::path::{Path, PathBuf};
-    use std::sync::{mpsc, Mutex, OnceLock};
+    use std::sync::{atomic::AtomicBool, mpsc, Mutex, OnceLock};
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
@@ -1712,7 +1918,9 @@ mod tests {
     #[derive(Debug, Default)]
     struct FakeSessionBus {
         method_replies: Vec<Result<BusReply, SessionBusError>>,
+        process_results: VecDeque<Result<Option<BusSignal>, SessionBusError>>,
         method_calls: Vec<(String, String, String, String)>,
+        signal_match_count: usize,
     }
 
     #[derive(Debug)]
@@ -1743,7 +1951,8 @@ mod tests {
 
         fn add_signal_match(&mut self, rule: BusSignalMatch<'_>) -> Result<(), SessionBusError> {
             let _ = rule;
-            unreachable!("signal matches are not used in runner poller tests")
+            self.signal_match_count += 1;
+            Ok(())
         }
 
         fn process(
@@ -1751,7 +1960,9 @@ mod tests {
             timeout: std::time::Duration,
         ) -> Result<Option<BusSignal>, SessionBusError> {
             let _ = timeout;
-            unreachable!("message pumping is not used in runner poller tests")
+            self.process_results
+                .pop_front()
+                .expect("test should provide every expected bus process result")
         }
     }
 
@@ -1813,6 +2024,62 @@ mod tests {
         )
         .with_sender(LOGIND_SERVICE_NAME)
         .with_body(vec![BusValue::Bool(value)])
+    }
+
+    fn logind_owner_changed_signal(old_owner: &str, new_owner: &str) -> BusSignal {
+        BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
+            .with_sender(DBUS_SERVICE_NAME)
+            .with_body(vec![
+                BusValue::String(LOGIND_SERVICE_NAME.to_string()),
+                BusValue::String(old_owner.to_string()),
+                BusValue::String(new_owner.to_string()),
+            ])
+    }
+
+    fn locked_hint_changed_signal(session_path: &str, owner: &str, locked: bool) -> BusSignal {
+        BusSignal::new(
+            session_path,
+            "org.freedesktop.DBus.Properties",
+            "PropertiesChanged",
+        )
+        .with_sender(owner)
+        .with_body(vec![
+            BusValue::String(LOGIND_SESSION_INTERFACE.to_string()),
+            BusValue::Dict(vec![(
+                BusValue::String("LockedHint".to_string()),
+                BusValue::Variant(Box::new(BusValue::Bool(locked))),
+            )]),
+            BusValue::Array(Vec::new()),
+        ])
+    }
+
+    fn graphical_session_properties(uid: u32) -> BusReply {
+        let variant = |value| BusValue::Variant(Box::new(value));
+        BusReply::new(vec![BusValue::Dict(vec![
+            (
+                BusValue::String("User".to_string()),
+                variant(BusValue::Struct(vec![
+                    BusValue::U32(uid),
+                    BusValue::ObjectPath(format!("/org/freedesktop/login1/user/_{uid}")),
+                ])),
+            ),
+            (
+                BusValue::String("Remote".to_string()),
+                variant(BusValue::Bool(false)),
+            ),
+            (
+                BusValue::String("Type".to_string()),
+                variant(BusValue::String("wayland".to_string())),
+            ),
+            (
+                BusValue::String("Class".to_string()),
+                variant(BusValue::String("user".to_string())),
+            ),
+            (
+                BusValue::String("Active".to_string()),
+                variant(BusValue::Bool(true)),
+            ),
+        ])])
     }
 
     fn unique_config_path(label: &str) -> PathBuf {
@@ -2067,24 +2334,187 @@ system_sleep_wake_policy={policy}
     }
 
     #[test]
-    fn unhandled_events_are_logged_without_running_actions() {
+    fn logind_lock_blanks_and_unlock_does_not_restore() {
         let executor = FakeActionExecutor::default();
         let mut dispatcher = SessionEventDispatcher::new(executor);
         let mut output = Vec::new();
 
-        for event in [SessionEvent::Lock, SessionEvent::Unlock] {
-            dispatcher
-                .dispatch_event(&mut output, event)
-                .expect("dispatch noop event");
-        }
+        dispatcher
+            .dispatch_event_from_source(&mut output, EventSource::LinuxLogind, SessionEvent::Lock)
+            .expect("dispatch lock event");
+        dispatcher
+            .dispatch_event_from_source(&mut output, EventSource::LinuxLogind, SessionEvent::Unlock)
+            .expect("dispatch unlock event");
 
         let output = String::from_utf8(output).expect("utf8");
-        assert!(output.contains("lock"));
-        assert!(output.contains("unlock"));
-        assert_eq!(dispatcher.executor.screen_off_calls, 0);
+        assert!(output.contains("Session locked"));
+        assert!(output.contains("no screen restore requested"));
+        assert_eq!(dispatcher.executor.screen_off_calls, 1);
         assert_eq!(dispatcher.executor.screen_on_calls, 0);
+        assert_eq!(
+            dispatcher.executor.screen_off_events,
+            vec![RuntimeEvent::new(
+                EventSource::LinuxLogind,
+                RuntimeEventKind::SessionLocked,
+            )]
+        );
         assert_eq!(dispatcher.executor.before_sleep_calls, 0);
         assert_eq!(dispatcher.executor.after_resume_calls, 0);
+    }
+
+    #[test]
+    fn logind_lock_monitor_reconciles_initial_locked_hint() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous_session_id = std::env::var_os("XDG_SESSION_ID");
+        std::env::set_var("XDG_SESSION_ID", "34");
+
+        let session_path = "/org/freedesktop/login1/session/_34";
+        let uid = super::current_effective_uid();
+        let mut bus = FakeSessionBus {
+            method_replies: vec![
+                Ok(BusReply::new(vec![BusValue::ObjectPath(
+                    session_path.to_string(),
+                )])),
+                Ok(graphical_session_properties(uid)),
+                Ok(BusReply::new(vec![BusValue::String(":1.42".to_string())])),
+                Ok(BusReply::new(vec![BusValue::Variant(Box::new(
+                    BusValue::Bool(true),
+                ))])),
+            ],
+            ..FakeSessionBus::default()
+        };
+        let (sender, receiver) = mpsc::channel();
+        let stop = AtomicBool::new(true);
+
+        run_logind_lock_monitor_process(&mut bus, &sender, &stop)
+            .expect("initial LockedHint should be reconciled before the signal loop");
+
+        match receiver.recv().expect("initial lock event") {
+            RunnerMessage::SessionEvent {
+                event,
+                source,
+                observed_at: _,
+            } => {
+                assert_eq!(event, SessionEvent::Lock);
+                assert_eq!(source, EventSource::LinuxLogind);
+            }
+            _ => panic!("expected canonical session lock event"),
+        }
+        assert_eq!(bus.signal_match_count, 2);
+        assert_eq!(
+            bus.method_calls
+                .iter()
+                .map(|call| call.3.as_str())
+                .collect::<Vec<_>>(),
+            vec!["GetSession", "GetAll", "GetNameOwner", "Get"]
+        );
+
+        match previous_session_id {
+            Some(value) => std::env::set_var("XDG_SESSION_ID", value),
+            None => std::env::remove_var("XDG_SESSION_ID"),
+        }
+    }
+
+    #[test]
+    fn logind_lock_monitor_rebinds_after_logind_restarts() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let previous_session_id = std::env::var_os("XDG_SESSION_ID");
+        std::env::set_var("XDG_SESSION_ID", "34");
+
+        let session_path = "/org/freedesktop/login1/session/_34";
+        let uid = super::current_effective_uid();
+        let bind_replies = |owner: &str, locked: bool| {
+            vec![
+                Ok(BusReply::new(vec![BusValue::ObjectPath(
+                    session_path.to_string(),
+                )])),
+                Ok(graphical_session_properties(uid)),
+                Ok(BusReply::new(vec![BusValue::String(owner.to_string())])),
+                Ok(BusReply::new(vec![BusValue::Variant(Box::new(
+                    BusValue::Bool(locked),
+                ))])),
+            ]
+        };
+        let mut bus = FakeSessionBus {
+            method_replies: bind_replies(":1.42", false)
+                .into_iter()
+                .chain(bind_replies(":1.99", false))
+                .collect(),
+            process_results: VecDeque::from([
+                Ok(Some(logind_owner_changed_signal(":1.42", ""))),
+                Ok(Some(logind_owner_changed_signal("", ":1.99"))),
+                Ok(Some(locked_hint_changed_signal(
+                    session_path,
+                    ":1.99",
+                    true,
+                ))),
+                Err(SessionBusError::Transport("stop test loop".to_string())),
+            ]),
+            ..FakeSessionBus::default()
+        };
+        let (sender, receiver) = mpsc::channel();
+        let stop = AtomicBool::new(false);
+
+        assert_eq!(
+            run_logind_lock_monitor_process(&mut bus, &sender, &stop),
+            Err(LogindSessionError::Bus(SessionBusError::Transport(
+                "stop test loop".to_string()
+            )))
+        );
+
+        match receiver.recv().expect("lock event after logind restart") {
+            RunnerMessage::SessionEvent { event, source, .. } => {
+                assert_eq!(event, SessionEvent::Lock);
+                assert_eq!(source, EventSource::LinuxLogind);
+            }
+            _ => panic!("expected canonical session lock event"),
+        }
+        assert!(receiver.try_recv().is_err());
+        assert_eq!(bus.signal_match_count, 3);
+        assert_eq!(
+            bus.method_calls
+                .iter()
+                .map(|call| call.3.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "GetSession",
+                "GetAll",
+                "GetNameOwner",
+                "Get",
+                "GetSession",
+                "GetAll",
+                "GetNameOwner",
+                "Get",
+            ]
+        );
+
+        match previous_session_id {
+            Some(value) => std::env::set_var("XDG_SESSION_ID", value),
+            None => std::env::remove_var("XDG_SESSION_ID"),
+        }
+    }
+
+    #[test]
+    fn unavailable_logind_lock_monitor_reports_diagnostic_without_exiting_native_monitor() {
+        let (sender, receiver) = mpsc::channel();
+
+        report_logind_lock_monitor_result(
+            &sender,
+            Err(LogindSessionError::NoCurrentGraphicalSession),
+        );
+
+        match receiver.recv().expect("availability diagnostic") {
+            RunnerMessage::Diagnostic(message) => {
+                assert!(message.contains("session lock monitoring unavailable"));
+                assert!(message.contains("no active local graphical logind session"));
+            }
+            _ => panic!("optional logind source must not terminate the native monitor"),
+        }
+        assert!(receiver.try_recv().is_err());
     }
 
     #[test]
@@ -2712,7 +3142,7 @@ system_sleep_wake_policy={policy}
         let mut dispatcher = SessionEventDispatcher::new(executor);
         let mut output = Vec::new();
 
-        let result = run_native_session_monitor(
+        let result = run_native_session_monitor_with_lock_monitor(
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
@@ -2729,6 +3159,7 @@ system_sleep_wake_policy={policy}
                     let _ = sender.send(RunnerMessage::MonitorExited(result));
                 })
             },
+            |_| None,
         );
 
         std::env::remove_var("LG_BUDDY_SESSION_RUNTIME_DIR");
@@ -2746,6 +3177,93 @@ system_sleep_wake_policy={policy}
                 RuntimeEventKind::UserActivityObserved,
             )]
         );
+    }
+
+    #[test]
+    fn lock_blank_ignores_unlock_signals_and_restores_for_fresh_independent_activity() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let runtime_dir = unique_config_path("native-session-lock-runtime");
+        std::env::set_var("LG_BUDDY_SESSION_RUNTIME_DIR", &runtime_dir);
+        std::env::set_var("LG_BUDDY_IDLE_TIMEOUT", "300");
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "disabled");
+
+        let executor = FakeActionExecutor::default();
+        let mut dispatcher = SessionEventDispatcher::new(executor);
+        let mut output = Vec::new();
+
+        let result = run_native_session_monitor_with_lock_monitor(
+            &mut output,
+            &mut dispatcher,
+            ScreenBackend::Auto,
+            |sender, _latest_inactivity| {
+                thread::spawn(move || {
+                    let locked_at = Instant::now();
+                    for event in [SessionEvent::Lock, SessionEvent::Lock] {
+                        let _ = sender.send(RunnerMessage::SessionEvent {
+                            event,
+                            source: EventSource::LinuxLogind,
+                            observed_at: locked_at,
+                        });
+                    }
+                    let _ = sender.send(RunnerMessage::ActivityObservation {
+                        source: EventSource::DesktopSession,
+                        observation: InactivityObservation::DesktopActivityObserved,
+                        observed_at: locked_at - Duration::from_millis(1),
+                    });
+                    for event in [SessionEvent::WakeRequested, SessionEvent::Active] {
+                        let _ = sender.send(RunnerMessage::SessionEvent {
+                            event,
+                            source: EventSource::DesktopSession,
+                            observed_at: locked_at + Duration::from_millis(1),
+                        });
+                    }
+                    let _ = sender.send(RunnerMessage::SessionEvent {
+                        event: SessionEvent::Unlock,
+                        source: EventSource::LinuxLogind,
+                        observed_at: locked_at + Duration::from_millis(2),
+                    });
+                    let _ = sender.send(RunnerMessage::SessionEvent {
+                        event: SessionEvent::Active,
+                        source: EventSource::DesktopSession,
+                        observed_at: locked_at + Duration::from_millis(2),
+                    });
+                    let _ = sender.send(RunnerMessage::ActivityObservation {
+                        source: EventSource::DesktopSession,
+                        observation: InactivityObservation::DesktopActivityObserved,
+                        observed_at: locked_at + Duration::from_millis(3),
+                    });
+                    let _ = sender.send(RunnerMessage::MonitorExited(Ok(())));
+                })
+            },
+            |_| None,
+        );
+
+        std::env::remove_var("LG_BUDDY_SESSION_RUNTIME_DIR");
+        std::env::remove_var("LG_BUDDY_IDLE_TIMEOUT");
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+
+        result.expect("shared native session runtime should process lock state");
+        assert_eq!(dispatcher.executor.screen_off_calls, 1);
+        assert_eq!(dispatcher.executor.screen_on_calls, 1);
+        assert_eq!(
+            dispatcher.executor.screen_off_events,
+            vec![RuntimeEvent::new(
+                EventSource::LinuxLogind,
+                RuntimeEventKind::SessionLocked,
+            )]
+        );
+        assert_eq!(
+            dispatcher.executor.screen_on_events,
+            vec![RuntimeEvent::new(
+                EventSource::DesktopSession,
+                RuntimeEventKind::UserActivityObserved,
+            )]
+        );
+        let output = String::from_utf8(output).expect("utf8");
+        assert_eq!(output.matches("Session locked").count(), 1);
+        assert!(output.contains("no screen restore requested"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/session_bus.rs
+++ b/crates/lg-buddy/src/session_bus.rs
@@ -61,6 +61,10 @@ pub enum BusValue {
     U32(u32),
     U64(u64),
     String(String),
+    ObjectPath(String),
+    Array(Vec<BusValue>),
+    Struct(Vec<BusValue>),
+    Dict(Vec<(BusValue, BusValue)>),
     Variant(Box<BusValue>),
 }
 
@@ -72,6 +76,10 @@ impl BusValue {
             Self::U32(_) => "u32",
             Self::U64(_) => "u64",
             Self::String(_) => "string",
+            Self::ObjectPath(_) => "object path",
+            Self::Array(_) => "array",
+            Self::Struct(_) => "struct",
+            Self::Dict(_) => "dict",
             Self::Variant(_) => "variant",
         }
     }
@@ -165,6 +173,20 @@ impl BusReply {
             }),
             _ => Err(SessionBusError::UnexpectedReplyShape {
                 expected: "single string",
+                actual: "multiple values",
+            }),
+        }
+    }
+
+    pub fn single_object_path(&self) -> Result<&str, SessionBusError> {
+        match self.body.as_slice() {
+            [BusValue::ObjectPath(value)] => Ok(value),
+            [value] => Err(SessionBusError::UnexpectedReplyShape {
+                expected: "single object path",
+                actual: value.kind(),
+            }),
+            _ => Err(SessionBusError::UnexpectedReplyShape {
+                expected: "single object path",
                 actual: "multiple values",
             }),
         }
@@ -567,9 +589,13 @@ fn append_dbus_message_value(
         BusValue::U32(value) => Ok(message.append1(value)),
         BusValue::U64(value) => Ok(message.append1(value)),
         BusValue::String(value) => Ok(message.append1(value)),
-        BusValue::Variant(_) => Err(SessionBusError::UnsupportedMessageBody {
+        unsupported @ (BusValue::ObjectPath(_)
+        | BusValue::Array(_)
+        | BusValue::Struct(_)
+        | BusValue::Dict(_)
+        | BusValue::Variant(_)) => Err(SessionBusError::UnsupportedMessageBody {
             context: "method-call body",
-            kind: "variant",
+            kind: unsupported.kind(),
         }),
     }
 }
@@ -581,11 +607,34 @@ fn bus_value_from_dbus_message_item(item: DbusMessageItem) -> Result<BusValue, S
         DbusMessageItem::UInt32(value) => Ok(BusValue::U32(value)),
         DbusMessageItem::UInt64(value) => Ok(BusValue::U64(value)),
         DbusMessageItem::Str(value) => Ok(BusValue::String(value)),
+        DbusMessageItem::ObjectPath(value) => Ok(BusValue::ObjectPath(value.to_string())),
+        DbusMessageItem::Array(values) => values
+            .into_vec()
+            .into_iter()
+            .map(bus_value_from_dbus_message_item)
+            .collect::<Result<Vec<_>, _>>()
+            .map(BusValue::Array),
+        DbusMessageItem::Struct(values) => values
+            .into_iter()
+            .map(bus_value_from_dbus_message_item)
+            .collect::<Result<Vec<_>, _>>()
+            .map(BusValue::Struct),
+        DbusMessageItem::Dict(values) => values
+            .into_vec()
+            .into_iter()
+            .map(|(key, value)| {
+                Ok((
+                    bus_value_from_dbus_message_item(key)?,
+                    bus_value_from_dbus_message_item(value)?,
+                ))
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map(BusValue::Dict),
         DbusMessageItem::Variant(value) => {
             bus_value_from_dbus_message_item(*value).map(|value| BusValue::Variant(Box::new(value)))
         }
         other => Err(SessionBusError::UnexpectedReplyShape {
-            expected: "bool/u32/u64/string/fd/variant",
+            expected: "bool/u32/u64/string/object-path/array/struct/dict/fd/variant",
             actual: dbus_message_item_kind(&other),
         }),
     }
@@ -647,10 +696,13 @@ fn dbus_message_item_kind(item: &DbusMessageItem) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::{
-        append_dbus_message_value, get_name_owner, parse_name_owner_changed_signal, BusMethodCall,
-        BusReply, BusSignal, BusSignalMatch, BusValue, NameOwnerChanged, SessionBusClient,
-        SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
+        append_dbus_message_value, bus_value_from_dbus_message_item, get_name_owner,
+        parse_name_owner_changed_signal, BusMethodCall, BusReply, BusSignal, BusSignalMatch,
+        BusValue, NameOwnerChanged, SessionBusClient, SessionBusError, DBUS_INTERFACE,
+        DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
     };
+    use dbus::arg::messageitem::{MessageItem, MessageItemArray, MessageItemDict};
+    use dbus::strings::{Path as DbusPath, Signature as DbusSignature};
     use dbus::Message as DbusMessage;
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::os::fd::AsRawFd;
@@ -855,6 +907,49 @@ mod tests {
                 context: "method-call body",
                 kind: "variant",
             }
+        );
+    }
+
+    #[test]
+    fn nested_logind_reply_shapes_decode_into_transport_values() {
+        let user = MessageItem::Struct(vec![
+            MessageItem::UInt32(1000),
+            MessageItem::ObjectPath(
+                DbusPath::new("/org/freedesktop/login1/user/_1000").expect("object path"),
+            ),
+        ]);
+        let properties = MessageItem::Dict(
+            MessageItemDict::new(
+                vec![(
+                    MessageItem::Str("User".to_string()),
+                    MessageItem::Variant(Box::new(user)),
+                )],
+                DbusSignature::new("s").expect("key signature"),
+                DbusSignature::new("v").expect("value signature"),
+            )
+            .expect("property dictionary"),
+        );
+        let invalidated = MessageItem::Array(
+            MessageItemArray::new(
+                vec![MessageItem::Str("LockedHint".to_string())],
+                DbusSignature::new("as").expect("array signature"),
+            )
+            .expect("invalidated property array"),
+        );
+
+        assert_eq!(
+            bus_value_from_dbus_message_item(properties).expect("decode properties"),
+            BusValue::Dict(vec![(
+                BusValue::String("User".to_string()),
+                BusValue::Variant(Box::new(BusValue::Struct(vec![
+                    BusValue::U32(1000),
+                    BusValue::ObjectPath("/org/freedesktop/login1/user/_1000".to_string()),
+                ]))),
+            )])
+        );
+        assert_eq!(
+            bus_value_from_dbus_message_item(invalidated).expect("decode invalidated array"),
+            BusValue::Array(vec![BusValue::String("LockedHint".to_string())])
         );
     }
 

--- a/crates/lg-buddy/src/sources/linux/logind.rs
+++ b/crates/lg-buddy/src/sources/linux/logind.rs
@@ -1,16 +1,93 @@
+use std::fmt;
 use std::os::fd::OwnedFd;
 
 use crate::events::RuntimeEvent;
 use crate::session_bus::{
-    BusMethodCall, BusSignal, BusSignalMatch, BusValue, SessionBusClient, SessionBusError,
+    get_name_owner, parse_name_owner_changed_signal, BusMethodCall, BusSignal, BusSignalMatch,
+    BusValue, SessionBusClient, SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH,
+    DBUS_SERVICE_NAME,
 };
 
 pub const LOGIND_SERVICE_NAME: &str = "org.freedesktop.login1";
 pub const LOGIND_MANAGER_PATH: &str = "/org/freedesktop/login1";
 pub const LOGIND_MANAGER_INTERFACE: &str = "org.freedesktop.login1.Manager";
+pub const LOGIND_SESSION_INTERFACE: &str = "org.freedesktop.login1.Session";
 pub const LOGIND_INHIBIT_WHO: &str = "LG Buddy";
 pub const LOGIND_INHIBIT_WHY: &str = "Handle LG TV power state around system sleep";
 const DBUS_PROPERTIES_INTERFACE: &str = "org.freedesktop.DBus.Properties";
+const GRAPHICAL_SESSION_TYPES: [&str; 2] = ["wayland", "x11"];
+const USER_SESSION_CLASSES: [&str; 3] = ["user", "user-early", "user-light"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogindSession {
+    pub id: String,
+    pub path: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LogindSessionError {
+    Bus(SessionBusError),
+    MalformedReply(&'static str),
+    NoCurrentGraphicalSession,
+    AmbiguousGraphicalSessions(Vec<String>),
+}
+
+impl fmt::Display for LogindSessionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Bus(err) => write!(f, "{err}"),
+            Self::MalformedReply(expected) => {
+                write!(f, "malformed logind reply: expected {expected}")
+            }
+            Self::NoCurrentGraphicalSession => {
+                write!(
+                    f,
+                    "no active local graphical logind session belongs to this user"
+                )
+            }
+            Self::AmbiguousGraphicalSessions(ids) => write!(
+                f,
+                "multiple active local graphical logind sessions belong to this user: {}",
+                ids.join(", ")
+            ),
+        }
+    }
+}
+
+impl std::error::Error for LogindSessionError {}
+
+impl From<SessionBusError> for LogindSessionError {
+    fn from(value: SessionBusError) -> Self {
+        Self::Bus(value)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LockedHintChange {
+    Changed(bool),
+    Invalidated,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct LockedHintTracker {
+    locked: Option<bool>,
+}
+
+impl LockedHintTracker {
+    pub fn observe(&mut self, locked: bool) -> Option<crate::session::SessionEvent> {
+        if self.locked == Some(locked) {
+            return None;
+        }
+
+        let previous = self.locked.replace(locked);
+        match (previous, locked) {
+            (None | Some(false), true) => Some(crate::session::SessionEvent::Lock),
+            (Some(true), false) => Some(crate::session::SessionEvent::Unlock),
+            (None | Some(false), false) => None,
+            (Some(true), true) => None,
+        }
+    }
+}
 
 pub fn logind_signal_match() -> BusSignalMatch<'static> {
     BusSignalMatch {
@@ -77,22 +154,311 @@ pub fn preparing_for_sleep(bus: &mut impl SessionBusClient) -> Result<bool, Sess
     .single_bool()
 }
 
+pub fn resolve_current_graphical_session(
+    bus: &mut impl SessionBusClient,
+    explicit_session_id: Option<&str>,
+    current_uid: u32,
+) -> Result<LogindSession, LogindSessionError> {
+    if let Some(id) = explicit_session_id.filter(|id| !id.is_empty()) {
+        let path = bus
+            .call_method(
+                BusMethodCall::new(
+                    LOGIND_SERVICE_NAME,
+                    LOGIND_MANAGER_PATH,
+                    LOGIND_MANAGER_INTERFACE,
+                    "GetSession",
+                )
+                .with_body(vec![BusValue::String(id.to_string())]),
+            )?
+            .single_object_path()?
+            .to_string();
+        let session = LogindSession {
+            id: id.to_string(),
+            path,
+        };
+        return session_properties(bus, &session)?
+            .is_eligible_for_uid(current_uid)
+            .then_some(session)
+            .ok_or(LogindSessionError::NoCurrentGraphicalSession);
+    }
+
+    let reply = bus.call_method(BusMethodCall::new(
+        LOGIND_SERVICE_NAME,
+        LOGIND_MANAGER_PATH,
+        LOGIND_MANAGER_INTERFACE,
+        "ListSessions",
+    ))?;
+    let [BusValue::Array(entries)] = reply.body.as_slice() else {
+        return Err(LogindSessionError::MalformedReply(
+            "one array of session records",
+        ));
+    };
+
+    let mut matches = Vec::new();
+    for entry in entries {
+        let BusValue::Struct(fields) = entry else {
+            return Err(LogindSessionError::MalformedReply("session record struct"));
+        };
+        let [BusValue::String(id), BusValue::U32(uid), BusValue::String(_user), BusValue::String(_seat), BusValue::ObjectPath(path)] =
+            fields.as_slice()
+        else {
+            return Err(LogindSessionError::MalformedReply(
+                "session record (id, uid, user, seat, object path)",
+            ));
+        };
+        if *uid != current_uid {
+            continue;
+        }
+
+        let session = LogindSession {
+            id: id.clone(),
+            path: path.clone(),
+        };
+        if session_properties(bus, &session)?.is_eligible_for_uid(current_uid) {
+            matches.push(session);
+        }
+    }
+
+    match matches.len() {
+        0 => Err(LogindSessionError::NoCurrentGraphicalSession),
+        1 => Ok(matches.remove(0)),
+        _ => Err(LogindSessionError::AmbiguousGraphicalSessions(
+            matches.into_iter().map(|session| session.id).collect(),
+        )),
+    }
+}
+
+pub fn resolve_logind_owner(bus: &mut impl SessionBusClient) -> Result<String, SessionBusError> {
+    get_name_owner(bus, LOGIND_SERVICE_NAME)
+}
+
+pub fn logind_owner_signal_match() -> BusSignalMatch<'static> {
+    BusSignalMatch {
+        sender: Some(DBUS_SERVICE_NAME),
+        path: Some(DBUS_OBJECT_PATH),
+        interface: Some(DBUS_INTERFACE),
+        member: Some("NameOwnerChanged"),
+    }
+}
+
+pub fn add_logind_owner_signal_match(
+    bus: &mut impl SessionBusClient,
+) -> Result<(), SessionBusError> {
+    bus.add_signal_match(logind_owner_signal_match())
+}
+
+pub fn logind_owner_changed(signal: &BusSignal) -> Option<Option<String>> {
+    if signal.sender.as_deref() != Some(DBUS_SERVICE_NAME) {
+        return None;
+    }
+
+    let owner_change = parse_name_owner_changed_signal(signal)?;
+    if owner_change.name != LOGIND_SERVICE_NAME {
+        return None;
+    }
+
+    Some(owner_change.new_owner)
+}
+
+pub fn locked_hint_signal_match<'a>(
+    session_path: &'a str,
+    logind_owner: &'a str,
+) -> BusSignalMatch<'a> {
+    BusSignalMatch {
+        sender: Some(logind_owner),
+        path: Some(session_path),
+        interface: Some(DBUS_PROPERTIES_INTERFACE),
+        member: Some("PropertiesChanged"),
+    }
+}
+
+pub fn add_locked_hint_signal_match(
+    bus: &mut impl SessionBusClient,
+    session: &LogindSession,
+    logind_owner: &str,
+) -> Result<(), SessionBusError> {
+    bus.add_signal_match(locked_hint_signal_match(&session.path, logind_owner))
+}
+
+pub fn locked_hint(
+    bus: &mut impl SessionBusClient,
+    session: &LogindSession,
+) -> Result<bool, SessionBusError> {
+    bus.call_method(
+        BusMethodCall::new(
+            LOGIND_SERVICE_NAME,
+            &session.path,
+            DBUS_PROPERTIES_INTERFACE,
+            "Get",
+        )
+        .with_body(vec![
+            BusValue::String(LOGIND_SESSION_INTERFACE.to_string()),
+            BusValue::String("LockedHint".to_string()),
+        ]),
+    )?
+    .single_bool()
+}
+
+pub fn map_locked_hint_change(
+    signal: &BusSignal,
+    session: &LogindSession,
+    logind_owner: &str,
+) -> Option<LockedHintChange> {
+    if signal.sender.as_deref() != Some(logind_owner)
+        || signal.path != session.path
+        || signal.interface != DBUS_PROPERTIES_INTERFACE
+        || signal.member != "PropertiesChanged"
+    {
+        return None;
+    }
+
+    let [BusValue::String(interface), BusValue::Dict(changed), BusValue::Array(invalidated)] =
+        signal.body.as_slice()
+    else {
+        return None;
+    };
+    if interface != LOGIND_SESSION_INTERFACE {
+        return None;
+    }
+
+    for (key, value) in changed {
+        if matches!(key, BusValue::String(name) if name == "LockedHint") {
+            return match value {
+                BusValue::Variant(value) => match value.as_ref() {
+                    BusValue::Bool(locked) => Some(LockedHintChange::Changed(*locked)),
+                    _ => None,
+                },
+                BusValue::Bool(locked) => Some(LockedHintChange::Changed(*locked)),
+                _ => None,
+            };
+        }
+    }
+
+    invalidated
+        .iter()
+        .any(|value| matches!(value, BusValue::String(name) if name == "LockedHint"))
+        .then_some(LockedHintChange::Invalidated)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LogindSessionProperties {
+    uid: u32,
+    remote: bool,
+    session_type: String,
+    class: String,
+    active: bool,
+}
+
+impl LogindSessionProperties {
+    fn is_eligible_for_uid(&self, uid: u32) -> bool {
+        self.uid == uid
+            && !self.remote
+            && self.active
+            && GRAPHICAL_SESSION_TYPES.contains(&self.session_type.as_str())
+            && USER_SESSION_CLASSES.contains(&self.class.as_str())
+    }
+}
+
+fn session_properties(
+    bus: &mut impl SessionBusClient,
+    session: &LogindSession,
+) -> Result<LogindSessionProperties, LogindSessionError> {
+    let reply = bus.call_method(
+        BusMethodCall::new(
+            LOGIND_SERVICE_NAME,
+            &session.path,
+            DBUS_PROPERTIES_INTERFACE,
+            "GetAll",
+        )
+        .with_body(vec![BusValue::String(LOGIND_SESSION_INTERFACE.to_string())]),
+    )?;
+    let [BusValue::Dict(properties)] = reply.body.as_slice() else {
+        return Err(LogindSessionError::MalformedReply(
+            "one session property dictionary",
+        ));
+    };
+
+    let user = property(properties, "User")?;
+    let BusValue::Struct(user) = unwrap_variant(user) else {
+        return Err(LogindSessionError::MalformedReply("User struct"));
+    };
+    let [BusValue::U32(uid), BusValue::ObjectPath(_user_path)] = user.as_slice() else {
+        return Err(LogindSessionError::MalformedReply(
+            "User (uid, object path)",
+        ));
+    };
+
+    Ok(LogindSessionProperties {
+        uid: *uid,
+        remote: property_bool(properties, "Remote")?,
+        session_type: property_string(properties, "Type")?.to_string(),
+        class: property_string(properties, "Class")?.to_string(),
+        active: property_bool(properties, "Active")?,
+    })
+}
+
+fn property<'a>(
+    properties: &'a [(BusValue, BusValue)],
+    name: &'static str,
+) -> Result<&'a BusValue, LogindSessionError> {
+    properties
+        .iter()
+        .find_map(|(key, value)| match key {
+            BusValue::String(key) if key == name => Some(value),
+            _ => None,
+        })
+        .ok_or(LogindSessionError::MalformedReply(name))
+}
+
+fn unwrap_variant(value: &BusValue) -> &BusValue {
+    match value {
+        BusValue::Variant(value) => value,
+        value => value,
+    }
+}
+
+fn property_bool(
+    properties: &[(BusValue, BusValue)],
+    name: &'static str,
+) -> Result<bool, LogindSessionError> {
+    match unwrap_variant(property(properties, name)?) {
+        BusValue::Bool(value) => Ok(*value),
+        _ => Err(LogindSessionError::MalformedReply(name)),
+    }
+}
+
+fn property_string<'a>(
+    properties: &'a [(BusValue, BusValue)],
+    name: &'static str,
+) -> Result<&'a str, LogindSessionError> {
+    match unwrap_variant(property(properties, name)?) {
+        BusValue::String(value) => Ok(value),
+        _ => Err(LogindSessionError::MalformedReply(name)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        acquire_sleep_delay_inhibitor, add_logind_signal_match, logind_signal_match,
-        map_prepare_for_sleep_signal, LOGIND_INHIBIT_WHO, LOGIND_INHIBIT_WHY,
-        LOGIND_MANAGER_INTERFACE, LOGIND_MANAGER_PATH, LOGIND_SERVICE_NAME,
+        acquire_sleep_delay_inhibitor, add_locked_hint_signal_match, add_logind_owner_signal_match,
+        add_logind_signal_match, locked_hint, locked_hint_signal_match, logind_owner_changed,
+        logind_owner_signal_match, logind_signal_match, map_locked_hint_change,
+        map_prepare_for_sleep_signal, resolve_current_graphical_session, LockedHintChange,
+        LockedHintTracker, LogindSession, LogindSessionError, LOGIND_INHIBIT_WHO,
+        LOGIND_INHIBIT_WHY, LOGIND_MANAGER_INTERFACE, LOGIND_MANAGER_PATH, LOGIND_SERVICE_NAME,
+        LOGIND_SESSION_INTERFACE,
     };
     use super::{preparing_for_sleep, DBUS_PROPERTIES_INTERFACE};
     use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
     use crate::session_bus::{
         BusMethodCall, BusReply, BusSignal, BusSignalMatch, BusValue, SessionBusClient,
-        SessionBusError,
+        SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
     };
     use std::collections::VecDeque;
     use std::os::fd::AsRawFd;
     use std::time::Duration;
+
+    const LOGIND_OWNER: &str = ":1.42";
 
     #[derive(Debug, Default)]
     struct FakeBus {
@@ -156,6 +522,89 @@ mod tests {
         )
         .with_sender(LOGIND_SERVICE_NAME)
         .with_body(vec![BusValue::Bool(value)])
+    }
+
+    fn variant(value: BusValue) -> BusValue {
+        BusValue::Variant(Box::new(value))
+    }
+
+    fn session_properties_reply(
+        uid: u32,
+        remote: bool,
+        session_type: &str,
+        class: &str,
+        active: bool,
+    ) -> BusReply {
+        BusReply::new(vec![BusValue::Dict(vec![
+            (
+                BusValue::String("User".to_string()),
+                variant(BusValue::Struct(vec![
+                    BusValue::U32(uid),
+                    BusValue::ObjectPath(format!("/org/freedesktop/login1/user/_{uid}")),
+                ])),
+            ),
+            (
+                BusValue::String("Remote".to_string()),
+                variant(BusValue::Bool(remote)),
+            ),
+            (
+                BusValue::String("Type".to_string()),
+                variant(BusValue::String(session_type.to_string())),
+            ),
+            (
+                BusValue::String("Class".to_string()),
+                variant(BusValue::String(class.to_string())),
+            ),
+            (
+                BusValue::String("Active".to_string()),
+                variant(BusValue::Bool(active)),
+            ),
+        ])])
+    }
+
+    fn session_record(id: &str, uid: u32, path: &str) -> BusValue {
+        BusValue::Struct(vec![
+            BusValue::String(id.to_string()),
+            BusValue::U32(uid),
+            BusValue::String("user".to_string()),
+            BusValue::String("seat0".to_string()),
+            BusValue::ObjectPath(path.to_string()),
+        ])
+    }
+
+    fn session(id: &str) -> LogindSession {
+        LogindSession {
+            id: id.to_string(),
+            path: format!("/org/freedesktop/login1/session/_{id}"),
+        }
+    }
+
+    fn properties_changed(
+        session: &LogindSession,
+        changed: Vec<(BusValue, BusValue)>,
+        invalidated: Vec<BusValue>,
+    ) -> BusSignal {
+        BusSignal::new(
+            &session.path,
+            DBUS_PROPERTIES_INTERFACE,
+            "PropertiesChanged",
+        )
+        .with_sender(LOGIND_OWNER)
+        .with_body(vec![
+            BusValue::String(LOGIND_SESSION_INTERFACE.to_string()),
+            BusValue::Dict(changed),
+            BusValue::Array(invalidated),
+        ])
+    }
+
+    fn owner_changed(name: &str, old_owner: &str, new_owner: &str) -> BusSignal {
+        BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
+            .with_sender(DBUS_SERVICE_NAME)
+            .with_body(vec![
+                BusValue::String(name.to_string()),
+                BusValue::String(old_owner.to_string()),
+                BusValue::String(new_owner.to_string()),
+            ])
     }
 
     #[test]
@@ -307,5 +756,247 @@ mod tests {
                 actual: "string",
             }
         );
+    }
+
+    #[test]
+    fn explicit_session_is_resolved_only_when_it_is_the_users_active_graphical_session() {
+        let expected = session("34");
+        let mut bus = FakeBus::default();
+        bus.replies
+            .push_back(BusReply::new(vec![BusValue::ObjectPath(
+                expected.path.clone(),
+            )]));
+        bus.replies.push_back(session_properties_reply(
+            1000, false, "wayland", "user", true,
+        ));
+
+        assert_eq!(
+            resolve_current_graphical_session(&mut bus, Some("34"), 1000),
+            Ok(expected)
+        );
+        assert_eq!(bus.calls[0].3, "GetSession");
+        assert_eq!(bus.calls[1].3, "GetAll");
+    }
+
+    #[test]
+    fn explicit_remote_or_other_user_session_is_rejected() {
+        for properties in [
+            session_properties_reply(1000, true, "wayland", "user", true),
+            session_properties_reply(1001, false, "wayland", "user", true),
+        ] {
+            let expected = session("34");
+            let mut bus = FakeBus::default();
+            bus.replies
+                .push_back(BusReply::new(vec![BusValue::ObjectPath(
+                    expected.path.clone(),
+                )]));
+            bus.replies.push_back(properties);
+
+            assert_eq!(
+                resolve_current_graphical_session(&mut bus, Some("34"), 1000),
+                Err(LogindSessionError::NoCurrentGraphicalSession)
+            );
+        }
+    }
+
+    #[test]
+    fn discovery_ignores_non_graphical_non_user_and_inactive_sessions() {
+        let selected = session("34");
+        let mut bus = FakeBus::default();
+        bus.replies
+            .push_back(BusReply::new(vec![BusValue::Array(vec![
+                session_record("other-user", 1001, "/other-user"),
+                session_record("manager", 1000, "/manager"),
+                session_record("remote", 1000, "/remote"),
+                session_record("greeter", 1000, "/greeter"),
+                session_record("inactive", 1000, "/inactive"),
+                session_record("34", 1000, &selected.path),
+            ])]));
+        bus.replies.push_back(session_properties_reply(
+            1000,
+            false,
+            "unspecified",
+            "manager",
+            true,
+        ));
+        bus.replies
+            .push_back(session_properties_reply(1000, true, "tty", "user", true));
+        bus.replies.push_back(session_properties_reply(
+            1000, false, "wayland", "greeter", true,
+        ));
+        bus.replies.push_back(session_properties_reply(
+            1000, false, "wayland", "user", false,
+        ));
+        bus.replies.push_back(session_properties_reply(
+            1000, false, "wayland", "user", true,
+        ));
+
+        assert_eq!(
+            resolve_current_graphical_session(&mut bus, None, 1000),
+            Ok(selected)
+        );
+        assert_eq!(
+            bus.calls.iter().filter(|call| call.3 == "GetAll").count(),
+            5,
+            "other-user sessions must be discarded before reading their properties"
+        );
+    }
+
+    #[test]
+    fn discovery_refuses_to_guess_between_multiple_graphical_sessions() {
+        let first = session("8");
+        let second = session("34");
+        let mut bus = FakeBus::default();
+        bus.replies
+            .push_back(BusReply::new(vec![BusValue::Array(vec![
+                session_record("8", 1000, &first.path),
+                session_record("34", 1000, &second.path),
+            ])]));
+        bus.replies
+            .push_back(session_properties_reply(1000, false, "x11", "user", true));
+        bus.replies.push_back(session_properties_reply(
+            1000, false, "wayland", "user", true,
+        ));
+
+        assert_eq!(
+            resolve_current_graphical_session(&mut bus, None, 1000),
+            Err(LogindSessionError::AmbiguousGraphicalSessions(vec![
+                "8".to_string(),
+                "34".to_string(),
+            ]))
+        );
+    }
+
+    #[test]
+    fn locked_hint_reads_the_target_session_property() {
+        let target = session("34");
+        let mut bus = FakeBus::default();
+        bus.replies
+            .push_back(BusReply::new(vec![variant(BusValue::Bool(true))]));
+
+        assert!(locked_hint(&mut bus, &target).expect("read LockedHint"));
+        assert_eq!(bus.calls.len(), 1);
+        assert_eq!(bus.calls[0].1, target.path);
+        assert_eq!(bus.calls[0].3, "Get");
+        assert_eq!(
+            bus.calls[0].4,
+            vec![
+                BusValue::String(LOGIND_SESSION_INTERFACE.to_string()),
+                BusValue::String("LockedHint".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn locked_hint_signal_match_targets_only_the_resolved_session() {
+        let target = session("34");
+        let mut bus = FakeBus::default();
+
+        add_locked_hint_signal_match(&mut bus, &target, LOGIND_OWNER)
+            .expect("add LockedHint match");
+
+        assert_eq!(
+            bus.matches,
+            vec![OwnedBusSignalMatch::from(locked_hint_signal_match(
+                &target.path,
+                LOGIND_OWNER,
+            ))]
+        );
+    }
+
+    #[test]
+    fn logind_owner_changes_are_subscribed_and_mapped() {
+        let mut bus = FakeBus::default();
+
+        add_logind_owner_signal_match(&mut bus).expect("add logind owner match");
+
+        assert_eq!(
+            bus.matches,
+            vec![OwnedBusSignalMatch::from(logind_owner_signal_match())]
+        );
+        assert_eq!(
+            logind_owner_changed(&owner_changed(LOGIND_SERVICE_NAME, ":1.42", ":1.99")),
+            Some(Some(":1.99".to_string()))
+        );
+        assert_eq!(
+            logind_owner_changed(&owner_changed(LOGIND_SERVICE_NAME, ":1.42", "")),
+            Some(None)
+        );
+        assert_eq!(
+            logind_owner_changed(&owner_changed("org.example.Other", ":1.42", ":1.99")),
+            None
+        );
+        assert_eq!(
+            logind_owner_changed(
+                &owner_changed(LOGIND_SERVICE_NAME, ":1.42", ":1.99").with_sender(":1.1")
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn locked_hint_changes_and_invalidation_are_mapped() {
+        let target = session("34");
+        let changed = properties_changed(
+            &target,
+            vec![(
+                BusValue::String("LockedHint".to_string()),
+                variant(BusValue::Bool(true)),
+            )],
+            Vec::new(),
+        );
+        let invalidated = properties_changed(
+            &target,
+            Vec::new(),
+            vec![BusValue::String("LockedHint".to_string())],
+        );
+
+        assert_eq!(
+            map_locked_hint_change(&changed, &target, LOGIND_OWNER),
+            Some(LockedHintChange::Changed(true))
+        );
+        assert_eq!(
+            map_locked_hint_change(&invalidated, &target, LOGIND_OWNER),
+            Some(LockedHintChange::Invalidated)
+        );
+        assert_eq!(
+            map_locked_hint_change(
+                &properties_changed(&session("35"), Vec::new(), Vec::new()),
+                &target,
+                LOGIND_OWNER,
+            ),
+            None
+        );
+        assert_eq!(
+            map_locked_hint_change(&changed.clone().with_sender(":1.99"), &target, LOGIND_OWNER),
+            None
+        );
+    }
+
+    #[test]
+    fn locked_hint_tracker_reconciles_initial_lock_and_deduplicates_transitions() {
+        let mut tracker = LockedHintTracker::default();
+
+        assert_eq!(
+            tracker.observe(true),
+            Some(crate::session::SessionEvent::Lock)
+        );
+        assert_eq!(tracker.observe(true), None);
+        assert_eq!(
+            tracker.observe(false),
+            Some(crate::session::SessionEvent::Unlock)
+        );
+        assert_eq!(tracker.observe(false), None);
+        assert_eq!(
+            tracker.observe(true),
+            Some(crate::session::SessionEvent::Lock)
+        );
+    }
+
+    #[test]
+    fn initial_unlocked_hint_does_not_emit_an_unlock_event() {
+        let mut tracker = LockedHintTracker::default();
+
+        assert_eq!(tracker.observe(false), None);
     }
 }

--- a/crates/lg-buddy/src/tv.rs
+++ b/crates/lg-buddy/src/tv.rs
@@ -1387,7 +1387,7 @@ mod tests {
     use std::path::Path;
     use std::rc::Rc;
     use std::time::Duration;
-    use support::{ExecutableScript, MockBscpylgtv, TestConfigFile};
+    use support::{find_command_in_path, MockBscpylgtv, TestConfigFile};
 
     #[test]
     fn oled_brightness_accepts_boundary_values() {
@@ -1752,13 +1752,12 @@ mod tests {
 
     #[test]
     fn command_timeout_stops_slow_helper() {
-        let script = ExecutableScript::new(
-            "tv-command-timeout",
-            "slow-bscpylgtvcommand",
-            "#!/bin/sh\nsleep 5\n",
-        );
-        let client = BscpylgtvCommandClient::new(ip("10.0.0.8"), script.path())
-            .with_command_timeout(Duration::from_millis(100));
+        let client = BscpylgtvCommandClient::with_args(
+            ip("10.0.0.8"),
+            find_command_in_path("sh").expect("shell executable"),
+            ["-c", "exec sleep 5", "mock-bscpylgtvcommand"],
+        )
+        .with_command_timeout(Duration::from_millis(100));
 
         let err = client
             .current_input()
@@ -1920,11 +1919,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn user_scoped_launcher_sets_identity_environment_when_uid_already_matches() {
-        let script = ExecutableScript::new(
-            "tv-user-scoped-launcher-env",
-            "print-env",
-            "#!/bin/sh\nprintf 'USER=%s\\n' \"$USER\"\nprintf 'LOGNAME=%s\\n' \"$LOGNAME\"\nprintf 'HOME=%s\\n' \"$HOME\"\nid -u\n",
-        );
         let current_uid = current_euid();
         let current_gid = unsafe { libc::getegid() };
         let identity = SystemUser::new(
@@ -1933,8 +1927,14 @@ mod tests {
             current_gid,
             "/tmp/lg-buddy-owner-home",
         );
-        let invocation =
-            BscpylgtvInvocation::new(script.path(), Vec::<String>::new(), Some(identity));
+        let invocation = BscpylgtvInvocation::new(
+            find_command_in_path("sh").expect("shell executable"),
+            vec![
+                "-c".to_string(),
+                "printf 'USER=%s\\n' \"$USER\"; printf 'LOGNAME=%s\\n' \"$LOGNAME\"; printf 'HOME=%s\\n' \"$HOME\"; id -u".to_string(),
+            ],
+            Some(identity),
+        );
 
         let result = UserScopedBscpylgtvCommandLauncher
             .run(&invocation)
@@ -1956,11 +1956,6 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn user_scoped_launcher_rejects_cross_user_request_without_root() {
-        let script = ExecutableScript::new(
-            "tv-user-scoped-launcher-denied",
-            "should-not-run",
-            "#!/bin/sh\nprintf 'unexpected\\n'\n",
-        );
         let current_uid = current_euid();
         let current_gid = unsafe { libc::getegid() };
         let identity = SystemUser::new(
@@ -1969,8 +1964,11 @@ mod tests {
             current_gid,
             "/tmp/other-user-home",
         );
-        let invocation =
-            BscpylgtvInvocation::new(script.path(), Vec::<String>::new(), Some(identity));
+        let invocation = BscpylgtvInvocation::new(
+            "/path/that/must/not/run",
+            Vec::<String>::new(),
+            Some(identity),
+        );
         let err = UserScopedBscpylgtvCommandLauncher
             .run(&invocation)
             .expect_err("non-root cross-user launch should fail before exec");
@@ -1996,13 +1994,14 @@ mod tests {
         };
         let identity =
             lookup_system_user_from_passwd(&sudo_user).expect("resolve sudo user from /etc/passwd");
-        let script = ExecutableScript::new(
-            "tv-user-scoped-launcher-root-drop",
-            "print-identity",
-            "#!/bin/sh\nprintf 'USER=%s\\n' \"$USER\"\nprintf 'LOGNAME=%s\\n' \"$LOGNAME\"\nprintf 'HOME=%s\\n' \"$HOME\"\nprintf 'UID=%s\\n' \"$(id -u)\"\nprintf 'GID=%s\\n' \"$(id -g)\"\nprintf 'GROUPS=%s\\n' \"$(id -G)\"\n",
+        let invocation = BscpylgtvInvocation::new(
+            find_command_in_path("sh").expect("shell executable"),
+            vec![
+                "-c".to_string(),
+                "printf 'USER=%s\\n' \"$USER\"; printf 'LOGNAME=%s\\n' \"$LOGNAME\"; printf 'HOME=%s\\n' \"$HOME\"; printf 'UID=%s\\n' \"$(id -u)\"; printf 'GID=%s\\n' \"$(id -g)\"; printf 'GROUPS=%s\\n' \"$(id -G)\"".to_string(),
+            ],
+            Some(identity.clone()),
         );
-        let invocation =
-            BscpylgtvInvocation::new(script.path(), Vec::<String>::new(), Some(identity.clone()));
 
         let result = UserScopedBscpylgtvCommandLauncher
             .run(&invocation)

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -103,6 +103,16 @@ fn mock_system_logind_preparing_for_sleep(world: &mut LgBuddyWorld, value: Strin
     world.configure_system_logind(value == "true");
 }
 
+#[given(regex = r#"mock system logind reports LockedHint=(true|false)"#)]
+fn mock_system_logind_locked_hint(world: &mut LgBuddyWorld, value: String) {
+    world.configure_system_logind_lock(value == "true");
+}
+
+#[given(regex = r#"mock system logind changes LockedHint to (true|false)"#)]
+fn mock_system_logind_changes_locked_hint(world: &mut LgBuddyWorld, value: String) {
+    world.queue_system_logind_lock(value == "true");
+}
+
 #[given(regex = r#"the TV auth key file override is "([^"]+)""#)]
 fn tv_auth_key_file_override(world: &mut LgBuddyWorld, path: String) {
     world.set_auth_key_file_override(&path);

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -274,6 +274,23 @@ exit 1\n",
         self.system_logind = Some(logind);
     }
 
+    pub fn configure_system_logind_lock(&mut self, locked: bool) {
+        let logind = MockSystemLogind::new("cucumber-system-logind-lock");
+        logind.reset();
+        logind.set_locked_hint(locked);
+        self.ensure_env()
+            .set("DBUS_SYSTEM_BUS_ADDRESS", logind.address());
+        self.ensure_env().set("XDG_SESSION_ID", "test-session");
+        self.system_logind = Some(logind);
+    }
+
+    pub fn queue_system_logind_lock(&self, locked: bool) {
+        self.system_logind
+            .as_ref()
+            .expect("mock system logind should be configured")
+            .queue_locked_hint_signal(locked);
+    }
+
     pub fn assert_native_access_token(&self, expected: &str) {
         let stored = self
             .native_access_token_store()

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -9,6 +9,7 @@ Feature: GNOME monitor
     And the TV is on input HDMI_2
     And the executable PATH is isolated
     And gamepad activity is observed after 0 seconds
+    And mock system logind reports LockedHint=true
     And GNOME monitor stays open for 0.1 seconds
     When I run the command "monitor"
     Then the command succeeds
@@ -25,6 +26,48 @@ Feature: GNOME monitor
     Then the command succeeds
     And stdout contains "session notification service unavailable"
     And stdout contains "screen idle backend unavailable"
+
+  Scenario: Locking the graphical session blanks the TV immediately
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 120 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And mock system logind reports LockedHint=false
+    And mock system logind changes LockedHint to true
+    And GNOME monitor stays open for 0.6 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Session locked; requesting screen blank."
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client did not receive "turn_screen_on"
+    And the session marker exists
+    And the TV screen is blanked
+
+  Scenario: Unlocking the graphical session does not restore the TV
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 120 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And mock system logind reports LockedHint=true
+    And mock system logind changes LockedHint to false
+    And GNOME monitor stays open for 0.6 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Session unlocked; no screen restore requested."
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client did not receive "turn_screen_on"
+    And the session marker exists
+    And the TV screen is blanked
 
   Scenario: GNOME ScreenSaver idle does not bypass the LG Buddy timeout
     Given a temporary LG Buddy config using input HDMI_2
@@ -144,15 +187,16 @@ Feature: GNOME monitor
 
   Scenario: GNOME lock-screen activity restores before ScreenSaver reports active
     Given a temporary LG Buddy config using input HDMI_2
-    And the idle timeout is 1 seconds
+    And the idle timeout is 120 seconds
     And LG Buddy session runtime is isolated
     And a mock TV client
     And the TV is on input HDMI_2
     And the executable PATH is isolated
     And GNOME Shell is available
-    And GNOME reports the session idle
-    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
-    And GNOME monitor stays open for 1.8 seconds
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000, 1000, 0"
+    And mock system logind reports LockedHint=true
+    And GNOME monitor stays open for 0.8 seconds
     When I run the command "monitor"
     Then the command succeeds
     And stdout contains "Session event `user-activity` requests screen restore."

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -2,6 +2,7 @@ use dbus::arg::{PropMap, Variant as DbusVariant};
 use dbus::blocking::Connection as DbusConnection;
 use dbus::channel::{MatchingReceiver, Sender as DbusSender};
 use dbus::Message as DbusMessage;
+use dbus::Path as DbusPath;
 use dbus_crossroads::{Crossroads, MethodErr};
 use serde_json::{json, Map, Value};
 use std::collections::VecDeque;
@@ -541,6 +542,10 @@ pub struct MockSystemLogind {
 struct MockSystemLogindState {
     preparing_for_sleep: bool,
     prepare_for_sleep_signals: VecDeque<bool>,
+    locked_hint: bool,
+    locked_hint_client_ready: bool,
+    locked_hint_read_count: usize,
+    locked_hint_signals: VecDeque<bool>,
 }
 
 #[allow(dead_code)]
@@ -564,6 +569,10 @@ impl MockSystemLogind {
         self.patch_state(|state| {
             state.preparing_for_sleep = false;
             state.prepare_for_sleep_signals.clear();
+            state.locked_hint = false;
+            state.locked_hint_client_ready = false;
+            state.locked_hint_read_count = 0;
+            state.locked_hint_signals.clear();
         });
     }
 
@@ -573,6 +582,14 @@ impl MockSystemLogind {
 
     pub fn queue_prepare_for_sleep_signal(&self, value: bool) {
         self.patch_state(|state| state.prepare_for_sleep_signals.push_back(value));
+    }
+
+    pub fn set_locked_hint(&self, value: bool) {
+        self.patch_state(|state| state.locked_hint = value);
+    }
+
+    pub fn queue_locked_hint_signal(&self, value: bool) {
+        self.patch_state(|state| state.locked_hint_signals.push_back(value));
     }
 
     fn patch_state<F>(&self, f: F)
@@ -817,10 +834,71 @@ fn spawn_mock_logind_service(
                     Ok((fd,))
                 },
             );
+            builder.method(
+                "GetSession",
+                ("session_id",),
+                ("session",),
+                move |_, _, (session_id,): (String,)| {
+                    if session_id != "test-session" {
+                        return Err(MethodErr::failed("unknown mock logind session"));
+                    }
+                    Ok((
+                        DbusPath::new("/org/freedesktop/login1/session/_test_session")
+                            .expect("mock session object path"),
+                    ))
+                },
+            );
+            builder.method("ListSessions", (), ("sessions",), move |_, _, ()| {
+                let uid = unsafe { libc::geteuid() };
+                Ok((vec![(
+                    "test-session".to_string(),
+                    uid,
+                    "test-user".to_string(),
+                    "seat0".to_string(),
+                    DbusPath::new("/org/freedesktop/login1/session/_test_session")
+                        .expect("mock session object path"),
+                )],))
+            });
+        });
+        let session_state = Arc::clone(&state);
+        let session_iface = crossroads.register("org.freedesktop.login1.Session", move |builder| {
+            builder
+                .property::<(u32, DbusPath<'static>), _>("User")
+                .get(move |_, _| {
+                    Ok((
+                        unsafe { libc::geteuid() },
+                        DbusPath::new("/org/freedesktop/login1/user/_test")
+                            .expect("mock user object path"),
+                    ))
+                });
+            builder
+                .property::<bool, _>("Remote")
+                .get(move |_, _| Ok(false));
+            builder
+                .property::<String, _>("Type")
+                .get(move |_, _| Ok("wayland".to_string()));
+            builder
+                .property::<String, _>("Class")
+                .get(move |_, _| Ok("user".to_string()));
+            builder
+                .property::<bool, _>("Active")
+                .get(move |_, _| Ok(true));
+            let state = Arc::clone(&session_state);
+            builder.property::<bool, _>("LockedHint").get(move |_, _| {
+                let mut state = state.lock().expect("mock logind state lock");
+                state.locked_hint_read_count += 1;
+                state.locked_hint_client_ready = state.locked_hint_read_count >= 2;
+                Ok(state.locked_hint)
+            });
         });
         crossroads.insert(
             "/org/freedesktop/login1",
             &[properties_iface, manager_iface],
+            (),
+        );
+        crossroads.insert(
+            "/org/freedesktop/login1/session/_test_session",
+            &[session_iface],
             (),
         );
 
@@ -850,23 +928,51 @@ fn emit_queued_mock_logind_signal(
     connection: &DbusConnection,
     state: &Arc<Mutex<MockSystemLogindState>>,
 ) {
-    let signal = {
+    let prepare_for_sleep = {
         let mut state = state.lock().expect("mock logind state lock");
         state.prepare_for_sleep_signals.pop_front()
     };
-    let Some(preparing_for_sleep) = signal else {
-        return;
+    if let Some(preparing_for_sleep) = prepare_for_sleep {
+        let message = DbusMessage::new_signal(
+            "/org/freedesktop/login1",
+            "org.freedesktop.login1.Manager",
+            "PrepareForSleep",
+        )
+        .expect("create mock PrepareForSleep signal")
+        .append1(preparing_for_sleep);
+
+        let _ = connection.send(message);
+    }
+
+    let locked_hint = {
+        let mut state = state.lock().expect("mock logind state lock");
+        if state.locked_hint_client_ready {
+            let locked_hint = state.locked_hint_signals.pop_front();
+            if let Some(value) = locked_hint {
+                state.locked_hint = value;
+            }
+            locked_hint
+        } else {
+            None
+        }
     };
+    if let Some(locked_hint) = locked_hint {
+        let mut changed = PropMap::new();
+        changed.insert("LockedHint".to_string(), DbusVariant(Box::new(locked_hint)));
+        let message = DbusMessage::new_signal(
+            "/org/freedesktop/login1/session/_test_session",
+            "org.freedesktop.DBus.Properties",
+            "PropertiesChanged",
+        )
+        .expect("create mock LockedHint PropertiesChanged signal")
+        .append3(
+            "org.freedesktop.login1.Session".to_string(),
+            changed,
+            Vec::<String>::new(),
+        );
 
-    let message = DbusMessage::new_signal(
-        "/org/freedesktop/login1",
-        "org.freedesktop.login1.Manager",
-        "PrepareForSleep",
-    )
-    .expect("create mock PrepareForSleep signal")
-    .append1(preparing_for_sleep);
-
-    let _ = connection.send(message);
+        let _ = connection.send(message);
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -1686,7 +1686,7 @@ pub fn prime_isolated_path_dependencies() {
     let _ = dbus_daemon_path();
 }
 
-fn python3_path() -> PathBuf {
+pub fn python3_path() -> PathBuf {
     static PYTHON3_PATH: OnceLock<PathBuf> = OnceLock::new();
 
     PYTHON3_PATH
@@ -1711,7 +1711,7 @@ fn dbus_daemon_path() -> PathBuf {
         .clone()
 }
 
-fn find_command_in_path(command: &str) -> Option<PathBuf> {
+pub fn find_command_in_path(command: &str) -> Option<PathBuf> {
     if command.contains(std::path::MAIN_SEPARATOR) {
         let path = PathBuf::from(command);
         return path.is_file().then_some(path);

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -95,8 +95,8 @@ The main runtime consumers are:
 
 - system lifecycle and service integrations, including systemd,
   NetworkManager, and logind
-- desktop environment and session integrations, including GNOME, `swayidle`,
-  and Linux input activity sources
+- desktop environment and session integrations, including GNOME, native
+  Wayland, `swayidle`, and Linux input activity sources
 - TTY users invoking the CLI directly
 - the stable `lg-buddy brightness` launcher, which opens the matching installed
   GTK executable and uses Zenity only when that executable is absent
@@ -108,13 +108,14 @@ The main runtime consumers are:
 flowchart LR
     subgraph Desktop["Desktop Session / External Tools"]
         GNOME["GNOME session bus<br/>ScreenSaver / Mutter signals"]
+        WAYLAND["Wayland compositor<br/>ext_idle_notifier_v1"]
         SWAY["swayidle<br/>idle hooks"]
         INPUT["Linux input devices<br/>gamepads / wheels / device events"]
         FDO_NOTIFY["desktop notification service<br/>org.freedesktop.Notifications"]
     end
 
     subgraph SystemLifecycle["System Lifecycle"]
-        LOGIND["logind system bus<br/>PrepareForSleep"]
+        LOGIND["logind system bus<br/>PrepareForSleep / session LockedHint"]
         NM["NetworkManager dispatcher<br/>pre-down"]
         UPDATE_TIMER["systemd user timer<br/>background update checks"]
     end
@@ -148,10 +149,11 @@ flowchart LR
             SESSIONMODEL["session.rs<br/>shared session model"]
             RUNNER["session::runner<br/>monitor + lifecycle commands"]
             GAMEPAD["session::gamepad<br/>gamepad activity source"]
+            LOCKMON["LogindLockThread<br/>current-session lock observer"]
             BUS["session_bus.rs<br/>generic D-Bus transport"]
 
             subgraph Sources["Source Adapters"]
-                LOGINDADAPTER["sources/linux/logind.rs<br/>logind lifecycle mapping"]
+                LOGINDADAPTER["sources/linux/logind.rs<br/>lifecycle + lock-state mapping"]
                 NMGATE["sources/linux/network_manager.rs<br/>pre-down event source"]
                 GADAPTER["sources/desktop/gnome.rs<br/>GNOME probe + signal mapping"]
                 WADAPTER["sources/desktop/wayland.rs<br/>Wayland registry + activity mapping"]
@@ -175,6 +177,7 @@ flowchart LR
     MAIN --> RUNNER
     RUNNER --> BACKEND
     RUNNER --> BUS
+    RUNNER -->|"owns"| LOCKMON
     BACKEND --> GADAPTER
     BACKEND --> WADAPTER
     BACKEND --> SADAPTER
@@ -182,10 +185,13 @@ flowchart LR
     GNOME --> BUS
     BUS --> GADAPTER
     GADAPTER -->|"SessionEvent"| SESSIONMODEL
+    WAYLAND --> WADAPTER
     WADAPTER -->|"DesktopActivityObserved"| RUNNER
     LOGIND --> BUS
     BUS --> LOGINDADAPTER
-    LOGINDADAPTER -->|"RuntimeEvent"| EVENTS
+    LOGINDADAPTER -->|"lifecycle RuntimeEvent"| EVENTS
+    LOGINDADAPTER -->|"LockedHint state"| LOCKMON
+    LOCKMON -->|"SessionEvent"| RUNNER
     NM --> MAIN
     TERMINAL --> MAIN
     MAIN -->|"brightness launcher"| GTK
@@ -216,7 +222,7 @@ flowchart LR
     RUNNER --> SESSIONNOTIFY
     SESSIONMODEL --> RUNNER
 
-    RUNNER -->|"Idle / Active / WakeRequested /<br/>UserActivity"| SCREEN
+    RUNNER -->|"Idle / Active / WakeRequested /<br/>UserActivity / Lock"| SCREEN
     RUNNER -->|"AfterResume"| LIFECYCLE
     COMMANDS --> CONFIG
     COMMANDS --> STATE
@@ -338,7 +344,7 @@ The intended split is:
 - `session_bus.rs`
   - generic blocking D-Bus transport seam
   - session-bus use for the GNOME monitor runtime
-  - system-bus use for the logind lifecycle runtime
+  - system-bus use for logind lifecycle and session lock state
 - `session/runner.rs`
   - backend-neutral monitor and lifecycle runners
   - starts the user-session notification surface before screen backend work
@@ -349,11 +355,13 @@ The intended split is:
   - runs delegated `swayidle` by invoking the current executable's
     `screen off` and `screen on` CLI commands
 - `sources/linux/logind.rs`
-  - Linux system lifecycle adapter
+  - Linux system lifecycle and current-session lock-state adapter
   - maps `org.freedesktop.login1` resume signals into canonical lifecycle
     events
   - reads the `PreparingForSleep` property used by the NetworkManager pre-down
     gate
+  - resolves only the current user's active local graphical session and maps
+    its `LockedHint` changes into canonical lock/unlock events
 - `sources/linux/network_manager.rs`
   - NetworkManager `pre-down` dispatcher source
   - emits `NetworkTeardownImminent` with the logind sleep-phase reading
@@ -381,8 +389,8 @@ The session-facing pieces should be read as one subsystem:
   - owns gamepad device discovery, event-triggered refresh, and reconciliation
   - see [gamepad-subsystem.md](gamepad-subsystem.md) for adapter and lifecycle details
 - `session/runner.rs`
-  - owns the shared native-session runtime, including the gamepad source
-    lifecycle independently of the selected desktop provider
+  - owns the shared native-session runtime, including gamepad activity and the
+    optional logind lock observer independently of the selected desktop provider
   - converts provider and auxiliary input into activity observations, resets
     the inactivity deadline, and dispatches source-classified runtime policy
   - treats `screen_idle_blank=disabled` as a passive user-session mode that
@@ -390,7 +398,8 @@ The session-facing pieces should be read as one subsystem:
   - treats delegated `swayidle` as a CLI/API client for timeout/resume actions
   - owns the `lifecycle` event loop for system sleep/wake handling
 - `sources/linux/logind.rs`
-  - adapts Linux system lifecycle signals into canonical lifecycle events
+  - adapts Linux system lifecycle signals and an eligible graphical session's
+    `LockedHint` into canonical events
 - `sources/desktop/gnome.rs`, `sources/desktop/wayland.rs`, and
   `sources/desktop/swayidle.rs`
   - adapt or model backend-specific surfaces against that shared session
@@ -878,14 +887,19 @@ asymmetric:
 - the shared native-session runtime consumes gamepad activity directly from
   Linux input devices as `AuxiliaryInput`, independently of desktop providers;
   GNOME and native Wayland use this runtime
+- the same runtime opportunistically observes `LockedHint` on the current
+  graphical logind session; lock requests the normal session blank policy,
+  unlock is informational, fresh independent activity can restore while locked,
+  and logind owner changes trigger session rebinding and reconciliation; failure
+  or lack of support does not affect the selected desktop backend
 - the gamepad source refreshes its device set from Linux device add, remove, and
   change events, with periodic reconciliation for missed events
 - delegated `swayidle` monitor execution is implemented as CLI/API delegation
   for `timeout` and `resume` parity with the shell monitor
 - `swayidle` systemd-style hooks such as `before-sleep`, `after-resume`,
   `lock`, and `unlock` are not wired into monitor behavior; system lifecycle is
-  handled by the NetworkManager pre-down gate plus logind lifecycle service
-  instead
+  handled by the NetworkManager pre-down gate plus logind lifecycle service,
+  while lock state is optional in the shared native runtime
 
 `swayidle` remains an explicit and automatic compatibility fallback during the
 1.x migration window, but emits a deprecation notice and is not offered by

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -134,11 +134,14 @@ choice.
 `screen_idle_blank` follows the same policy model:
 
 - automatic session idle blank/restore defaults to enabled
-- users who want update notifications without idle-driven TV control can set
+- in supported environments, a reported session lock also requests the same
+  immediate blank policy; unlock never requests restore
+- users who want update notifications without session-driven TV control can set
   `screen_idle_blank=disabled`
 - the installed user-session service still runs so notification handoff remains
   available
 - the supported values are `enabled` and `disabled`
+- there is no separate session-lock setting
 
 `system_sleep_wake_policy` follows the same model:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -239,7 +239,7 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity deadline and phase synthesis |
 | `crates/lg-buddy/src/session/gamepad/` | Gamepad activity discovery, device-event refresh, adapters, capture, registry, and policy |
 | `crates/lg-buddy/src/session_bus.rs` | Generic D-Bus transport used by session and system event sources |
-| `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle signal and property adapter |
+| `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle and current-session lock-state adapter |
 | `crates/lg-buddy/src/sources/linux/network_manager.rs` | NetworkManager pre-down lifecycle source adapter |
 | `crates/lg-buddy/src/sources/desktop/gnome.rs` | GNOME backend integration |
 | `crates/lg-buddy/src/sources/desktop/wayland.rs` | Native Wayland idle/activity provider |

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -40,6 +40,7 @@ the shared native-session path.
 | NetworkManager `pre-down` while logind `PreparingForSleep=true` | `lg-buddy nm-pre-down` | `sources::linux::network_manager` -> `lifecycle` | Join the central suspend rail before network teardown; wait for an in-progress logind rail or run the pre-sleep TV decision. |
 | logind `PrepareForSleep(true)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Enter the central suspend rail under the logind delay inhibitor so systems without a NetworkManager `pre-down` hook still get bounded pre-sleep TV handling. |
 | logind `PrepareForSleep(false)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Run wake restore policy and clear sleep-cycle coordination state. |
+| graphical logind session `LockedHint=true` | `lg-buddy monitor` | `sources::linux::logind` -> `session::runner` -> `screen` | Enter the normal blanked inactivity state and apply session screen-off policy. |
 | user graphical session start | `lg-buddy monitor` | `session::runner::run_monitor` | Detect the session backend and run the selected monitor path. |
 | manual screen blank | `lg-buddy screen off` | `commands` -> `screen` | Blank or power off the TV if LG Buddy owns the configured input. |
 | manual screen restore | `lg-buddy screen on` | `commands` -> `screen` | Restore the screen when marker and restore-policy rules allow it. |
@@ -71,6 +72,7 @@ lifecycle paths:
 
 ```text
 system lifecycle sources
+session lock state
 desktop idle/activity sources
 auxiliary activity sources
   -> narrow source adapters
@@ -89,6 +91,7 @@ Examples:
 | Source category | Example source | Runtime representation |
 | --- | --- | --- |
 | system lifecycle | `org.freedesktop.login1`, platform-native lifecycle APIs | `MachinePreparingForSleep`, `MachineResumed`, `NetworkTeardownImminent` |
+| session lock state | current graphical logind session `LockedHint` | `SessionLocked`, `SessionUnlocked` from `LinuxLogind` |
 | desktop activity | Mutter, native Wayland idle protocols | activity observations |
 | desktop wake request | GNOME ScreenSaver wake signal, future equivalents | `WakeRequested` |
 | auxiliary activity | Linux gamepad input | `UserActivityObserved` |
@@ -107,8 +110,10 @@ auxiliary activity facts
   -> inactivity observations
   -> reset the InactivityEngine deadline
   -> configured timeout expires
-  -> Idle / Active / WakeRequested / UserActivity
-  -> screen policy
+  -> Idle / Active / WakeRequested / UserActivity ─┐
+                                                    ├-> screen policy
+current-session logind LockedHint=true              │
+  -> immediate Lock / BlankNow ─────────────────────┘
 ```
 
 Current native-runtime inputs:
@@ -120,17 +125,24 @@ Current native-runtime inputs:
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | `InactivityEngine` |
 | Recent activity reported by `org.gnome.Mutter.IdleMonitor.GetIdletime` | `DesktopActivityObserved` | `InactivityEngine` |
 | Linux gamepad activity | `UserActivityObserved` from `AuxiliaryInput` | Shared native-session runtime -> `InactivityEngine` |
+| Initial or changed logind `LockedHint=true` | `SessionEvent::Lock` from `LinuxLogind` | Shared native-session runtime -> `InactivityEngine` |
+| Changed logind `LockedHint=false` after lock | `SessionEvent::Unlock` from `LinuxLogind` | Clear the observed lock state without requesting screen restore |
 
 The desktop rows are GNOME-specific source surfaces. Gamepad activity is an
 independent auxiliary source owned by the shared native-session runtime. The
 key architectural point is that blank/restore decisions are made after
 normalization, not inside a desktop adapter.
 
+After a lock blank, only independent desktop or gamepad activity newer than the
+lock can produce `RestoreNow`. Stale observations and GNOME provider
+active/wake signals do not make unlock itself a restore trigger.
+
 The resulting decisions are dispatched as:
 
 | Inactivity decision | Dispatched event | Policy target |
 | --- | --- | --- |
 | `BlankNow` | `SessionEvent::Idle` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_off_from_env_for_event` |
+| `BlankNow` from session lock | `SessionEvent::Lock` -> `RuntimeEvent::SessionLocked` from `LinuxLogind` | `screen::run_screen_off_from_env_for_event` |
 | `RestoreNow` from provider active | `SessionEvent::Active` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from wake request | `SessionEvent::WakeRequested` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from desktop activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
@@ -228,15 +240,25 @@ and resume to direct `screen off` / `screen on` CLI/API commands; richer
 | `UserActivity` | Run `screen on`. |
 | `BeforeSleep` | Run pre-sleep TV power-off policy. |
 | `AfterResume` | Run wake restore policy. |
-| `Lock` | Log as unhandled. |
-| `Unlock` | Log as unhandled. |
+| `Lock` | Run `screen off` through normal session policy. |
+| `Unlock` | Log the transition without a screen action. |
 
-For session-originated `Idle`, `Active`, `WakeRequested`, and `UserActivity`,
-screen policy checks `runtime_phase.rs` before doing TV I/O. If logind reports
+For session-originated `Idle`, `Active`, `WakeRequested`, `UserActivity`, and
+`Lock`, screen policy checks `runtime_phase.rs` before doing TV I/O. If logind reports
 that machine sleep is pending and lifecycle automation is enabled, screen policy
 records a runtime-phase no-action decision and leaves TV/state untouched. If the
 phase read fails, screen policy fails open and proceeds with the ordinary
 screen action.
+
+The lock observer resolves only the current UID's active, local graphical
+logind session. `XDG_SESSION_ID`, when present, is validated; otherwise exactly
+one eligible session must exist. It watches logind bus ownership and re-resolves
+and reconciles the session after logind restarts. Missing, ambiguous, or
+unavailable session state produces a diagnostic without changing inactivity
+behavior or native backend eligibility. A desktop or locker that never updates
+`LockedHint` simply produces no lock events. Unlock never sends a wake, restore,
+or activity event. Fresh independent activity observed while locked remains able
+to restore the screen through the existing marker policy.
 
 ## Lifecycle Default And Migration Stance
 

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -62,6 +62,11 @@ These are the semantic events the runtime should reason about.
 - `WakeRequested` is optional.
   - Some providers expose an explicit wake request.
   - Others only expose idle/resume transitions.
+- Lock state is an optional cross-cutting Linux source, not a prerequisite of a
+  selected desktop backend. The shared native runtime observes the resolved
+  graphical logind session's `LockedHint` when available. Initial or changed
+  `true` maps to `Lock`; `false` maps to `Unlock` only after a prior locked
+  state. Unlock is informational and never requests screen restore.
 
 ## Capability Model
 
@@ -120,8 +125,8 @@ This is the current mapping for the known backends, with implementation status c
 
 | Backend | Idle | Active | WakeRequested | UserActivity | BeforeSleep | AfterResume | Lock/Unlock | Idle Timeout Source | Current Rust Status |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| GNOME | Yes | Yes | Yes | Yes | No current surface in LG Buddy | No current surface in LG Buddy | No current surface in LG Buddy | `LgBuddyConfigured` | Implemented with LG Buddy-owned timeout policy over ScreenSaver and Mutter observations |
-| Native Wayland | Observed but not authoritative | Resumed notification | No | Yes | No | No | No | `LgBuddyConfigured` | Explicit opt-in using `ext_idle_notifier_v1` version 2 or newer |
+| GNOME | Yes | Yes | Yes | Yes | No current surface in LG Buddy | No current surface in LG Buddy | No desktop-provider surface; optional logind overlay | `LgBuddyConfigured` | Implemented with LG Buddy-owned timeout policy over ScreenSaver and Mutter observations |
+| Native Wayland | Observed but not authoritative | Resumed notification | No | Yes | No | No | No desktop-provider surface; optional logind overlay | `LgBuddyConfigured` | Explicit opt-in using `ext_idle_notifier_v1` version 2 or newer |
 | `swayidle` | Yes | Yes | No | No direct equivalent | Yes | Yes | Yes, when built with systemd support | `LgBuddyConfigured` | Implemented for delegated `timeout -> Idle` and `resume -> Active`; `before-sleep`, `after-resume`, `lock`, and `unlock` are modeled but not executed |
 
 ## Provider-Specific Mapping
@@ -165,6 +170,47 @@ hosts where those reports do not appear on the evdev node.
 GNOME and native Wayland use the shared native-session runtime. The Wayland
 provider owns only its connection, registry, seats, notifications, and activity
 facts; it does not acquire gamepad responsibility.
+
+### Session Lock State
+
+GNOME and native Wayland also start an optional system-bus observer for the
+current graphical logind session. Session selection accepts only an active,
+local `x11` or `wayland` session in a user class and owned by the current UID.
+An explicit `XDG_SESSION_ID` is validated against those rules; without it, LG
+Buddy requires exactly one matching session and refuses ambiguous candidates.
+
+The observer resolves logind's current unique bus owner, subscribes to
+`org.freedesktop.DBus.Properties.PropertiesChanged` from that owner for the
+exact session, and reconciles the initial `LockedHint` before processing changes.
+It watches ownership of `org.freedesktop.login1` and repeats session resolution,
+subscription, and reconciliation when logind restarts.
+A lock enters the existing blanked inactivity state and dispatches
+`SessionLocked` from `LinuxLogind`, so configured-input, marker, sleep-phase,
+and restore policy remain centralized in `screen.rs`. Unlock performs no screen
+action. Independent desktop or gamepad activity observed after the lock can
+restore the picture while the lock screen is still shown. Stale pre-lock
+observations and provider wake/deactivation signals associated with unlocking do
+not restore it; normal inactivity timing resumes from fresh activity.
+
+Known environment support follows whether the desktop or locker maintains
+logind's `LockedHint` for the graphical session:
+
+| Environment | Lock observation |
+| --- | --- |
+| GNOME Shell 40 or newer on Wayland or X11 | Supported |
+| KDE Plasma 5.20 or newer on Wayland or X11 | Supported |
+| niri built with D-Bus support and a valid `XDG_SESSION_ID` | Supported |
+| stock sway with swaylock | Absent by default; `LockedHint` is not maintained |
+| Hyprland with hyprlock | Absent by default; `LockedHint` is not maintained |
+
+This behavior is opportunistic. If logind is unavailable or no eligible session
+can be resolved, LG Buddy logs a diagnostic and continues ordinary idle/activity
+monitoring. If the desktop or locker never updates `LockedHint`, no lock event is
+observed and ordinary monitoring likewise continues unchanged. It does not use
+desktop-name checks, logind lock-request signals, locker hooks, or a Wayland
+session-lock protocol. The logind observer is not a backend eligibility or
+selection requirement. The delegated `swayidle` path does not host the shared
+native observer.
 
 ### Native Wayland
 
@@ -218,6 +264,9 @@ The code split is:
   - GNOME-specific probing and event mapping
 - `crates/lg-buddy/src/sources/desktop/wayland.rs`
   - native Wayland registry, seat, idle-notification, and activity mapping
+- `crates/lg-buddy/src/sources/linux/logind.rs`
+  - system lifecycle mapping plus optional current-session `LockedHint`
+    discovery and observation
 - `crates/lg-buddy/src/sources/desktop/swayidle.rs`
   - `swayidle`-specific probing and event mapping
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -29,6 +29,7 @@ This is where most tests should live.
 - backend selection rules
 - GNOME signal-to-event mapping
 - native Wayland registry, seat, and resumed-notification mapping
+- logind current-session selection and `LockedHint` mapping
 - gamepad device discovery, device-event filtering, raw event mapping, registry
   behavior, and activity policy
 - TV command output parsing
@@ -80,8 +81,8 @@ This is the place for integration tests and contract tests.
 - backend detection against mocked command/process boundaries
 - GNOME runner behavior against a private session-bus harness
 - native Wayland provider capability and registry-churn behavior
-- logind lifecycle and NetworkManager gate behavior against a private system-bus
-  harness
+- logind lifecycle, current-session lock state, and NetworkManager gate behavior
+  against a private system-bus harness
 - desktop and auxiliary gamepad activity resetting one LG Buddy-owned deadline
 - update-install orchestration ordering against an injected runtime, including
   refusal, decline, concurrent acquisition, candidate preflight, installer,
@@ -146,6 +147,8 @@ It is useful when we want to express scenarios like:
 
 - when the configured HDMI input is active and the user goes idle, LG Buddy blanks the TV and records ownership
 - when the user returns after LG Buddy blanked the TV, LG Buddy restores the screen
+- when the graphical session locks, LG Buddy blanks the TV without waiting for
+  the inactivity timeout
 - when aggressive restore policy is enabled, wake/activity can restore even without a marker
 - when GNOME is available, backend detection resolves to `gnome`
 - when fresh configuration accepts the default `lg_webos` platform, pairing
@@ -248,6 +251,10 @@ Examples:
 - native Wayland resumed-notification and registry-removal mapping
 - gamepad activity integration with the LG Buddy inactivity deadline
 - screen runtime-phase eligibility over the private logind system-bus seam
+- logind lock state entering the shared blanked state without making unlock a
+  restore trigger, while fresh independent activity still restores
+- logind lock monitoring rebinding and reconciling after logind changes its
+  unique D-Bus owner
 
 Native Wayland changes also require manual checks on Plasma/KWin and at least
 one other target compositor. Verify that explicit and automatic `wayland`


### PR DESCRIPTION
## Summary

- observe LockedHint on the current graphical logind session from the shared native runtime
- blank through the existing screen policy when the session locks while keeping unlock informational
- allow fresh desktop or gamepad activity to restore the picture on the lock screen, without accepting stale or unlock-correlated provider events
- rebind and reconcile the lock observer when logind changes its D-Bus owner
- document and test the supported behavior and graceful fallback boundary

## Validation

- `cargo test -p lg-buddy --lib -- --test-threads=1` — 792 passed, 1 ignored
- `cargo test -p lg-buddy --test cucumber` — 128 scenarios and 1,493 steps passed
- `cargo clippy -p lg-buddy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #138.