### PR TITLE
Power off blanked TV after prolonged inactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ LG Buddy can:
 
 - turn the TV on at boot and wake
 - turn the TV off at shutdown and before system sleep
-- blank and restore the panel on supported desktop idle backends
+- blank and restore the panel on supported desktop idle backends, then power it
+  off after five additional minutes without activity
 - keep the panel awake when supported gamepads are active
 - adjust OLED pixel brightness from a desktop dialog or the command line
 - control TV volume and mute from the command line

--- a/crates/lg-buddy/src/dev.rs
+++ b/crates/lg-buddy/src/dev.rs
@@ -380,7 +380,7 @@ fn run_webos_power_off_probe<W: Write>(writer: &mut W) -> Result<(), DevError> {
         )
         .map_err(DevError::Authentication)?;
         let power_state = client.power_state().map_err(DevError::PowerState)?;
-        require_active_power_state(&power_state)?;
+        require_power_off_state(&power_state)?;
         client.power_off().map_err(DevError::Control)?;
         Ok(power_state)
     })
@@ -417,8 +417,11 @@ fn run_webos_set_backlight_probe<W: Write>(
     )
 }
 
-fn require_active_power_state(power_state: &WebOsPowerState) -> Result<(), DevError> {
-    if power_state == &WebOsPowerState::Active {
+fn require_power_off_state(power_state: &WebOsPowerState) -> Result<(), DevError> {
+    if matches!(
+        power_state,
+        WebOsPowerState::Active | WebOsPowerState::ScreenOff
+    ) {
         Ok(())
     } else {
         Err(DevError::PowerOffPrecondition {
@@ -681,8 +684,8 @@ fn write_auth_event<W: Write>(
 #[cfg(test)]
 mod tests {
     use super::{
-        require_active_backlight_write_state, require_active_power_state,
-        run_webos_auth_probe_with, run_webos_power_off_probe_with, run_webos_read_probe_with,
+        require_active_backlight_write_state, require_power_off_state, run_webos_auth_probe_with,
+        run_webos_power_off_probe_with, run_webos_read_probe_with,
         run_webos_screen_control_probe_with, run_webos_set_backlight_probe_with,
         run_webos_set_input_probe_with, DevCommand, DevError, DevParseError,
         WebOsControlProbeCommand, WebOsProbeContext, WebOsReadProbeResult,
@@ -999,15 +1002,16 @@ LG Buddy WebOS Control Probe: power_off_from=Active\n"
     }
 
     #[test]
-    fn power_off_probe_requires_active_power_state() {
-        assert!(require_active_power_state(&WebOsPowerState::Active).is_ok());
+    fn power_off_probe_accepts_active_and_screen_off_states() {
+        assert!(require_power_off_state(&WebOsPowerState::Active).is_ok());
+        assert!(require_power_off_state(&WebOsPowerState::ScreenOff).is_ok());
 
-        let error = require_active_power_state(&WebOsPowerState::ScreenOff)
-            .expect_err("screen-off TV should not be powered off by the probe");
+        let error = require_power_off_state(&WebOsPowerState::Suspend)
+            .expect_err("suspended TV should not be powered off by the probe");
         assert!(matches!(
             error,
             DevError::PowerOffPrecondition {
-                actual: WebOsPowerState::ScreenOff
+                actual: WebOsPowerState::Suspend
             }
         ));
     }

--- a/crates/lg-buddy/src/events.rs
+++ b/crates/lg-buddy/src/events.rs
@@ -59,6 +59,7 @@ pub enum RuntimeEventKind {
     MachineResumed,
     NetworkTeardownImminent { machine_sleep_pending: Option<bool> },
     SessionIdle,
+    SessionTimedPowerOff,
     SessionActive,
     SessionLocked,
     SessionUnlocked,

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -278,6 +278,7 @@ impl LifecycleEvent {
             RuntimeEventKind::MachinePreparingForSleep => Some(Self::MachinePreparingForSleep),
             RuntimeEventKind::MachineResumed => Some(Self::MachineResumed),
             RuntimeEventKind::SessionIdle
+            | RuntimeEventKind::SessionTimedPowerOff
             | RuntimeEventKind::SessionActive
             | RuntimeEventKind::SessionLocked
             | RuntimeEventKind::SessionUnlocked

--- a/crates/lg-buddy/src/policy.rs
+++ b/crates/lg-buddy/src/policy.rs
@@ -67,6 +67,7 @@ pub enum ActionKind {
     TvScreenBlank,
     TvScreenRestore,
     TvPowerOffFallback,
+    TvTimedIdlePowerOff,
     TvInputRestore,
     WakeOnLan,
     TvSystemSleepPowerOff,

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -238,6 +238,18 @@ pub(crate) fn run_screen_off_from_env_for_event<W: Write>(
     writer: &mut W,
     event: RuntimeEvent,
 ) -> Result<(), RunError> {
+    run_screen_off_from_env_for_event_with_result(writer, event).map(|_| ())
+}
+
+#[derive(Debug)]
+pub(crate) struct ScreenOffActionResult {
+    pub(crate) blank_succeeded: bool,
+}
+
+pub(crate) fn run_screen_off_from_env_for_event_with_result<W: Write>(
+    writer: &mut W,
+    event: RuntimeEvent,
+) -> Result<ScreenOffActionResult, RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
     let config = load_config(&config_path).map_err(RunError::Config)?;
     let marker =
@@ -252,7 +264,7 @@ pub(crate) fn run_screen_off_from_env_for_event<W: Write>(
     let lifecycle_status =
         SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
 
-    run_screen_off_with_event(
+    run_screen_off_with_result_for_event(
         writer,
         &config,
         &marker,
@@ -261,6 +273,53 @@ pub(crate) fn run_screen_off_from_env_for_event<W: Write>(
         &mut phase_provider,
         &lifecycle_status,
     )
+    .map(|result| ScreenOffActionResult {
+        blank_succeeded: result.blank_succeeded,
+    })
+}
+
+pub(crate) fn run_timed_power_off_from_env_for_event<W: Write>(
+    writer: &mut W,
+    event: RuntimeEvent,
+) -> Result<(), RunError> {
+    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
+    let config = load_config(&config_path).map_err(RunError::Config)?;
+    let marker =
+        ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
+    if !config.screen_idle_blank.is_enabled() {
+        writeln!(
+            writer,
+            "LG Buddy Timed Power Off: Screen idle blanking is disabled; skipping power-off."
+        )?;
+        return Ok(());
+    }
+    if !marker.exists() {
+        writeln!(
+            writer,
+            "LG Buddy Timed Power Off: Screen ownership marker is absent; skipping power-off."
+        )?;
+        return Ok(());
+    }
+    let tv_client = build_tv_client(
+        &config_path,
+        config.tv_ip,
+        config.tv_platform,
+        TvClientBuildOptions::production(),
+    )?;
+    let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
+    let lifecycle_status =
+        SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
+
+    run_timed_power_off_with_event(
+        writer,
+        &config,
+        &marker,
+        &tv_client,
+        event,
+        &mut phase_provider,
+        &lifecycle_status,
+    )
+    .map(|_| ())
 }
 
 pub(crate) fn run_screen_on_from_env<W: Write>(writer: &mut W) -> Result<(), RunError> {
@@ -328,6 +387,7 @@ pub(crate) fn run_screen_off_with<W: Write>(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn run_screen_off_with_event<
     W: Write,
     C: TvClient,
@@ -374,6 +434,7 @@ pub(crate) fn run_screen_off_with_outcome<W: Write, C: TvClient>(
     )
 }
 
+#[cfg(test)]
 pub(crate) fn run_screen_off_with_outcome_for_event<
     W: Write,
     C: TvClient,
@@ -388,6 +449,38 @@ pub(crate) fn run_screen_off_with_outcome_for_event<
     phase_provider: &mut P,
     lifecycle_status: &L,
 ) -> Result<PolicyOutcome, RunError> {
+    run_screen_off_with_result_for_event(
+        writer,
+        config,
+        marker,
+        tv_client,
+        event,
+        phase_provider,
+        lifecycle_status,
+    )
+    .map(|result| result.outcome)
+}
+
+struct ScreenOffExecutionResult {
+    #[cfg(test)]
+    outcome: PolicyOutcome,
+    blank_succeeded: bool,
+}
+
+fn run_screen_off_with_result_for_event<
+    W: Write,
+    C: TvClient,
+    P: RuntimePhaseProvider,
+    L: SystemLifecycleStatusProvider,
+>(
+    writer: &mut W,
+    config: &Config,
+    marker: &ScreenOwnershipMarker,
+    tv_client: &C,
+    event: RuntimeEvent,
+    phase_provider: &mut P,
+    lifecycle_status: &L,
+) -> Result<ScreenOffExecutionResult, RunError> {
     let mut outcome = PolicyOutcome::new();
     if !apply_screen_action_eligibility(
         writer,
@@ -398,10 +491,15 @@ pub(crate) fn run_screen_off_with_outcome_for_event<
         lifecycle_status,
         &mut outcome,
     )? {
-        return Ok(outcome);
+        return Ok(ScreenOffExecutionResult {
+            #[cfg(test)]
+            outcome,
+            blank_succeeded: false,
+        });
     }
 
     let tv = TvDevice::new(tv_client, config.tv_ip);
+    let mut blank_succeeded = false;
 
     match tv.input().current() {
         Ok(current_input) => {
@@ -414,7 +512,7 @@ pub(crate) fn run_screen_off_with_outcome_for_event<
             let next = decision.next;
             outcome.merge(decision.outcome);
             if next == ScreenOffNext::Blank {
-                execute_screen_blank(writer, config, marker, &tv, &mut outcome)?;
+                blank_succeeded = execute_screen_blank(writer, config, marker, &tv, &mut outcome)?;
             }
         }
         Err(err) => {
@@ -438,6 +536,156 @@ pub(crate) fn run_screen_off_with_outcome_for_event<
                     &mut outcome,
                 )?;
             }
+        }
+    }
+
+    Ok(ScreenOffExecutionResult {
+        #[cfg(test)]
+        outcome,
+        blank_succeeded,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn run_timed_power_off_with<W: Write, C: TvClient>(
+    writer: &mut W,
+    config: &Config,
+    marker: &ScreenOwnershipMarker,
+    tv_client: &C,
+) -> Result<PolicyOutcome, RunError> {
+    let mut phase_provider = NoopRuntimePhaseProvider;
+    let lifecycle_status = NoopSystemLifecycleStatusProvider;
+    run_timed_power_off_with_event(
+        writer,
+        config,
+        marker,
+        tv_client,
+        RuntimeEvent::new(
+            EventSource::DesktopSession,
+            RuntimeEventKind::SessionTimedPowerOff,
+        ),
+        &mut phase_provider,
+        &lifecycle_status,
+    )
+}
+
+pub(crate) fn run_timed_power_off_with_event<
+    W: Write,
+    C: TvClient,
+    P: RuntimePhaseProvider,
+    L: SystemLifecycleStatusProvider,
+>(
+    writer: &mut W,
+    config: &Config,
+    marker: &ScreenOwnershipMarker,
+    tv_client: &C,
+    event: RuntimeEvent,
+    phase_provider: &mut P,
+    lifecycle_status: &L,
+) -> Result<PolicyOutcome, RunError> {
+    const PREFIX: &str = "LG Buddy Timed Power Off";
+
+    if !config.screen_idle_blank.is_enabled() {
+        writeln!(
+            writer,
+            "{PREFIX}: Screen idle blanking is disabled; skipping power-off."
+        )?;
+        return Ok(PolicyOutcome::new()
+            .with_no_action(DecisionReason::new(DecisionReasonCode::ConfigDisabled)));
+    }
+
+    let mut outcome = PolicyOutcome::new();
+    if !apply_screen_action_eligibility(
+        writer,
+        PREFIX,
+        config,
+        event,
+        phase_provider,
+        lifecycle_status,
+        &mut outcome,
+    )? {
+        return Ok(outcome);
+    }
+
+    if !marker.exists() {
+        writeln!(
+            writer,
+            "{PREFIX}: Screen ownership marker is absent; skipping power-off."
+        )?;
+        outcome.merge(
+            PolicyOutcome::new()
+                .with_no_action(DecisionReason::new(DecisionReasonCode::MarkerMissing)),
+        );
+        return Ok(outcome);
+    }
+
+    let tv = TvDevice::new(tv_client, config.tv_ip);
+    let current_input = match tv.input().current() {
+        Ok(input) => input,
+        Err(err) => {
+            writeln!(
+                writer,
+                "{PREFIX}: Could not query TV input; skipping power-off without a blind fallback. {err}"
+            )?;
+            outcome.merge(
+                PolicyOutcome::new()
+                    .with_no_action(DecisionReason::with_detail(
+                        DecisionReasonCode::TransportFailure,
+                        err.to_string(),
+                    ))
+                    .with_diagnostic(Diagnostic::warning(format!(
+                        "timed power-off input query failed: {err}"
+                    ))),
+            );
+            return Ok(outcome);
+        }
+    };
+
+    if !current_input.is_hdmi(config.input) {
+        let mismatch = PolicyOutcome::new()
+            .with_no_action(DecisionReason::with_detail(
+                DecisionReasonCode::InputMismatch,
+                format!("TV is on {current_input}, not {}", config.input.as_str()),
+            ))
+            .with_state_transition(clear_session_marker(TransitionReasonCode::InputMismatch));
+        apply_screen_state_transitions(marker, &mismatch)?;
+        outcome.merge(mismatch);
+        writeln!(
+            writer,
+            "{PREFIX}: TV is on {current_input} (not {}); ownership was lost, so power-off was skipped and the marker cleared.",
+            config.input.as_str()
+        )?;
+        return Ok(outcome);
+    }
+
+    outcome.merge(
+        PolicyOutcome::new()
+            .with_action(
+                ActionKind::TvTimedIdlePowerOff,
+                DecisionReason::new(DecisionReasonCode::RuntimeEvent),
+            )
+            .with_state_transition(StateTransition::preserve_marker(
+                StateMarker::SessionScreenOwnership,
+                TransitionReason::new(TransitionReasonCode::ActionSelected),
+            )),
+    );
+    writeln!(
+        writer,
+        "{PREFIX}: Ownership, input, and lifecycle checks passed; powering off TV."
+    )?;
+    match tv.power().off() {
+        Ok(()) => writeln!(
+            writer,
+            "{PREFIX}: TV power-off succeeded; preserving the ownership marker for activity restore."
+        )?,
+        Err(err) => {
+            writeln!(
+                writer,
+                "{PREFIX}: TV power-off failed; preserving the ownership marker. {err}"
+            )?;
+            outcome.merge(PolicyOutcome::new().with_diagnostic(Diagnostic::warning(format!(
+                "timed TV power-off failed: {err}"
+            ))));
         }
     }
 
@@ -887,11 +1135,12 @@ fn execute_screen_blank<W: Write, C: TvClient>(
     marker: &ScreenOwnershipMarker,
     tv: &TvDevice<'_, C>,
     outcome: &mut PolicyOutcome,
-) -> Result<(), RunError> {
+) -> Result<bool, RunError> {
     let observation = match tv.screen().blank() {
         Ok(_) => TvEffectObservation::Succeeded,
         Err(err) => TvEffectObservation::Failed(err.to_string()),
     };
+    let blank_succeeded = matches!(observation, TvEffectObservation::Succeeded);
     let decision = decide_screen_off_after_blank_result(observation.clone());
     apply_screen_state_transitions(marker, &decision.outcome)?;
 
@@ -922,7 +1171,7 @@ fn execute_screen_blank<W: Write, C: TvClient>(
         )?;
     }
 
-    Ok(())
+    Ok(blank_succeeded)
 }
 
 fn execute_screen_off_power_off_fallback<W: Write, C: TvClient>(
@@ -1234,10 +1483,11 @@ mod tests {
     use super::{
         decide_screen_action_eligibility, decide_screen_off_after_input, decide_screen_on_start,
         run_screen_off_with_outcome, run_screen_off_with_outcome_for_event,
-        run_screen_on_with_outcome, run_screen_on_with_outcome_for_event,
-        NoopSystemLifecycleStatusProvider, ScreenActionBlockReason, ScreenActionEligibilityInput,
-        ScreenEligibilityNext, ScreenOffInputObservation, ScreenOffNext, ScreenOnDeps,
-        ScreenOnNext, Sleeper, SystemLifecycleStatusProvider,
+        run_screen_off_with_result_for_event, run_screen_on_with_outcome,
+        run_screen_on_with_outcome_for_event, run_timed_power_off_with,
+        run_timed_power_off_with_event, NoopSystemLifecycleStatusProvider, ScreenActionBlockReason,
+        ScreenActionEligibilityInput, ScreenEligibilityNext, ScreenOffInputObservation,
+        ScreenOffNext, ScreenOnDeps, ScreenOnNext, Sleeper, SystemLifecycleStatusProvider,
     };
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenIdleBlankPolicy, ScreenRestorePolicy,
@@ -1460,6 +1710,214 @@ mod tests {
         assert_eq!(outcome.actions.len(), 1);
         assert_eq!(outcome.actions[0].kind, ActionKind::TvScreenBlank);
         assert!(marker.exists());
+    }
+
+    #[test]
+    fn screen_off_result_arms_escalation_only_for_an_actual_blank() {
+        let temp_dir = TestDir::new("screen-off-actual-blank-result");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let mock = MockBscpylgtv::new("screen-off-actual-blank-result-tv");
+        mock.set_input("HDMI_2");
+        mock.queue_error("turn_screen_off", 1, "blank failed\n");
+        let client = client_for_mock(&mock);
+        let mut phase = FixedRuntimePhaseProvider::not_pending();
+        let lifecycle_status = NoopSystemLifecycleStatusProvider;
+
+        let result = run_screen_off_with_result_for_event(
+            &mut Vec::new(),
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+            RuntimeEvent::new(EventSource::DesktopSession, RuntimeEventKind::SessionIdle),
+            &mut phase,
+            &lifecycle_status,
+        )
+        .expect("fallback power-off should complete");
+
+        assert!(!result.blank_succeeded);
+        assert!(marker.exists());
+        assert_call_commands(&mock, &["get_input", "turn_screen_off", "power_off"]);
+    }
+
+    #[test]
+    fn timed_power_off_rechecks_input_and_preserves_marker_after_success() {
+        let temp_dir = TestDir::new("timed-power-off-success");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create ownership marker");
+        let mock = MockBscpylgtv::new("timed-power-off-success-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let mut output = Vec::new();
+
+        let outcome = run_timed_power_off_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+        )
+        .expect("timed power-off should complete");
+
+        assert!(marker.exists());
+        assert_eq!(outcome.actions.len(), 1);
+        assert_eq!(outcome.actions[0].kind, ActionKind::TvTimedIdlePowerOff);
+        assert_eq!(
+            outcome.state_transitions,
+            vec![StateTransition::preserve_marker(
+                StateMarker::SessionScreenOwnership,
+                TransitionReason::new(TransitionReasonCode::ActionSelected),
+            )]
+        );
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+        assert!(rendered(&output).contains("TV power-off succeeded"));
+    }
+
+    #[test]
+    fn timed_power_off_requires_the_ownership_marker() {
+        let temp_dir = TestDir::new("timed-power-off-marker-missing");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        let mock = MockBscpylgtv::new("timed-power-off-marker-missing-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let mut output = Vec::new();
+
+        let outcome = run_timed_power_off_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+        )
+        .expect("missing marker should skip safely");
+
+        assert!(mock.calls().is_empty());
+        assert_eq!(
+            outcome.no_actions[0].reason.code,
+            DecisionReasonCode::MarkerMissing
+        );
+        assert!(rendered(&output).contains("ownership marker is absent"));
+    }
+
+    #[test]
+    fn timed_power_off_respects_disabled_idle_blanking() {
+        let temp_dir = TestDir::new("timed-power-off-disabled");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create ownership marker");
+        let mock = MockBscpylgtv::new("timed-power-off-disabled-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let mut config = sample_config(HdmiInput::Hdmi2);
+        config.screen_idle_blank = ScreenIdleBlankPolicy::Disabled;
+        let mut output = Vec::new();
+
+        let outcome = run_timed_power_off_with(&mut output, &config, &marker, &client)
+            .expect("disabled idle blanking should skip safely");
+
+        assert!(mock.calls().is_empty());
+        assert_eq!(
+            outcome.no_actions[0].reason.code,
+            DecisionReasonCode::ConfigDisabled
+        );
+        assert!(rendered(&output).contains("idle blanking is disabled"));
+    }
+
+    #[test]
+    fn timed_power_off_clears_ownership_on_input_mismatch() {
+        let temp_dir = TestDir::new("timed-power-off-input-mismatch");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create ownership marker");
+        let mock = MockBscpylgtv::new("timed-power-off-input-mismatch-tv");
+        mock.set_input("HDMI_4");
+        let client = client_for_mock(&mock);
+        let mut output = Vec::new();
+
+        run_timed_power_off_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+        )
+        .expect("input mismatch should skip safely");
+
+        assert!(!marker.exists());
+        assert_call_commands(&mock, &["get_input"]);
+        assert!(rendered(&output).contains("ownership was lost"));
+    }
+
+    #[test]
+    fn timed_power_off_does_not_fall_back_when_input_query_fails() {
+        let temp_dir = TestDir::new("timed-power-off-input-failure");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create ownership marker");
+        let mock = MockBscpylgtv::new("timed-power-off-input-failure-tv");
+        mock.queue_error("get_input", 1, "query failed\n");
+        let client = client_for_mock(&mock);
+        let mut output = Vec::new();
+
+        run_timed_power_off_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+        )
+        .expect("input query failure should skip safely");
+
+        assert!(marker.exists());
+        assert_call_commands(&mock, &["get_input"]);
+        assert!(rendered(&output).contains("without a blind fallback"));
+    }
+
+    #[test]
+    fn timed_power_off_rechecks_lifecycle_eligibility() {
+        let temp_dir = TestDir::new("timed-power-off-lifecycle-pending");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create ownership marker");
+        let mock = MockBscpylgtv::new("timed-power-off-lifecycle-pending-tv");
+        mock.set_input("HDMI_2");
+        let client = client_for_mock(&mock);
+        let mut phase = FixedRuntimePhaseProvider::pending();
+        let lifecycle_status = NoopSystemLifecycleStatusProvider;
+        let mut output = Vec::new();
+
+        run_timed_power_off_with_event(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+            RuntimeEvent::new(
+                EventSource::DesktopSession,
+                RuntimeEventKind::SessionTimedPowerOff,
+            ),
+            &mut phase,
+            &lifecycle_status,
+        )
+        .expect("pending lifecycle should skip timed power-off");
+
+        assert!(marker.exists());
+        assert!(mock.calls().is_empty());
+        assert!(rendered(&output).contains("Machine sleep is pending"));
+    }
+
+    #[test]
+    fn timed_power_off_attempt_failure_preserves_marker_without_retrying_here() {
+        let temp_dir = TestDir::new("timed-power-off-failure");
+        let marker = ScreenOwnershipMarker::new(temp_dir.path().to_path_buf());
+        marker.create().expect("create ownership marker");
+        let mock = MockBscpylgtv::new("timed-power-off-failure-tv");
+        mock.set_input("HDMI_2");
+        mock.queue_error("power_off", 1, "power failed\n");
+        let client = client_for_mock(&mock);
+        let mut output = Vec::new();
+
+        run_timed_power_off_with(
+            &mut output,
+            &sample_config(HdmiInput::Hdmi2),
+            &marker,
+            &client,
+        )
+        .expect("power failure should remain a completed attempt");
+
+        assert!(marker.exists());
+        assert_call_commands(&mock, &["get_input", "power_off"]);
+        assert!(rendered(&output).contains("TV power-off failed"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -11,6 +11,7 @@ pub enum InactivityObservation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InactivityDecision {
     BlankNow,
+    TimedPowerOffNow,
     RestoreNow,
     NoOp,
 }
@@ -19,13 +20,19 @@ pub enum InactivityDecision {
 enum InactivityPhase {
     Unknown,
     Active,
-    Idle,
+    BlankRequested,
+    Blanked,
+    InactiveWithoutEscalation,
+    TimedPowerOffAttempted,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct InactivityEngine {
     blank_after: Duration,
-    blank_at: Instant,
+    blank_at: Option<Instant>,
+    provider_driven_blank: bool,
+    power_off_after: Duration,
+    power_off_at: Option<Instant>,
     phase: InactivityPhase,
     restore_pending: bool,
     session_locked_since: Option<Instant>,
@@ -34,10 +41,45 @@ pub struct InactivityEngine {
 }
 
 impl InactivityEngine {
+    pub const DEFAULT_POWER_OFF_AFTER: Duration = Duration::from_secs(5 * 60);
+
     pub fn new(blank_after: Duration, started_at: Instant) -> Self {
+        Self::new_with_power_off_after(blank_after, Self::DEFAULT_POWER_OFF_AFTER, started_at)
+    }
+
+    pub fn new_provider_driven(power_off_after: Duration, started_at: Instant) -> Self {
+        let mut engine =
+            Self::new_with_power_off_after(Duration::ZERO, power_off_after, started_at);
+        engine.blank_at = None;
+        engine.provider_driven_blank = true;
+        engine
+    }
+
+    pub fn new_provider_driven_with_restore_pending(
+        power_off_after: Duration,
+        started_at: Instant,
+    ) -> Self {
+        let mut engine = Self::new_with_restore_pending_and_power_off_after(
+            Duration::ZERO,
+            power_off_after,
+            started_at,
+        );
+        engine.blank_at = None;
+        engine.provider_driven_blank = true;
+        engine
+    }
+
+    pub fn new_with_power_off_after(
+        blank_after: Duration,
+        power_off_after: Duration,
+        started_at: Instant,
+    ) -> Self {
         Self {
             blank_after,
-            blank_at: started_at + blank_after,
+            blank_at: Some(started_at + blank_after),
+            provider_driven_blank: false,
+            power_off_after,
+            power_off_at: None,
             phase: InactivityPhase::Unknown,
             restore_pending: false,
             session_locked_since: None,
@@ -47,10 +89,25 @@ impl InactivityEngine {
     }
 
     pub fn new_with_restore_pending(blank_after: Duration, started_at: Instant) -> Self {
+        Self::new_with_restore_pending_and_power_off_after(
+            blank_after,
+            Self::DEFAULT_POWER_OFF_AFTER,
+            started_at,
+        )
+    }
+
+    pub fn new_with_restore_pending_and_power_off_after(
+        blank_after: Duration,
+        power_off_after: Duration,
+        started_at: Instant,
+    ) -> Self {
         Self {
             blank_after,
-            blank_at: started_at + blank_after,
-            phase: InactivityPhase::Unknown,
+            blank_at: Some(started_at + blank_after),
+            provider_driven_blank: false,
+            power_off_after,
+            power_off_at: Some(started_at + power_off_after),
+            phase: InactivityPhase::Blanked,
             restore_pending: true,
             session_locked_since: None,
             lock_activity_floor: None,
@@ -58,8 +115,50 @@ impl InactivityEngine {
         }
     }
 
-    pub fn time_until_blank(&self, now: Instant) -> Option<Duration> {
-        (self.phase != InactivityPhase::Idle).then(|| self.blank_at.saturating_duration_since(now))
+    pub fn time_until_action(&self, now: Instant) -> Option<Duration> {
+        match self.phase {
+            InactivityPhase::Unknown | InactivityPhase::Active => self
+                .blank_at
+                .map(|deadline| deadline.saturating_duration_since(now)),
+            InactivityPhase::Blanked => self
+                .power_off_at
+                .map(|deadline| deadline.saturating_duration_since(now)),
+            InactivityPhase::BlankRequested
+            | InactivityPhase::InactiveWithoutEscalation
+            | InactivityPhase::TimedPowerOffAttempted => None,
+        }
+    }
+
+    pub fn timed_power_off_pending(&self) -> bool {
+        self.phase == InactivityPhase::Blanked && self.power_off_at.is_some()
+    }
+
+    pub fn observe_provider_idle(&mut self) -> InactivityDecision {
+        if matches!(
+            self.phase,
+            InactivityPhase::Unknown | InactivityPhase::Active
+        ) {
+            self.phase = InactivityPhase::BlankRequested;
+            self.blank_at = None;
+            return InactivityDecision::BlankNow;
+        }
+
+        InactivityDecision::NoOp
+    }
+
+    pub fn complete_blank(&mut self, succeeded: bool, completed_at: Instant) {
+        if self.phase != InactivityPhase::BlankRequested {
+            return;
+        }
+
+        if succeeded {
+            self.phase = InactivityPhase::Blanked;
+            self.restore_pending = true;
+            self.power_off_at = Some(completed_at + self.power_off_after);
+        } else {
+            self.phase = InactivityPhase::InactiveWithoutEscalation;
+            self.power_off_at = None;
+        }
     }
 
     pub fn observe_activity(
@@ -87,24 +186,40 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
-        if self.phase == InactivityPhase::Idle
-            && self.lock_activity_floor.is_some_and(|locked_at| {
-                !matches!(
-                    observation,
-                    InactivityObservation::DesktopActivityObserved
-                        | InactivityObservation::UserActivityObserved
-                ) || observed_at <= locked_at
-            })
-        {
+        if matches!(
+            self.phase,
+            InactivityPhase::BlankRequested
+                | InactivityPhase::Blanked
+                | InactivityPhase::InactiveWithoutEscalation
+                | InactivityPhase::TimedPowerOffAttempted
+        ) && self.lock_activity_floor.is_some_and(|locked_at| {
+            !matches!(
+                observation,
+                InactivityObservation::DesktopActivityObserved
+                    | InactivityObservation::UserActivityObserved
+            ) || observed_at <= locked_at
+        }) {
             return InactivityDecision::NoOp;
         }
 
-        self.blank_at = self.blank_at.max(observed_at + self.blank_after);
+        if self.provider_driven_blank {
+            self.blank_at = None;
+        } else {
+            self.blank_at = Some(
+                self.blank_at
+                    .unwrap_or(observed_at)
+                    .max(observed_at + self.blank_after),
+            );
+        }
 
         match self.phase {
-            InactivityPhase::Idle => {
+            InactivityPhase::BlankRequested
+            | InactivityPhase::Blanked
+            | InactivityPhase::InactiveWithoutEscalation
+            | InactivityPhase::TimedPowerOffAttempted => {
                 self.phase = InactivityPhase::Active;
                 self.restore_pending = false;
+                self.power_off_at = None;
                 self.lock_activity_floor = None;
                 InactivityDecision::RestoreNow
             }
@@ -124,13 +239,27 @@ impl InactivityEngine {
     }
 
     pub fn observe_time(&mut self, observed_at: Instant) -> InactivityDecision {
-        if self.phase == InactivityPhase::Idle || observed_at < self.blank_at {
-            return InactivityDecision::NoOp;
+        match self.phase {
+            InactivityPhase::Unknown | InactivityPhase::Active
+                if self
+                    .blank_at
+                    .is_some_and(|deadline| observed_at >= deadline) =>
+            {
+                self.phase = InactivityPhase::BlankRequested;
+                self.lock_activity_floor = self.session_locked_since;
+                InactivityDecision::BlankNow
+            }
+            InactivityPhase::Blanked
+                if self
+                    .power_off_at
+                    .is_some_and(|deadline| observed_at >= deadline) =>
+            {
+                self.phase = InactivityPhase::TimedPowerOffAttempted;
+                self.power_off_at = None;
+                InactivityDecision::TimedPowerOffNow
+            }
+            _ => InactivityDecision::NoOp,
         }
-
-        self.phase = InactivityPhase::Idle;
-        self.lock_activity_floor = self.session_locked_since;
-        InactivityDecision::BlankNow
     }
 
     pub fn observe_lock(&mut self, observed_at: Instant) -> InactivityDecision {
@@ -144,11 +273,18 @@ impl InactivityEngine {
         }
         self.lock_activity_floor = Some(locked_at);
 
-        if self.phase == InactivityPhase::Idle {
+        if matches!(
+            self.phase,
+            InactivityPhase::BlankRequested
+                | InactivityPhase::Blanked
+                | InactivityPhase::InactiveWithoutEscalation
+                | InactivityPhase::TimedPowerOffAttempted
+        ) {
             return InactivityDecision::NoOp;
         }
 
-        self.phase = InactivityPhase::Idle;
+        self.phase = InactivityPhase::BlankRequested;
+        self.blank_at = None;
         InactivityDecision::BlankNow
     }
 
@@ -223,14 +359,163 @@ mod tests {
     }
 
     #[test]
-    fn pending_restore_does_not_suppress_timeout_reconciliation() {
+    fn restart_with_owned_blank_starts_a_fresh_power_off_grace_period() {
         let started_at = Instant::now();
-        let mut engine =
-            InactivityEngine::new_with_restore_pending(Duration::from_secs(5), started_at);
+        let mut engine = InactivityEngine::new_with_restore_pending_and_power_off_after(
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            started_at,
+        );
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_millis(4_999)),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::TimedPowerOffNow
+        );
+    }
+
+    #[test]
+    fn successful_blank_schedules_one_power_off_from_completion_time() {
+        let started_at = Instant::now();
+        let mut engine = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            started_at,
+        );
 
         assert_eq!(
             engine.observe_time(started_at + Duration::from_secs(5)),
             InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, started_at + Duration::from_secs(7));
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(11)),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(12)),
+            InactivityDecision::TimedPowerOffNow
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(20)),
+            InactivityDecision::NoOp
+        );
+    }
+
+    #[test]
+    fn failed_or_skipped_blank_never_schedules_power_off() {
+        let started_at = Instant::now();
+        let mut engine = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            started_at,
+        );
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(false, started_at + Duration::from_secs(5));
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(30)),
+            InactivityDecision::NoOp
+        );
+        assert!(!engine.timed_power_off_pending());
+    }
+
+    #[test]
+    fn activity_at_power_off_deadline_cancels_before_timeout_is_observed() {
+        let started_at = Instant::now();
+        let mut engine = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(5),
+            Duration::from_secs(5),
+            started_at,
+        );
+        let deadline = started_at + Duration::from_secs(10);
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, started_at + Duration::from_secs(5));
+        assert_eq!(
+            engine.observe_activity(InactivityObservation::UserActivityObserved, deadline),
+            InactivityDecision::RestoreNow
+        );
+        assert_eq!(engine.observe_time(deadline), InactivityDecision::NoOp);
+    }
+
+    #[test]
+    fn provider_driven_idle_uses_the_same_post_blank_policy() {
+        let started_at = Instant::now();
+        let mut engine = InactivityEngine::new_provider_driven(Duration::from_secs(5), started_at);
+
+        assert_eq!(engine.time_until_action(started_at), None);
+        assert_eq!(engine.observe_provider_idle(), InactivityDecision::BlankNow);
+        engine.complete_blank(true, started_at);
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::TimedPowerOffNow
+        );
+    }
+
+    #[test]
+    fn provider_driven_activity_waits_for_the_next_provider_idle() {
+        let started_at = Instant::now();
+        let mut engine = InactivityEngine::new_provider_driven(Duration::from_secs(5), started_at);
+
+        assert_eq!(engine.observe_provider_idle(), InactivityDecision::BlankNow);
+        engine.complete_blank(true, started_at);
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::ProviderActive,
+                started_at + Duration::from_secs(1),
+            ),
+            InactivityDecision::RestoreNow
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(30)),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(engine.observe_provider_idle(), InactivityDecision::BlankNow);
+    }
+
+    #[test]
+    fn fresh_activity_allows_one_attempt_in_the_next_idle_cycle() {
+        let started_at = Instant::now();
+        let mut engine = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            started_at,
+        );
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(1)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, started_at + Duration::from_secs(1));
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(2)),
+            InactivityDecision::TimedPowerOffNow
+        );
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                started_at + Duration::from_secs(3),
+            ),
+            InactivityDecision::RestoreNow
+        );
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(4)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, started_at + Duration::from_secs(4));
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::TimedPowerOffNow
         );
     }
 
@@ -319,14 +604,14 @@ mod tests {
         let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.time_until_blank(started_at),
+            engine.time_until_action(started_at),
             Some(Duration::from_secs(5))
         );
         assert_eq!(
             engine.observe_time(started_at + Duration::from_secs(5)),
             InactivityDecision::BlankNow
         );
-        assert_eq!(engine.time_until_blank(started_at), None);
+        assert_eq!(engine.time_until_action(started_at), None);
     }
 
     #[test]
@@ -337,7 +622,7 @@ mod tests {
 
         assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
         assert_eq!(engine.observe_lock(locked_at), InactivityDecision::NoOp);
-        assert_eq!(engine.time_until_blank(started_at), None);
+        assert_eq!(engine.time_until_action(started_at), None);
         assert_eq!(
             engine.observe_activity(
                 InactivityObservation::DesktopActivityObserved,
@@ -387,7 +672,7 @@ mod tests {
         );
         assert_eq!(engine.observe_lock(locked_at), InactivityDecision::NoOp);
         assert_eq!(
-            engine.time_until_blank(activity_at),
+            engine.time_until_action(activity_at),
             Some(Duration::from_secs(5))
         );
     }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::io::{self, Write};
 use std::os::fd::OwnedFd;
 use std::path::Path;
+use std::process;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     mpsc, Arc, Mutex,
@@ -55,9 +56,17 @@ const LIFECYCLE_MONITOR_TEST_TIMEOUT_SECS_ENV: &str =
 const LIFECYCLE_MONITOR_TEST_EVENT_LIMIT_ENV: &str = "LG_BUDDY_LIFECYCLE_MONITOR_TEST_EVENT_LIMIT";
 const GAMEPAD_ACTIVITY_SOURCE_ENV: &str = "LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE";
 const GAMEPAD_ACTIVITY_TEST_AFTER_SECS_ENV: &str = "LG_BUDDY_GAMEPAD_ACTIVITY_TEST_AFTER_SECS";
+const TIMED_POWER_OFF_TEST_AFTER_SECS_ENV: &str = "LG_BUDDY_TIMED_POWER_OFF_TEST_AFTER_SECS";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScreenOffResult {
+    pub output: String,
+    pub blank_succeeded: bool,
+}
 
 pub trait SessionActionExecutor {
-    fn screen_off(&mut self, event: RuntimeEvent) -> Result<String, RunError>;
+    fn screen_off(&mut self, event: RuntimeEvent) -> Result<ScreenOffResult, RunError>;
+    fn timed_power_off(&mut self, event: RuntimeEvent) -> Result<String, RunError>;
     fn screen_on(&mut self, event: RuntimeEvent) -> Result<String, RunError>;
     fn before_sleep(&mut self, event: RuntimeEvent) -> Result<String, RunError>;
     fn after_resume(&mut self, event: RuntimeEvent) -> Result<String, RunError>;
@@ -77,8 +86,18 @@ pub trait SessionActionExecutor {
 pub struct RuntimeActionExecutor;
 
 impl SessionActionExecutor for RuntimeActionExecutor {
-    fn screen_off(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
-        run_action(|writer| crate::screen::run_screen_off_from_env_for_event(writer, event))
+    fn screen_off(&mut self, event: RuntimeEvent) -> Result<ScreenOffResult, RunError> {
+        let mut output = Vec::new();
+        let result =
+            crate::screen::run_screen_off_from_env_for_event_with_result(&mut output, event)?;
+        Ok(ScreenOffResult {
+            output: String::from_utf8_lossy(&output).into_owned(),
+            blank_succeeded: result.blank_succeeded,
+        })
+    }
+
+    fn timed_power_off(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
+        run_action(|writer| crate::screen::run_timed_power_off_from_env_for_event(writer, event))
     }
 
     fn screen_on(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
@@ -196,26 +215,14 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
         match event {
             SessionEvent::Idle => {
                 writeln!(writer, "LG Buddy Monitor: Session became idle.")?;
-                let runtime_event = RuntimeEvent::from_session_event(source, event);
-                match self.executor.screen_off(runtime_event) {
-                    Ok(output) => write_command_output(writer, &output)?,
-                    Err(err) => {
-                        writeln!(writer, "LG Buddy Monitor: screen-off action failed. {err}")?
-                    }
-                }
+                let _ = self.dispatch_screen_off(writer, source, event)?;
             }
             SessionEvent::Lock => {
                 writeln!(
                     writer,
                     "LG Buddy Monitor: Session locked; requesting screen blank."
                 )?;
-                let runtime_event = RuntimeEvent::from_session_event(source, event);
-                match self.executor.screen_off(runtime_event) {
-                    Ok(output) => write_command_output(writer, &output)?,
-                    Err(err) => {
-                        writeln!(writer, "LG Buddy Monitor: screen-off action failed. {err}")?
-                    }
-                }
+                let _ = self.dispatch_screen_off(writer, source, event)?;
             }
             SessionEvent::Active | SessionEvent::WakeRequested | SessionEvent::UserActivity => {
                 writeln!(
@@ -268,6 +275,43 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
             }
         }
 
+        Ok(())
+    }
+
+    fn dispatch_screen_off<W: Write>(
+        &mut self,
+        writer: &mut W,
+        source: EventSource,
+        event: SessionEvent,
+    ) -> Result<bool, SessionRunnerError> {
+        let runtime_event = RuntimeEvent::from_session_event(source, event);
+        match self.executor.screen_off(runtime_event) {
+            Ok(result) => {
+                write_command_output(writer, &result.output)?;
+                Ok(result.blank_succeeded)
+            }
+            Err(err) => {
+                writeln!(writer, "LG Buddy Monitor: screen-off action failed. {err}")?;
+                Ok(false)
+            }
+        }
+    }
+
+    fn dispatch_timed_power_off<W: Write>(
+        &mut self,
+        writer: &mut W,
+    ) -> Result<(), SessionRunnerError> {
+        let event = RuntimeEvent::new(
+            EventSource::DesktopSession,
+            crate::events::RuntimeEventKind::SessionTimedPowerOff,
+        );
+        match self.executor.timed_power_off(event) {
+            Ok(output) => write_command_output(writer, &output)?,
+            Err(err) => writeln!(
+                writer,
+                "LG Buddy Monitor: timed power-off action failed. {err}"
+            )?,
+        }
         Ok(())
     }
 
@@ -625,7 +669,12 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
                         })?;
                         return run_wayland_monitor(writer, &mut dispatcher, connection);
                     }
-                    ScreenBackend::Swayidle => return run_swayidle_monitor(writer),
+                    ScreenBackend::Swayidle => {
+                        let mut dispatcher = SessionEventDispatcher::new(
+                            executor.take().expect("executor available"),
+                        );
+                        return run_swayidle_monitor(writer, &mut dispatcher);
+                    }
                     ScreenBackend::Auto => {
                         return Err(SessionRunnerError::Failed {
                             backend: ScreenBackend::Auto,
@@ -773,12 +822,53 @@ where
     S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
     L: FnOnce(mpsc::Sender<RunnerMessage>) -> Option<LogindLockObserver>,
 {
+    run_session_monitor_with_lock_monitor(
+        writer,
+        dispatcher,
+        backend,
+        InitialBlankTrigger::Deadline,
+        spawn_monitor,
+        spawn_lock_monitor,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InitialBlankTrigger {
+    Deadline,
+    Provider,
+}
+
+fn run_session_monitor_with_lock_monitor<W, E, S, L>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    backend: ScreenBackend,
+    initial_blank_trigger: InitialBlankTrigger,
+    spawn_monitor: S,
+    spawn_lock_monitor: L,
+) -> Result<(), SessionRunnerError>
+where
+    W: Write,
+    E: SessionActionExecutor,
+    S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
+    L: FnOnce(mpsc::Sender<RunnerMessage>) -> Option<LogindLockObserver>,
+{
     let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
+    let power_off_after = resolve_timed_power_off_after();
     let started_at = Instant::now();
-    let mut inactivity = if session_screen_ownership_marker_exists(backend)? {
-        InactivityEngine::new_with_restore_pending(blank_after, started_at)
+    let marker_exists = session_screen_ownership_marker_exists(backend)?;
+    let mut inactivity = if marker_exists && initial_blank_trigger == InitialBlankTrigger::Provider
+    {
+        InactivityEngine::new_provider_driven_with_restore_pending(power_off_after, started_at)
+    } else if marker_exists {
+        InactivityEngine::new_with_restore_pending_and_power_off_after(
+            blank_after,
+            power_off_after,
+            started_at,
+        )
+    } else if initial_blank_trigger == InitialBlankTrigger::Provider {
+        InactivityEngine::new_provider_driven(power_off_after, started_at)
     } else {
-        InactivityEngine::new(blank_after, started_at)
+        InactivityEngine::new_with_power_off_after(blank_after, power_off_after, started_at)
     };
 
     let (sender, receiver) = mpsc::channel();
@@ -789,7 +879,7 @@ where
     let mut monitor_result = Ok(());
 
     loop {
-        let message = match inactivity.time_until_blank(Instant::now()) {
+        let message = match inactivity.time_until_action(Instant::now()) {
             Some(wait) => match receiver.recv_timeout(wait) {
                 Ok(message) => message,
                 Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -831,10 +921,20 @@ where
             )?,
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Idle,
+                source,
                 ..
             } => {
-                // Provider idle is observational. Only LG Buddy's inactivity
-                // deadline decides when to blank.
+                if initial_blank_trigger == InitialBlankTrigger::Provider
+                    && inactivity.observe_provider_idle() == InactivityDecision::BlankNow
+                {
+                    handle_blank_request(
+                        writer,
+                        dispatcher,
+                        &mut inactivity,
+                        source,
+                        SessionEvent::Idle,
+                    )?;
+                }
             }
             RunnerMessage::SessionEvent {
                 event: SessionEvent::Active,
@@ -902,22 +1002,50 @@ where
     monitor_result
 }
 
-fn run_swayidle_monitor<W: Write>(writer: &mut W) -> Result<(), SessionRunnerError> {
+fn run_swayidle_monitor<W: Write, E: SessionActionExecutor>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+) -> Result<(), SessionRunnerError> {
     let idle_timeout_secs = resolve_idle_timeout_secs();
-    let current_exe = std::env::current_exe()?;
+    let marker = ScreenOwnershipMarker::from_env(StateScope::Session).map_err(|err| {
+        SessionRunnerError::Failed {
+            backend: ScreenBackend::Swayidle,
+            message: format!("failed to resolve swayidle event path: {err}"),
+        }
+    })?;
+    let event_path = marker
+        .state_dir()
+        .join(format!("swayidle-session-events-{}", process::id()));
 
     writeln!(
         writer,
         "LG Buddy Monitor: Using swayidle backend (timeout: {idle_timeout_secs}s)."
     )?;
 
-    run_swayidle_source(idle_timeout_secs, &current_exe).map_err(|err| match err {
-        SwayidleSourceError::Io(err) => SessionRunnerError::Io(err.to_string()),
-        SwayidleSourceError::Exited(_) => SessionRunnerError::Failed {
-            backend: ScreenBackend::Swayidle,
-            message: err.to_string(),
+    run_session_monitor_with_lock_monitor(
+        writer,
+        dispatcher,
+        ScreenBackend::Swayidle,
+        InitialBlankTrigger::Provider,
+        move |sender, _latest_observation| {
+            thread::spawn(move || {
+                let event_sender = sender.clone();
+                let result =
+                    run_swayidle_source(idle_timeout_secs, &event_path, move |observation| {
+                        send_source_observation(&event_sender, observation)
+                    })
+                    .map_err(|err| match err {
+                        SwayidleSourceError::Io(err) => SessionRunnerError::Io(err.to_string()),
+                        SwayidleSourceError::Exited(_) => SessionRunnerError::Failed {
+                            backend: ScreenBackend::Swayidle,
+                            message: err.to_string(),
+                        },
+                    });
+                let _ = sender.send(RunnerMessage::MonitorExited(result));
+            })
         },
-    })
+        |sender| Some(spawn_logind_lock_monitor(sender)),
+    )
 }
 
 fn map_gnome_source_error(err: GnomeSourceError) -> SessionRunnerError {
@@ -962,6 +1090,15 @@ fn session_screen_ownership_marker_exists(
 
 fn resolve_idle_timeout_ms() -> u64 {
     resolve_idle_timeout_secs().saturating_mul(1000)
+}
+
+fn resolve_timed_power_off_after() -> Duration {
+    std::env::var(TIMED_POWER_OFF_TEST_AFTER_SECS_ENV)
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .and_then(|value| Duration::try_from_secs_f64(value).ok())
+        .unwrap_or(InactivityEngine::DEFAULT_POWER_OFF_AFTER)
 }
 
 fn resolve_lifecycle_monitor_test_timeout() -> Option<Duration> {
@@ -1474,10 +1611,12 @@ fn handle_inactivity_observation<W: Write, E: SessionActionExecutor>(
     observation: InactivityObservation,
     observed_at: Instant,
 ) -> Result<(), SessionRunnerError> {
+    let canceled_power_off = inactivity.timed_power_off_pending();
     let decision = inactivity.observe_activity(observation, observed_at);
     let event = match (observation, decision) {
         (_, InactivityDecision::NoOp) => None,
         (_, InactivityDecision::BlankNow) => None,
+        (_, InactivityDecision::TimedPowerOffNow) => None,
         (InactivityObservation::ProviderActive, InactivityDecision::RestoreNow) => {
             Some(SessionEvent::Active)
         }
@@ -1492,6 +1631,12 @@ fn handle_inactivity_observation<W: Write, E: SessionActionExecutor>(
     };
 
     if let Some(event) = event {
+        if canceled_power_off {
+            writeln!(
+                writer,
+                "LG Buddy Monitor: Activity canceled the pending timed power-off."
+            )?;
+        }
         dispatcher.dispatch_event_from_source(writer, source, event)?;
     }
 
@@ -1504,8 +1649,22 @@ fn handle_inactivity_timeout<W: Write, E: SessionActionExecutor>(
     inactivity: &mut InactivityEngine,
     observed_at: Instant,
 ) -> Result<(), SessionRunnerError> {
-    if inactivity.observe_time(observed_at) == InactivityDecision::BlankNow {
-        dispatcher.dispatch_event(writer, SessionEvent::Idle)?;
+    match inactivity.observe_time(observed_at) {
+        InactivityDecision::BlankNow => handle_blank_request(
+            writer,
+            dispatcher,
+            inactivity,
+            EventSource::DesktopSession,
+            SessionEvent::Idle,
+        )?,
+        InactivityDecision::TimedPowerOffNow => {
+            writeln!(
+                writer,
+                "LG Buddy Monitor: Timed power-off deadline reached; rechecking ownership, input, and lifecycle eligibility."
+            )?;
+            dispatcher.dispatch_timed_power_off(writer)?;
+        }
+        InactivityDecision::RestoreNow | InactivityDecision::NoOp => {}
     }
 
     Ok(())
@@ -1519,7 +1678,41 @@ fn handle_session_lock<W: Write, E: SessionActionExecutor>(
     observed_at: Instant,
 ) -> Result<(), SessionRunnerError> {
     if inactivity.observe_lock(observed_at) == InactivityDecision::BlankNow {
-        dispatcher.dispatch_event_from_source(writer, source, SessionEvent::Lock)?;
+        handle_blank_request(writer, dispatcher, inactivity, source, SessionEvent::Lock)?;
+    }
+
+    Ok(())
+}
+
+fn handle_blank_request<W: Write, E: SessionActionExecutor>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    inactivity: &mut InactivityEngine,
+    source: EventSource,
+    event: SessionEvent,
+) -> Result<(), SessionRunnerError> {
+    match event {
+        SessionEvent::Idle => writeln!(writer, "LG Buddy Monitor: Session became idle.")?,
+        SessionEvent::Lock => writeln!(
+            writer,
+            "LG Buddy Monitor: Session locked; requesting screen blank."
+        )?,
+        _ => unreachable!("only idle and lock request automatic blanking"),
+    }
+
+    let blank_succeeded = dispatcher.dispatch_screen_off(writer, source, event)?;
+    inactivity.complete_blank(blank_succeeded, Instant::now());
+    if blank_succeeded {
+        writeln!(
+            writer,
+            "LG Buddy Monitor: Screen blank succeeded; timed power-off scheduled in {}s.",
+            resolve_timed_power_off_after().as_secs_f64()
+        )?;
+    } else {
+        writeln!(
+            writer,
+            "LG Buddy Monitor: Screen was not blanked; timed power-off was not scheduled."
+        )?;
     }
 
     Ok(())
@@ -1571,6 +1764,7 @@ mod tests {
     use crate::sources::linux::logind::{
         LogindSessionError, LOGIND_MANAGER_INTERFACE, LOGIND_MANAGER_PATH, LOGIND_SERVICE_NAME,
     };
+    use crate::state::ScreenOwnershipMarker;
     use crate::RunError;
     use std::collections::VecDeque;
     use std::fs;
@@ -1596,6 +1790,11 @@ mod tests {
         before_sleep_events: Vec<RuntimeEvent>,
         after_resume_events: Vec<RuntimeEvent>,
         screen_off_output: String,
+        screen_off_blank_succeeded: bool,
+        timed_power_off_calls: usize,
+        timed_power_off_events: Vec<RuntimeEvent>,
+        timed_power_off_output: String,
+        timed_power_off_error: Option<String>,
         screen_on_output: String,
         before_sleep_output: String,
         after_resume_output: String,
@@ -1618,13 +1817,25 @@ mod tests {
     }
 
     impl SessionActionExecutor for FakeActionExecutor {
-        fn screen_off(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
+        fn screen_off(&mut self, event: RuntimeEvent) -> Result<super::ScreenOffResult, RunError> {
             self.screen_off_calls += 1;
             self.screen_off_events.push(event);
             if let Some(message) = &self.screen_off_error {
                 return Err(RunError::Policy(message.clone()));
             }
-            Ok(self.screen_off_output.clone())
+            Ok(super::ScreenOffResult {
+                output: self.screen_off_output.clone(),
+                blank_succeeded: self.screen_off_blank_succeeded,
+            })
+        }
+
+        fn timed_power_off(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
+            self.timed_power_off_calls += 1;
+            self.timed_power_off_events.push(event);
+            if let Some(message) = &self.timed_power_off_error {
+                return Err(RunError::Policy(message.clone()));
+            }
+            Ok(self.timed_power_off_output.clone())
         }
 
         fn screen_on(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
@@ -2324,6 +2535,135 @@ system_sleep_wake_policy={policy}
     }
 
     #[test]
+    fn successful_blank_dispatches_one_timed_power_off_after_the_grace_period() {
+        let executor = FakeActionExecutor {
+            screen_off_blank_succeeded: true,
+            timed_power_off_output: "timed power-off output\n".to_string(),
+            ..FakeActionExecutor::default()
+        };
+        let mut dispatcher = SessionEventDispatcher::new(executor);
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            started_at,
+        );
+        let mut output = Vec::new();
+
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(1),
+        )
+        .expect("blank at inactivity deadline");
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(2),
+        )
+        .expect("power off at post-blank deadline");
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(3),
+        )
+        .expect("do not retry timed power-off");
+
+        assert_eq!(dispatcher.executor.screen_off_calls, 1);
+        assert_eq!(dispatcher.executor.timed_power_off_calls, 1);
+        assert_eq!(
+            dispatcher.executor.timed_power_off_events,
+            vec![RuntimeEvent::new(
+                EventSource::DesktopSession,
+                RuntimeEventKind::SessionTimedPowerOff,
+            )]
+        );
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("Timed power-off deadline reached"));
+        assert!(output.contains("timed power-off output"));
+    }
+
+    #[test]
+    fn unsuccessful_blank_does_not_dispatch_timed_power_off() {
+        let mut dispatcher = SessionEventDispatcher::new(FakeActionExecutor::default());
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            started_at,
+        );
+        let mut output = Vec::new();
+
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(1),
+        )
+        .expect("screen-off skip completes");
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(30),
+        )
+        .expect("no escalation follows the skip");
+
+        assert_eq!(dispatcher.executor.timed_power_off_calls, 0);
+        assert!(String::from_utf8(output)
+            .expect("utf8")
+            .contains("timed power-off was not scheduled"));
+    }
+
+    #[test]
+    fn activity_cancels_timed_power_off_before_restoring() {
+        let executor = FakeActionExecutor {
+            screen_off_blank_succeeded: true,
+            ..FakeActionExecutor::default()
+        };
+        let mut dispatcher = SessionEventDispatcher::new(executor);
+        let started_at = Instant::now();
+        let mut inactivity = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(1),
+            Duration::from_secs(1),
+            started_at,
+        );
+        let mut output = Vec::new();
+
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(1),
+        )
+        .expect("blank at inactivity deadline");
+        handle_inactivity_observation(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            EventSource::AuxiliaryInput,
+            InactivityObservation::UserActivityObserved,
+            started_at + Duration::from_millis(1_500),
+        )
+        .expect("cancel and restore on activity");
+        handle_inactivity_timeout(
+            &mut output,
+            &mut dispatcher,
+            &mut inactivity,
+            started_at + Duration::from_secs(2),
+        )
+        .expect("canceled escalation remains canceled");
+
+        assert_eq!(dispatcher.executor.timed_power_off_calls, 0);
+        assert_eq!(dispatcher.executor.screen_on_calls, 1);
+        let output = String::from_utf8(output).expect("utf8");
+        assert!(output.contains("Activity canceled the pending timed power-off"));
+    }
+
+    #[test]
     fn desktop_activity_restores_and_resets_the_timeout() {
         let executor = FakeActionExecutor {
             screen_off_output: "screen-off output\n".to_string(),
@@ -2474,6 +2814,52 @@ system_sleep_wake_policy={policy}
             vec![RuntimeEvent::new(
                 EventSource::AuxiliaryInput,
                 RuntimeEventKind::UserActivityObserved,
+            )]
+        );
+    }
+
+    #[test]
+    fn native_wayland_shared_runtime_applies_restart_power_off_grace() {
+        let _guard = env_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let runtime_dir = unique_config_path("native-wayland-timed-power-off");
+        let marker = ScreenOwnershipMarker::new(runtime_dir.clone());
+        marker.create().expect("create session ownership marker");
+        std::env::set_var("LG_BUDDY_SESSION_RUNTIME_DIR", &runtime_dir);
+        std::env::set_var("LG_BUDDY_IDLE_TIMEOUT", "300");
+        std::env::set_var(super::TIMED_POWER_OFF_TEST_AFTER_SECS_ENV, "0.05");
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "disabled");
+
+        let mut dispatcher = SessionEventDispatcher::new(FakeActionExecutor::default());
+        let mut output = Vec::new();
+        let result = run_native_session_monitor_with_lock_monitor(
+            &mut output,
+            &mut dispatcher,
+            ScreenBackend::Wayland,
+            |sender, _latest_inactivity| {
+                thread::spawn(move || {
+                    thread::sleep(Duration::from_millis(150));
+                    let _ = sender.send(RunnerMessage::MonitorExited(Ok(())));
+                })
+            },
+            |_| None,
+        );
+
+        std::env::remove_var("LG_BUDDY_SESSION_RUNTIME_DIR");
+        std::env::remove_var("LG_BUDDY_IDLE_TIMEOUT");
+        std::env::remove_var(super::TIMED_POWER_OFF_TEST_AFTER_SECS_ENV);
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+        fs::remove_dir_all(&runtime_dir).expect("remove runtime directory");
+
+        result.expect("native Wayland shared runtime should process the deadline");
+        assert_eq!(dispatcher.executor.screen_off_calls, 0);
+        assert_eq!(dispatcher.executor.timed_power_off_calls, 1);
+        assert_eq!(
+            dispatcher.executor.timed_power_off_events,
+            vec![RuntimeEvent::new(
+                EventSource::DesktopSession,
+                RuntimeEventKind::SessionTimedPowerOff,
             )]
         );
     }

--- a/crates/lg-buddy/src/sources/desktop/swayidle.rs
+++ b/crates/lg-buddy/src/sources/desktop/swayidle.rs
@@ -1,7 +1,18 @@
 use std::fmt;
-use std::io;
-use std::path::Path;
-use std::process::{Command, ExitStatus};
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, BufRead, BufReader};
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, ExitStatus};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::events::EventSource;
+use crate::session::inactivity::InactivityObservation;
+use crate::session::{SessionEvent, SessionObservation};
+
+const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
 #[derive(Debug)]
 pub(crate) enum SwayidleSourceError {
@@ -20,28 +31,114 @@ impl fmt::Display for SwayidleSourceError {
 
 impl std::error::Error for SwayidleSourceError {}
 
-pub(crate) fn run(idle_timeout_secs: u64, current_exe: &Path) -> Result<(), SwayidleSourceError> {
-    let status = Command::new("swayidle")
-        .args(command_args(idle_timeout_secs, current_exe))
-        .status()
+pub(crate) fn run(
+    idle_timeout_secs: u64,
+    event_path: &Path,
+    mut on_observation: impl FnMut(SessionObservation) -> bool,
+) -> Result<(), SwayidleSourceError> {
+    let event_file = create_event_file(event_path).map_err(SwayidleSourceError::Io)?;
+    let _event_file_guard = EventFileGuard(event_path.to_path_buf());
+    let mut reader = BufReader::new(event_file);
+    let child = Command::new("swayidle")
+        .args(command_args(idle_timeout_secs, event_path))
+        .spawn()
         .map_err(SwayidleSourceError::Io)?;
+    let mut child = ChildGuard(child);
 
-    if status.success() {
-        Ok(())
-    } else {
-        Err(SwayidleSourceError::Exited(status))
+    loop {
+        if !drain_events(&mut reader, &mut on_observation).map_err(SwayidleSourceError::Io)? {
+            let _ = child.0.kill();
+            let _ = child.0.wait();
+            return Ok(());
+        }
+
+        if let Some(status) = child.0.try_wait().map_err(SwayidleSourceError::Io)? {
+            let _ =
+                drain_events(&mut reader, &mut on_observation).map_err(SwayidleSourceError::Io)?;
+            return if status.success() {
+                Ok(())
+            } else {
+                Err(SwayidleSourceError::Exited(status))
+            };
+        }
+
+        thread::sleep(EVENT_POLL_INTERVAL);
     }
 }
 
-fn command_args(idle_timeout_secs: u64, current_exe: &Path) -> Vec<String> {
-    let executable = shell_quote(current_exe);
+struct EventFileGuard(PathBuf);
+
+impl Drop for EventFileGuard {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+struct ChildGuard(Child);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+fn create_event_file(path: &Path) -> io::Result<File> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    match fs::remove_file(path) {
+        Ok(()) => {}
+        Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+        Err(err) => return Err(err),
+    }
+
+    let mut options = OpenOptions::new();
+    options.read(true).write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    options.open(path)
+}
+
+fn drain_events<R: BufRead>(
+    reader: &mut R,
+    on_observation: &mut impl FnMut(SessionObservation) -> bool,
+) -> io::Result<bool> {
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line)? == 0 {
+            return Ok(true);
+        }
+
+        let observed_at = Instant::now();
+        let observation = match line.trim() {
+            "idle" => SessionObservation::Event {
+                event: SessionEvent::Idle,
+                source: EventSource::DesktopSession,
+                observed_at,
+            },
+            "active" => SessionObservation::Inactivity {
+                observation: InactivityObservation::DesktopActivityObserved,
+                source: EventSource::DesktopSession,
+                observed_at,
+            },
+            _ => continue,
+        };
+        if !on_observation(observation) {
+            return Ok(false);
+        }
+    }
+}
+
+fn command_args(idle_timeout_secs: u64, event_path: &Path) -> Vec<String> {
+    let path = shell_quote(event_path);
     vec![
         "-w".to_string(),
         "timeout".to_string(),
         idle_timeout_secs.to_string(),
-        format!("{executable} screen off"),
+        format!("printf '%s\\n' idle >> {path}"),
         "resume".to_string(),
-        format!("{executable} screen on"),
+        format!("printf '%s\\n' active >> {path}"),
     ]
 }
 
@@ -53,20 +150,24 @@ fn shell_quote(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{command_args, shell_quote};
+    use super::{command_args, drain_events, shell_quote};
+    use crate::events::EventSource;
+    use crate::session::inactivity::InactivityObservation;
+    use crate::session::{SessionEvent, SessionObservation};
+    use std::io::Cursor;
     use std::path::Path;
 
     #[test]
-    fn production_invocation_uses_only_timeout_and_resume_commands() {
+    fn production_invocation_emits_idle_and_active_facts() {
         assert_eq!(
-            command_args(300, Path::new("/opt/LG Buddy/lg-buddy")),
+            command_args(300, Path::new("/run/user/1000/LG Buddy/events")),
             vec![
                 "-w",
                 "timeout",
                 "300",
-                "'/opt/LG Buddy/lg-buddy' screen off",
+                "printf '%s\\n' idle >> '/run/user/1000/LG Buddy/events'",
                 "resume",
-                "'/opt/LG Buddy/lg-buddy' screen on",
+                "printf '%s\\n' active >> '/run/user/1000/LG Buddy/events'",
             ]
         );
     }
@@ -78,5 +179,34 @@ mod tests {
             shell_quote(Path::new("/tmp/that'one")),
             "'/tmp/that'\"'\"'one'"
         );
+    }
+
+    #[test]
+    fn resume_is_independent_desktop_activity() {
+        let mut input = Cursor::new(b"idle\nactive\n");
+        let mut observations = Vec::new();
+
+        assert!(drain_events(&mut input, &mut |observation| {
+            observations.push(observation);
+            true
+        })
+        .expect("read swayidle observations"));
+
+        assert!(matches!(
+            observations[0],
+            SessionObservation::Event {
+                event: SessionEvent::Idle,
+                source: EventSource::DesktopSession,
+                ..
+            }
+        ));
+        assert!(matches!(
+            observations[1],
+            SessionObservation::Inactivity {
+                observation: InactivityObservation::DesktopActivityObserved,
+                source: EventSource::DesktopSession,
+                ..
+            }
+        ));
     }
 }

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -125,7 +125,7 @@ impl WebOsTvClient {
         Ok(())
     }
 
-    fn power_off_active_session(&self) -> Result<(), TvError> {
+    fn power_off_controllable_session(&self) -> Result<(), TvError> {
         let operation = TvOperation::PowerOff;
         let mut session = self.lock_session(operation)?;
         self.ensure_session(operation, &mut session)?;
@@ -145,12 +145,15 @@ impl WebOsTvClient {
             }
         };
 
-        if power_state != WebOsPowerState::Active {
+        if !matches!(
+            power_state,
+            WebOsPowerState::Active | WebOsPowerState::ScreenOff
+        ) {
             return Err(TvError::new(
                 operation,
                 TvErrorKind::Rejected,
                 format!(
-                    "native webOS power-off requires power state `Active`, but the TV reported `{power_state}`"
+                    "native webOS power-off requires power state `Active` or `Screen Off`, but the TV reported `{power_state}`"
                 ),
             ));
         }
@@ -357,7 +360,7 @@ impl TvClient for WebOsTvClient {
     }
 
     fn power_off(&self) -> Result<(), TvError> {
-        self.power_off_active_session()
+        self.power_off_controllable_session()
     }
 
     fn blank_screen(&self) -> Result<(), TvError> {
@@ -951,7 +954,7 @@ mod tests {
     }
 
     #[test]
-    fn power_off_requires_active_state_and_keeps_rejected_session_usable() {
+    fn power_off_accepts_screen_off_state() {
         let server = WebOsTestServer::screen_off(
             WebOsTestVersion::WebOs24Version92261,
             WebOsTestInput::Hdmi3,
@@ -959,13 +962,23 @@ mod tests {
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
 
-        let error = client
-            .power_off()
-            .expect_err("screen-off state fails native power-off guard");
-        assert_eq!(error.kind(), TvErrorKind::Rejected);
+        assert_eq!(
+            client
+                .current_input()
+                .expect("hardware-characterized foreground input remains readable"),
+            CurrentInput::Hdmi(HdmiInput::Hdmi3)
+        );
+        assert_eq!(
+            client
+                .oled_brightness()
+                .expect("hardware-characterized backlight remains readable")
+                .as_percent(),
+            100
+        );
         client
-            .unblank_screen()
-            .expect("guard rejection keeps session usable");
+            .power_off()
+            .expect("hardware-characterized screen-off power-off should succeed");
+        assert_eq!(server.snapshot().power_state, WebOsPowerState::PowerOff);
         assert_eq!(server.snapshot().connection_count, 1);
         server.finish();
     }

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -198,7 +198,10 @@ impl WebOsTestTv {
                     return webos_error(request_id, "401 insufficient permissions", json!({}));
                 }
                 assert_eq!(payload, &json!({}));
-                assert_eq!(self.power_state, WebOsPowerState::Active);
+                assert!(matches!(
+                    self.power_state,
+                    WebOsPowerState::Active | WebOsPowerState::ScreenOff
+                ));
                 response(
                     request_id,
                     json!({
@@ -220,7 +223,10 @@ impl WebOsTestTv {
                         "keys": ["backlight"],
                     })
                 );
-                assert_eq!(self.power_state, WebOsPowerState::Active);
+                assert!(matches!(
+                    self.power_state,
+                    WebOsPowerState::Active | WebOsPowerState::ScreenOff
+                ));
                 response(
                     request_id,
                     json!({
@@ -484,7 +490,10 @@ impl WebOsTestTv {
             POWER_OFF_URI => {
                 require_top_level_permission(permissions, "CONTROL_POWER", uri);
                 assert_eq!(payload, &json!({}));
-                assert_eq!(self.power_state, WebOsPowerState::Active);
+                assert!(matches!(
+                    self.power_state,
+                    WebOsPowerState::Active | WebOsPowerState::ScreenOff
+                ));
                 self.power_state = WebOsPowerState::PowerOff;
                 response(request_id, json!({"returnValue": true}))
             }

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -26,6 +26,14 @@ fn idle_timeout_seconds(world: &mut LgBuddyWorld, seconds: u64) {
     world.set_idle_timeout_secs(seconds);
 }
 
+#[given(regex = r#"the timed power-off grace is ([0-9]+(?:\.[0-9]+)?) seconds"#)]
+fn timed_power_off_grace_seconds(world: &mut LgBuddyWorld, seconds: String) {
+    let seconds = seconds
+        .parse::<f64>()
+        .unwrap_or_else(|err| panic!("invalid timed power-off grace `{seconds}`: {err}"));
+    world.set_timed_power_off_grace_secs(seconds);
+}
+
 #[given("the current config is remembered")]
 fn current_config_is_remembered(world: &mut LgBuddyWorld) {
     world.remember_config_contents();
@@ -327,6 +335,14 @@ fn swayidle_will_emit_timeout(world: &mut LgBuddyWorld) {
 #[given("swayidle will emit a resume event")]
 fn swayidle_will_emit_resume(world: &mut LgBuddyWorld) {
     world.swayidle_emits_resume();
+}
+
+#[given(regex = r#"swayidle stays open for ([0-9]+(?:\.[0-9]+)?) seconds"#)]
+fn swayidle_stays_open_for_seconds(world: &mut LgBuddyWorld, seconds: String) {
+    let seconds = seconds
+        .parse::<f64>()
+        .unwrap_or_else(|err| panic!("invalid swayidle linger `{seconds}`: {err}"));
+    world.swayidle_stays_open_for_secs(seconds);
 }
 
 #[given("the next input restore attempt powers the TV back on")]

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -98,6 +98,13 @@ impl LgBuddyWorld {
             .set("LG_BUDDY_IDLE_TIMEOUT", seconds.to_string());
     }
 
+    pub fn set_timed_power_off_grace_secs(&mut self, seconds: f64) {
+        self.ensure_env().set(
+            "LG_BUDDY_TIMED_POWER_OFF_TEST_AFTER_SECS",
+            seconds.to_string(),
+        );
+    }
+
     pub fn remember_config_contents(&mut self) {
         self.config_snapshot = Some(self.read_config_contents());
     }
@@ -650,6 +657,14 @@ exit 1\n",
             .as_ref()
             .expect("mock swayidle configured")
             .queue_resume_emission();
+    }
+
+    pub fn swayidle_stays_open_for_secs(&mut self, seconds: f64) {
+        self.install_swayidle_stub();
+        self.swayidle
+            .as_ref()
+            .expect("mock swayidle configured")
+            .set_linger_seconds(seconds);
     }
 
     pub fn install_systemctl_stub(&mut self, reboot_pending: bool) {

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -69,6 +69,29 @@ Feature: GNOME monitor
     And the session marker exists
     And the TV screen is blanked
 
+  Scenario: A lock-owned blank uses the same timed power-off policy
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 120 seconds
+    And the timed power-off grace is 0.2 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And mock system logind reports LockedHint=false
+    And mock system logind changes LockedHint to true
+    And GNOME monitor stays open for 0.8 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Session locked; requesting screen blank."
+    And stdout contains "Timed power-off deadline reached"
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client received "power_off" exactly 1 times
+    And the session marker exists
+    And the TV is powered off
+
   Scenario: GNOME ScreenSaver idle does not bypass the LG Buddy timeout
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 2 seconds
@@ -147,6 +170,66 @@ Feature: GNOME monitor
     And the session marker exists
     And the TV screen is blanked
 
+  Scenario: LG Buddy powers off an owned blank screen after the fixed grace period
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 1 seconds
+    And the timed power-off grace is 0.2 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And GNOME monitor stays open for 1.5 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Timed power-off deadline reached"
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client received "power_off" exactly 1 times
+    And the session marker exists
+    And the TV is powered off
+
+  Scenario: Activity cancels the pending power-off before restoring the screen
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 1 seconds
+    And the timed power-off grace is 0.5 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000"
+    And gamepad activity is observed after 1.2 seconds
+    And GNOME monitor stays open for 1.6 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Activity canceled the pending timed power-off"
+    And the TV client did not receive "power_off"
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the session marker is absent
+
+  Scenario: Restarting with an ownership marker starts a fresh grace period
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 120 seconds
+    And the timed power-off grace is 0.5 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the TV screen is blanked
+    And the session marker exists
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And GNOME monitor stays open for 0.2 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "power_off"
+    And the session marker exists
+    And the TV screen is blanked
+
   Scenario: LG Buddy does not blank repeatedly without intervening activity
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 1 seconds
@@ -211,7 +294,6 @@ Feature: GNOME monitor
     And LG Buddy session runtime is isolated
     And a mock TV client
     And the TV is on input HDMI_3
-    And the session marker exists
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals

--- a/crates/lg-buddy/tests/features/monitor_swayidle.feature
+++ b/crates/lg-buddy/tests/features/monitor_swayidle.feature
@@ -1,5 +1,5 @@
 Feature: swayidle monitor
-  LG Buddy should translate delegated swayidle hooks into TV behavior through the monitor loop.
+  LG Buddy should consume swayidle idle and activity facts through the shared monitor policy.
 
   Scenario: swayidle timeout blanks the configured TV input
     Given a temporary LG Buddy config using input HDMI_2
@@ -17,6 +17,25 @@ Feature: swayidle monitor
     And the TV client received "turn_screen_off"
     And the session marker exists
     And the TV screen is blanked
+
+  Scenario: swayidle idle feeds the shared timed power-off policy
+    Given a temporary LG Buddy config using input HDMI_2
+    And the timed power-off grace is 0.2 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And swayidle is installed
+    And the backend override is "swayidle"
+    And swayidle will emit an idle timeout
+    And swayidle stays open for 0.5 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Timed power-off deadline reached"
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client received "power_off" exactly 1 times
+    And the session marker exists
+    And the TV is powered off
 
   Scenario: swayidle resume restores a previously blanked TV output
     Given a temporary LG Buddy config using input HDMI_3

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -226,6 +226,27 @@ Feature: Native webOS TV platform
     And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
     And the native TV pairing prompt count is 0
 
+  Scenario: Native GNOME inactivity powers off an owned blank screen after the grace period
+    Given a temporary LG Buddy config using input HDMI_2
+    And the existing config selects TV platform "lg_webos"
+    And the idle timeout is 1 seconds
+    And the timed power-off grace is 0.2 seconds
+    And LG Buddy session runtime is isolated
+    And a native webOS TV on input HDMI_2 with brightness 90
+    And a valid native TV access token is stored
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And GNOME monitor stays open for 1.5 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "Timed power-off deadline reached"
+    And the session marker exists
+    And the TV is powered off
+    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV pairing prompt count is 0
+
   Scenario: Native power on restoration is followed by native power off
     Given a temporary LG Buddy config using input HDMI_2
     And the existing config selects TV platform "lg_webos"

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -266,6 +266,7 @@ impl MockSwayidle {
         };
         mock.save_state(json!({
             "emissions": [],
+            "linger_seconds": 0.0,
         }));
         mock
     }
@@ -298,6 +299,15 @@ impl MockSwayidle {
 
     pub fn queue_resume_emission(&self) {
         self.queue_emission("resume");
+    }
+
+    pub fn set_linger_seconds(&self, seconds: f64) {
+        let mut state = self.load_state();
+        state
+            .as_object_mut()
+            .expect("mock swayidle state object")
+            .insert("linger_seconds".to_string(), json!(seconds));
+        self.save_state(state);
     }
 
     fn script_path() -> PathBuf {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -156,7 +156,7 @@ flowchart LR
                 NMGATE["sources/linux/network_manager.rs<br/>pre-down event source"]
                 GADAPTER["sources/desktop/gnome.rs<br/>GNOME bus + observation source"]
                 WADAPTER["sources/desktop/wayland.rs<br/>Wayland registry + observation source"]
-                SADAPTER["sources/desktop/swayidle.rs<br/>delegated process source"]
+                SADAPTER["sources/desktop/swayidle.rs<br/>process fact source"]
             end
         end
 
@@ -213,7 +213,8 @@ flowchart LR
 
     RUNNER -->|"starts"| SADAPTER
     SADAPTER --> SWAY
-    SWAY -->|"delegated timeout / resume<br/>screen off / screen on CLI"| MAIN
+    SWAY -->|"timeout / resume facts"| SADAPTER
+    SADAPTER -->|"SessionObservation"| RUNNER
     INPUT --> GAMEPAD
     GAMEPAD -->|"UserActivity"| RUNNER
     NOTIFICATIONS --> FDO_NOTIFY
@@ -222,7 +223,7 @@ flowchart LR
     RUNNER --> SESSIONNOTIFY
     SESSIONMODEL --> RUNNER
 
-    RUNNER -->|"Idle / Active / WakeRequested /<br/>UserActivity / Lock"| SCREEN
+    RUNNER -->|"Idle / Active / WakeRequested /<br/>UserActivity / Lock / TimedPowerOff"| SCREEN
     RUNNER -->|"AfterResume"| LIFECYCLE
     COMMANDS --> CONFIG
     COMMANDS --> STATE
@@ -328,9 +329,11 @@ The intended split is:
   - top-level event consumption is mapped separately in
     [runtime-event-handler-map.md](runtime-event-handler-map.md)
 - `session/inactivity.rs`
-  - owns the configured inactivity deadline
+  - owns the configured inactivity deadline and fixed five-minute post-blank
+    power-off deadline
   - resets the deadline from normalized activity observations and blanks when
     it expires
+  - arms power-off only after confirmed blank success and cancels it on activity
   - keeps blank and restore decisions edge-triggered instead of poll-triggered
 - `session/gamepad/`
   - discovers readable Linux gamepad-like input devices
@@ -370,8 +373,8 @@ The intended split is:
   - native Wayland capability probing and dynamic registry/seat ownership
   - maps zero-timeout resumed notifications into desktop activity facts
 - `sources/desktop/swayidle.rs`
-  - owns the production `swayidle` process and its timeout/resume command shape
-  - delegates actions through the CLI/API command path
+  - owns the production `swayidle` process and translates timeout/resume
+    callbacks into idle/activity facts
 
 The session-facing pieces should be read as one subsystem:
 
@@ -386,13 +389,13 @@ The session-facing pieces should be read as one subsystem:
   - owns gamepad device discovery, event-triggered refresh, and reconciliation
   - see [gamepad-subsystem.md](gamepad-subsystem.md) for adapter and lifecycle details
 - `session/runner.rs`
-  - owns shared native-session orchestration, including source selection,
+  - owns shared session orchestration, including source selection,
     worker lifetime, multiplexing, and gamepad activity
   - converts provider and auxiliary input into activity observations, resets
     the inactivity deadline, and dispatches source-classified runtime policy
   - treats `screen_idle_blank=disabled` as a passive user-session mode that
     preserves update notification handoff without TV idle blank/restore actions
-  - treats delegated `swayidle` as a CLI/API client for timeout/resume actions
+  - consumes `swayidle` timeout/resume facts through the same inactivity policy
   - owns the `lifecycle` event loop for system sleep/wake handling
 - `sources/linux/logind.rs`
   - adapts Linux system lifecycle signals and owns observation of an eligible
@@ -400,7 +403,7 @@ The session-facing pieces should be read as one subsystem:
 - `sources/desktop/gnome.rs`, `sources/desktop/wayland.rs`, and
   `sources/desktop/swayidle.rs`
   - own their provider-specific connection or process mechanics and expose
-    normalized observations or delegated CLI/API execution to the runner
+    normalized observations to the runner
 
 ## Command Model
 
@@ -576,6 +579,15 @@ Flow:
 7. If another input is active:
    - clear the marker
    - do nothing to the TV
+
+After a successful automatic blank, the inactivity engine starts a fixed
+five-minute grace period. Activity cancels it before restore. At expiry,
+`screen.rs` rechecks that automatic blanking is enabled, the session marker is
+present, the configured input is still active, and machine lifecycle allows a
+session action. It then attempts `power_off` once and preserves the marker for
+later activity restore. Input mismatch clears ownership; input-query failure
+skips without a blind power-off fallback. A monitor restart with an existing
+marker starts a fresh grace period.
 
 ### `screen on`
 
@@ -856,18 +868,9 @@ Wayland connection, registry, every advertised seat, and zero-timeout idle
 notifications. Resumed notifications become desktop activity observations in
 the shared inactivity runtime; compositor idle does not directly blank the TV.
 
-`sources/desktop/swayidle.rs` is the delegated-tool adapter. It currently provides:
-
-- production process invocation with command strings pointing back to the
-  current LG Buddy executable:
-
-- `screen off` for timeout
-- `screen on` for resume
-
-That means `swayidle` acts as a CLI/API client of LG Buddy. It is delegated, but
-not a separate quirks path for screen policy: the invoked commands load config
-and state normally, construct canonical CLI/API runtime events, and enter
-`screen.rs` through the same command surface as manual invocations.
+`sources/desktop/swayidle.rs` is the compatibility process adapter. Its timeout
+callback publishes `Idle`; its resume callback publishes independent desktop
+activity. The adapter does not invoke TV-facing commands or own screen policy.
 
 The session subsystem is intentionally asymmetric where the providers are
 asymmetric:
@@ -875,9 +878,9 @@ asymmetric:
 - the current GNOME provider treats ScreenSaver active/wake and recent Mutter
   input as activity that resets LG Buddy's inactivity deadline; ScreenSaver
   idle is not a blanking authority
-- the shared native-session runtime consumes gamepad activity directly from
+- the shared session runtime consumes gamepad activity directly from
   Linux input devices as `AuxiliaryInput`, independently of desktop providers;
-  GNOME and native Wayland use this runtime
+  every enabled monitor backend uses this runtime
 - the same runtime opportunistically observes `LockedHint` on the current
   graphical logind session; lock requests the normal session blank policy,
   unlock is informational, fresh independent activity can restore while locked,
@@ -885,10 +888,9 @@ asymmetric:
   or lack of support does not affect the selected desktop backend
 - the gamepad source refreshes its device set from Linux device add, remove, and
   change events, with periodic reconciliation for missed events
-- delegated `swayidle` monitor execution is implemented as CLI/API delegation
-  for `timeout` and `resume` parity with the shell monitor
+- `swayidle` timeout and resume callbacks feed the shared inactivity engine
 - system lifecycle is handled by the NetworkManager pre-down gate plus logind
-  lifecycle service, while lock state is optional in the shared native runtime
+  lifecycle service, while lock state is optional in the shared session runtime
 
 `swayidle` remains an explicit and automatic compatibility fallback during the
 1.x migration window, but emits a deprecation notice and is not offered by
@@ -972,7 +974,6 @@ The shell layer still owns:
 
 What is still not implemented:
 
-- `swayidle` `before-sleep`, `after-resume`, `lock`, and `unlock` handling
 - additional desktop backends
 - an immutable-distribution install layout that avoids conventional `/usr`
   writes

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -22,25 +22,24 @@ LG Buddy has four related but distinct event/result shapes.
 | Policy outcome | `policy.rs` | Explicit selected actions, no-action decisions, diagnostics, and state transitions. |
 
 The command entrypoint layer remains the external integration surface. The
-session event layer is active for native monitor behavior and delegated backend
-modeling. System lifecycle handling is normalized through `RuntimeEvent` and
-the lifecycle policy domain. The inactivity observation layer owns one
-deadline. Every activity observation resets it; expiry produces an
-edge-triggered blank decision.
+session event layer is active for monitor behavior. System lifecycle handling
+is normalized through `RuntimeEvent` and the lifecycle policy domain. The
+inactivity observation layer owns the initial blank deadline and, after a
+successful automatic blank, a fixed five-minute power-off deadline. Activity
+resets or cancels the applicable deadline; each expiry is edge-triggered.
 
-GNOME and native Wayland feed the same normalized inactivity observations into
-the shared native-session path.
+GNOME, native Wayland, and `swayidle` feed the shared session path.
 
 ## Current Top-Level Handlers
 
 | External event source | Runtime entrypoint | Primary handler | Current action |
 | --- | --- | --- | --- |
-| system boot / service start | `lg-buddy startup boot` | `commands` -> `lifecycle` | Send Wake-on-LAN and restore the configured input. |
 | system shutdown / service stop | `lg-buddy shutdown` | `commands` -> `lifecycle` | Power off the TV when the configured input is active, unless a reboot is pending. |
 | NetworkManager `pre-down` while logind `PreparingForSleep=true` | `lg-buddy nm-pre-down` | `sources::linux::network_manager` -> `lifecycle` | Join the central suspend rail before network teardown; wait for an in-progress logind rail or run the pre-sleep TV decision. |
 | logind `PrepareForSleep(true)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Enter the central suspend rail under the logind delay inhibitor so systems without a NetworkManager `pre-down` hook still get bounded pre-sleep TV handling. |
 | logind `PrepareForSleep(false)` | `lg-buddy lifecycle` | `sources::linux::logind` -> `session::runner` -> `lifecycle` | Run wake restore policy and clear sleep-cycle coordination state. |
 | graphical logind session `LockedHint=true` | `lg-buddy monitor` | `sources::linux::logind` -> `session::runner` -> `screen` | Enter the normal blanked inactivity state and apply session screen-off policy. |
+| five minutes after a successful automatic blank | internal monitor deadline | `session::inactivity` -> `session::runner` -> `screen` | Recheck ownership, configured input, and lifecycle eligibility, then attempt one TV power-off while preserving the session marker. |
 | user graphical session start | `lg-buddy monitor` | `session::runner::run_monitor` | Detect the session backend and run the selected monitor path. |
 | manual screen blank | `lg-buddy screen off` | `commands` -> `screen` | Blank or power off the TV if LG Buddy owns the configured input. |
 | manual screen restore | `lg-buddy screen on` | `commands` -> `screen` | Restore the screen when marker and restore-policy rules allow it. |
@@ -98,11 +97,10 @@ Examples:
 
 ## Monitor Event Paths
 
-### Native Inactivity Path
+### Shared Inactivity Path
 
-The native inactivity path is used by GNOME and native Wayland, including
-Wayland selected by `auto`. Both feed activity facts into the same inactivity model instead of
-delegating blank/restore commands to an external tool.
+GNOME and native Wayland provide activity facts while `swayidle` provides
+timeout/resume facts. All feed the same inactivity model and policy dispatcher.
 
 ```text
 native desktop activity facts
@@ -114,9 +112,14 @@ auxiliary activity facts
                                                     ├-> screen policy
 current-session logind LockedHint=true              │
   -> immediate Lock / BlankNow ─────────────────────┘
+successful automatic blank
+  -> fixed five-minute grace
+  -> TimedPowerOffNow -> guarded TV power-off
+activity before expiry
+  -> cancel grace -> restore
 ```
 
-Current native-runtime inputs:
+Current shared-runtime inputs:
 
 | Provider surface | Runtime representation | Consumed by |
 | --- | --- | --- |
@@ -124,12 +127,13 @@ Current native-runtime inputs:
 | `org.gnome.ScreenSaver.ActiveChanged(false)` | `ProviderActive` | `InactivityEngine` |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | `InactivityEngine` |
 | Recent activity reported by `org.gnome.Mutter.IdleMonitor.GetIdletime` | `DesktopActivityObserved` | `InactivityEngine` |
-| Linux gamepad activity | `UserActivityObserved` from `AuxiliaryInput` | Shared native-session runtime -> `InactivityEngine` |
-| Initial or changed logind `LockedHint=true` | `SessionEvent::Lock` from `LinuxLogind` | Shared native-session runtime -> `InactivityEngine` |
+| Linux gamepad activity | `UserActivityObserved` from `AuxiliaryInput` | Shared session runtime -> `InactivityEngine` |
+| Initial or changed logind `LockedHint=true` | `SessionEvent::Lock` from `LinuxLogind` | Shared session runtime -> `InactivityEngine` |
 | Changed logind `LockedHint=false` after lock | `SessionEvent::Unlock` from `LinuxLogind` | Clear the observed lock state without requesting screen restore |
+| `swayidle` timeout/resume | `Idle` / `DesktopActivityObserved` | `swayidle` source -> shared runner |
 
 The desktop rows are GNOME-specific source surfaces. Gamepad activity is an
-independent auxiliary source owned by the shared native-session runtime. The
+independent auxiliary source owned by the shared session runtime. The
 key architectural point is that blank/restore decisions are made after
 normalization, not inside a desktop adapter.
 
@@ -143,34 +147,38 @@ The resulting decisions are dispatched as:
 | --- | --- | --- |
 | `BlankNow` | `SessionEvent::Idle` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_off_from_env_for_event` |
 | `BlankNow` from session lock | `SessionEvent::Lock` -> `RuntimeEvent::SessionLocked` from `LinuxLogind` | `screen::run_screen_off_from_env_for_event` |
+| `TimedPowerOffNow` | `RuntimeEvent::SessionTimedPowerOff` from `DesktopSession` | `screen::run_timed_power_off_from_env_for_event` |
 | `RestoreNow` from provider active | `SessionEvent::Active` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from wake request | `SessionEvent::WakeRequested` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from desktop activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `DesktopSession` | `screen::run_screen_on_from_env_for_event` |
 | `RestoreNow` from auxiliary activity | `SessionEvent::UserActivity` -> `RuntimeEvent` from `AuxiliaryInput` | `screen::run_screen_on_from_env_for_event` |
 
-### Delegated `swayidle` CLI/API Path
+Only an actual successful screen-blank effect arms the second deadline. Skips,
+lifecycle exclusions, input-query fallback power-off, and blank-failure
+fallback power-off do not. At the deadline, policy rechecks the session marker,
+configured input, and machine lifecycle. Input-query failure skips without a
+blind fallback. The marker is preserved after the power-off attempt so later
+activity can restore the TV; input mismatch clears it as lost ownership. One
+attempt is allowed per uninterrupted idle period. On process restart, an
+existing marker starts a fresh five-minute grace period.
 
-The `swayidle` monitor is a delegated CLI/API client path.
+### `swayidle` Compatibility Path
+
+The `swayidle` monitor is a compatibility fact source.
 
 ```text
 swayidle timeout/resume
-  -> external command string
-  -> lg-buddy screen off / lg-buddy screen on
-  -> canonical CLI/API RuntimeEvent
-  -> screen policy
+  -> private idle/activity event transport
+  -> shared runner and InactivityEngine
+  -> screen policy and timed power-off policy
 ```
 
-`sources/desktop/swayidle.rs` owns the production process invocation and creates
-only the delegated timeout/resume command shape shown above. It does not expose
-an unused hook-to-event capability model.
+`sources/desktop/swayidle.rs` owns only process invocation and translation of
+timeout/resume callbacks into facts. It does not invoke public TV commands.
 
 This deprecated path remains for existing explicit selections and as an
-automatic compatibility fallback on unsupported native sessions. It is
-delegated, but it is not a separate screen-policy quirks mode: `swayidle` re-enters LG Buddy
-through the same CLI/API command surface as manual `screen off` and `screen on`.
-Retiring it means replacing delegated timeout/resume execution with native
-idle/activity facts that feed the same inactivity engine used by the current
-native path.
+automatic compatibility fallback on unsupported native sessions, without a
+separate screen-policy mode.
 
 ## System Lifecycle Event Handling
 
@@ -227,8 +235,7 @@ Current lifecycle signal mapping:
 | `PrepareForSleep(false)` | `MachineResumed` | `run_system_resume` |
 
 The current `SessionEventDispatcher` handles these session events when a
-backend path dispatches them. The production `swayidle` path delegates timeout
-and resume to direct `screen off` / `screen on` CLI/API commands.
+backend path dispatches them.
 
 | Session event | Current action |
 | --- | --- |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -64,7 +64,7 @@ These are the semantic events the runtime should reason about.
   - Some providers expose an explicit wake request.
   - Others only expose idle/resume transitions.
 - Lock state is an optional cross-cutting Linux source, not a prerequisite of a
-  selected desktop backend. The shared native runtime observes the resolved
+  selected desktop backend. The shared session runtime observes the resolved
   graphical logind session's `LockedHint` when available. Initial or changed
   `true` maps to `Lock`; `false` maps to `Unlock` only after a prior locked
   state. Unlock is informational and never requests screen restore.
@@ -76,11 +76,11 @@ canonical session event or inactivity fact, an `EventSource`, and the time it
 was observed. Source modules do not decide whether to blank or restore the
 screen.
 
-GNOME and native Wayland feed the shared runner. LG Buddy owns their configured
-inactivity deadline. The delegated `swayidle` source instead receives the same
-configured timeout and invokes LG Buddy's existing `screen off` and `screen on`
-CLI/API commands. Startup and wake retry delays remain runtime policy and are
-unrelated to session-source timing.
+GNOME and native Wayland feed activity facts to the shared runner, which owns
+their configured inactivity deadline. `swayidle` owns its initial timeout but
+publishes `Idle` and independent desktop-activity observations back to the same
+runner. All three backends therefore share blank, restore, and post-blank
+power-off policy.
 
 ## Provider Map
 
@@ -90,7 +90,7 @@ This is the current mapping for the known backends, with implementation status c
 | --- | --- | --- | --- | --- | --- | --- |
 | GNOME | Observed but not authoritative | Yes | Yes | Yes | Optional logind source | Shared runner owns the configured deadline over ScreenSaver and Mutter observations |
 | Native Wayland | Observed but not authoritative | Resumed notification | No | Yes | Optional logind source | Shared runner owns the configured deadline using `ext_idle_notifier_v1` version 2 or newer |
-| `swayidle` | Delegated timeout command | Delegated resume command | No | No direct equivalent | No shared logind observer | Source-owned process receives the configured timeout and invokes the CLI/API screen commands |
+| `swayidle` | Timeout becomes `Idle` | Resume becomes independent desktop activity | No | No direct equivalent | Optional logind source | Source process owns the configured initial timeout; shared runner owns policy and post-blank timing |
 
 ## Provider-Specific Mapping
 
@@ -120,7 +120,7 @@ Notes:
 ### Auxiliary Activity Sources
 
 Linux gamepad input is a desktop-independent auxiliary activity source. The
-shared native-session runtime owns its lifecycle and feeds
+shared session runtime owns its lifecycle and feeds
 `UserActivityObserved` into the same inactivity engine as the selected desktop
 provider. Resulting runtime events retain the `AuxiliaryInput` source.
 
@@ -130,13 +130,13 @@ reconciles in case an event is missed. Standard controller input is read from
 evdev. Logitech G923 wheel and pedal activity has a narrow raw HID fallback for
 hosts where those reports do not appear on the evdev node.
 
-GNOME and native Wayland use the shared native-session runtime. The Wayland
+GNOME, native Wayland, and `swayidle` use the shared session runtime. The Wayland
 provider owns only its connection, registry, seats, notifications, and activity
 facts; it does not acquire gamepad responsibility.
 
 ### Session Lock State
 
-GNOME and native Wayland also start an optional system-bus observer for the
+Every enabled monitor backend also starts an optional system-bus observer for the
 current graphical logind session. Session selection accepts only an active,
 local `x11` or `wayland` session in a user class and owned by the current UID.
 An explicit `XDG_SESSION_ID` is validated against those rules; without it, LG
@@ -172,8 +172,7 @@ monitoring. If the desktop or locker never updates `LockedHint`, no lock event i
 observed and ordinary monitoring likewise continues unchanged. It does not use
 desktop-name checks, logind lock-request signals, locker hooks, or a Wayland
 session-lock protocol. The logind observer is not a backend eligibility or
-selection requirement. The delegated `swayidle` path does not host the shared
-native observer.
+selection requirement.
 
 ### Native Wayland
 
@@ -195,8 +194,8 @@ Current mapping:
 
 | Provider surface | Canonical meaning | Current Rust Status |
 | --- | --- | --- |
-| `timeout <n> <cmd>` | Invoke `lg-buddy screen off` | Implemented |
-| `resume <cmd>` | Invoke `lg-buddy screen on` | Implemented |
+| `timeout <n> <cmd>` | Publish `Idle` to the shared runner | Implemented |
+| `resume <cmd>` | Publish independent desktop activity to the shared runner | Implemented |
 
 Notes:
 
@@ -206,6 +205,9 @@ Notes:
 - `swayidle` does not provide a clear equivalent of GNOME's `WakeRequested`.
 - `swayidle` does not provide a Mutter-style early activity surface.
 - LG Buddy owns the configured timeout value for this backend.
+- The shared runner owns lock observation, screen policy, and the post-blank
+  power-off deadline. Gamepad activity can cancel that second deadline, but
+  does not reset swayidle's source-owned initial timeout.
 
 ## Module Ownership
 
@@ -229,7 +231,7 @@ The code split is:
     including bus setup, session resolution, rebinding, and `LockedHint`
     translation
 - `crates/lg-buddy/src/sources/desktop/swayidle.rs`
-  - production `swayidle` process invocation and timeout/resume command shape
+  - production `swayidle` process invocation and timeout/resume fact transport
 
 This keeps backend-specific details out of runtime policy and prevents each
 backend from quietly defining its own semantics.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -120,6 +120,13 @@ lg-buddy settings set screen.restore_policy conservative
 Set `screen.idle_blank` to `disabled` to stop idle-driven TV blanking and
 restoring. The user service remains available for update notifications.
 
+When an automatic idle or session-lock action successfully blanks the screen,
+LG Buddy powers the TV off after five more minutes without activity. This grace
+period is a fixed safety default rather than a setting. Any desktop or gamepad
+activity cancels the pending power-off and restores the screen. Before powering
+off, LG Buddy rechecks its ownership marker, the configured input, and machine
+lifecycle state; it skips safely if those checks no longer permit the action.
+
 The restore policies are:
 
 - `conservative`: restore only when LG Buddy previously blanked or powered off
@@ -175,7 +182,10 @@ continue to run without being rewritten.
 ### Gamepad Activity
 
 With the `gnome` and `wayland` backends, supported controller activity resets
-the same idle timer as desktop activity. No additional setting is required.
+the same idle timer as desktop activity. On the deprecated `swayidle` backend,
+controller activity can restore an already blanked screen and cancel its
+pending timed power-off, but it does not reset swayidle's initial timeout. No
+additional setting is required.
 
 If controller activity is ignored, verify that the user running
 `LG_Buddy_screen.service` can read the controller's Linux input devices. Normal

--- a/tools/mock_swayidle.py
+++ b/tools/mock_swayidle.py
@@ -8,11 +8,13 @@ import argparse
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
 DEFAULT_STATE = {
     "emissions": [],
+    "linger_seconds": 0.0,
 }
 
 
@@ -85,6 +87,7 @@ def main(argv: list[str]) -> int:
         return 2
 
     emit_planned_events(state, timeout_command, resume_command)
+    time.sleep(float(state.get("linger_seconds", 0.0)))
     save_state(state_path, state)
     return 0
 


### PR DESCRIPTION
## Summary

- add a fixed five-minute power-off stage after a successful automatic screen blank
- cancel escalation on activity and preserve the existing restore path and ownership marker semantics
- recheck input ownership and lifecycle eligibility before one bounded power-off attempt
- route swayidle timeout/resume facts through the shared inactivity policy while retaining its documented compatibility limitations
- support native webOS power-off from `Screen Off` and align the hardware-characterized mock behavior
- document the two-stage timing and backend behavior

Addresses #139.

## Validation

- `cargo test -p lg-buddy` (795 library tests; 134 behavior scenarios)
- `cargo clippy -p lg-buddy --all-targets -- -D warnings`
- `git diff --check`
- connected native webOS probe: foreground input and backlight remained readable in `Screen Off`; native power-off succeeded; TV was restored and verified `Active` on HDMI 3
