### PR TITLE
Prepare 1.5.0-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.4.0"
+version = "1.5.0-beta.1"
 dependencies = [
  "base64",
  "cucumber",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "lg-buddy-gui"
-version = "1.4.0"
+version = "1.5.0-beta.1"
 dependencies = [
  "gtk4",
  "lg-buddy",

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy-gui"
-version = "1.4.0"
+version = "1.5.0-beta.1"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.4.0"
+version = "1.5.0-beta.1"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- bump the runtime and GTK GUI crates to `1.5.0-beta.1`
- keep both lockfile package identities aligned
- establish the prerelease candidate required before stable `1.5.0` promotion

## Validation

- `git diff --check`
- `cargo check --workspace --locked` in a Nix development shell
- `cargo test --locked -p lg-buddy --lib version::tests` (6 tests)
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_release_promotion.py` (21 tests)
- `actionlint`
- local prerelease-contract validation for `v1.5.0-beta.1`