### PR TITLE
Ignore incidental activity after session lock

### DIFF
--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -16,6 +16,10 @@ pub enum InactivityDecision {
     NoOp,
 }
 
+/// Ignore independent input briefly after a lock-triggered blank so input from
+/// disengaging from the machine cannot immediately undo the blank.
+pub(crate) const POST_LOCK_ACTIVITY_GRACE: Duration = Duration::from_secs(1);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InactivityPhase {
     Unknown,
@@ -37,6 +41,7 @@ pub struct InactivityEngine {
     restore_pending: bool,
     session_locked_since: Option<Instant>,
     lock_activity_floor: Option<Instant>,
+    post_lock_activity_grace_until: Option<Instant>,
     latest_independent_activity_at: Option<Instant>,
 }
 
@@ -84,6 +89,7 @@ impl InactivityEngine {
             restore_pending: false,
             session_locked_since: None,
             lock_activity_floor: None,
+            post_lock_activity_grace_until: None,
             latest_independent_activity_at: None,
         }
     }
@@ -111,6 +117,7 @@ impl InactivityEngine {
             restore_pending: true,
             session_locked_since: None,
             lock_activity_floor: None,
+            post_lock_activity_grace_until: None,
             latest_independent_activity_at: None,
         }
     }
@@ -166,11 +173,12 @@ impl InactivityEngine {
         observation: InactivityObservation,
         observed_at: Instant,
     ) -> InactivityDecision {
-        if matches!(
+        let independent_activity = matches!(
             observation,
             InactivityObservation::DesktopActivityObserved
                 | InactivityObservation::UserActivityObserved
-        ) {
+        );
+        if independent_activity {
             self.latest_independent_activity_at = Some(
                 self.latest_independent_activity_at
                     .map_or(observed_at, |latest| latest.max(observed_at)),
@@ -186,19 +194,27 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
-        if matches!(
+        let inactive = matches!(
             self.phase,
             InactivityPhase::BlankRequested
                 | InactivityPhase::Blanked
                 | InactivityPhase::InactiveWithoutEscalation
                 | InactivityPhase::TimedPowerOffAttempted
-        ) && self.lock_activity_floor.is_some_and(|locked_at| {
-            !matches!(
-                observation,
-                InactivityObservation::DesktopActivityObserved
-                    | InactivityObservation::UserActivityObserved
-            ) || observed_at <= locked_at
-        }) {
+        );
+        if inactive
+            && independent_activity
+            && self
+                .post_lock_activity_grace_until
+                .is_some_and(|grace_until| observed_at < grace_until)
+        {
+            return InactivityDecision::NoOp;
+        }
+
+        if inactive
+            && self
+                .lock_activity_floor
+                .is_some_and(|locked_at| !independent_activity || observed_at <= locked_at)
+        {
             return InactivityDecision::NoOp;
         }
 
@@ -263,15 +279,21 @@ impl InactivityEngine {
     }
 
     pub fn observe_lock(&mut self, observed_at: Instant) -> InactivityDecision {
-        let locked_at = *self.session_locked_since.get_or_insert(observed_at);
-        if self
-            .latest_independent_activity_at
-            .is_some_and(|activity_at| activity_at > locked_at)
-        {
-            self.lock_activity_floor = None;
+        if self.session_locked_since.is_some() {
             return InactivityDecision::NoOp;
         }
-        self.lock_activity_floor = Some(locked_at);
+
+        self.session_locked_since = Some(observed_at);
+        let grace_until = observed_at + POST_LOCK_ACTIVITY_GRACE;
+        if self
+            .latest_independent_activity_at
+            .is_some_and(|activity_at| activity_at >= grace_until)
+        {
+            self.lock_activity_floor = None;
+            self.post_lock_activity_grace_until = None;
+            return InactivityDecision::NoOp;
+        }
+        self.lock_activity_floor = Some(observed_at);
 
         if matches!(
             self.phase,
@@ -283,6 +305,7 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
+        self.post_lock_activity_grace_until = Some(grace_until);
         self.phase = InactivityPhase::BlankRequested;
         self.blank_at = None;
         InactivityDecision::BlankNow
@@ -295,7 +318,9 @@ impl InactivityEngine {
 
 #[cfg(test)]
 mod tests {
-    use super::{InactivityDecision, InactivityEngine, InactivityObservation};
+    use super::{
+        InactivityDecision, InactivityEngine, InactivityObservation, POST_LOCK_ACTIVITY_GRACE,
+    };
     use std::time::{Duration, Instant};
 
     fn test_engine(started_at: Instant) -> InactivityEngine {
@@ -615,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn lock_blanks_immediately_once_and_activity_can_restore() {
+    fn lock_blanks_immediately_once_and_activity_at_the_grace_boundary_can_restore() {
         let started_at = Instant::now();
         let mut engine = test_engine(started_at);
         let locked_at = started_at + Duration::from_secs(1);
@@ -626,7 +651,7 @@ mod tests {
         assert_eq!(
             engine.observe_activity(
                 InactivityObservation::DesktopActivityObserved,
-                started_at + Duration::from_secs(2),
+                locked_at + POST_LOCK_ACTIVITY_GRACE,
             ),
             InactivityDecision::RestoreNow
         );
@@ -637,33 +662,87 @@ mod tests {
     }
 
     #[test]
-    fn lock_restore_requires_independent_activity_newer_than_the_lock() {
+    fn lock_grace_suppresses_pre_lock_and_immediate_independent_activity() {
         let started_at = Instant::now();
         let locked_at = started_at + Duration::from_secs(1);
-        let mut engine = test_engine(started_at);
 
-        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
-        assert_eq!(
-            engine.observe_activity(
-                InactivityObservation::DesktopActivityObserved,
-                started_at + Duration::from_millis(900),
-            ),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(
-            engine.observe_activity(
-                InactivityObservation::DesktopActivityObserved,
-                started_at + Duration::from_secs(2),
-            ),
-            InactivityDecision::RestoreNow
-        );
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            let mut engine = test_engine(started_at);
+            assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+            engine.complete_blank(true, locked_at);
+
+            for observed_at in [
+                locked_at - Duration::from_millis(1),
+                locked_at + Duration::from_millis(1),
+            ] {
+                assert_eq!(
+                    engine.observe_activity(observation, observed_at),
+                    InactivityDecision::NoOp
+                );
+                assert!(engine.timed_power_off_pending());
+            }
+        }
     }
 
     #[test]
-    fn newer_independent_activity_processed_before_lock_keeps_the_screen_active() {
+    fn lock_grace_accepts_independent_activity_at_and_after_the_boundary() {
         let started_at = Instant::now();
         let locked_at = started_at + Duration::from_secs(1);
-        let activity_at = started_at + Duration::from_secs(2);
+
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            for observed_at in [
+                locked_at + POST_LOCK_ACTIVITY_GRACE,
+                locked_at + POST_LOCK_ACTIVITY_GRACE + Duration::from_millis(1),
+            ] {
+                let mut engine = test_engine(started_at);
+                assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+                engine.complete_blank(true, locked_at);
+
+                assert_eq!(
+                    engine.observe_activity(observation, observed_at),
+                    InactivityDecision::RestoreNow
+                );
+                assert!(!engine.timed_power_off_pending());
+            }
+        }
+    }
+
+    #[test]
+    fn activity_inside_the_grace_processed_before_lock_does_not_prevent_blanking() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            let mut engine = test_engine(started_at);
+            assert_eq!(
+                engine.observe_activity(
+                    observation,
+                    locked_at + POST_LOCK_ACTIVITY_GRACE - Duration::from_millis(1),
+                ),
+                if observation == InactivityObservation::DesktopActivityObserved {
+                    InactivityDecision::NoOp
+                } else {
+                    InactivityDecision::RestoreNow
+                }
+            );
+            assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+        }
+    }
+
+    #[test]
+    fn activity_at_the_grace_boundary_processed_before_lock_keeps_the_screen_active() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+        let activity_at = locked_at + POST_LOCK_ACTIVITY_GRACE;
         let mut engine = test_engine(started_at);
 
         assert_eq!(

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -294,6 +294,7 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
         self.lock_activity_floor = Some(observed_at);
+        self.post_lock_activity_grace_until = Some(grace_until);
 
         if matches!(
             self.phase,
@@ -305,7 +306,6 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
-        self.post_lock_activity_grace_until = Some(grace_until);
         self.phase = InactivityPhase::BlankRequested;
         self.blank_at = None;
         InactivityDecision::BlankNow
@@ -711,6 +711,30 @@ mod tests {
                 assert!(!engine.timed_power_off_pending());
             }
         }
+    }
+
+    #[test]
+    fn lock_grace_applies_when_the_screen_is_already_blanked() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(6);
+        let mut engine = test_engine(started_at);
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, started_at + Duration::from_secs(5));
+        assert!(engine.timed_power_off_pending());
+
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::NoOp);
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                locked_at + Duration::from_millis(1),
+            ),
+            InactivityDecision::NoOp
+        );
+        assert!(engine.timed_power_off_pending());
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -1755,7 +1755,9 @@ mod tests {
     };
     use crate::config::ScreenBackend;
     use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
-    use crate::session::inactivity::{InactivityEngine, InactivityObservation};
+    use crate::session::inactivity::{
+        InactivityEngine, InactivityObservation, POST_LOCK_ACTIVITY_GRACE,
+    };
     use crate::session::SessionEvent;
     use crate::session_bus::{
         BusMethodCall, BusReply, BusSignal, BusSignalMatch, BusValue, SessionBusClient,
@@ -2915,9 +2917,14 @@ system_sleep_wake_policy={policy}
                         observed_at: locked_at + Duration::from_millis(2),
                     });
                     let _ = sender.send(RunnerMessage::ActivityObservation {
+                        source: EventSource::AuxiliaryInput,
+                        observation: InactivityObservation::UserActivityObserved,
+                        observed_at: locked_at + Duration::from_millis(3),
+                    });
+                    let _ = sender.send(RunnerMessage::ActivityObservation {
                         source: EventSource::DesktopSession,
                         observation: InactivityObservation::DesktopActivityObserved,
-                        observed_at: locked_at + Duration::from_millis(3),
+                        observed_at: locked_at + POST_LOCK_ACTIVITY_GRACE,
                     });
                     let _ = sender.send(RunnerMessage::MonitorExited(Ok(())));
                 })

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -268,7 +268,7 @@ Feature: GNOME monitor
     And the session marker is absent
     And the TV screen is visible
 
-  Scenario: GNOME lock-screen activity restores before ScreenSaver reports active
+  Scenario: GNOME lock-screen activity inside the grace period stays blanked
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 120 seconds
     And LG Buddy session runtime is isolated
@@ -282,11 +282,11 @@ Feature: GNOME monitor
     And GNOME monitor stays open for 0.8 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And stdout contains "Session event `user-activity` requests screen restore."
+    And stdout does not contain "Session event `user-activity` requests screen restore."
     And the TV client received "turn_screen_off" exactly 1 times
-    And the TV client received "turn_screen_on" exactly 1 times
-    And the session marker is absent
-    And the TV screen is visible
+    And the TV client did not receive "turn_screen_on"
+    And the session marker exists
+    And the TV screen is blanked
 
   Scenario: GNOME inactivity skips TV blanking on a different input
     Given a temporary LG Buddy config using input HDMI_2

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -883,9 +883,10 @@ asymmetric:
   every enabled monitor backend uses this runtime
 - the same runtime opportunistically observes `LockedHint` on the current
   graphical logind session; lock requests the normal session blank policy,
-  unlock is informational, fresh independent activity can restore while locked,
-  and logind owner changes trigger session rebinding and reconciliation; failure
-  or lack of support does not affect the selected desktop backend
+  unlock is informational, fresh independent activity can restore while locked
+  after the fixed one-second post-lock grace, and logind owner changes trigger
+  session rebinding and reconciliation; failure or lack of support does not
+  affect the selected desktop backend
 - the gamepad source refreshes its device set from Linux device add, remove, and
   change events, with periodic reconciliation for missed events
 - `swayidle` timeout and resume callbacks feed the shared inactivity engine

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -136,6 +136,9 @@ choice.
 - automatic session idle blank/restore defaults to enabled
 - in supported environments, a reported session lock also requests the same
   immediate blank policy; unlock never requests restore
+- a lock-triggered blank ignores desktop and gamepad activity for a fixed one
+  second before accepting activity-driven restore; this is a safety constant,
+  not a user setting
 - users who want update notifications without session-driven TV control can set
   `screen_idle_blank=disabled`
 - the installed user-session service still runs so notification handoff remains

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -137,9 +137,11 @@ independent auxiliary source owned by the shared session runtime. The
 key architectural point is that blank/restore decisions are made after
 normalization, not inside a desktop adapter.
 
-After a lock blank, only independent desktop or gamepad activity newer than the
-lock can produce `RestoreNow`. Stale observations and GNOME provider
-active/wake signals do not make unlock itself a restore trigger.
+After a lock-triggered blank, independent desktop or gamepad activity can
+produce `RestoreNow` only when its monotonic observation time is at least one
+second newer than the lock. Earlier samples leave the blank and its timed
+power-off deadline intact. GNOME provider active/wake signals do not make unlock
+itself a restore trigger.
 
 The resulting decisions are dispatched as:
 
@@ -262,9 +264,9 @@ connection, subscriptions, owner rebinding, reconciliation, and translation to
 normalized lock observations. Missing, ambiguous, or unavailable session state
 produces a diagnostic without changing inactivity behavior or native backend
 eligibility. A desktop or locker that never updates `LockedHint` simply produces
-no lock events. Unlock never sends a wake, restore, or activity event. Fresh
-independent activity observed while locked remains able to restore the screen
-through the existing marker policy.
+no lock events. Unlock never sends a wake, restore, or activity event. After the
+fixed one-second post-lock grace, fresh independent activity observed while
+locked remains able to restore the screen through the existing marker policy.
 
 ## Lifecycle Default And Migration Stance
 

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -150,10 +150,14 @@ subscription, and reconciliation when logind restarts.
 A lock enters the existing blanked inactivity state and dispatches
 `SessionLocked` from `LinuxLogind`, so configured-input, marker, sleep-phase,
 and restore policy remain centralized in `screen.rs`. Unlock performs no screen
-action. Independent desktop or gamepad activity observed after the lock can
-restore the picture while the lock screen is still shown. Stale pre-lock
-observations and provider wake/deactivation signals associated with unlocking do
-not restore it; normal inactivity timing resumes from fresh activity.
+action. A lock-triggered blank starts a fixed one-second activity grace period.
+Independent desktop or gamepad activity observed before the lock or inside that
+period is ignored without canceling the pending timed power-off. At the grace
+boundary, the first fresh independent activity can restore the picture while the
+lock screen is still shown. The shared policy compares each sample's monotonic
+observation time with the lock time, so delayed dispatch does not change the
+decision. Provider wake/deactivation signals associated with unlocking do not
+restore it; normal inactivity timing resumes from accepted fresh activity.
 
 Known environment support follows whether the desktop or locker maintains
 logind's `LockedHint` for the graphical session:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -254,7 +254,8 @@ Examples:
 - gamepad activity integration with the LG Buddy inactivity deadline
 - screen runtime-phase eligibility over the private logind system-bus seam
 - logind lock state entering the shared blanked state without making unlock a
-  restore trigger, while fresh independent activity still restores
+  restore trigger, while observation-time tests cover pre-lock, post-lock grace,
+  boundary, and accepted desktop and auxiliary activity
 - logind lock monitoring rebinding and reconciling after logind changes its
   unique D-Bus owner
 - swayidle production timeout/resume process arguments

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -122,10 +122,14 @@ restoring. The user service remains available for update notifications.
 
 When an automatic idle or session-lock action successfully blanks the screen,
 LG Buddy powers the TV off after five more minutes without activity. This grace
-period is a fixed safety default rather than a setting. Any desktop or gamepad
-activity cancels the pending power-off and restores the screen. Before powering
-off, LG Buddy rechecks its ownership marker, the configured input, and machine
-lifecycle state; it skips safely if those checks no longer permit the action.
+period is a fixed safety default rather than a setting. After a session-lock
+blank, desktop and gamepad activity is ignored for one second so incidental
+input while stepping away does not immediately restore the screen. The first
+activity at or after that boundary cancels the pending power-off and restores
+the screen, even while the session remains locked. Idle-triggered blanks retain
+their immediate activity restore behavior. Before powering off, LG Buddy
+rechecks its ownership marker, the configured input, and machine lifecycle
+state; it skips safely if those checks no longer permit the action.
 
 The restore policies are:
 


### PR DESCRIPTION
## Summary

- add a fixed one-second grace after a session lock triggers screen blanking
- suppress desktop and gamepad activity inside that window without restoring or canceling timed power-off
- use monotonic observation timestamps so queued samples retain the same boundary semantics
- document the behavior and cover the GNOME user-visible outcome

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

A lock-triggered blank ignores desktop and gamepad activity for one second, allowing the user to disengage from the machine without immediately restoring the TV. Activity at or after the boundary still restores while locked. Unlock remains informational, and idle-triggered blanking is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p lg-buddy`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- No hardware smoke run; the change is confined to normalized inactivity policy and is covered by deterministic unit, runner, and mock-backed GNOME tests.

## Related Issue

Fixes #166