### PR TITLE
Install GUI runtime dependencies from release bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Validate shell scripts
         run: |
-          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-installer-gui-dependencies.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
           python3 -m py_compile scripts/test-release-gui-accessibility.py scripts/xwd_mean.py
 
       - name: Validate release promotion contract
@@ -180,9 +180,11 @@ jobs:
         include:
           - name: Fedora 43
             image: fedora:43
+            package_manager: dnf
             setup: dnf install -y at-spi2-core binutils curl dbus-x11 findutils glib2 gobject-introspection gsettings-desktop-schemas gtk4 gzip libadwaita libglvnd-gles python3 python3-pyatspi shadow-utils strace tar util-linux which xdotool xorg-x11-server-Xvfb xorg-x11-xauth xwd zenity
           - name: Arch current
             image: archlinux:latest
+            package_manager: pacman
             setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd zenity
     container:
       image: ${{ matrix.image }}
@@ -212,6 +214,11 @@ jobs:
           runuser -u tester -- bash ./scripts/test-release-linkage.sh \
               "$bundle/lg-buddy" \
               "$bundle/docs/lg-buddy-gui-x86_64-unknown-linux-gnu"
+          runuser -u tester -- bash ./scripts/test-installer-gui-dependencies.sh \
+              "$bundle/install.sh" \
+              "$bundle/lg-buddy" \
+              "$bundle/docs/lg-buddy-gui-x86_64-unknown-linux-gnu" \
+              "${{ matrix.package_manager }}"
           runuser -u tester -- dbus-run-session -- xvfb-run -a \
               env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals LG_BUDDY_TEST_PLATFORM_CONTRACT=1 \
               bash ./scripts/test-installed-gui.sh \

--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ require Python. Native-only packages can omit the Python client, `venv`, and
 `pip`. The release-bundle installer still provisions `bscpylgtv` as an explicit
 compatibility fallback, so it checks for Python 3 with a `venv` that provisions
 `pip`, plus `zenity`. Official release bundles target the Ubuntu 24.04 runtime
-baseline: GTK 4.14, libadwaita 1.5, and glibc 2.39 or newer. The installer
-verifies that the GUI executable can load and has the same release identity as
-the runtime before changing the installation.
+baseline: GTK 4.14, libadwaita 1.5, and glibc 2.39 or newer. Before executing
+the GUI, the installer checks the installed GTK and libadwaita runtime versions.
+On apt, dnf, and pacman systems it can install the mapped runtime packages after
+explicit confirmation; refusal and noninteractive operation without that opt-in
+leave package installation to the user. The installer then verifies that the GUI
+executable can load and has the same release identity as the runtime before
+changing the LG Buddy installation.
 Zenity remains the compatibility fallback when the GUI executable is absent.
 `swayidle` is needed only by an existing explicit selection or as the deprecated
 compatibility fallback.

--- a/docs/development.md
+++ b/docs/development.md
@@ -179,9 +179,11 @@ dbus-run-session -- xvfb-run -a ./scripts/test-release-bundle.sh \
 The smoke test validates `release-manifest.json` against the archive name and
 bundled runtime and GUI before running installer code. It then installs into a temporary
 root and exercises upgrade refusal, preservation, Python repair, owned-file
-replacement, service ordering, installed identity, mocked GUI read/apply/failure/
-cancel behavior, lifecycle topology, and uninstall cleanup without mutating the
-host installation.
+replacement, service ordering, GTK/libadwaita dependency confirmation and
+refusal, installed identity, mocked GUI read/apply/failure/cancel behavior,
+lifecycle topology, and uninstall cleanup without mutating the host installation.
+The supported Fedora and Arch lanes repeat the dependency flow with their native
+package-manager mappings.
 
 Run the cross-version smoke with explicit previous and candidate archives:
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -338,6 +338,12 @@ light/dark rendering, and 1x/2x window-geometry coverage. The display-backed
 renderer suite separately asserts the same GTK semantics directly at the widget
 boundary.
 
+The Ubuntu bundle smoke and the Fedora and Arch installation lanes also exercise
+GUI runtime dependency handling. They prove that an unconfirmed install does not
+invoke the package manager or GUI, an accepted install requests the correct
+native package names before GUI identity validation, insufficient versions abort
+before LG Buddy mutation, and already-satisfied hosts perform no package action.
+
 The Rust release-bundle acquisition suite covers exact asset selection, fresh
 release metadata, bounded responses and downloads, GitHub and published digest
 agreement, lightweight and annotated tags, restrictive staging and locking,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -291,6 +291,14 @@ bundle, reruns preflight from the candidate, invokes `install.sh --upgrade`,
 and verifies the installed release identity. It does not accept channel or
 version arguments, downgrade, migrate legacy installations, or run unattended.
 
+Before a fresh installation or upgrade executes the bundled GUI, the installer
+checks for GTK 4.14 or newer and libadwaita 1.5 or newer. If either is missing,
+apt systems offer `libgtk-4-1` and `libadwaita-1-0`; dnf and pacman systems offer
+`gtk4` and `libadwaita`. Installing them requires a separate explicit
+confirmation. Declining, running noninteractively without that opt-in, using an
+unsupported package manager, or remaining below the required versions aborts
+before LG Buddy installation files are changed and prints a manual command.
+
 `v1.4.0-beta.2` is the first release that contains `updates install`. Older
 installations require one normal manual installation of an updater-capable
 release before this assisted path is available.

--- a/install.sh
+++ b/install.sh
@@ -294,7 +294,7 @@ print_manual_install_command() {
         apt) echo "  sudo apt install ${MISSING_PKGS[*]}" ;;
         dnf) echo "  sudo dnf install ${MISSING_PKGS[*]}" ;;
         pacman) echo "  sudo pacman -S ${MISSING_PKGS[*]}" ;;
-        *) echo "Install GTK 4.14 or newer and libadwaita 1.5 or newer with your system package manager." ;;
+        *) echo "Install these requirements with your system package manager: ${MISSING_PKGS[*]}" ;;
     esac
 }
 

--- a/install.sh
+++ b/install.sh
@@ -110,6 +110,7 @@ SCREEN_IDLE_BLANK="enabled"
 SYSTEM_CONFIG_OVERRIDE_TMP=""
 CONFIG_POINTER_TMP=""
 NM_HOOK_TMP=""
+PM=""
 INSTALL_CMD=()
 
 prefix_path() {
@@ -197,6 +198,104 @@ check_python3_venv() {
 
     rm -rf "$tmp_venv_dir"
     return 1
+}
+
+detect_package_manager() {
+    if command -v apt &>/dev/null; then
+        PM="apt"
+        INSTALL_CMD=(apt install -y)
+    elif command -v dnf &>/dev/null; then
+        PM="dnf"
+        INSTALL_CMD=(dnf install -y)
+    elif command -v pacman &>/dev/null; then
+        PM="pacman"
+        INSTALL_CMD=(pacman -S --noconfirm)
+    else
+        PM=""
+        INSTALL_CMD=()
+    fi
+}
+
+gui_runtime_package() {
+    local requirement="$1"
+
+    case "$PM:$requirement" in
+        apt:gtk) printf '%s\n' "libgtk-4-1" ;;
+        apt:libadwaita) printf '%s\n' "libadwaita-1-0" ;;
+        dnf:gtk|pacman:gtk) printf '%s\n' "gtk4" ;;
+        dnf:libadwaita|pacman:libadwaita) printf '%s\n' "libadwaita" ;;
+        *:gtk) printf '%s\n' "GTK 4.14 or newer" ;;
+        *:libadwaita) printf '%s\n' "libadwaita 1.5 or newer" ;;
+    esac
+}
+
+gui_runtime_version_at_least() {
+    local library="$1"
+    local symbol_prefix="$2"
+    local required_major="$3"
+    local required_minor="$4"
+
+    if [ -n "${LG_BUDDY_GUI_RUNTIME_PROBE:-}" ]; then
+        "$LG_BUDDY_GUI_RUNTIME_PROBE" \
+            "$library" "$symbol_prefix" "$required_major" "$required_minor"
+        return
+    fi
+
+    python3 - "$library" "$symbol_prefix" "$required_major" "$required_minor" <<'PY'
+import ctypes
+import sys
+
+library, prefix, required_major, required_minor = sys.argv[1:]
+try:
+    runtime = ctypes.CDLL(library)
+    major = getattr(runtime, f"{prefix}_get_major_version")
+    minor = getattr(runtime, f"{prefix}_get_minor_version")
+    major.argtypes = []
+    minor.argtypes = []
+    major.restype = ctypes.c_uint
+    minor.restype = ctypes.c_uint
+    installed = (major(), minor())
+except (AttributeError, OSError):
+    raise SystemExit(1)
+
+required = (int(required_major), int(required_minor))
+raise SystemExit(0 if installed >= required else 1)
+PY
+}
+
+check_gui_runtime_prerequisites() {
+    check_dep \
+        "GTK 4.14 or newer" \
+        "$(gui_runtime_package gtk)" \
+        "gui_runtime_version_at_least libgtk-4.so.1 gtk 4 14"
+    check_dep \
+        "libadwaita 1.5 or newer" \
+        "$(gui_runtime_package libadwaita)" \
+        "gui_runtime_version_at_least libadwaita-1.so.0 adw 1 5"
+}
+
+verify_gui_runtime_prerequisites() {
+    local missing=0
+
+    if ! gui_runtime_version_at_least libgtk-4.so.1 gtk 4 14; then
+        echo "Error: GTK 4.14 or newer is still unavailable."
+        missing=1
+    fi
+    if ! gui_runtime_version_at_least libadwaita-1.so.0 adw 1 5; then
+        echo "Error: libadwaita 1.5 or newer is still unavailable."
+        missing=1
+    fi
+
+    [ "$missing" -eq 0 ] || return 1
+}
+
+print_manual_install_command() {
+    case "$PM" in
+        apt) echo "  sudo apt install ${MISSING_PKGS[*]}" ;;
+        dnf) echo "  sudo dnf install ${MISSING_PKGS[*]}" ;;
+        pacman) echo "  sudo pacman -S ${MISSING_PKGS[*]}" ;;
+        *) echo "Install GTK 4.14 or newer and libadwaita 1.5 or newer with your system package manager." ;;
+    esac
 }
 
 write_config_override() {
@@ -352,19 +451,6 @@ install_missing_prerequisites() {
     echo ""
     echo "Missing: ${MISSING_PKGS[*]}"
 
-    if command -v apt &>/dev/null; then
-        PM="apt"
-        INSTALL_CMD=(apt install -y)
-    elif command -v dnf &>/dev/null; then
-        PM="dnf"
-        INSTALL_CMD=(dnf install -y)
-    elif command -v pacman &>/dev/null; then
-        PM="pacman"
-        INSTALL_CMD=(pacman -S --noconfirm)
-    else
-        PM=""
-    fi
-
     if [ -n "$PM" ]; then
         AUTO_INSTALL="${LG_BUDDY_AUTO_INSTALL_DEPS:-}"
         if [ -z "$AUTO_INSTALL" ] && [ "$NONINTERACTIVE" != "1" ]; then
@@ -372,27 +458,42 @@ install_missing_prerequisites() {
         fi
         case "$AUTO_INSTALL" in
             [Yy]*)
-                run_privileged "${INSTALL_CMD[@]}" "${MISSING_PKGS[@]}"
+                if ! run_privileged "${INSTALL_CMD[@]}" "${MISSING_PKGS[@]}"; then
+                    echo "Failed to install the missing packages. Install them manually and re-run install.sh."
+                    print_manual_install_command
+                    exit 1
+                fi
                 ;;
             *)
                 echo "Please install the missing packages manually and re-run install.sh."
+                print_manual_install_command
                 exit 1
                 ;;
         esac
     else
         echo "Could not detect a supported package manager (apt/dnf/pacman)."
         echo "Please install the missing packages manually and re-run install.sh."
+        print_manual_install_command
         exit 1
     fi
 }
 
-check_fresh_install_prerequisites() {
+check_install_prerequisites() {
     echo ""
     echo "Checking prerequisites..."
     MISSING_PKGS=()
-    check_dep "python3-venv" "python3-venv" "check_python3_venv"
-    check_dep "zenity" "zenity" "command -v zenity"
+    detect_package_manager
+    check_gui_runtime_prerequisites
+    if [ "$UPGRADE_MODE" -eq 0 ]; then
+        check_dep "python3-venv" "python3-venv" "check_python3_venv"
+        check_dep "zenity" "zenity" "command -v zenity"
+    fi
     install_missing_prerequisites
+    if ! verify_gui_runtime_prerequisites; then
+        echo "The installed packages do not satisfy the GUI runtime requirements."
+        print_manual_install_command
+        exit 1
+    fi
 }
 
 require_python_repair_prerequisites() {
@@ -487,6 +588,7 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
     "$RUNTIME_BINARY" upgrade-preflight "$SCRIPT_DIR"
     resolve_gui_binary
     resolve_app_icon
+    check_install_prerequisites
     validate_candidate_binary_identity
     load_upgrade_configuration
 
@@ -502,8 +604,8 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
 else
     resolve_gui_binary
     resolve_app_icon
+    check_install_prerequisites
     validate_candidate_binary_identity
-    check_fresh_install_prerequisites
 
 # CONFIGURE FRESH INSTALLATION
 echo ""

--- a/scripts/test-installer-gui-dependencies.sh
+++ b/scripts/test-installer-gui-dependencies.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+usage() {
+    echo "Usage: $0 <install.sh> <runtime-binary> <gui-binary> <apt|dnf|pacman>"
+    exit 1
+}
+
+[ "$#" -eq 4 ] || usage
+[ "$(id -u)" -ne 0 ] || {
+    echo "Installer dependency smoke must run as a regular user."
+    exit 1
+}
+
+INSTALL_SCRIPT="$(realpath "$1")"
+RUNTIME_BINARY="$(realpath "$2")"
+GUI_BINARY="$(realpath "$3")"
+PACKAGE_MANAGER="$4"
+
+case "$PACKAGE_MANAGER" in
+    apt)
+        EXPECTED_ARGS="install -y libgtk-4-1 libadwaita-1-0"
+        EXPECTED_MANUAL="sudo apt install libgtk-4-1 libadwaita-1-0"
+        ;;
+    dnf)
+        EXPECTED_ARGS="install -y gtk4 libadwaita"
+        EXPECTED_MANUAL="sudo dnf install gtk4 libadwaita"
+        ;;
+    pacman)
+        EXPECTED_ARGS="-S --noconfirm gtk4 libadwaita"
+        EXPECTED_MANUAL="sudo pacman -S gtk4 libadwaita"
+        ;;
+    *) usage ;;
+esac
+
+WORK_DIR="$(mktemp -d)"
+STUB_DIR="$WORK_DIR/stubs"
+DEPENDENCIES_INSTALLED="$WORK_DIR/dependencies-installed"
+PACKAGE_LOG="$WORK_DIR/package-manager.log"
+SEQUENCE_LOG="$WORK_DIR/sequence.log"
+GUI_WRAPPER="$WORK_DIR/lg-buddy-gui"
+PROBE="$WORK_DIR/gui-runtime-probe"
+
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$STUB_DIR"
+
+cat >"$PROBE" <<'EOF'
+#!/bin/sh
+[ -e "${LG_BUDDY_DEPENDENCIES_INSTALLED:?}" ]
+EOF
+
+cat >"$STUB_DIR/$PACKAGE_MANAGER" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >"${LG_BUDDY_PACKAGE_LOG:?}"
+printf '%s\n' package-manager >>"${LG_BUDDY_SEQUENCE_LOG:?}"
+if [ "${LG_BUDDY_FAKE_PACKAGE_MANAGER_FAIL:-0}" = "1" ]; then
+    exit 65
+fi
+if [ "${LG_BUDDY_FAKE_INSTALL_SATISFIES:-1}" = "1" ]; then
+    : >"${LG_BUDDY_DEPENDENCIES_INSTALLED:?}"
+fi
+EOF
+
+cat >"$STUB_DIR/systemctl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    is-system-running|"--user is-system-running") printf '%s\n' running ;;
+esac
+exit 0
+EOF
+
+cat >"$STUB_DIR/systemd-tmpfiles" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$GUI_WRAPPER" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' gui-identity >>"${LG_BUDDY_SEQUENCE_LOG:?}"
+exec "${LG_BUDDY_REAL_GUI:?}" "$@"
+EOF
+
+chmod 755 "$PROBE" "$GUI_WRAPPER" "$STUB_DIR/$PACKAGE_MANAGER" \
+    "$STUB_DIR/systemctl" "$STUB_DIR/systemd-tmpfiles"
+
+run_fresh_install() {
+    local scenario="$1"
+    local output="$2"
+    local auto_install="$3"
+    local install_satisfies="$4"
+    local package_manager_fails="${5:-0}"
+    local root="$WORK_DIR/$scenario/root"
+    local home="$WORK_DIR/$scenario/home"
+
+    mkdir -p "$root" "$home/Desktop"
+    (
+        export PATH="$STUB_DIR:$PATH"
+        export HOME="$home"
+        export XDG_CONFIG_HOME="$home/.config"
+        export LG_BUDDY_INSTALL_ROOT="$root"
+        export LG_BUDDY_SUDO_CMD="none"
+        export LG_BUDDY_NONINTERACTIVE="1"
+        export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+        export LG_BUDDY_SKIP_PIP_INSTALL="1"
+        export LG_BUDDY_TV_IP="192.0.2.10"
+        export LG_BUDDY_TV_MAC="02:00:00:00:00:10"
+        export LG_BUDDY_INPUT="HDMI_1"
+        export LG_BUDDY_TV_PLATFORM="bscpylgtv"
+        export LG_BUDDY_SCREEN_BACKEND="auto"
+        export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+        export LG_BUDDY_GUI_RUNTIME_PROBE="$PROBE"
+        export LG_BUDDY_DEPENDENCIES_INSTALLED="$DEPENDENCIES_INSTALLED"
+        export LG_BUDDY_PACKAGE_LOG="$PACKAGE_LOG"
+        export LG_BUDDY_SEQUENCE_LOG="$SEQUENCE_LOG"
+        export LG_BUDDY_REAL_GUI="$GUI_BINARY"
+        export LG_BUDDY_FAKE_INSTALL_SATISFIES="$install_satisfies"
+        export LG_BUDDY_FAKE_PACKAGE_MANAGER_FAIL="$package_manager_fails"
+        if [ "$auto_install" = "1" ]; then
+            export LG_BUDDY_AUTO_INSTALL_DEPS="yes"
+        else
+            unset LG_BUDDY_AUTO_INSTALL_DEPS
+        fi
+        cd "$(dirname "$INSTALL_SCRIPT")"
+        bash "$INSTALL_SCRIPT" \
+            --runtime-binary "$RUNTIME_BINARY" \
+            --gui-binary "$GUI_WRAPPER" >"$output" 2>&1
+    )
+}
+
+REFUSAL_OUTPUT="$WORK_DIR/refusal.output"
+if run_fresh_install refusal "$REFUSAL_OUTPUT" 0 1; then
+    echo "Noninteractive install unexpectedly installed missing GUI dependencies."
+    exit 1
+fi
+grep -F -q '  [MISSING] GTK 4.14 or newer' "$REFUSAL_OUTPUT"
+grep -F -q '  [MISSING] libadwaita 1.5 or newer' "$REFUSAL_OUTPUT"
+grep -F -q "$EXPECTED_MANUAL" "$REFUSAL_OUTPUT"
+[ ! -e "$PACKAGE_LOG" ] || {
+    echo "Refused dependency installation invoked $PACKAGE_MANAGER."
+    exit 1
+}
+[ ! -e "$SEQUENCE_LOG" ] || {
+    echo "Refused dependency installation executed the GUI candidate."
+    exit 1
+}
+[ -z "$(find "$WORK_DIR/refusal/root" -mindepth 1 -print -quit)" ] || {
+    echo "Refused dependency installation mutated the installation root."
+    exit 1
+}
+
+UNAVAILABLE_OUTPUT="$WORK_DIR/unavailable.output"
+rm -f "$PACKAGE_LOG" "$SEQUENCE_LOG" "$DEPENDENCIES_INSTALLED"
+if run_fresh_install unavailable "$UNAVAILABLE_OUTPUT" 1 0 1; then
+    echo "Install unexpectedly accepted an unavailable GUI runtime package."
+    exit 1
+fi
+[ "$(cat "$PACKAGE_LOG")" = "$EXPECTED_ARGS" ]
+grep -F -q 'Failed to install the missing packages.' "$UNAVAILABLE_OUTPUT"
+grep -F -q "$EXPECTED_MANUAL" "$UNAVAILABLE_OUTPUT"
+[ "$(cat "$SEQUENCE_LOG")" = "package-manager" ]
+[ -z "$(find "$WORK_DIR/unavailable/root" -mindepth 1 -print -quit)" ] || {
+    echo "Unavailable GUI runtime packages mutated the installation root."
+    exit 1
+}
+
+UNSATISFIED_OUTPUT="$WORK_DIR/unsatisfied.output"
+rm -f "$PACKAGE_LOG" "$SEQUENCE_LOG" "$DEPENDENCIES_INSTALLED"
+if run_fresh_install unsatisfied "$UNSATISFIED_OUTPUT" 1 0; then
+    echo "Install unexpectedly accepted insufficient GUI runtime versions."
+    exit 1
+fi
+[ "$(cat "$PACKAGE_LOG")" = "$EXPECTED_ARGS" ]
+grep -F -q 'The installed packages do not satisfy the GUI runtime requirements.' "$UNSATISFIED_OUTPUT"
+grep -F -q "$EXPECTED_MANUAL" "$UNSATISFIED_OUTPUT"
+[ "$(cat "$SEQUENCE_LOG")" = "package-manager" ]
+[ -z "$(find "$WORK_DIR/unsatisfied/root" -mindepth 1 -print -quit)" ] || {
+    echo "Insufficient GUI runtime versions mutated the installation root."
+    exit 1
+}
+
+SUCCESS_OUTPUT="$WORK_DIR/success.output"
+rm -f "$PACKAGE_LOG" "$SEQUENCE_LOG" "$DEPENDENCIES_INSTALLED"
+if ! run_fresh_install success "$SUCCESS_OUTPUT" 1 1; then
+    cat "$SUCCESS_OUTPUT"
+    echo "Fresh install failed after satisfying GUI runtime dependencies."
+    exit 1
+fi
+[ "$(cat "$PACKAGE_LOG")" = "$EXPECTED_ARGS" ]
+[ "$(sed -n '1p' "$SEQUENCE_LOG")" = "package-manager" ]
+[ "$(sed -n '2p' "$SEQUENCE_LOG")" = "gui-identity" ]
+[ "$(grep -F -c package-manager "$SEQUENCE_LOG")" -eq 1 ]
+[ -x "$WORK_DIR/success/root/usr/bin/lg-buddy" ]
+[ -x "$WORK_DIR/success/root/usr/bin/lg-buddy-gui" ]
+
+echo "$PACKAGE_MANAGER installer dependency smoke passed."

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -369,6 +369,8 @@ assert_executable "$BUNDLE_GUI"
     exit 1
 }
 bash "$SCRIPT_DIR/test-release-linkage.sh" "$BUNDLE_DIR/lg-buddy" "$BUNDLE_GUI"
+bash "$SCRIPT_DIR/test-installer-gui-dependencies.sh" \
+    "$BUNDLE_DIR/install.sh" "$BUNDLE_DIR/lg-buddy" "$BUNDLE_GUI" apt
 
 PAYLOAD_REFUSAL_ROOT="$WORK_DIR/payload-refusal-root"
 PAYLOAD_REFUSAL_HOME="$WORK_DIR/payload-refusal-home"
@@ -880,12 +882,31 @@ cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE"
 mkdir -p "$(dirname "$USER_DESKTOP_ENTRY")"
 printf 'stale user desktop launcher\n' >"$USER_DESKTOP_ENTRY"
 
+UPGRADE_DEPENDENCIES_INSTALLED="$WORK_DIR/upgrade-dependencies-installed"
+UPGRADE_PACKAGE_LOG="$WORK_DIR/upgrade-package-manager.log"
+UPGRADE_RUNTIME_PROBE="$INSTALLER_STUB_DIR/gui-runtime-probe"
+cat >"$UPGRADE_RUNTIME_PROBE" <<'EOF'
+#!/bin/sh
+[ -e "${LG_BUDDY_UPGRADE_DEPENDENCIES_INSTALLED:?}" ]
+EOF
+cat >"$INSTALLER_STUB_DIR/apt" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >"${LG_BUDDY_UPGRADE_PACKAGE_LOG:?}"
+: >"${LG_BUDDY_UPGRADE_DEPENDENCIES_INSTALLED:?}"
+EOF
+chmod 755 "$UPGRADE_RUNTIME_PROBE" "$INSTALLER_STUB_DIR/apt"
+
 UPGRADE_STATUS=0
 if (
     export PATH="$INSTALLER_STUB_DIR:$PATH"
     export LG_BUDDY_CONFIGURE_MARKER="$CONFIGURE_MARKER"
     export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
+    export LG_BUDDY_AUTO_INSTALL_DEPS="yes"
+    export LG_BUDDY_GUI_RUNTIME_PROBE="$UPGRADE_RUNTIME_PROBE"
+    export LG_BUDDY_UPGRADE_DEPENDENCIES_INSTALLED="$UPGRADE_DEPENDENCIES_INSTALLED"
+    export LG_BUDDY_UPGRADE_PACKAGE_LOG="$UPGRADE_PACKAGE_LOG"
     cd "$BUNDLE_DIR"
     bash ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
 ); then
@@ -905,6 +926,7 @@ fi
     exit 1
 }
 grep -F -q 'Upgrade complete!' "$UPGRADE_OUTPUT"
+[ "$(cat "$UPGRADE_PACKAGE_LOG")" = 'install -y libgtk-4-1 libadwaita-1-0' ]
 cat >"$EXPECTED_SERVICE_ACTION_LOG" <<EOF
 systemctl is-system-running
 systemctl --user is-system-running


### PR DESCRIPTION
## Summary

- probe GTK 4.14 and libadwaita 1.5 before executing the bundled GUI
- install the distro-native packages through the existing explicit confirmation flow on fresh installs and upgrades
- abort before LG Buddy mutation when installation is refused, fails, or leaves insufficient versions
- cover apt, dnf, and pacman behavior in the bundle lanes and document the flow

## Verification

- bash syntax and whitespace checks
- actionlint
- release promotion, publication, manifest, and response-recorder suites
- focused apt/dnf/pacman installer smoke tests
- real runtime probes on Ubuntu 24.04, Fedora 43, and Arch
- cargo test -p lg-buddy

Fixes #165