### PR TITLE
test(gui): observe rendered state before actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib platform_access_token::tests::persist_assigns_requested_owner_when_running_as_root -- --exact
 
       - name: Install GTK test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev xdotool xvfb zenity
+        run: sudo apt-get update && sudo apt-get install -y at-spi2-core dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev python3-pyatspi xdotool xvfb zenity
 
       - name: Run display-backed GTK test suite
         run: |
@@ -106,7 +106,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install smoke-test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools strace xdotool xvfb zenity
+        run: sudo apt-get update && sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
 
       - name: Build headless runtime and GTK GUI
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
           python-version: "3.x"
 
       - name: Install release prerequisites
-        run: sudo apt-get update && sudo apt-get install -y binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools strace xdotool xvfb zenity
+        run: sudo apt-get update && sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
 
       - name: Build headless runtime and GTK GUI
         env:

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,6 +16,8 @@ Compiling and testing the GTK frontend additionally requires:
 - `pkg-config`
 - a graphical session or virtual display for renderer tests
 - `xdotool` for the executable launch smoke test
+- AT-SPI 2 and its Python bindings (`python3-pyatspi` on Debian/Fedora,
+  `python-atspi` on Arch) for observable GUI behavior tests
 
 Running the interactive installer, exercising the legacy TV fallback, and
 testing release bundles also requires:
@@ -254,8 +256,8 @@ the branch contract and recovery process, see
 | `scripts/release_bundle_manifest.py` | Release-bundle identity manifest creator and validator |
 | `scripts/build-release-bundle.sh` | Release bundle builder |
 | `scripts/test-installed-gui.sh` | Installed GTK launcher and removal smoke test |
-| `scripts/test-release-gui-behavior.sh` | Display-backed installed GUI behavior smoke test |
-| `scripts/test-release-gui-accessibility.py` | External AT-SPI contract probe for the installed GTK GUI |
+| `scripts/test-release-gui-behavior.sh` | Display-backed installed GUI behavior smoke with externally observed presentation-state gates |
+| `scripts/test-release-gui-accessibility.py` | External AT-SPI presentation-state and accessibility contract probe for the installed GTK GUI |
 | `scripts/xwd_mean.py` | Standard-library XWD luminance probe for release theme smoke tests |
 | `scripts/test-release-linkage.sh` | Static runtime and GNU GUI linkage baseline check |
 | `scripts/test-release-bundle.sh` | Release bundle smoke test |

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import argparse
+import math
 import sys
 import time
 
@@ -10,7 +12,7 @@ import pyatspi
 
 WINDOW_TITLE = "LG TV Brightness"
 CONTROL_NAME = "OLED Pixel Brightness"
-TIMEOUT_SECONDS = 10
+DEFAULT_TIMEOUT_SECONDS = 10
 MAX_ACCESSIBLES = 256
 
 
@@ -53,7 +55,7 @@ def normalized_name(accessible: object) -> str:
     return name(accessible).replace("_", "")
 
 
-def find_contract() -> tuple[list[object], object, object, object, object] | None:
+def find_ready_contract() -> tuple[list[object], object, object, object, object] | None:
     accessibles = accessible_tree()
     if not any(name(item) == WINDOW_TITLE for item in accessibles):
         return None
@@ -97,41 +99,157 @@ def find_contract() -> tuple[list[object], object, object, object, object] | Non
     return accessibles, heading, slider, cancel, apply
 
 
+def find_read_failure_contract() -> (
+    tuple[list[object], object, object, object, object] | None
+):
+    accessibles = accessible_tree()
+    if not any(name(item) == WINDOW_TITLE for item in accessibles):
+        return None
+
+    heading = next(
+        (
+            item
+            for item in accessibles
+            if role(item) == pyatspi.ROLE_HEADING and name(item) == CONTROL_NAME
+        ),
+        None,
+    )
+    alert = next(
+        (
+            item
+            for item in accessibles
+            if role(item) == pyatspi.ROLE_ALERT and name(item)
+        ),
+        None,
+    )
+    cancel = next(
+        (
+            item
+            for item in accessibles
+            if role(item) == pyatspi.ROLE_PUSH_BUTTON
+            and normalized_name(item) == "Cancel"
+        ),
+        None,
+    )
+    retry = next(
+        (
+            item
+            for item in accessibles
+            if role(item) == pyatspi.ROLE_PUSH_BUTTON
+            and normalized_name(item) == "Retry"
+        ),
+        None,
+    )
+    has_slider = any(
+        role(item) == pyatspi.ROLE_SLIDER and name(item) == CONTROL_NAME
+        for item in accessibles
+    )
+    if any(item is None for item in (heading, alert, cancel, retry)) or has_slider:
+        return None
+    return accessibles, heading, alert, cancel, retry
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Wait for and verify the installed GTK GUI's AT-SPI contract."
+    )
+    parser.add_argument(
+        "--expected-state",
+        choices=("ready", "read-failed"),
+        default="ready",
+        help="presentation state to observe (default: ready)",
+    )
+    parser.add_argument(
+        "--expected-slider-value",
+        type=float,
+        help="wait until the ready slider exposes this value",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help=f"maximum observation time in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
+    )
+    args = parser.parse_args()
+    if args.timeout <= 0:
+        parser.error("--timeout must be greater than zero")
+    if args.expected_state != "ready" and args.expected_slider_value is not None:
+        parser.error("--expected-slider-value requires --expected-state ready")
+    return args
+
+
+def observed_contract(
+    expected_state: str,
+    expected_slider_value: float | None,
+) -> tuple[list[object], float | None] | None:
+    if expected_state == "read-failed":
+        failure_contract = find_read_failure_contract()
+        if failure_contract is None:
+            return None
+        accessibles, _heading, _alert, cancel, retry = failure_contract
+        try:
+            if any(
+                not action.getState().contains(pyatspi.STATE_FOCUSABLE)
+                for action in (cancel, retry)
+            ):
+                return None
+        except Exception:  # The UI may change between related remote queries.
+            return None
+        return accessibles, None
+
+    contract = find_ready_contract()
+    if contract is None:
+        return None
+
+    accessibles, _heading, slider, cancel, apply = contract
+    try:
+        if not slider.getState().contains(pyatspi.STATE_FOCUSABLE):
+            return None
+        if any(
+            not action.getState().contains(pyatspi.STATE_FOCUSABLE)
+            for action in (cancel, apply)
+        ):
+            return None
+        slider_value = float(slider.queryValue().currentValue)
+    except Exception:  # The UI may change between related remote queries.
+        return None
+
+    if not 0 <= slider_value <= 100:
+        return None
+    if expected_slider_value is not None and not math.isclose(
+        slider_value, expected_slider_value, abs_tol=0.01
+    ):
+        return None
+    return accessibles, slider_value
+
+
 def main() -> int:
-    deadline = time.monotonic() + TIMEOUT_SECONDS
+    args = parse_args()
+    deadline = time.monotonic() + args.timeout
     contract = None
     while time.monotonic() < deadline:
-        contract = find_contract()
+        contract = observed_contract(args.expected_state, args.expected_slider_value)
         if contract is not None:
             break
         time.sleep(0.1)
 
     if contract is None:
+        expected = f" {args.expected_state} state"
+        if args.expected_slider_value is not None:
+            expected += f" at slider value {args.expected_slider_value:g}"
         raise SystemExit(
-            "installed GUI did not expose its window, heading, slider, and actions over AT-SPI"
+            f"installed GUI did not expose its expected focusable{expected} over AT-SPI"
         )
 
-    accessibles, _heading, slider, cancel, apply = contract
-    if not slider.getState().contains(pyatspi.STATE_FOCUSABLE):
-        raise SystemExit("installed GUI slider is not exposed as focusable over AT-SPI")
-    for action in (cancel, apply):
-        if not action.getState().contains(pyatspi.STATE_FOCUSABLE):
-            raise SystemExit(
-                f"installed GUI action {normalized_name(action)!r} is not exposed as focusable over AT-SPI"
-            )
-
-    slider_value = slider.queryValue().currentValue
-    if not 0 <= slider_value <= 100:
-        raise SystemExit(f"installed GUI exposed invalid slider value {slider_value}")
+    accessibles, slider_value = contract
 
     observed = sorted(
-        {
-            (role_name(item), name(item))
-            for item in accessibles
-            if name(item)
-        }
+        {(role_name(item), name(item)) for item in accessibles if name(item)}
     )
     print("AT-SPI accessibility contract verified:")
+    print(f"  presentation state: {args.expected_state}")
+    if slider_value is not None:
+        print(f"  slider value: {slider_value:g}")
     for observed_role, accessible_name in observed:
         print(f"  {observed_role}: {accessible_name}")
     return 0

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -19,6 +19,7 @@ GUI_PID=""
 WINDOW_ID=""
 ACCESSIBILITY_BUS_PID=""
 ACCESSIBILITY_REGISTRY_PID=""
+ACCESSIBILITY_PYTHON=""
 
 fail() {
     echo "$1" >&2
@@ -126,6 +127,11 @@ finish_gui() {
         sleep 0.1
     done
     if kill -0 "$GUI_PID" 2>/dev/null; then
+        if xdotool search --onlyvisible --name "^${WINDOW_TITLE}$" >/dev/null 2>&1; then
+            echo "Brightness window remained visible; the closing action was not observed." >&2
+        else
+            echo "Brightness window closed, but the GUI process remained alive." >&2
+        fi
         if [ -s "$WORK_DIR/gui.output" ]; then
             echo "GUI output for $scenario:" >&2
             sed 's/^/  /' "$WORK_DIR/gui.output" >&2
@@ -147,6 +153,17 @@ start_accessibility_bus() {
     local launcher=""
     local registry=""
     local candidate=""
+
+    for candidate in \
+        "$(command -v python3 2>/dev/null || true)" \
+        /usr/bin/python3; do
+        if [ -n "$candidate" ] && [ -x "$candidate" ] && \
+            "$candidate" -c 'import pyatspi' >/dev/null 2>&1; then
+            ACCESSIBILITY_PYTHON="$candidate"
+            break
+        fi
+    done
+    [ -n "$ACCESSIBILITY_PYTHON" ] || fail "Python AT-SPI bindings are required for GUI state verification."
 
     for candidate in \
         "$(command -v at-spi-bus-launcher 2>/dev/null || true)" \
@@ -180,12 +197,18 @@ start_accessibility_bus() {
     sleep 0.2
 }
 
+observe_gui_state() {
+    "$ACCESSIBILITY_PYTHON" "$SCRIPT_DIR/test-release-gui-accessibility.py" \
+        --timeout 30 "$@"
+}
+
 # Read current state, reach the slider through the focus chain, edit it through
 # the keyboard, and apply it through its mnemonic.
 printf '%s\n' '{"backlight":50,"calls":[],"plan":{}}' >"$STATE_FILE"
-start_gui
+start_accessibility_bus
+start_gui enabled
 wait_for_calls get_picture_settings 1
-sleep 0.2
+observe_gui_state --expected-state ready --expected-slider-value 50
 xdotool windowfocus --sync "$WINDOW_ID"
 for _ in 1 2 3; do
     xdotool key --window "$WINDOW_ID" Tab Right
@@ -202,14 +225,16 @@ assert state["backlight"] != 50, state
 assert any(call.get("command") == "set_settings" for call in state["calls"]), state
 PY
 
-# A failed read stays visible and Retry performs a fresh read.
+# A failed read stays visible and Retry performs a fresh read. Observe each
+# rendered presentation before sending the action that depends on it.
 printf '%s\n' '{"backlight":64,"calls":[],"plan":{"get_picture_settings":[{"result":"error","status":1,"stderr":"planned read failure"},{"result":"success","stdout":"{\u0027backlight\u0027: 64}"}]}}' >"$STATE_FILE"
-start_gui
+start_gui enabled
 wait_for_calls get_picture_settings 1
-sleep 0.2
+observe_gui_state --expected-state read-failed
 xdotool windowfocus --sync "$WINDOW_ID"
 xdotool key --window "$WINDOW_ID" alt+r
 wait_for_calls get_picture_settings 2
+observe_gui_state --expected-state ready --expected-slider-value 64
 xdotool windowfocus --sync "$WINDOW_ID"
 send_closing_mnemonic alt+c
 finish_gui "read-failure cancellation"
@@ -233,40 +258,34 @@ PY
 
 if [ "${LG_BUDDY_TEST_PLATFORM_CONTRACT:-0}" = "1" ]; then
     command -v xwd >/dev/null || fail "xwd is required for theme verification."
-    start_accessibility_bus
 
     capture_platform_state() {
         local label="$1"
         local color_scheme="$2"
         local scale="$3"
-        local accessibility="$4"
         local geometry=""
         local screenshot="$WORK_DIR/$label.xwd"
 
         printf '%s\n' '{"backlight":50,"calls":[],"plan":{}}' >"$STATE_FILE"
-        start_gui "$accessibility" "$color_scheme" "$scale"
+        start_gui enabled "$color_scheme" "$scale"
         wait_for_calls get_picture_settings 1
-        sleep 0.3
+        observe_gui_state --expected-state ready --expected-slider-value 50
         geometry="$(xdotool getwindowgeometry --shell "$WINDOW_ID")"
         PLATFORM_WIDTH="$(printf '%s\n' "$geometry" | sed -n 's/^WIDTH=//p')"
         PLATFORM_HEIGHT="$(printf '%s\n' "$geometry" | sed -n 's/^HEIGHT=//p')"
         xwd -silent -id "$WINDOW_ID" -out "$screenshot"
         PLATFORM_MEAN="$(python3 "$SCRIPT_DIR/xwd_mean.py" "$screenshot")"
 
-        if [ "$accessibility" = "enabled" ]; then
-            python3 "$SCRIPT_DIR/test-release-gui-accessibility.py"
-        fi
-
         xdotool windowfocus --sync "$WINDOW_ID"
         send_closing_mnemonic alt+c
         finish_gui "$label platform-state cancellation"
     }
 
-    capture_platform_state light prefer-light 1 enabled
+    capture_platform_state light prefer-light 1
     LIGHT_WIDTH="$PLATFORM_WIDTH"
     LIGHT_HEIGHT="$PLATFORM_HEIGHT"
     LIGHT_MEAN="$PLATFORM_MEAN"
-    capture_platform_state dark prefer-dark 2 disabled
+    capture_platform_state dark prefer-dark 2
     DARK_WIDTH="$PLATFORM_WIDTH"
     DARK_HEIGHT="$PLATFORM_HEIGHT"
     DARK_MEAN="$PLATFORM_MEAN"


### PR DESCRIPTION
## Summary

- gate GUI actions on externally observed AT-SPI presentation states instead of fixed sleeps
- assert read-failure and ready slider values before Retry, Cancel, Apply, and platform captures
- add deterministic timeout diagnostics and the required Ubuntu AT-SPI test dependencies

## Validation

- Arch current packaged GUI behavior smoke: 20/20 passes with one CPU under continuous CPU contention
- Arch current full platform contract, including theme and scale captures
- Actionlint, ShellCheck, Ruff, Python compilation, Bash syntax, and diff checks

Closes #156