### PR TITLE
Separate release staging from publication approval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Dry-run publish release assets
         env:
           GH_RELEASE_DRY_RUN: "1"
-        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag "v${SMOKE_VERSION}" --commit "${{ github.sha }}"
+        run: ./scripts/publish-release-assets.sh stage-draft --dist-dir dist --tag "v${SMOKE_VERSION}" --commit "${{ github.sha }}"
 
       - name: Upload bundle for supported-distro checks
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       channel: ${{ steps.contract.outputs.channel }}
       head_sha: ${{ steps.contract.outputs.head_sha }}
       prerelease_sha: ${{ steps.contract.outputs.prerelease_sha }}
-      publish: ${{ steps.contract.outputs.publish }}
+      prepare: ${{ steps.contract.outputs.prepare }}
       source_sha: ${{ steps.contract.outputs.source_sha }}
       tag: ${{ steps.contract.outputs.tag }}
       version: ${{ steps.contract.outputs.version }}
@@ -63,7 +63,7 @@ jobs:
               --github-output "$GITHUB_OUTPUT"
 
   build-release-bundle:
-    if: needs.validate.outputs.publish == 'true'
+    if: needs.validate.outputs.prepare == 'true'
     runs-on: ubuntu-24.04
     needs: validate
 
@@ -154,10 +154,11 @@ jobs:
             dist/*.tar.gz
             dist/sha256sums.txt
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 30
 
-  publish:
-    if: needs.validate.outputs.publish == 'true'
+  stage-release-draft:
+    name: stage-release-draft
+    if: needs.validate.outputs.prepare == 'true'
     runs-on: ubuntu-latest
     environment: release-promotion
     needs:
@@ -251,7 +252,7 @@ jobs:
           fi
           update_ref dev "$SOURCE_SHA"
 
-      - name: Publish release
+      - name: Stage verified release draft
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
           HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
@@ -271,7 +272,85 @@ jobs:
           if ! git rev-parse --verify "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
               git tag "$RELEASE_TAG" "$HEAD_SHA"
           fi
-          ./scripts/publish-release-assets.sh \
+          ./scripts/publish-release-assets.sh stage-draft \
+              --dist-dir dist \
+              --tag "$RELEASE_TAG" \
+              --commit "$HEAD_SHA"
+
+          release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
+          {
+              echo "## Verified release draft"
+              echo
+              echo "[$RELEASE_TAG]($release_url) is ready for release-note review."
+              echo "After reviewing the draft and its assets, approve the release-publication environment to publish it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: publish-reviewed-release
+    if: needs.validate.outputs.prepare == 'true'
+    runs-on: ubuntu-latest
+    environment: release-publication
+    permissions:
+      actions: read
+      contents: write
+    needs:
+      - validate
+      - build-release-bundle
+      - stage-release-draft
+
+    steps:
+      - name: Check out staged release commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Fetch and revalidate release refs
+        run: |
+          git fetch --force origin \
+              +refs/heads/main:refs/remotes/origin/main \
+              +refs/heads/prerelease:refs/remotes/origin/prerelease \
+              +refs/heads/dev:refs/remotes/origin/dev \
+              +refs/tags/*:refs/tags/*
+          python3 scripts/release_promotion.py \
+              --merged \
+              --target "${{ github.ref_name }}" \
+              --head-ref "${{ needs.validate.outputs.head_sha }}" \
+              --base-sha "${{ needs.validate.outputs.base_sha }}"
+
+      - name: Download staged release bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: lg-buddy-release-${{ needs.validate.outputs.tag }}
+          path: dist
+
+      - name: Verify staged checksums
+        run: cd dist && sha256sum -c sha256sums.txt
+
+      - name: Revalidate staged bundle identity
+        run: |
+          python3 scripts/release_bundle_manifest.py validate \
+              --archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
+              --expected-release-tag "${{ needs.validate.outputs.tag }}" \
+              --expected-version "${{ needs.validate.outputs.version }}" \
+              --expected-channel "${{ needs.validate.outputs.channel }}" \
+              --expected-target x86_64-unknown-linux-musl \
+              --expected-gui-target x86_64-unknown-linux-gnu \
+              --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Publish reviewed release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          ./scripts/publish-release-assets.sh publish-draft \
               --dist-dir dist \
               --tag "$RELEASE_TAG" \
               --commit "$HEAD_SHA"
@@ -290,7 +369,7 @@ jobs:
 
   production-prerelease-canary:
     name: production-prerelease-canary
-    if: needs.validate.outputs.publish == 'true' && needs.validate.outputs.channel == 'prerelease'
+    if: needs.validate.outputs.prepare == 'true' && needs.validate.outputs.channel == 'prerelease'
     runs-on: ubuntu-latest
     needs:
       - validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
             dist/*.tar.gz
             dist/sha256sums.txt
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 35
 
   stage-release-draft:
     name: stage-release-draft

--- a/docs/development.md
+++ b/docs/development.md
@@ -208,16 +208,17 @@ Run the focused manifest contract tests with:
 python3 scripts/test_release_bundle_manifest.py
 ```
 
-Run the mock-backed draft publication and retry contract tests with:
+Run the mock-backed draft staging, reviewed publication, and retry contract tests
+with:
 
 ```bash
 python3 scripts/test_publish_release_assets.py
 ```
 
-Dry-run the GitHub release publish step with:
+Dry-run the GitHub release draft-staging step with:
 
 ```bash
-GH_RELEASE_DRY_RUN=1 ./scripts/publish-release-assets.sh --dist-dir ./dist --tag v0.0.0-dev
+GH_RELEASE_DRY_RUN=1 ./scripts/publish-release-assets.sh stage-draft --dist-dir ./dist --tag v<version>
 ```
 
 Official releases are created only through a reviewed `dev` promotion PR. For
@@ -264,11 +265,11 @@ the branch contract and recovery process, see
 | `scripts/test-cross-version-upgrade.sh` | Pinned previous-to-candidate archive upgrade smoke test |
 | `scripts/test-production-upgrade-canary.sh` | Post-publication production GitHub upgrade canary |
 | `scripts/record_github_release_responses.py` | Sanitized production response recorder for offline mocks |
-| `scripts/publish-release-assets.sh` | GitHub release publish helper |
+| `scripts/publish-release-assets.sh` | Verified GitHub release draft staging and publication helper |
 | `scripts/release_promotion.py` | Promotion version, branch, and tag validator |
 | `.github/workflows/ci.yml` | CI validation workflow |
 | `.github/workflows/promotion-pr.yml` | Read-only promotion PR contract check using the target branch's validator |
-| `.github/workflows/release.yml` | Post-merge promotion build and publication workflow |
+| `.github/workflows/release.yml` | Post-merge build, draft staging, approval, and publication workflow |
 | `bin/LG_Buddy_Common` | Shared shell config helper used by setup scripts |
 | `systemd/` | Installed unit files and tmpfiles config, including the logind lifecycle service |
 | `docs/architecture-overview.md` | Runtime architecture |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,14 +13,15 @@ same-repository `dev` branch and whose base is `main` or `prerelease`.
 
 ## Promotion contract
 
-The promotion PR is the review and approval surface. Required checks gate its
-merge, and merging the PR is the release authorization. The merged target-branch
-commit is the release commit; there is no separate approval label or publish
-action.
+The promotion PR is the code and release-identity review surface. Required checks
+gate its merge, and merging the PR authorizes preparation of a verified release
+draft. The merged target-branch commit is the release commit. Publishing that
+draft is a separate explicit approval after its release notes and assets have
+been reviewed.
 
 The release App is not a substitute for merging. After the merged commit has
 passed the release build and smoke test, the App performs protected tag and
-release writes and keeps the persistent streams aligned. A prerelease merge
+draft-release writes and keeps the persistent streams aligned. A prerelease merge
 advances `dev` to the merged prerelease commit. A stable merge advances both
 `prerelease` and `dev` to the merged stable commit.
 
@@ -49,15 +50,23 @@ There is no separate version input.
 1. Prepare the exact release version in `Cargo.toml` and `Cargo.lock` on `dev`.
 2. Open a PR from `dev` to `prerelease` or `main`.
 3. Wait for `verify`, `bundle-smoke-test`, and `validate-promotion` to pass.
-4. Merge the promotion PR. This is the release authorization.
+4. Merge the promotion PR. This authorizes preparation of the release draft.
 5. The resulting push starts the serialized release workflow, which builds and
    smoke-tests the merged release commit without write credentials, including
    an archive-driven upgrade from the pinned public baseline.
-6. The final job obtains a short-lived token from the dedicated repository-only
-   GitHub App, aligns the remaining release streams, creates or resumes a draft,
-   verifies its complete asset set, and publishes it. Repository release
-   immutability then locks the tag and assets.
-7. A published prerelease then runs `v1.4.0-beta.2` through the real production
+6. The staging job obtains a short-lived token from the dedicated repository-only
+   GitHub App, aligns the remaining release streams, creates or resumes the exact
+   release draft, uploads any missing assets, and verifies the complete asset set.
+7. Fill in the draft's release-specific notes and review its title, classification,
+   tag, and assets. Then approve the waiting `release-publication` environment.
+   The approval does not accept an independent version, tag, commit, artifact, or
+   workflow-run identifier.
+8. The publication job downloads the same workflow artifact again, revalidates the
+   merged refs, tag, checksums, manifest, draft classification, complete remote
+   asset set, and non-placeholder notes, then makes only that draft public. It
+   preserves the reviewed title and notes. Repository release immutability then
+   locks the tag and assets.
+9. A published prerelease then runs `v1.4.0-beta.2` through the real production
    `lg-buddy updates install` path. The newly installed candidate performs a
    cold-cache production update check, and the canary records sanitized GitHub
    response evidence for the deterministic mock. This is supplemental
@@ -65,19 +74,23 @@ There is no separate version input.
 
 Promotion through `prerelease` is optional. A direct `dev -> main` promotion
 runs the same required PR validation and post-merge release build as a
-`dev -> prerelease` promotion. After stable publication, the release App
+`dev -> prerelease` promotion. During stable draft staging, the release App
 fast-forwards both `prerelease` and `dev` to the reviewed stable commit.
 
-Replace the publisher's generic release description with concise,
-release-specific notes for user-visible default or compatibility changes before
-announcing the release.
+Replace the draft's placeholder with concise, release-specific notes before
+approving publication. The workflow does not impose a notes template, but it
+refuses to publish empty, whitespace-only, or unchanged placeholder notes.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge
 release run can be rerun safely: an incomplete draft remains private and is
 resumed only when its tag, classification, and existing assets match the merged
-release commit. A published release is accepted only when its expected asset set
-is complete and byte-for-byte identical.
+release commit. If publication was attempted before the notes were ready, update
+the draft, rerun the failed jobs, and approve the environment again. The staged
+workflow artifact is retained for 30 days, matching GitHub's maximum wait for an
+environment approval; after that, rerun the whole workflow to rebuild it. A
+published release is accepted only when its expected asset set is complete and
+byte-for-byte identical.
 
 Repository release immutability must remain enabled. GitHub applies it only when
 a draft is published, so the publisher uploads and verifies every expected asset
@@ -100,10 +113,12 @@ The workflow:
    preserved user state plus replaced owned integration files.
 7. Generates and verifies `sha256sums.txt`.
 8. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
-9. Stages the exact release assets privately, then publishes them together under
-   the repository's immutable-release policy.
-10. Downloads the published assets and verifies their checksums independently.
-11. For prereleases, exercises production GitHub discovery, acquisition,
+9. Stages and verifies the exact release assets privately.
+10. Waits for release-note review and explicit publication approval.
+11. Revalidates and publishes only the staged draft, preserving its reviewed
+    title and notes.
+12. Downloads the published assets and verifies their checksums independently.
+13. For prereleases, exercises production GitHub discovery, acquisition,
     confirmation, installation, and final identity from the pinned baseline.
 
 `install.sh` is only an installer. It does not build the runtime or GUI.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -87,10 +87,10 @@ release run can be rerun safely: an incomplete draft remains private and is
 resumed only when its tag, classification, and existing assets match the merged
 release commit. If publication was attempted before the notes were ready, update
 the draft, rerun the failed jobs, and approve the environment again. The staged
-workflow artifact is retained for 30 days, matching GitHub's maximum wait for an
-environment approval; after that, rerun the whole workflow to rebuild it. A
-published release is accepted only when its expected asset set is complete and
-byte-for-byte identical.
+workflow artifact is retained for 35 days, leaving a margin beyond GitHub's
+30-day maximum wait for an environment approval; after that, rerun the whole
+workflow to rebuild it. A published release is accepted only when its expected
+asset set is complete and byte-for-byte identical.
 
 Repository release immutability must remain enabled. GitHub applies it only when
 a draft is published, so the publisher uploads and verifies every expected asset

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -381,6 +381,14 @@ and upgrades to an explicit candidate archive. It checks initial and candidate
 refusals before network, sudo, or mutation, then verifies preserved user state,
 candidate-owned file replacement, service action order, and final identity.
 
+The mock-backed release publisher suite keeps draft staging and publication as
+separate capabilities. It proves that staging can create and resume a complete
+draft but cannot publish it, while publication cannot create or upload anything.
+Publication requires reviewed non-placeholder notes and an exact remote asset
+match, changes only the draft state, and preserves the reviewed title and notes.
+Checksum, manifest, classification, unexpected-asset, partial-upload, corrupted
+upload, retry, and already-published paths are covered without GitHub access.
+
 After a prerelease is public, `production-prerelease-canary` installs the same
 baseline and drives its real `updates install` command through a PTY against
 GitHub. It then clears the update cache and proves that the newly installed

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -5,9 +5,17 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 usage() {
-    echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
+    echo "Usage: $0 <stage-draft|publish-draft> [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
     exit 1
 }
+
+[ "$#" -gt 0 ] || usage
+MODE="$1"
+shift
+case "$MODE" in
+    stage-draft|publish-draft) ;;
+    *) usage ;;
+esac
 
 DIST_DIR="dist"
 TAG="${GITHUB_REF_NAME:-}"
@@ -64,6 +72,8 @@ CHECKSUM_FILE="$DIST_DIR/sha256sums.txt"
     exit 1
 }
 
+(cd "$DIST_DIR" && sha256sum --strict -c "$(basename "$CHECKSUM_FILE")")
+
 VERSION="${TAG#v}"
 [ -n "$VERSION" ] || {
     echo "Release tag must include a version after v."
@@ -71,7 +81,7 @@ VERSION="${TAG#v}"
 }
 
 TITLE="LG Buddy ${VERSION}"
-NOTES="Prebuilt LG Buddy release bundle for Linux. Extract the archive and run ./install.sh from inside the bundle."
+PLACEHOLDER_NOTES="Release notes pending maintainer review."
 RELEASE_FLAGS=()
 EXPECTED_CHANNEL="stable"
 
@@ -95,7 +105,7 @@ for archive in "${ARCHIVES[@]}"; do
 done
 
 if [ "$DRY_RUN" = "1" ]; then
-    echo "Dry run: would publish tag $TAG"
+    echo "Dry run: would run $MODE for tag $TAG"
     printf 'Archive: %s\n' "${ARCHIVES[@]}"
     echo "Checksum file: $CHECKSUM_FILE"
     echo "Title: $TITLE"
@@ -121,9 +131,11 @@ if [ "${#RELEASE_FLAGS[@]}" -gt 0 ]; then
     EXPECTED_PRERELEASE="true"
 fi
 
+RELEASE_EXISTS="false"
 RELEASE_IS_DRAFT="true"
 if gh release view "$TAG" >/dev/null 2>&1; then
-    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    RELEASE_EXISTS="true"
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
     RELEASE_IS_DRAFT="$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)"
     case "$RELEASE_IS_DRAFT" in
         true|false) ;;
@@ -136,8 +148,21 @@ if gh release view "$TAG" >/dev/null 2>&1; then
         echo "Existing release $TAG has the wrong prerelease classification."
         exit 1
     }
-else
-    gh release create "$TAG" --draft --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
+fi
+
+if [ "$MODE" = "publish-draft" ] && [ "$RELEASE_EXISTS" = "false" ]; then
+    echo "Release draft $TAG does not exist. Run stage-draft first."
+    exit 1
+fi
+
+if [ "$MODE" = "stage-draft" ] && [ "$RELEASE_EXISTS" = "false" ]; then
+    gh release create "$TAG" \
+        --draft \
+        --verify-tag \
+        --title "$TITLE" \
+        --notes "$PLACEHOLDER_NOTES" \
+        "${RELEASE_FLAGS[@]}"
+    RELEASE_EXISTS="true"
 fi
 
 EXPECTED_ASSETS=("${ARCHIVES[@]}" "$CHECKSUM_FILE")
@@ -173,8 +198,8 @@ done <<< "$RELEASE_ASSET_NAMES"
 for asset in "${EXPECTED_ASSETS[@]}"; do
     asset_name="$(basename "$asset")"
     if ! grep -F -x -q -- "$asset_name" <<< "$RELEASE_ASSET_NAMES"; then
-        [ "$RELEASE_IS_DRAFT" = "true" ] || {
-            echo "Published release $TAG is missing required asset: $asset_name"
+        [ "$MODE" = "stage-draft" ] && [ "$RELEASE_IS_DRAFT" = "true" ] || {
+            echo "Release $TAG is missing required asset: $asset_name"
             exit 1
         }
         gh release upload "$TAG" "$asset"
@@ -229,30 +254,77 @@ for asset in "${EXPECTED_ASSETS[@]}"; do
     }
 done
 
-if [ "$RELEASE_IS_DRAFT" = "true" ]; then
-    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
-        echo "Release $TAG was published before asset verification completed."
-        exit 1
-    }
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
-        echo "Release $TAG changed prerelease classification before publication."
-        exit 1
-    }
-
-    gh release edit "$TAG" \
-        --draft=false \
-        --prerelease="$EXPECTED_PRERELEASE" \
-        --title "$TITLE" \
-        --notes "$NOTES"
-
-    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
-        echo "Release $TAG remained a draft after publication."
-        exit 1
-    }
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
-        echo "Published release $TAG has the wrong prerelease classification."
-        exit 1
-    }
+if [ "$MODE" = "stage-draft" ]; then
+    if [ "$RELEASE_IS_DRAFT" = "true" ]; then
+        RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
+        [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
+            echo "Release $TAG was published before draft verification completed."
+            exit 1
+        }
+        [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+            echo "Release $TAG changed prerelease classification during draft staging."
+            exit 1
+        }
+        echo "Verified release draft $TAG is ready for release-note review and publication approval."
+    else
+        echo "Published release $TAG already has the complete verified asset set."
+    fi
+    exit 0
 fi
+
+release_notes_are_ready() {
+    local state="$1"
+    printf '%s' "$state" | jq -e --arg placeholder "$PLACEHOLDER_NOTES" '
+        (.body // "") as $body |
+        ($body != $placeholder) and (($body | gsub("\\s"; "") | length) > 0)
+    ' >/dev/null
+}
+
+release_notes_are_ready "$RELEASE_STATE" || {
+    echo "Release $TAG still has empty or placeholder release notes."
+    exit 1
+}
+
+if [ "$RELEASE_IS_DRAFT" = "false" ]; then
+    echo "Published release $TAG already has the complete verified asset set and reviewed notes."
+    exit 0
+fi
+
+RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
+[ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
+    echo "Release $TAG was published before final verification completed."
+    exit 1
+}
+[ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+    echo "Release $TAG changed prerelease classification before publication."
+    exit 1
+}
+release_notes_are_ready "$RELEASE_STATE" || {
+    echo "Release $TAG still has empty or placeholder release notes."
+    exit 1
+}
+
+REVIEWED_BODY="$(printf '%s' "$RELEASE_STATE" | jq -c '.body')"
+REVIEWED_NAME="$(printf '%s' "$RELEASE_STATE" | jq -c '.name')"
+
+gh release edit "$TAG" --draft=false
+
+PUBLISHED_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -r .isDraft)" = "false" ] || {
+    echo "Release $TAG remained a draft after publication."
+    exit 1
+}
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+    echo "Published release $TAG has the wrong prerelease classification."
+    exit 1
+}
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -c '.body')" = "$REVIEWED_BODY" ] || {
+    echo "Published release $TAG did not preserve the reviewed release notes."
+    exit 1
+}
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -c '.name')" = "$REVIEWED_NAME" ] || {
+    echo "Published release $TAG did not preserve the reviewed title."
+    exit 1
+}
+
+echo "Published verified release $TAG with its reviewed title and notes unchanged."

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -276,7 +276,9 @@ release_notes_are_ready() {
     local state="$1"
     printf '%s' "$state" | jq -e --arg placeholder "$PLACEHOLDER_NOTES" '
         (.body // "") as $body |
-        ($body != $placeholder) and (($body | gsub("\\s"; "") | length) > 0)
+        ($body | gsub("\\s"; "")) as $normalized_body |
+        ($placeholder | gsub("\\s"; "")) as $normalized_placeholder |
+        ($normalized_body != $normalized_placeholder) and ($normalized_body | length > 0)
     ' >/dev/null
 }
 

--- a/scripts/release_promotion.py
+++ b/scripts/release_promotion.py
@@ -263,7 +263,7 @@ def validate_promotion(
 
     return {
         **identity,
-        "publish": True,
+        "prepare": True,
         "head_sha": head_sha,
         "source_sha": dev_sha,
         "base_sha": target_sha,
@@ -296,7 +296,7 @@ def validate_merged_promotion(
     if target == "prerelease" and main_sha == head_sha:
         version = package_version_at_ref(repository, head_sha, RUNTIME_MANIFEST_PATH)
         return {
-            "publish": False,
+            "prepare": False,
             "version": version,
             "tag": f"v{version}",
             "channel": "stable",
@@ -324,7 +324,7 @@ def validate_merged_promotion(
     )
     return {
         **identity,
-        "publish": True,
+        "prepare": True,
         "head_sha": head_sha,
         "source_sha": source_sha,
         "base_sha": previous_sha,

--- a/scripts/test_publish_release_assets.py
+++ b/scripts/test_publish_release_assets.py
@@ -6,7 +6,6 @@ import hashlib
 import io
 import json
 import os
-import shutil
 import subprocess
 import tarfile
 import tempfile
@@ -26,6 +25,7 @@ VERSION = "9.8.7-beta.1"
 TAG = f"v{VERSION}"
 TARGET = "x86_64-unknown-linux-musl"
 GUI_TARGET = "x86_64-unknown-linux-gnu"
+PLACEHOLDER_NOTES = "Release notes pending maintainer review."
 
 
 FAKE_GH = r"""#!/usr/bin/env python3
@@ -48,6 +48,11 @@ state = json.loads(state_path.read_text(encoding="utf-8"))
 
 def save():
     state_path.write_text(json.dumps(state), encoding="utf-8")
+
+def option_value(arguments, option, default=None):
+    if option not in arguments:
+        return default
+    return arguments[arguments.index(option) + 1]
 
 if len(args) < 3 or args[0] != "release":
     sys.exit("unsupported fake gh invocation")
@@ -80,6 +85,8 @@ if command == "view":
         print(json.dumps({
             "isDraft": state["draft"],
             "isPrerelease": state["prerelease"],
+            "body": state["body"],
+            "name": state["title"],
         }))
     sys.exit(0)
 
@@ -90,6 +97,8 @@ if command == "create":
         "exists": True,
         "draft": "--draft" in rest,
         "prerelease": "--prerelease" in rest,
+        "body": option_value(rest, "--notes", ""),
+        "title": option_value(rest, "--title", ""),
         "assets": [],
     })
     save()
@@ -114,19 +123,18 @@ if command == "upload":
     save()
     sys.exit(0)
 
-if command == "download":
-    pattern = rest[rest.index("--pattern") + 1]
-    destination = Path(rest[rest.index("--dir") + 1])
-    destination.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(asset_dir / pattern, destination / pattern)
-    sys.exit(0)
-
 if command == "edit":
     for argument in rest:
         if argument.startswith("--draft="):
             state["draft"] = argument.split("=", 1)[1] == "true"
         elif argument.startswith("--prerelease="):
             state["prerelease"] = argument.split("=", 1)[1] == "true"
+    notes = option_value(rest, "--notes")
+    title = option_value(rest, "--title")
+    if notes is not None:
+        state["body"] = notes
+    if title is not None:
+        state["title"] = title
     save()
     sys.exit(0)
 
@@ -219,10 +227,14 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         exists: bool = False,
         draft: bool = True,
         prerelease: bool = True,
+        body: str = "Reviewed release notes",
+        title: str = "Reviewed release title",
         assets: dict[str, bytes] | None = None,
     ) -> None:
         asset_values = assets or {}
         self.remote_assets.mkdir(parents=True, exist_ok=True)
+        for existing in self.remote_assets.iterdir():
+            existing.unlink()
         for name, content in asset_values.items():
             (self.remote_assets / name).write_bytes(content)
         self.state_path.write_text(
@@ -231,6 +243,8 @@ class PublishReleaseAssetsTests(unittest.TestCase):
                     "exists": exists,
                     "draft": draft,
                     "prerelease": prerelease,
+                    "body": body,
+                    "title": title,
                     "assets": list(asset_values),
                 }
             ),
@@ -239,6 +253,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
 
     def run_publisher(
         self,
+        mode: str = "stage-draft",
         *,
         fail_upload: str | None = None,
         corrupt_upload: str | None = None,
@@ -252,6 +267,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
             [
                 "bash",
                 self.publisher,
+                mode,
                 "--dist-dir",
                 self.dist,
                 "--tag",
@@ -287,24 +303,22 @@ class PublishReleaseAssetsTests(unittest.TestCase):
             self.checksums.name: self.checksums.read_bytes(),
         }
 
-    def test_new_release_is_published_only_after_assets_are_uploaded(self) -> None:
+    def test_new_release_is_staged_as_a_complete_draft(self) -> None:
         result = self.run_publisher()
 
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertEqual(set(self.state()["assets"]), set(self.complete_assets()))
-        self.assertFalse(self.state()["draft"])
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.state()["body"], PLACEHOLDER_NOTES)
         create = self.mutations("create")
         uploads = self.mutations("upload")
-        edit = self.mutations("edit")
         self.assertEqual(len(create), 1)
         self.assertIn("--draft", create[0])
         self.assertEqual(len(uploads), 2)
-        self.assertEqual(len(edit), 1)
-        self.assertIn("--draft=false", edit[0])
+        self.assertEqual(self.mutations("edit"), [])
         self.assertLess(self.calls().index(create[0]), self.calls().index(uploads[0]))
-        self.assertLess(self.calls().index(uploads[-1]), self.calls().index(edit[0]))
 
-    def test_retry_resumes_a_partially_uploaded_draft(self) -> None:
+    def test_staging_retry_resumes_a_partially_uploaded_draft(self) -> None:
         first = self.run_publisher(fail_upload=self.checksums.name)
         self.assertNotEqual(first.returncode, 0)
         self.assertTrue(self.state()["draft"])
@@ -312,15 +326,32 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         second = self.run_publisher()
 
         self.assertEqual(second.returncode, 0, second.stdout)
-        self.assertFalse(self.state()["draft"])
+        self.assertTrue(self.state()["draft"])
         self.assertEqual(len(self.mutations("create")), 1)
         archive_uploads = [
             call for call in self.mutations("upload") if call[-1] == str(self.archive)
         ]
         self.assertEqual(len(archive_uploads), 1)
-        self.assertEqual(len(self.mutations("edit")), 1)
+        self.assertEqual(self.mutations("edit"), [])
 
-    def test_unexpected_draft_asset_blocks_publication_without_mutation(self) -> None:
+    def test_staging_preserves_existing_reviewed_title_and_notes(self) -> None:
+        self.write_state(
+            exists=True,
+            body="Carefully reviewed notes\n",
+            title="Custom title",
+            assets=self.complete_assets(),
+        )
+
+        result = self.run_publisher()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.state()["body"], "Carefully reviewed notes\n")
+        self.assertEqual(self.state()["title"], "Custom title")
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_unexpected_draft_asset_blocks_staging_without_mutation(self) -> None:
         self.write_state(exists=True, assets={"unexpected.txt": b"unexpected"})
 
         result = self.run_publisher()
@@ -345,11 +376,8 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertEqual(self.mutations("upload"), [])
         self.assertEqual(self.mutations("edit"), [])
 
-    def test_mismatched_draft_asset_blocks_publication(self) -> None:
-        self.write_state(
-            exists=True,
-            assets={self.archive.name: b"different archive"},
-        )
+    def test_mismatched_draft_asset_blocks_staging(self) -> None:
+        self.write_state(exists=True, assets={self.archive.name: b"different archive"})
 
         result = self.run_publisher()
 
@@ -358,7 +386,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertTrue(self.state()["draft"])
         self.assertEqual(self.mutations("edit"), [])
 
-    def test_successful_but_corrupted_upload_blocks_publication(self) -> None:
+    def test_successful_but_corrupted_upload_blocks_staging(self) -> None:
         result = self.run_publisher(corrupt_upload=self.checksums.name)
 
         self.assertNotEqual(result.returncode, 0)
@@ -366,7 +394,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertTrue(self.state()["draft"])
         self.assertEqual(self.mutations("edit"), [])
 
-    def test_complete_published_release_is_verification_only(self) -> None:
+    def test_complete_published_release_is_staging_verification_only(self) -> None:
         self.write_state(exists=True, draft=False, assets=self.complete_assets())
 
         result = self.run_publisher()
@@ -375,6 +403,100 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertEqual(self.mutations("create"), [])
         self.assertEqual(self.mutations("upload"), [])
         self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_requires_an_existing_draft(self) -> None:
+        result = self.run_publisher("publish-draft")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not exist", result.stdout)
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_rejects_missing_assets_without_uploading(self) -> None:
+        self.write_state(
+            exists=True,
+            assets={self.archive.name: self.archive.read_bytes()},
+        )
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is missing required asset", result.stdout)
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_rejects_mismatched_draft_classification(self) -> None:
+        self.write_state(
+            exists=True,
+            prerelease=False,
+            assets=self.complete_assets(),
+        )
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("wrong prerelease classification", result.stdout)
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_preserves_reviewed_title_and_notes(self) -> None:
+        self.write_state(
+            exists=True,
+            body="Reviewed notes\nwith details.\n",
+            title="Custom reviewed title",
+            assets=self.complete_assets(),
+        )
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.state()["draft"])
+        self.assertEqual(self.state()["body"], "Reviewed notes\nwith details.\n")
+        self.assertEqual(self.state()["title"], "Custom reviewed title")
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        edits = self.mutations("edit")
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(edits[0][3:], ["--draft=false"])
+
+    def test_empty_or_placeholder_notes_block_publication(self) -> None:
+        for notes in ("", " \n\t", PLACEHOLDER_NOTES):
+            with self.subTest(notes=notes):
+                self.write_state(
+                    exists=True,
+                    body=notes,
+                    assets=self.complete_assets(),
+                )
+                if self.log_path.exists():
+                    self.log_path.unlink()
+
+                result = self.run_publisher("publish-draft")
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("empty or placeholder release notes", result.stdout)
+                self.assertTrue(self.state()["draft"])
+                self.assertEqual(self.mutations("edit"), [])
+
+    def test_complete_published_release_is_publication_verification_only(self) -> None:
+        self.write_state(exists=True, draft=False, assets=self.complete_assets())
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_invalid_local_checksum_blocks_before_github_access(self) -> None:
+        self.checksums.write_text(
+            f"{'0' * 64}  {self.archive.name}\n", encoding="utf-8"
+        )
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.calls(), [])
 
 
 if __name__ == "__main__":

--- a/scripts/test_publish_release_assets.py
+++ b/scripts/test_publish_release_assets.py
@@ -461,7 +461,13 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertEqual(edits[0][3:], ["--draft=false"])
 
     def test_empty_or_placeholder_notes_block_publication(self) -> None:
-        for notes in ("", " \n\t", PLACEHOLDER_NOTES):
+        for notes in (
+            "",
+            " \n\t",
+            PLACEHOLDER_NOTES,
+            f" \n{PLACEHOLDER_NOTES}\t\n",
+            PLACEHOLDER_NOTES.replace(" ", "\n"),
+        ):
             with self.subTest(notes=notes):
                 self.write_state(
                     exists=True,

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -259,7 +259,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("prerelease", merged, base)
 
-        self.assertTrue(result["publish"])
+        self.assertTrue(result["prepare"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["source_sha"], source)
         self.assertEqual(result["tag"], "v1.4.0-beta.1")
@@ -275,7 +275,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("main", merged, base)
 
-        self.assertTrue(result["publish"])
+        self.assertTrue(result["prepare"])
         self.assertEqual(result["source_sha"], source)
         self.assertEqual(result["tag"], "v1.4.0")
         self.assertEqual(result["channel"], "stable")
@@ -286,7 +286,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("main", merged, base)
 
-        self.assertTrue(result["publish"])
+        self.assertTrue(result["prepare"])
         self.assertEqual(result["source_sha"], source)
         self.assertEqual(result["tag"], "v1.4.0")
         self.assertEqual(result["channel"], "stable")
@@ -302,7 +302,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("prerelease", merged, prerelease)
 
-        self.assertFalse(result["publish"])
+        self.assertFalse(result["prepare"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["base_sha"], prerelease)
         self.assertEqual(result["channel"], "stable")
@@ -318,7 +318,7 @@ class PromotionTests(unittest.TestCase):
             "prerelease", merged, self.repository.stable_sha
         )
 
-        self.assertFalse(result["publish"])
+        self.assertFalse(result["prepare"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["base_sha"], self.repository.stable_sha)
         self.assertEqual(result["channel"], "stable")


### PR DESCRIPTION
## Summary

- stage and verify the exact promoted release as a private GitHub draft
- require the `release-publication` environment approval before finalization
- revalidate refs, identity, checksums, manifest, remote assets, classification, and reviewed notes before changing only the draft state
- preserve maintainer-edited release title and notes and keep prerelease canaries post-publication

## Validation

- `python3 scripts/test_release_promotion.py`
- `python3 scripts/test_publish_release_assets.py`
- `python3 scripts/test_release_bundle_manifest.py`
- `shellcheck scripts/publish-release-assets.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check`

Closes #167