### PR TITLE
Prepare 1.5.0 for direct stable promotion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,25 +66,6 @@ jobs:
       - name: Validate GitHub response recorder
         run: python3 scripts/test_record_github_release_responses.py
 
-      - name: Require successful production prerelease canary for stable promotion
-        if: github.event_name == 'pull_request' && github.base_ref == 'main'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          prerelease_sha="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/prerelease" --jq .object.sha)"
-          [ "$prerelease_sha" != "${{ github.event.pull_request.base.sha }}" ] || {
-              echo "Stable promotion requires a distinct prerelease candidate."
-              exit 1
-          }
-          matching_checks="$(gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/$GITHUB_REPOSITORY/commits/$prerelease_sha/check-runs?per_page=100" \
-              --jq '[.check_runs[] | select(.name == "production-prerelease-canary" and .status == "completed" and .conclusion == "success" and .app.slug == "github-actions")] | length')"
-          [ "$matching_checks" -gt 0 ] || {
-              echo "No successful production-prerelease canary exists for $prerelease_sha."
-              exit 1
-          }
-
   bundle-smoke-test:
     runs-on: ubuntu-24.04
     needs: verify

--- a/.github/workflows/promotion-check.yml
+++ b/.github/workflows/promotion-check.yml
@@ -96,23 +96,3 @@ jobs:
               [ "$CHANNEL" = "stable" ] || expected_prerelease="true"
               [ "$(printf '%s' "$release_state" | jq -r .isPrerelease)" = "$expected_prerelease" ]
           fi
-
-      - name: Require production prerelease upgrade canary
-        if: github.event.pull_request.base.ref == 'main'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          MAIN_SHA: ${{ steps.contract.outputs.main_sha }}
-          PRERELEASE_SHA: ${{ steps.contract.outputs.prerelease_sha }}
-        run: |
-          [ "$PRERELEASE_SHA" != "$MAIN_SHA" ] || {
-              echo "Stable promotion requires a distinct prerelease candidate."
-              exit 1
-          }
-          matching_checks="$(gh api \
-              -H 'Accept: application/vnd.github+json' \
-              "repos/$GITHUB_REPOSITORY/commits/$PRERELEASE_SHA/check-runs?per_page=100" \
-              --jq '[.check_runs[] | select(.name == "production-prerelease-canary" and .status == "completed" and .conclusion == "success" and .app.slug == "github-actions")] | length')"
-          [ "$matching_checks" -gt 0 ] || {
-              echo "No successful production-prerelease canary exists for $PRERELEASE_SHA."
-              exit 1
-          }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.5.0-beta.1"
+version = "1.5.0"
 dependencies = [
  "base64",
  "cucumber",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "lg-buddy-gui"
-version = "1.5.0-beta.1"
+version = "1.5.0"
 dependencies = [
  "gtk4",
  "lg-buddy",

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy-gui"
-version = "1.5.0-beta.1"
+version = "1.5.0"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.5.0-beta.1"
+version = "1.5.0"
 edition = "2021"
 publish = false
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -35,8 +35,6 @@ Required promotion checks prove that:
 - the derived `v<crate-version>` tag is absent before merge
 - normal CI and the release-bundle smoke test pass; the bundle smoke includes a
   pinned cross-version upgrade from `v1.4.0-beta.2`
-- a stable promotion has a successful production upgrade canary on the exact
-  prerelease commit
 
 Requiring every candidate to advance both release-channel heads keeps release
 publication globally monotonic. The newest published release is therefore also
@@ -62,8 +60,13 @@ There is no separate version input.
 7. A published prerelease then runs `v1.4.0-beta.2` through the real production
    `lg-buddy updates install` path. The newly installed candidate performs a
    cold-cache production update check, and the canary records sanitized GitHub
-   response evidence for the deterministic mock. Stable promotion remains
-   blocked until this exact prerelease commit has a successful canary.
+   response evidence for the deterministic mock. This is supplemental
+   post-publication evidence, not a prerequisite for stable promotion.
+
+Promotion through `prerelease` is optional. A direct `dev -> main` promotion
+runs the same required PR validation and post-merge release build as a
+`dev -> prerelease` promotion. After stable publication, the release App
+fast-forwards both `prerelease` and `dev` to the reviewed stable commit.
 
 Replace the publisher's generic release description with concise,
 release-specific notes for user-visible default or compatibility changes before

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -389,8 +389,8 @@ that sanitized newest-release response, the release-by-tag response, tag ref,
 and asset redirects as a workflow artifact. Signed redirect queries and URL
 userinfo are never retained. The observed beta.2 newest-release fields also
 live in `crates/lg-buddy/testdata/github/` and are replayed by the normal offline
-Rust suite. A successful canary on the exact prerelease commit is a
-stable-promotion prerequisite.
+Rust suite. The canary is supplemental post-publication evidence and is not a
+prerequisite for stable promotion.
 
 ## Current Practical Gaps
 

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -166,6 +166,14 @@ class PromotionTests(unittest.TestCase):
         self.assertEqual(result["tag"], "v1.4.0")
         self.assertEqual(result["channel"], "stable")
 
+    def test_direct_stable_promotion(self) -> None:
+        head = self.repository.candidate("1.4.0")
+
+        result = self.repository.validate("main", head)
+
+        self.assertEqual(result["tag"], "v1.4.0")
+        self.assertEqual(result["channel"], "stable")
+
     def test_channel_mismatch_is_rejected(self) -> None:
         prerelease = self.repository.candidate("1.4.0-beta.1")
         with self.assertRaisesRegex(PromotionError, "main requires a stable version"):
@@ -272,6 +280,17 @@ class PromotionTests(unittest.TestCase):
         self.assertEqual(result["tag"], "v1.4.0")
         self.assertEqual(result["channel"], "stable")
 
+    def test_merged_direct_stable_release_is_publishable(self) -> None:
+        self.repository.candidate("1.4.0")
+        base, source, merged = self.repository.merge_promotion("main")
+
+        result = self.repository.validate_merged("main", merged, base)
+
+        self.assertTrue(result["publish"])
+        self.assertEqual(result["source_sha"], source)
+        self.assertEqual(result["tag"], "v1.4.0")
+        self.assertEqual(result["channel"], "stable")
+
     def test_stable_alignment_push_to_prerelease_does_not_publish_again(self) -> None:
         prerelease = self.repository.candidate("1.4.0-beta.1")
         self.repository.git("branch", "-f", "prerelease", prerelease)
@@ -286,6 +305,22 @@ class PromotionTests(unittest.TestCase):
         self.assertFalse(result["publish"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["base_sha"], prerelease)
+        self.assertEqual(result["channel"], "stable")
+
+    def test_direct_stable_alignment_push_to_prerelease_does_not_publish_again(
+        self,
+    ) -> None:
+        self.repository.candidate("1.4.0")
+        _, _, merged = self.repository.merge_promotion("main")
+        self.repository.git("branch", "-f", "prerelease", merged)
+
+        result = self.repository.validate_merged(
+            "prerelease", merged, self.repository.stable_sha
+        )
+
+        self.assertFalse(result["publish"])
+        self.assertEqual(result["head_sha"], merged)
+        self.assertEqual(result["base_sha"], self.repository.stable_sha)
         self.assertEqual(result["channel"], "stable")
 
     def test_release_branch_fast_forward_without_a_merge_is_rejected(self) -> None:


### PR DESCRIPTION
## Summary

- set the runtime, GTK GUI, and lockfile package identities to final `1.5.0`
- remove the requirement that stable promotion first pass through a published prerelease canary
- retain the same `verify`, release-bundle, cross-version upgrade, Fedora, Arch, and promotion-contract checks for PRs targeting either release channel
- keep the post-publication prerelease canary as supplemental evidence only
- document and test direct stable publication plus automatic `prerelease`/`dev` alignment

This replaces withdrawn prerelease promotion #161.

## Validation

- `git diff --check`
- `actionlint`
- `cargo check --workspace --locked`
- `cargo test --locked -p lg-buddy --lib version::tests` (6 tests)
- `PYTHONDONTWRITEBYTECODE=1 python3 scripts/test_release_promotion.py` (24 tests)
- local direct-stable contract validation for `v1.5.0` with `main == prerelease`