### PR TITLE
Fix GTK application name and icon grouping

### DIFF
--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -17,6 +17,7 @@ use lg_buddy::brightness::{
 use lg_buddy::presentation::brightness::{BrightnessFrontendUpdate, BrightnessIntent};
 
 pub const APPLICATION_ID: &str = "io.github.staphylococcus.LGBuddy";
+pub const APPLICATION_NAME: &str = "LG Buddy";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuiCommand {
@@ -79,6 +80,7 @@ pub fn run(command: GuiCommand) -> glib::ExitCode {
 }
 
 fn run_brightness_application() -> glib::ExitCode {
+    glib::set_application_name(APPLICATION_NAME);
     let application = adw::Application::builder()
         .application_id(APPLICATION_ID)
         .build();

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -19,11 +19,13 @@ fn brightness_desktop_entry_uses_the_stable_headless_launcher() {
     let desktop_entry = fs::read_to_string(
         std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../..")
-            .join("LG_Buddy_Brightness.desktop"),
+            .join("io.github.staphylococcus.LGBuddy.desktop"),
     )
     .expect("read brightness desktop entry");
     let lines = desktop_entry.lines().collect::<Vec<_>>();
 
+    assert!(lines.contains(&"Name=LG Buddy"));
+    assert!(lines.contains(&"Icon=io.github.staphylococcus.LGBuddy"));
     assert!(lines.contains(&"Exec=/usr/bin/lg-buddy brightness"));
     assert!(lines.contains(&"Terminal=false"));
     assert!(!lines

--- a/install.sh
+++ b/install.sh
@@ -156,6 +156,12 @@ APPLICATIONS_DIR="$(prefix_path "/usr/share/applications")"
 DESKTOP_ENTRY_NAME="io.github.staphylococcus.LGBuddy.desktop"
 DESKTOP_ENTRY_PATH="${APPLICATIONS_DIR}/${DESKTOP_ENTRY_NAME}"
 LEGACY_DESKTOP_ENTRY_PATH="${APPLICATIONS_DIR}/LG_Buddy_Brightness.desktop"
+DESKTOP_ENTRY_SOURCE="${SCRIPT_DIR}/${DESKTOP_ENTRY_NAME}"
+if [ ! -f "$DESKTOP_ENTRY_SOURCE" ]; then
+    # Release archives retain this internal name for compatibility with
+    # updaters shipped before the application-ID filename was adopted.
+    DESKTOP_ENTRY_SOURCE="${SCRIPT_DIR}/LG_Buddy_Brightness.desktop"
+fi
 APP_ICON_DIR="$(prefix_path "/usr/share/icons/hicolor/scalable/apps")"
 APP_ICON_PATH="${APP_ICON_DIR}/${APP_ICON_NAME}"
 USER_DESKTOP_ENTRY_PATH="${HOME}/Desktop/${DESKTOP_ENTRY_NAME}"
@@ -639,15 +645,15 @@ if [ "$UPGRADE_MODE" -eq 0 ]; then
 fi
 echo "Installing brightness control desktop entry..."
 run_privileged install -d "$APPLICATIONS_DIR"
-run_privileged install -m 644 "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" "$DESKTOP_ENTRY_PATH"
+run_privileged install -m 644 "$DESKTOP_ENTRY_SOURCE" "$DESKTOP_ENTRY_PATH"
 run_privileged rm -f "$LEGACY_DESKTOP_ENTRY_PATH"
 run_privileged install -d "$APP_ICON_DIR"
 run_privileged install -m 644 "$APP_ICON" "$APP_ICON_PATH"
 if [ "$UPGRADE_MODE" -eq 0 ]; then
-    cp "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" "$USER_DESKTOP_ENTRY_PATH" 2>/dev/null || true
+    cp "$DESKTOP_ENTRY_SOURCE" "$USER_DESKTOP_ENTRY_PATH" 2>/dev/null || true
     rm -f "$LEGACY_USER_DESKTOP_ENTRY_PATH"
 elif [ -f "$USER_DESKTOP_ENTRY_PATH" ] || [ -f "$LEGACY_USER_DESKTOP_ENTRY_PATH" ]; then
-    cp "$SCRIPT_DIR/LG_Buddy_Brightness.desktop" "$USER_DESKTOP_ENTRY_PATH"
+    cp "$DESKTOP_ENTRY_SOURCE" "$USER_DESKTOP_ENTRY_PATH"
     rm -f "$LEGACY_USER_DESKTOP_ENTRY_PATH"
 fi
 echo "Done."

--- a/io.github.staphylococcus.LGBuddy.desktop
+++ b/io.github.staphylococcus.LGBuddy.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Type=Application
-Name=TV Brightness
+Name=LG Buddy
 Comment=Control LG TV OLED Pixel Brightness
 Exec=/usr/bin/lg-buddy brightness
 Icon=io.github.staphylococcus.LGBuddy

--- a/scripts/build-release-bundle.sh
+++ b/scripts/build-release-bundle.sh
@@ -79,7 +79,10 @@ install -m 755 "$REPO_ROOT/install.sh" "$BUNDLE_DIR/install.sh"
 install -m 755 "$REPO_ROOT/configure.sh" "$BUNDLE_DIR/configure.sh"
 install -m 755 "$REPO_ROOT/uninstall.sh" "$BUNDLE_DIR/uninstall.sh"
 install -m 755 "$REPO_ROOT/bin/LG_Buddy_Common" "$BUNDLE_DIR/bin/LG_Buddy_Common"
-install -m 644 "$REPO_ROOT/LG_Buddy_Brightness.desktop" "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
+# Keep the legacy archive member name until pre-1.5 updaters no longer need to
+# validate new bundles. install.sh still installs the application-ID filename.
+install -m 644 "$REPO_ROOT/io.github.staphylococcus.LGBuddy.desktop" \
+    "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 install -m 644 "$REPO_ROOT/README.md" "$BUNDLE_DIR/README.md"
 install -m 644 "$REPO_ROOT/LICENSE" "$BUNDLE_DIR/LICENSE"
 cp -R "$REPO_ROOT/docs/." "$BUNDLE_DIR/docs/"

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -332,6 +332,7 @@ assert_executable "$BUNDLE_DIR/bin/LG_Buddy_Common"
 assert_file "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 assert_file "$BUNDLE_ICON"
 assert_mode "$BUNDLE_ICON" 644
+grep -F -q 'Name=LG Buddy' "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 grep -F -q 'Icon=io.github.staphylococcus.LGBuddy' "$BUNDLE_DIR/LG_Buddy_Brightness.desktop"
 assert_file "$BUNDLE_DIR/README.md"
 assert_file "$BUNDLE_DIR/LICENSE"


### PR DESCRIPTION
## Summary

- name the GTK application and desktop entry `LG Buddy`
- rename the source desktop file to match `io.github.staphylococcus.LGBuddy`, allowing GNOME to associate the running window with its launcher and icon
- continue launching through the stable `lg-buddy brightness` command
- install only the canonical application-ID filename while retaining the legacy desktop filename inside release archives for compatibility with already-shipped updater validation
- assert the application name and icon metadata in tests

## Validation

- `desktop-file-validate io.github.staphylococcus.LGBuddy.desktop`
- `cargo test -p lg-buddy --lib` (795 tests)
- `cargo test -p lg-buddy --test runtime_entrypoints` (18 tests)
- display-backed `cargo test -p lg-buddy-gui -- --test-threads=1` (2 tests)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- shell syntax validation for installer and release scripts
- constructed a prerelease bundle and verified its compatibility member contains `Name=LG Buddy` and `Icon=io.github.staphylococcus.LGBuddy`
- GLib desktop metadata lookup resolved `name=LG Buddy` and the application-ID icon
