### PR TITLE
Reduce redundant GitHub Actions usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   pull_request:
-  push:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   checks: read
@@ -11,6 +14,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository
@@ -68,6 +72,7 @@ jobs:
 
   bundle-smoke-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     needs: verify
     env:
       SMOKE_VERSION: 1.4.0-beta.2.ci
@@ -161,10 +166,12 @@ jobs:
           name: ci-release-bundle
           path: dist/*.tar.gz
           if-no-files-found: error
+          retention-days: 7
 
   bundle-supported-distros:
     needs: bundle-smoke-test
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     env:
       SMOKE_VERSION: 1.4.0-beta.2.ci
     strategy:


### PR DESCRIPTION
## Summary

- run the full CI workflow once per pull request instead of repeating it for every push, protected-branch update, and release tag
- cancel superseded runs for the same pull request
- cap each CI job at 20 minutes
- retain the intermediate CI release bundle for 7 days instead of the default 90

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read CONTRIBUTING.md and the relevant docs linked there.
- [x] This is a small workflow correction backed by the measured Actions usage.

## User-Visible Behavior

None. Every pull request still runs verify, bundle-smoke-test, and both supported-distribution checks.

## Validation

- actionlint on all GitHub Actions workflows
- 24 release-promotion contract tests
- 15 release-publication contract tests
- 22 release-bundle manifest tests
- 6 GitHub response recorder tests
- shell syntax validation
- git diff --check

## Related Issue

Fixes #169