### PR TITLE
Prepare LG Buddy 1.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64",
  "cucumber",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "lg-buddy-gui"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "gtk4",
  "lg-buddy",

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy-gui"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary

- bump the `lg-buddy` runtime and GTK GUI packages from 1.5.0 to 1.5.1
- keep `Cargo.lock` aligned with both package manifests

## Scope

- [x] This PR contains only the release identity change.
- [x] The user-facing fixes are already reviewed and merged into `dev`.

## Validation

- `cargo metadata --locked --no-deps --format-version 1`
- 24 release-promotion contract tests
- 22 release-bundle manifest tests
- 15 release-publication contract tests
- `git diff --check`

## Release

Prepares the direct `dev` to `main` promotion for LG Buddy 1.5.1.