### PR TITLE
Release LG Buddy 1.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Validate shell scripts
         run: |
-          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-installer-gui-dependencies.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
           python3 -m py_compile scripts/test-release-gui-accessibility.py scripts/xwd_mean.py
 
       - name: Validate release promotion contract
@@ -180,9 +180,11 @@ jobs:
         include:
           - name: Fedora 43
             image: fedora:43
+            package_manager: dnf
             setup: dnf install -y at-spi2-core binutils curl dbus-x11 findutils glib2 gobject-introspection gsettings-desktop-schemas gtk4 gzip libadwaita libglvnd-gles python3 python3-pyatspi shadow-utils strace tar util-linux which xdotool xorg-x11-server-Xvfb xorg-x11-xauth xwd zenity
           - name: Arch current
             image: archlinux:latest
+            package_manager: pacman
             setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd zenity
     container:
       image: ${{ matrix.image }}
@@ -212,6 +214,11 @@ jobs:
           runuser -u tester -- bash ./scripts/test-release-linkage.sh \
               "$bundle/lg-buddy" \
               "$bundle/docs/lg-buddy-gui-x86_64-unknown-linux-gnu"
+          runuser -u tester -- bash ./scripts/test-installer-gui-dependencies.sh \
+              "$bundle/install.sh" \
+              "$bundle/lg-buddy" \
+              "$bundle/docs/lg-buddy-gui-x86_64-unknown-linux-gnu" \
+              "${{ matrix.package_manager }}"
           runuser -u tester -- dbus-run-session -- xvfb-run -a \
               env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals LG_BUDDY_TEST_PLATFORM_CONTRACT=1 \
               bash ./scripts/test-installed-gui.sh \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Dry-run publish release assets
         env:
           GH_RELEASE_DRY_RUN: "1"
-        run: ./scripts/publish-release-assets.sh --dist-dir dist --tag "v${SMOKE_VERSION}" --commit "${{ github.sha }}"
+        run: ./scripts/publish-release-assets.sh stage-draft --dist-dir dist --tag "v${SMOKE_VERSION}" --commit "${{ github.sha }}"
 
       - name: Upload bundle for supported-distro checks
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI
 
 on:
   pull_request:
-  push:
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   checks: read
@@ -11,6 +14,7 @@ permissions:
 jobs:
   verify:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository
@@ -68,6 +72,7 @@ jobs:
 
   bundle-smoke-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     needs: verify
     env:
       SMOKE_VERSION: 1.4.0-beta.2.ci
@@ -161,10 +166,12 @@ jobs:
           name: ci-release-bundle
           path: dist/*.tar.gz
           if-no-files-found: error
+          retention-days: 7
 
   bundle-supported-distros:
     needs: bundle-smoke-test
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     env:
       SMOKE_VERSION: 1.4.0-beta.2.ci
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       channel: ${{ steps.contract.outputs.channel }}
       head_sha: ${{ steps.contract.outputs.head_sha }}
       prerelease_sha: ${{ steps.contract.outputs.prerelease_sha }}
-      publish: ${{ steps.contract.outputs.publish }}
+      prepare: ${{ steps.contract.outputs.prepare }}
       source_sha: ${{ steps.contract.outputs.source_sha }}
       tag: ${{ steps.contract.outputs.tag }}
       version: ${{ steps.contract.outputs.version }}
@@ -63,7 +63,7 @@ jobs:
               --github-output "$GITHUB_OUTPUT"
 
   build-release-bundle:
-    if: needs.validate.outputs.publish == 'true'
+    if: needs.validate.outputs.prepare == 'true'
     runs-on: ubuntu-24.04
     needs: validate
 
@@ -154,10 +154,11 @@ jobs:
             dist/*.tar.gz
             dist/sha256sums.txt
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 30
 
-  publish:
-    if: needs.validate.outputs.publish == 'true'
+  stage-release-draft:
+    name: stage-release-draft
+    if: needs.validate.outputs.prepare == 'true'
     runs-on: ubuntu-latest
     environment: release-promotion
     needs:
@@ -251,7 +252,7 @@ jobs:
           fi
           update_ref dev "$SOURCE_SHA"
 
-      - name: Publish release
+      - name: Stage verified release draft
         env:
           GH_TOKEN: ${{ steps.release-token.outputs.token }}
           HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
@@ -271,7 +272,85 @@ jobs:
           if ! git rev-parse --verify "refs/tags/$RELEASE_TAG" >/dev/null 2>&1; then
               git tag "$RELEASE_TAG" "$HEAD_SHA"
           fi
-          ./scripts/publish-release-assets.sh \
+          ./scripts/publish-release-assets.sh stage-draft \
+              --dist-dir dist \
+              --tag "$RELEASE_TAG" \
+              --commit "$HEAD_SHA"
+
+          release_url="$(gh release view "$RELEASE_TAG" --json url --jq .url)"
+          {
+              echo "## Verified release draft"
+              echo
+              echo "[$RELEASE_TAG]($release_url) is ready for release-note review."
+              echo "After reviewing the draft and its assets, approve the release-publication environment to publish it."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: publish-reviewed-release
+    if: needs.validate.outputs.prepare == 'true'
+    runs-on: ubuntu-latest
+    environment: release-publication
+    permissions:
+      actions: read
+      contents: write
+    needs:
+      - validate
+      - build-release-bundle
+      - stage-release-draft
+
+    steps:
+      - name: Check out staged release commit
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.validate.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+
+      - name: Fetch and revalidate release refs
+        run: |
+          git fetch --force origin \
+              +refs/heads/main:refs/remotes/origin/main \
+              +refs/heads/prerelease:refs/remotes/origin/prerelease \
+              +refs/heads/dev:refs/remotes/origin/dev \
+              +refs/tags/*:refs/tags/*
+          python3 scripts/release_promotion.py \
+              --merged \
+              --target "${{ github.ref_name }}" \
+              --head-ref "${{ needs.validate.outputs.head_sha }}" \
+              --base-sha "${{ needs.validate.outputs.base_sha }}"
+
+      - name: Download staged release bundle
+        uses: actions/download-artifact@v7
+        with:
+          name: lg-buddy-release-${{ needs.validate.outputs.tag }}
+          path: dist
+
+      - name: Verify staged checksums
+        run: cd dist && sha256sum -c sha256sums.txt
+
+      - name: Revalidate staged bundle identity
+        run: |
+          python3 scripts/release_bundle_manifest.py validate \
+              --archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
+              --expected-release-tag "${{ needs.validate.outputs.tag }}" \
+              --expected-version "${{ needs.validate.outputs.version }}" \
+              --expected-channel "${{ needs.validate.outputs.channel }}" \
+              --expected-target x86_64-unknown-linux-musl \
+              --expected-gui-target x86_64-unknown-linux-gnu \
+              --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Publish reviewed release draft
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ needs.validate.outputs.head_sha }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          ./scripts/publish-release-assets.sh publish-draft \
               --dist-dir dist \
               --tag "$RELEASE_TAG" \
               --commit "$HEAD_SHA"
@@ -290,7 +369,7 @@ jobs:
 
   production-prerelease-canary:
     name: production-prerelease-canary
-    if: needs.validate.outputs.publish == 'true' && needs.validate.outputs.channel == 'prerelease'
+    if: needs.validate.outputs.prepare == 'true' && needs.validate.outputs.channel == 'prerelease'
     runs-on: ubuntu-latest
     needs:
       - validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
             dist/*.tar.gz
             dist/sha256sums.txt
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 35
 
   stage-release-draft:
     name: stage-release-draft

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "base64",
  "cucumber",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "lg-buddy-gui"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "gtk4",
  "lg-buddy",

--- a/README.md
+++ b/README.md
@@ -48,9 +48,13 @@ require Python. Native-only packages can omit the Python client, `venv`, and
 `pip`. The release-bundle installer still provisions `bscpylgtv` as an explicit
 compatibility fallback, so it checks for Python 3 with a `venv` that provisions
 `pip`, plus `zenity`. Official release bundles target the Ubuntu 24.04 runtime
-baseline: GTK 4.14, libadwaita 1.5, and glibc 2.39 or newer. The installer
-verifies that the GUI executable can load and has the same release identity as
-the runtime before changing the installation.
+baseline: GTK 4.14, libadwaita 1.5, and glibc 2.39 or newer. Before executing
+the GUI, the installer checks the installed GTK and libadwaita runtime versions.
+On apt, dnf, and pacman systems it can install the mapped runtime packages after
+explicit confirmation; refusal and noninteractive operation without that opt-in
+leave package installation to the user. The installer then verifies that the GUI
+executable can load and has the same release identity as the runtime before
+changing the LG Buddy installation.
 Zenity remains the compatibility fallback when the GUI executable is absent.
 `swayidle` is needed only by an existing explicit selection or as the deprecated
 compatibility fallback.

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy-gui"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -16,6 +16,10 @@ pub enum InactivityDecision {
     NoOp,
 }
 
+/// Ignore independent input briefly after a lock-triggered blank so input from
+/// disengaging from the machine cannot immediately undo the blank.
+pub(crate) const POST_LOCK_ACTIVITY_GRACE: Duration = Duration::from_secs(1);
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InactivityPhase {
     Unknown,
@@ -37,6 +41,7 @@ pub struct InactivityEngine {
     restore_pending: bool,
     session_locked_since: Option<Instant>,
     lock_activity_floor: Option<Instant>,
+    post_lock_activity_grace_until: Option<Instant>,
     latest_independent_activity_at: Option<Instant>,
 }
 
@@ -84,6 +89,7 @@ impl InactivityEngine {
             restore_pending: false,
             session_locked_since: None,
             lock_activity_floor: None,
+            post_lock_activity_grace_until: None,
             latest_independent_activity_at: None,
         }
     }
@@ -111,6 +117,7 @@ impl InactivityEngine {
             restore_pending: true,
             session_locked_since: None,
             lock_activity_floor: None,
+            post_lock_activity_grace_until: None,
             latest_independent_activity_at: None,
         }
     }
@@ -166,11 +173,12 @@ impl InactivityEngine {
         observation: InactivityObservation,
         observed_at: Instant,
     ) -> InactivityDecision {
-        if matches!(
+        let independent_activity = matches!(
             observation,
             InactivityObservation::DesktopActivityObserved
                 | InactivityObservation::UserActivityObserved
-        ) {
+        );
+        if independent_activity {
             self.latest_independent_activity_at = Some(
                 self.latest_independent_activity_at
                     .map_or(observed_at, |latest| latest.max(observed_at)),
@@ -186,19 +194,27 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
-        if matches!(
+        let inactive = matches!(
             self.phase,
             InactivityPhase::BlankRequested
                 | InactivityPhase::Blanked
                 | InactivityPhase::InactiveWithoutEscalation
                 | InactivityPhase::TimedPowerOffAttempted
-        ) && self.lock_activity_floor.is_some_and(|locked_at| {
-            !matches!(
-                observation,
-                InactivityObservation::DesktopActivityObserved
-                    | InactivityObservation::UserActivityObserved
-            ) || observed_at <= locked_at
-        }) {
+        );
+        if inactive
+            && independent_activity
+            && self
+                .post_lock_activity_grace_until
+                .is_some_and(|grace_until| observed_at < grace_until)
+        {
+            return InactivityDecision::NoOp;
+        }
+
+        if inactive
+            && self
+                .lock_activity_floor
+                .is_some_and(|locked_at| !independent_activity || observed_at <= locked_at)
+        {
             return InactivityDecision::NoOp;
         }
 
@@ -263,15 +279,21 @@ impl InactivityEngine {
     }
 
     pub fn observe_lock(&mut self, observed_at: Instant) -> InactivityDecision {
-        let locked_at = *self.session_locked_since.get_or_insert(observed_at);
-        if self
-            .latest_independent_activity_at
-            .is_some_and(|activity_at| activity_at > locked_at)
-        {
-            self.lock_activity_floor = None;
+        if self.session_locked_since.is_some() {
             return InactivityDecision::NoOp;
         }
-        self.lock_activity_floor = Some(locked_at);
+
+        self.session_locked_since = Some(observed_at);
+        let grace_until = observed_at + POST_LOCK_ACTIVITY_GRACE;
+        if self
+            .latest_independent_activity_at
+            .is_some_and(|activity_at| activity_at >= grace_until)
+        {
+            self.lock_activity_floor = None;
+            self.post_lock_activity_grace_until = None;
+            return InactivityDecision::NoOp;
+        }
+        self.lock_activity_floor = Some(observed_at);
 
         if matches!(
             self.phase,
@@ -283,6 +305,7 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
+        self.post_lock_activity_grace_until = Some(grace_until);
         self.phase = InactivityPhase::BlankRequested;
         self.blank_at = None;
         InactivityDecision::BlankNow
@@ -295,7 +318,9 @@ impl InactivityEngine {
 
 #[cfg(test)]
 mod tests {
-    use super::{InactivityDecision, InactivityEngine, InactivityObservation};
+    use super::{
+        InactivityDecision, InactivityEngine, InactivityObservation, POST_LOCK_ACTIVITY_GRACE,
+    };
     use std::time::{Duration, Instant};
 
     fn test_engine(started_at: Instant) -> InactivityEngine {
@@ -615,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn lock_blanks_immediately_once_and_activity_can_restore() {
+    fn lock_blanks_immediately_once_and_activity_at_the_grace_boundary_can_restore() {
         let started_at = Instant::now();
         let mut engine = test_engine(started_at);
         let locked_at = started_at + Duration::from_secs(1);
@@ -626,7 +651,7 @@ mod tests {
         assert_eq!(
             engine.observe_activity(
                 InactivityObservation::DesktopActivityObserved,
-                started_at + Duration::from_secs(2),
+                locked_at + POST_LOCK_ACTIVITY_GRACE,
             ),
             InactivityDecision::RestoreNow
         );
@@ -637,33 +662,87 @@ mod tests {
     }
 
     #[test]
-    fn lock_restore_requires_independent_activity_newer_than_the_lock() {
+    fn lock_grace_suppresses_pre_lock_and_immediate_independent_activity() {
         let started_at = Instant::now();
         let locked_at = started_at + Duration::from_secs(1);
-        let mut engine = test_engine(started_at);
 
-        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
-        assert_eq!(
-            engine.observe_activity(
-                InactivityObservation::DesktopActivityObserved,
-                started_at + Duration::from_millis(900),
-            ),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(
-            engine.observe_activity(
-                InactivityObservation::DesktopActivityObserved,
-                started_at + Duration::from_secs(2),
-            ),
-            InactivityDecision::RestoreNow
-        );
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            let mut engine = test_engine(started_at);
+            assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+            engine.complete_blank(true, locked_at);
+
+            for observed_at in [
+                locked_at - Duration::from_millis(1),
+                locked_at + Duration::from_millis(1),
+            ] {
+                assert_eq!(
+                    engine.observe_activity(observation, observed_at),
+                    InactivityDecision::NoOp
+                );
+                assert!(engine.timed_power_off_pending());
+            }
+        }
     }
 
     #[test]
-    fn newer_independent_activity_processed_before_lock_keeps_the_screen_active() {
+    fn lock_grace_accepts_independent_activity_at_and_after_the_boundary() {
         let started_at = Instant::now();
         let locked_at = started_at + Duration::from_secs(1);
-        let activity_at = started_at + Duration::from_secs(2);
+
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            for observed_at in [
+                locked_at + POST_LOCK_ACTIVITY_GRACE,
+                locked_at + POST_LOCK_ACTIVITY_GRACE + Duration::from_millis(1),
+            ] {
+                let mut engine = test_engine(started_at);
+                assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+                engine.complete_blank(true, locked_at);
+
+                assert_eq!(
+                    engine.observe_activity(observation, observed_at),
+                    InactivityDecision::RestoreNow
+                );
+                assert!(!engine.timed_power_off_pending());
+            }
+        }
+    }
+
+    #[test]
+    fn activity_inside_the_grace_processed_before_lock_does_not_prevent_blanking() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            let mut engine = test_engine(started_at);
+            assert_eq!(
+                engine.observe_activity(
+                    observation,
+                    locked_at + POST_LOCK_ACTIVITY_GRACE - Duration::from_millis(1),
+                ),
+                if observation == InactivityObservation::DesktopActivityObserved {
+                    InactivityDecision::NoOp
+                } else {
+                    InactivityDecision::RestoreNow
+                }
+            );
+            assert_eq!(engine.observe_lock(locked_at), InactivityDecision::BlankNow);
+        }
+    }
+
+    #[test]
+    fn activity_at_the_grace_boundary_processed_before_lock_keeps_the_screen_active() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(1);
+        let activity_at = locked_at + POST_LOCK_ACTIVITY_GRACE;
         let mut engine = test_engine(started_at);
 
         assert_eq!(

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -294,6 +294,7 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
         self.lock_activity_floor = Some(observed_at);
+        self.post_lock_activity_grace_until = Some(grace_until);
 
         if matches!(
             self.phase,
@@ -305,7 +306,6 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
-        self.post_lock_activity_grace_until = Some(grace_until);
         self.phase = InactivityPhase::BlankRequested;
         self.blank_at = None;
         InactivityDecision::BlankNow
@@ -711,6 +711,30 @@ mod tests {
                 assert!(!engine.timed_power_off_pending());
             }
         }
+    }
+
+    #[test]
+    fn lock_grace_applies_when_the_screen_is_already_blanked() {
+        let started_at = Instant::now();
+        let locked_at = started_at + Duration::from_secs(6);
+        let mut engine = test_engine(started_at);
+
+        assert_eq!(
+            engine.observe_time(started_at + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, started_at + Duration::from_secs(5));
+        assert!(engine.timed_power_off_pending());
+
+        assert_eq!(engine.observe_lock(locked_at), InactivityDecision::NoOp);
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::UserActivityObserved,
+                locked_at + Duration::from_millis(1),
+            ),
+            InactivityDecision::NoOp
+        );
+        assert!(engine.timed_power_off_pending());
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -1755,7 +1755,9 @@ mod tests {
     };
     use crate::config::ScreenBackend;
     use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
-    use crate::session::inactivity::{InactivityEngine, InactivityObservation};
+    use crate::session::inactivity::{
+        InactivityEngine, InactivityObservation, POST_LOCK_ACTIVITY_GRACE,
+    };
     use crate::session::SessionEvent;
     use crate::session_bus::{
         BusMethodCall, BusReply, BusSignal, BusSignalMatch, BusValue, SessionBusClient,
@@ -2915,9 +2917,14 @@ system_sleep_wake_policy={policy}
                         observed_at: locked_at + Duration::from_millis(2),
                     });
                     let _ = sender.send(RunnerMessage::ActivityObservation {
+                        source: EventSource::AuxiliaryInput,
+                        observation: InactivityObservation::UserActivityObserved,
+                        observed_at: locked_at + Duration::from_millis(3),
+                    });
+                    let _ = sender.send(RunnerMessage::ActivityObservation {
                         source: EventSource::DesktopSession,
                         observation: InactivityObservation::DesktopActivityObserved,
-                        observed_at: locked_at + Duration::from_millis(3),
+                        observed_at: locked_at + POST_LOCK_ACTIVITY_GRACE,
                     });
                     let _ = sender.send(RunnerMessage::MonitorExited(Ok(())));
                 })

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -268,7 +268,7 @@ Feature: GNOME monitor
     And the session marker is absent
     And the TV screen is visible
 
-  Scenario: GNOME lock-screen activity restores before ScreenSaver reports active
+  Scenario: GNOME lock-screen activity inside the grace period stays blanked
     Given a temporary LG Buddy config using input HDMI_2
     And the idle timeout is 120 seconds
     And LG Buddy session runtime is isolated
@@ -282,11 +282,11 @@ Feature: GNOME monitor
     And GNOME monitor stays open for 0.8 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And stdout contains "Session event `user-activity` requests screen restore."
+    And stdout does not contain "Session event `user-activity` requests screen restore."
     And the TV client received "turn_screen_off" exactly 1 times
-    And the TV client received "turn_screen_on" exactly 1 times
-    And the session marker is absent
-    And the TV screen is visible
+    And the TV client did not receive "turn_screen_on"
+    And the session marker exists
+    And the TV screen is blanked
 
   Scenario: GNOME inactivity skips TV blanking on a different input
     Given a temporary LG Buddy config using input HDMI_2

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -883,9 +883,10 @@ asymmetric:
   every enabled monitor backend uses this runtime
 - the same runtime opportunistically observes `LockedHint` on the current
   graphical logind session; lock requests the normal session blank policy,
-  unlock is informational, fresh independent activity can restore while locked,
-  and logind owner changes trigger session rebinding and reconciliation; failure
-  or lack of support does not affect the selected desktop backend
+  unlock is informational, fresh independent activity can restore while locked
+  after the fixed one-second post-lock grace, and logind owner changes trigger
+  session rebinding and reconciliation; failure or lack of support does not
+  affect the selected desktop backend
 - the gamepad source refreshes its device set from Linux device add, remove, and
   change events, with periodic reconciliation for missed events
 - `swayidle` timeout and resume callbacks feed the shared inactivity engine

--- a/docs/defaults-and-configuration.md
+++ b/docs/defaults-and-configuration.md
@@ -136,6 +136,9 @@ choice.
 - automatic session idle blank/restore defaults to enabled
 - in supported environments, a reported session lock also requests the same
   immediate blank policy; unlock never requests restore
+- a lock-triggered blank ignores desktop and gamepad activity for a fixed one
+  second before accepting activity-driven restore; this is a safety constant,
+  not a user setting
 - users who want update notifications without session-driven TV control can set
   `screen_idle_blank=disabled`
 - the installed user-session service still runs so notification handoff remains

--- a/docs/development.md
+++ b/docs/development.md
@@ -179,9 +179,11 @@ dbus-run-session -- xvfb-run -a ./scripts/test-release-bundle.sh \
 The smoke test validates `release-manifest.json` against the archive name and
 bundled runtime and GUI before running installer code. It then installs into a temporary
 root and exercises upgrade refusal, preservation, Python repair, owned-file
-replacement, service ordering, installed identity, mocked GUI read/apply/failure/
-cancel behavior, lifecycle topology, and uninstall cleanup without mutating the
-host installation.
+replacement, service ordering, GTK/libadwaita dependency confirmation and
+refusal, installed identity, mocked GUI read/apply/failure/cancel behavior,
+lifecycle topology, and uninstall cleanup without mutating the host installation.
+The supported Fedora and Arch lanes repeat the dependency flow with their native
+package-manager mappings.
 
 Run the cross-version smoke with explicit previous and candidate archives:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -208,16 +208,17 @@ Run the focused manifest contract tests with:
 python3 scripts/test_release_bundle_manifest.py
 ```
 
-Run the mock-backed draft publication and retry contract tests with:
+Run the mock-backed draft staging, reviewed publication, and retry contract tests
+with:
 
 ```bash
 python3 scripts/test_publish_release_assets.py
 ```
 
-Dry-run the GitHub release publish step with:
+Dry-run the GitHub release draft-staging step with:
 
 ```bash
-GH_RELEASE_DRY_RUN=1 ./scripts/publish-release-assets.sh --dist-dir ./dist --tag v0.0.0-dev
+GH_RELEASE_DRY_RUN=1 ./scripts/publish-release-assets.sh stage-draft --dist-dir ./dist --tag v<version>
 ```
 
 Official releases are created only through a reviewed `dev` promotion PR. For
@@ -264,11 +265,11 @@ the branch contract and recovery process, see
 | `scripts/test-cross-version-upgrade.sh` | Pinned previous-to-candidate archive upgrade smoke test |
 | `scripts/test-production-upgrade-canary.sh` | Post-publication production GitHub upgrade canary |
 | `scripts/record_github_release_responses.py` | Sanitized production response recorder for offline mocks |
-| `scripts/publish-release-assets.sh` | GitHub release publish helper |
+| `scripts/publish-release-assets.sh` | Verified GitHub release draft staging and publication helper |
 | `scripts/release_promotion.py` | Promotion version, branch, and tag validator |
 | `.github/workflows/ci.yml` | CI validation workflow |
 | `.github/workflows/promotion-pr.yml` | Read-only promotion PR contract check using the target branch's validator |
-| `.github/workflows/release.yml` | Post-merge promotion build and publication workflow |
+| `.github/workflows/release.yml` | Post-merge build, draft staging, approval, and publication workflow |
 | `bin/LG_Buddy_Common` | Shared shell config helper used by setup scripts |
 | `systemd/` | Installed unit files and tmpfiles config, including the logind lifecycle service |
 | `docs/architecture-overview.md` | Runtime architecture |

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -13,14 +13,15 @@ same-repository `dev` branch and whose base is `main` or `prerelease`.
 
 ## Promotion contract
 
-The promotion PR is the review and approval surface. Required checks gate its
-merge, and merging the PR is the release authorization. The merged target-branch
-commit is the release commit; there is no separate approval label or publish
-action.
+The promotion PR is the code and release-identity review surface. Required checks
+gate its merge, and merging the PR authorizes preparation of a verified release
+draft. The merged target-branch commit is the release commit. Publishing that
+draft is a separate explicit approval after its release notes and assets have
+been reviewed.
 
 The release App is not a substitute for merging. After the merged commit has
 passed the release build and smoke test, the App performs protected tag and
-release writes and keeps the persistent streams aligned. A prerelease merge
+draft-release writes and keeps the persistent streams aligned. A prerelease merge
 advances `dev` to the merged prerelease commit. A stable merge advances both
 `prerelease` and `dev` to the merged stable commit.
 
@@ -49,15 +50,23 @@ There is no separate version input.
 1. Prepare the exact release version in `Cargo.toml` and `Cargo.lock` on `dev`.
 2. Open a PR from `dev` to `prerelease` or `main`.
 3. Wait for `verify`, `bundle-smoke-test`, and `validate-promotion` to pass.
-4. Merge the promotion PR. This is the release authorization.
+4. Merge the promotion PR. This authorizes preparation of the release draft.
 5. The resulting push starts the serialized release workflow, which builds and
    smoke-tests the merged release commit without write credentials, including
    an archive-driven upgrade from the pinned public baseline.
-6. The final job obtains a short-lived token from the dedicated repository-only
-   GitHub App, aligns the remaining release streams, creates or resumes a draft,
-   verifies its complete asset set, and publishes it. Repository release
-   immutability then locks the tag and assets.
-7. A published prerelease then runs `v1.4.0-beta.2` through the real production
+6. The staging job obtains a short-lived token from the dedicated repository-only
+   GitHub App, aligns the remaining release streams, creates or resumes the exact
+   release draft, uploads any missing assets, and verifies the complete asset set.
+7. Fill in the draft's release-specific notes and review its title, classification,
+   tag, and assets. Then approve the waiting `release-publication` environment.
+   The approval does not accept an independent version, tag, commit, artifact, or
+   workflow-run identifier.
+8. The publication job downloads the same workflow artifact again, revalidates the
+   merged refs, tag, checksums, manifest, draft classification, complete remote
+   asset set, and non-placeholder notes, then makes only that draft public. It
+   preserves the reviewed title and notes. Repository release immutability then
+   locks the tag and assets.
+9. A published prerelease then runs `v1.4.0-beta.2` through the real production
    `lg-buddy updates install` path. The newly installed candidate performs a
    cold-cache production update check, and the canary records sanitized GitHub
    response evidence for the deterministic mock. This is supplemental
@@ -65,19 +74,23 @@ There is no separate version input.
 
 Promotion through `prerelease` is optional. A direct `dev -> main` promotion
 runs the same required PR validation and post-merge release build as a
-`dev -> prerelease` promotion. After stable publication, the release App
+`dev -> prerelease` promotion. During stable draft staging, the release App
 fast-forwards both `prerelease` and `dev` to the reviewed stable commit.
 
-Replace the publisher's generic release description with concise,
-release-specific notes for user-visible default or compatibility changes before
-announcing the release.
+Replace the draft's placeholder with concise, release-specific notes before
+approving publication. The workflow does not impose a notes template, but it
+refuses to publish empty, whitespace-only, or unchanged placeholder notes.
 
 Do not push version tags manually. Protected `v*` tags and stream-alignment
 writes permit bypass only to the dedicated release App. A failed post-merge
 release run can be rerun safely: an incomplete draft remains private and is
 resumed only when its tag, classification, and existing assets match the merged
-release commit. A published release is accepted only when its expected asset set
-is complete and byte-for-byte identical.
+release commit. If publication was attempted before the notes were ready, update
+the draft, rerun the failed jobs, and approve the environment again. The staged
+workflow artifact is retained for 30 days, matching GitHub's maximum wait for an
+environment approval; after that, rerun the whole workflow to rebuild it. A
+published release is accepted only when its expected asset set is complete and
+byte-for-byte identical.
 
 Repository release immutability must remain enabled. GitHub applies it only when
 a draft is published, so the publisher uploads and verifies every expected asset
@@ -100,10 +113,12 @@ The workflow:
    preserved user state plus replaced owned integration files.
 7. Generates and verifies `sha256sums.txt`.
 8. Keeps `main`, `prerelease`, and `dev` aligned for the next promotion.
-9. Stages the exact release assets privately, then publishes them together under
-   the repository's immutable-release policy.
-10. Downloads the published assets and verifies their checksums independently.
-11. For prereleases, exercises production GitHub discovery, acquisition,
+9. Stages and verifies the exact release assets privately.
+10. Waits for release-note review and explicit publication approval.
+11. Revalidates and publishes only the staged draft, preserving its reviewed
+    title and notes.
+12. Downloads the published assets and verifies their checksums independently.
+13. For prereleases, exercises production GitHub discovery, acquisition,
     confirmation, installation, and final identity from the pinned baseline.
 
 `install.sh` is only an installer. It does not build the runtime or GUI.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -87,10 +87,10 @@ release run can be rerun safely: an incomplete draft remains private and is
 resumed only when its tag, classification, and existing assets match the merged
 release commit. If publication was attempted before the notes were ready, update
 the draft, rerun the failed jobs, and approve the environment again. The staged
-workflow artifact is retained for 30 days, matching GitHub's maximum wait for an
-environment approval; after that, rerun the whole workflow to rebuild it. A
-published release is accepted only when its expected asset set is complete and
-byte-for-byte identical.
+workflow artifact is retained for 35 days, leaving a margin beyond GitHub's
+30-day maximum wait for an environment approval; after that, rerun the whole
+workflow to rebuild it. A published release is accepted only when its expected
+asset set is complete and byte-for-byte identical.
 
 Repository release immutability must remain enabled. GitHub applies it only when
 a draft is published, so the publisher uploads and verifies every expected asset

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -137,9 +137,11 @@ independent auxiliary source owned by the shared session runtime. The
 key architectural point is that blank/restore decisions are made after
 normalization, not inside a desktop adapter.
 
-After a lock blank, only independent desktop or gamepad activity newer than the
-lock can produce `RestoreNow`. Stale observations and GNOME provider
-active/wake signals do not make unlock itself a restore trigger.
+After a lock-triggered blank, independent desktop or gamepad activity can
+produce `RestoreNow` only when its monotonic observation time is at least one
+second newer than the lock. Earlier samples leave the blank and its timed
+power-off deadline intact. GNOME provider active/wake signals do not make unlock
+itself a restore trigger.
 
 The resulting decisions are dispatched as:
 
@@ -262,9 +264,9 @@ connection, subscriptions, owner rebinding, reconciliation, and translation to
 normalized lock observations. Missing, ambiguous, or unavailable session state
 produces a diagnostic without changing inactivity behavior or native backend
 eligibility. A desktop or locker that never updates `LockedHint` simply produces
-no lock events. Unlock never sends a wake, restore, or activity event. Fresh
-independent activity observed while locked remains able to restore the screen
-through the existing marker policy.
+no lock events. Unlock never sends a wake, restore, or activity event. After the
+fixed one-second post-lock grace, fresh independent activity observed while
+locked remains able to restore the screen through the existing marker policy.
 
 ## Lifecycle Default And Migration Stance
 

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -150,10 +150,14 @@ subscription, and reconciliation when logind restarts.
 A lock enters the existing blanked inactivity state and dispatches
 `SessionLocked` from `LinuxLogind`, so configured-input, marker, sleep-phase,
 and restore policy remain centralized in `screen.rs`. Unlock performs no screen
-action. Independent desktop or gamepad activity observed after the lock can
-restore the picture while the lock screen is still shown. Stale pre-lock
-observations and provider wake/deactivation signals associated with unlocking do
-not restore it; normal inactivity timing resumes from fresh activity.
+action. A lock-triggered blank starts a fixed one-second activity grace period.
+Independent desktop or gamepad activity observed before the lock or inside that
+period is ignored without canceling the pending timed power-off. At the grace
+boundary, the first fresh independent activity can restore the picture while the
+lock screen is still shown. The shared policy compares each sample's monotonic
+observation time with the lock time, so delayed dispatch does not change the
+decision. Provider wake/deactivation signals associated with unlocking do not
+restore it; normal inactivity timing resumes from accepted fresh activity.
 
 Known environment support follows whether the desktop or locker maintains
 logind's `LockedHint` for the graphical session:

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -381,6 +381,14 @@ and upgrades to an explicit candidate archive. It checks initial and candidate
 refusals before network, sudo, or mutation, then verifies preserved user state,
 candidate-owned file replacement, service action order, and final identity.
 
+The mock-backed release publisher suite keeps draft staging and publication as
+separate capabilities. It proves that staging can create and resume a complete
+draft but cannot publish it, while publication cannot create or upload anything.
+Publication requires reviewed non-placeholder notes and an exact remote asset
+match, changes only the draft state, and preserves the reviewed title and notes.
+Checksum, manifest, classification, unexpected-asset, partial-upload, corrupted
+upload, retry, and already-published paths are covered without GitHub access.
+
 After a prerelease is public, `production-prerelease-canary` installs the same
 baseline and drives its real `updates install` command through a PTY against
 GitHub. It then clears the update cache and proves that the newly installed

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -254,7 +254,8 @@ Examples:
 - gamepad activity integration with the LG Buddy inactivity deadline
 - screen runtime-phase eligibility over the private logind system-bus seam
 - logind lock state entering the shared blanked state without making unlock a
-  restore trigger, while fresh independent activity still restores
+  restore trigger, while observation-time tests cover pre-lock, post-lock grace,
+  boundary, and accepted desktop and auxiliary activity
 - logind lock monitoring rebinding and reconciling after logind changes its
   unique D-Bus owner
 - swayidle production timeout/resume process arguments

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -338,6 +338,12 @@ light/dark rendering, and 1x/2x window-geometry coverage. The display-backed
 renderer suite separately asserts the same GTK semantics directly at the widget
 boundary.
 
+The Ubuntu bundle smoke and the Fedora and Arch installation lanes also exercise
+GUI runtime dependency handling. They prove that an unconfirmed install does not
+invoke the package manager or GUI, an accepted install requests the correct
+native package names before GUI identity validation, insufficient versions abort
+before LG Buddy mutation, and already-satisfied hosts perform no package action.
+
 The Rust release-bundle acquisition suite covers exact asset selection, fresh
 release metadata, bounded responses and downloads, GitHub and published digest
 agreement, lightweight and annotated tags, restrictive staging and locking,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -122,10 +122,14 @@ restoring. The user service remains available for update notifications.
 
 When an automatic idle or session-lock action successfully blanks the screen,
 LG Buddy powers the TV off after five more minutes without activity. This grace
-period is a fixed safety default rather than a setting. Any desktop or gamepad
-activity cancels the pending power-off and restores the screen. Before powering
-off, LG Buddy rechecks its ownership marker, the configured input, and machine
-lifecycle state; it skips safely if those checks no longer permit the action.
+period is a fixed safety default rather than a setting. After a session-lock
+blank, desktop and gamepad activity is ignored for one second so incidental
+input while stepping away does not immediately restore the screen. The first
+activity at or after that boundary cancels the pending power-off and restores
+the screen, even while the session remains locked. Idle-triggered blanks retain
+their immediate activity restore behavior. Before powering off, LG Buddy
+rechecks its ownership marker, the configured input, and machine lifecycle
+state; it skips safely if those checks no longer permit the action.
 
 The restore policies are:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -291,6 +291,14 @@ bundle, reruns preflight from the candidate, invokes `install.sh --upgrade`,
 and verifies the installed release identity. It does not accept channel or
 version arguments, downgrade, migrate legacy installations, or run unattended.
 
+Before a fresh installation or upgrade executes the bundled GUI, the installer
+checks for GTK 4.14 or newer and libadwaita 1.5 or newer. If either is missing,
+apt systems offer `libgtk-4-1` and `libadwaita-1-0`; dnf and pacman systems offer
+`gtk4` and `libadwaita`. Installing them requires a separate explicit
+confirmation. Declining, running noninteractively without that opt-in, using an
+unsupported package manager, or remaining below the required versions aborts
+before LG Buddy installation files are changed and prints a manual command.
+
 `v1.4.0-beta.2` is the first release that contains `updates install`. Older
 installations require one normal manual installation of an updater-capable
 release before this assisted path is available.

--- a/install.sh
+++ b/install.sh
@@ -294,7 +294,7 @@ print_manual_install_command() {
         apt) echo "  sudo apt install ${MISSING_PKGS[*]}" ;;
         dnf) echo "  sudo dnf install ${MISSING_PKGS[*]}" ;;
         pacman) echo "  sudo pacman -S ${MISSING_PKGS[*]}" ;;
-        *) echo "Install GTK 4.14 or newer and libadwaita 1.5 or newer with your system package manager." ;;
+        *) echo "Install these requirements with your system package manager: ${MISSING_PKGS[*]}" ;;
     esac
 }
 

--- a/install.sh
+++ b/install.sh
@@ -110,6 +110,7 @@ SCREEN_IDLE_BLANK="enabled"
 SYSTEM_CONFIG_OVERRIDE_TMP=""
 CONFIG_POINTER_TMP=""
 NM_HOOK_TMP=""
+PM=""
 INSTALL_CMD=()
 
 prefix_path() {
@@ -197,6 +198,104 @@ check_python3_venv() {
 
     rm -rf "$tmp_venv_dir"
     return 1
+}
+
+detect_package_manager() {
+    if command -v apt &>/dev/null; then
+        PM="apt"
+        INSTALL_CMD=(apt install -y)
+    elif command -v dnf &>/dev/null; then
+        PM="dnf"
+        INSTALL_CMD=(dnf install -y)
+    elif command -v pacman &>/dev/null; then
+        PM="pacman"
+        INSTALL_CMD=(pacman -S --noconfirm)
+    else
+        PM=""
+        INSTALL_CMD=()
+    fi
+}
+
+gui_runtime_package() {
+    local requirement="$1"
+
+    case "$PM:$requirement" in
+        apt:gtk) printf '%s\n' "libgtk-4-1" ;;
+        apt:libadwaita) printf '%s\n' "libadwaita-1-0" ;;
+        dnf:gtk|pacman:gtk) printf '%s\n' "gtk4" ;;
+        dnf:libadwaita|pacman:libadwaita) printf '%s\n' "libadwaita" ;;
+        *:gtk) printf '%s\n' "GTK 4.14 or newer" ;;
+        *:libadwaita) printf '%s\n' "libadwaita 1.5 or newer" ;;
+    esac
+}
+
+gui_runtime_version_at_least() {
+    local library="$1"
+    local symbol_prefix="$2"
+    local required_major="$3"
+    local required_minor="$4"
+
+    if [ -n "${LG_BUDDY_GUI_RUNTIME_PROBE:-}" ]; then
+        "$LG_BUDDY_GUI_RUNTIME_PROBE" \
+            "$library" "$symbol_prefix" "$required_major" "$required_minor"
+        return
+    fi
+
+    python3 - "$library" "$symbol_prefix" "$required_major" "$required_minor" <<'PY'
+import ctypes
+import sys
+
+library, prefix, required_major, required_minor = sys.argv[1:]
+try:
+    runtime = ctypes.CDLL(library)
+    major = getattr(runtime, f"{prefix}_get_major_version")
+    minor = getattr(runtime, f"{prefix}_get_minor_version")
+    major.argtypes = []
+    minor.argtypes = []
+    major.restype = ctypes.c_uint
+    minor.restype = ctypes.c_uint
+    installed = (major(), minor())
+except (AttributeError, OSError):
+    raise SystemExit(1)
+
+required = (int(required_major), int(required_minor))
+raise SystemExit(0 if installed >= required else 1)
+PY
+}
+
+check_gui_runtime_prerequisites() {
+    check_dep \
+        "GTK 4.14 or newer" \
+        "$(gui_runtime_package gtk)" \
+        "gui_runtime_version_at_least libgtk-4.so.1 gtk 4 14"
+    check_dep \
+        "libadwaita 1.5 or newer" \
+        "$(gui_runtime_package libadwaita)" \
+        "gui_runtime_version_at_least libadwaita-1.so.0 adw 1 5"
+}
+
+verify_gui_runtime_prerequisites() {
+    local missing=0
+
+    if ! gui_runtime_version_at_least libgtk-4.so.1 gtk 4 14; then
+        echo "Error: GTK 4.14 or newer is still unavailable."
+        missing=1
+    fi
+    if ! gui_runtime_version_at_least libadwaita-1.so.0 adw 1 5; then
+        echo "Error: libadwaita 1.5 or newer is still unavailable."
+        missing=1
+    fi
+
+    [ "$missing" -eq 0 ] || return 1
+}
+
+print_manual_install_command() {
+    case "$PM" in
+        apt) echo "  sudo apt install ${MISSING_PKGS[*]}" ;;
+        dnf) echo "  sudo dnf install ${MISSING_PKGS[*]}" ;;
+        pacman) echo "  sudo pacman -S ${MISSING_PKGS[*]}" ;;
+        *) echo "Install GTK 4.14 or newer and libadwaita 1.5 or newer with your system package manager." ;;
+    esac
 }
 
 write_config_override() {
@@ -352,19 +451,6 @@ install_missing_prerequisites() {
     echo ""
     echo "Missing: ${MISSING_PKGS[*]}"
 
-    if command -v apt &>/dev/null; then
-        PM="apt"
-        INSTALL_CMD=(apt install -y)
-    elif command -v dnf &>/dev/null; then
-        PM="dnf"
-        INSTALL_CMD=(dnf install -y)
-    elif command -v pacman &>/dev/null; then
-        PM="pacman"
-        INSTALL_CMD=(pacman -S --noconfirm)
-    else
-        PM=""
-    fi
-
     if [ -n "$PM" ]; then
         AUTO_INSTALL="${LG_BUDDY_AUTO_INSTALL_DEPS:-}"
         if [ -z "$AUTO_INSTALL" ] && [ "$NONINTERACTIVE" != "1" ]; then
@@ -372,27 +458,42 @@ install_missing_prerequisites() {
         fi
         case "$AUTO_INSTALL" in
             [Yy]*)
-                run_privileged "${INSTALL_CMD[@]}" "${MISSING_PKGS[@]}"
+                if ! run_privileged "${INSTALL_CMD[@]}" "${MISSING_PKGS[@]}"; then
+                    echo "Failed to install the missing packages. Install them manually and re-run install.sh."
+                    print_manual_install_command
+                    exit 1
+                fi
                 ;;
             *)
                 echo "Please install the missing packages manually and re-run install.sh."
+                print_manual_install_command
                 exit 1
                 ;;
         esac
     else
         echo "Could not detect a supported package manager (apt/dnf/pacman)."
         echo "Please install the missing packages manually and re-run install.sh."
+        print_manual_install_command
         exit 1
     fi
 }
 
-check_fresh_install_prerequisites() {
+check_install_prerequisites() {
     echo ""
     echo "Checking prerequisites..."
     MISSING_PKGS=()
-    check_dep "python3-venv" "python3-venv" "check_python3_venv"
-    check_dep "zenity" "zenity" "command -v zenity"
+    detect_package_manager
+    check_gui_runtime_prerequisites
+    if [ "$UPGRADE_MODE" -eq 0 ]; then
+        check_dep "python3-venv" "python3-venv" "check_python3_venv"
+        check_dep "zenity" "zenity" "command -v zenity"
+    fi
     install_missing_prerequisites
+    if ! verify_gui_runtime_prerequisites; then
+        echo "The installed packages do not satisfy the GUI runtime requirements."
+        print_manual_install_command
+        exit 1
+    fi
 }
 
 require_python_repair_prerequisites() {
@@ -487,6 +588,7 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
     "$RUNTIME_BINARY" upgrade-preflight "$SCRIPT_DIR"
     resolve_gui_binary
     resolve_app_icon
+    check_install_prerequisites
     validate_candidate_binary_identity
     load_upgrade_configuration
 
@@ -502,8 +604,8 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
 else
     resolve_gui_binary
     resolve_app_icon
+    check_install_prerequisites
     validate_candidate_binary_identity
-    check_fresh_install_prerequisites
 
 # CONFIGURE FRESH INSTALLATION
 echo ""

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -5,9 +5,17 @@ set -euo pipefail
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 
 usage() {
-    echo "Usage: $0 [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
+    echo "Usage: $0 <stage-draft|publish-draft> [--dist-dir <dir>] [--tag <release-tag>] [--commit <release-commit>]"
     exit 1
 }
+
+[ "$#" -gt 0 ] || usage
+MODE="$1"
+shift
+case "$MODE" in
+    stage-draft|publish-draft) ;;
+    *) usage ;;
+esac
 
 DIST_DIR="dist"
 TAG="${GITHUB_REF_NAME:-}"
@@ -64,6 +72,8 @@ CHECKSUM_FILE="$DIST_DIR/sha256sums.txt"
     exit 1
 }
 
+(cd "$DIST_DIR" && sha256sum --strict -c "$(basename "$CHECKSUM_FILE")")
+
 VERSION="${TAG#v}"
 [ -n "$VERSION" ] || {
     echo "Release tag must include a version after v."
@@ -71,7 +81,7 @@ VERSION="${TAG#v}"
 }
 
 TITLE="LG Buddy ${VERSION}"
-NOTES="Prebuilt LG Buddy release bundle for Linux. Extract the archive and run ./install.sh from inside the bundle."
+PLACEHOLDER_NOTES="Release notes pending maintainer review."
 RELEASE_FLAGS=()
 EXPECTED_CHANNEL="stable"
 
@@ -95,7 +105,7 @@ for archive in "${ARCHIVES[@]}"; do
 done
 
 if [ "$DRY_RUN" = "1" ]; then
-    echo "Dry run: would publish tag $TAG"
+    echo "Dry run: would run $MODE for tag $TAG"
     printf 'Archive: %s\n' "${ARCHIVES[@]}"
     echo "Checksum file: $CHECKSUM_FILE"
     echo "Title: $TITLE"
@@ -121,9 +131,11 @@ if [ "${#RELEASE_FLAGS[@]}" -gt 0 ]; then
     EXPECTED_PRERELEASE="true"
 fi
 
+RELEASE_EXISTS="false"
 RELEASE_IS_DRAFT="true"
 if gh release view "$TAG" >/dev/null 2>&1; then
-    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
+    RELEASE_EXISTS="true"
+    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
     RELEASE_IS_DRAFT="$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)"
     case "$RELEASE_IS_DRAFT" in
         true|false) ;;
@@ -136,8 +148,21 @@ if gh release view "$TAG" >/dev/null 2>&1; then
         echo "Existing release $TAG has the wrong prerelease classification."
         exit 1
     }
-else
-    gh release create "$TAG" --draft --verify-tag --title "$TITLE" --notes "$NOTES" "${RELEASE_FLAGS[@]}"
+fi
+
+if [ "$MODE" = "publish-draft" ] && [ "$RELEASE_EXISTS" = "false" ]; then
+    echo "Release draft $TAG does not exist. Run stage-draft first."
+    exit 1
+fi
+
+if [ "$MODE" = "stage-draft" ] && [ "$RELEASE_EXISTS" = "false" ]; then
+    gh release create "$TAG" \
+        --draft \
+        --verify-tag \
+        --title "$TITLE" \
+        --notes "$PLACEHOLDER_NOTES" \
+        "${RELEASE_FLAGS[@]}"
+    RELEASE_EXISTS="true"
 fi
 
 EXPECTED_ASSETS=("${ARCHIVES[@]}" "$CHECKSUM_FILE")
@@ -173,8 +198,8 @@ done <<< "$RELEASE_ASSET_NAMES"
 for asset in "${EXPECTED_ASSETS[@]}"; do
     asset_name="$(basename "$asset")"
     if ! grep -F -x -q -- "$asset_name" <<< "$RELEASE_ASSET_NAMES"; then
-        [ "$RELEASE_IS_DRAFT" = "true" ] || {
-            echo "Published release $TAG is missing required asset: $asset_name"
+        [ "$MODE" = "stage-draft" ] && [ "$RELEASE_IS_DRAFT" = "true" ] || {
+            echo "Release $TAG is missing required asset: $asset_name"
             exit 1
         }
         gh release upload "$TAG" "$asset"
@@ -229,30 +254,77 @@ for asset in "${EXPECTED_ASSETS[@]}"; do
     }
 done
 
-if [ "$RELEASE_IS_DRAFT" = "true" ]; then
-    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
-        echo "Release $TAG was published before asset verification completed."
-        exit 1
-    }
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
-        echo "Release $TAG changed prerelease classification before publication."
-        exit 1
-    }
-
-    gh release edit "$TAG" \
-        --draft=false \
-        --prerelease="$EXPECTED_PRERELEASE" \
-        --title "$TITLE" \
-        --notes "$NOTES"
-
-    RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease)"
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "false" ] || {
-        echo "Release $TAG remained a draft after publication."
-        exit 1
-    }
-    [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
-        echo "Published release $TAG has the wrong prerelease classification."
-        exit 1
-    }
+if [ "$MODE" = "stage-draft" ]; then
+    if [ "$RELEASE_IS_DRAFT" = "true" ]; then
+        RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
+        [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
+            echo "Release $TAG was published before draft verification completed."
+            exit 1
+        }
+        [ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+            echo "Release $TAG changed prerelease classification during draft staging."
+            exit 1
+        }
+        echo "Verified release draft $TAG is ready for release-note review and publication approval."
+    else
+        echo "Published release $TAG already has the complete verified asset set."
+    fi
+    exit 0
 fi
+
+release_notes_are_ready() {
+    local state="$1"
+    printf '%s' "$state" | jq -e --arg placeholder "$PLACEHOLDER_NOTES" '
+        (.body // "") as $body |
+        ($body != $placeholder) and (($body | gsub("\\s"; "") | length) > 0)
+    ' >/dev/null
+}
+
+release_notes_are_ready "$RELEASE_STATE" || {
+    echo "Release $TAG still has empty or placeholder release notes."
+    exit 1
+}
+
+if [ "$RELEASE_IS_DRAFT" = "false" ]; then
+    echo "Published release $TAG already has the complete verified asset set and reviewed notes."
+    exit 0
+fi
+
+RELEASE_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
+[ "$(printf '%s' "$RELEASE_STATE" | jq -r .isDraft)" = "true" ] || {
+    echo "Release $TAG was published before final verification completed."
+    exit 1
+}
+[ "$(printf '%s' "$RELEASE_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+    echo "Release $TAG changed prerelease classification before publication."
+    exit 1
+}
+release_notes_are_ready "$RELEASE_STATE" || {
+    echo "Release $TAG still has empty or placeholder release notes."
+    exit 1
+}
+
+REVIEWED_BODY="$(printf '%s' "$RELEASE_STATE" | jq -c '.body')"
+REVIEWED_NAME="$(printf '%s' "$RELEASE_STATE" | jq -c '.name')"
+
+gh release edit "$TAG" --draft=false
+
+PUBLISHED_STATE="$(gh release view "$TAG" --json isDraft,isPrerelease,body,name)"
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -r .isDraft)" = "false" ] || {
+    echo "Release $TAG remained a draft after publication."
+    exit 1
+}
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -r .isPrerelease)" = "$EXPECTED_PRERELEASE" ] || {
+    echo "Published release $TAG has the wrong prerelease classification."
+    exit 1
+}
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -c '.body')" = "$REVIEWED_BODY" ] || {
+    echo "Published release $TAG did not preserve the reviewed release notes."
+    exit 1
+}
+[ "$(printf '%s' "$PUBLISHED_STATE" | jq -c '.name')" = "$REVIEWED_NAME" ] || {
+    echo "Published release $TAG did not preserve the reviewed title."
+    exit 1
+}
+
+echo "Published verified release $TAG with its reviewed title and notes unchanged."

--- a/scripts/publish-release-assets.sh
+++ b/scripts/publish-release-assets.sh
@@ -276,7 +276,9 @@ release_notes_are_ready() {
     local state="$1"
     printf '%s' "$state" | jq -e --arg placeholder "$PLACEHOLDER_NOTES" '
         (.body // "") as $body |
-        ($body != $placeholder) and (($body | gsub("\\s"; "") | length) > 0)
+        ($body | gsub("\\s"; "")) as $normalized_body |
+        ($placeholder | gsub("\\s"; "")) as $normalized_placeholder |
+        ($normalized_body != $normalized_placeholder) and ($normalized_body | length > 0)
     ' >/dev/null
 }
 

--- a/scripts/release_promotion.py
+++ b/scripts/release_promotion.py
@@ -263,7 +263,7 @@ def validate_promotion(
 
     return {
         **identity,
-        "publish": True,
+        "prepare": True,
         "head_sha": head_sha,
         "source_sha": dev_sha,
         "base_sha": target_sha,
@@ -296,7 +296,7 @@ def validate_merged_promotion(
     if target == "prerelease" and main_sha == head_sha:
         version = package_version_at_ref(repository, head_sha, RUNTIME_MANIFEST_PATH)
         return {
-            "publish": False,
+            "prepare": False,
             "version": version,
             "tag": f"v{version}",
             "channel": "stable",
@@ -324,7 +324,7 @@ def validate_merged_promotion(
     )
     return {
         **identity,
-        "publish": True,
+        "prepare": True,
         "head_sha": head_sha,
         "source_sha": source_sha,
         "base_sha": previous_sha,

--- a/scripts/test-installer-gui-dependencies.sh
+++ b/scripts/test-installer-gui-dependencies.sh
@@ -1,0 +1,203 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+usage() {
+    echo "Usage: $0 <install.sh> <runtime-binary> <gui-binary> <apt|dnf|pacman>"
+    exit 1
+}
+
+[ "$#" -eq 4 ] || usage
+[ "$(id -u)" -ne 0 ] || {
+    echo "Installer dependency smoke must run as a regular user."
+    exit 1
+}
+
+INSTALL_SCRIPT="$(realpath "$1")"
+RUNTIME_BINARY="$(realpath "$2")"
+GUI_BINARY="$(realpath "$3")"
+PACKAGE_MANAGER="$4"
+
+case "$PACKAGE_MANAGER" in
+    apt)
+        EXPECTED_ARGS="install -y libgtk-4-1 libadwaita-1-0"
+        EXPECTED_MANUAL="sudo apt install libgtk-4-1 libadwaita-1-0"
+        ;;
+    dnf)
+        EXPECTED_ARGS="install -y gtk4 libadwaita"
+        EXPECTED_MANUAL="sudo dnf install gtk4 libadwaita"
+        ;;
+    pacman)
+        EXPECTED_ARGS="-S --noconfirm gtk4 libadwaita"
+        EXPECTED_MANUAL="sudo pacman -S gtk4 libadwaita"
+        ;;
+    *) usage ;;
+esac
+
+WORK_DIR="$(mktemp -d)"
+STUB_DIR="$WORK_DIR/stubs"
+DEPENDENCIES_INSTALLED="$WORK_DIR/dependencies-installed"
+PACKAGE_LOG="$WORK_DIR/package-manager.log"
+SEQUENCE_LOG="$WORK_DIR/sequence.log"
+GUI_WRAPPER="$WORK_DIR/lg-buddy-gui"
+PROBE="$WORK_DIR/gui-runtime-probe"
+
+cleanup() {
+    rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$STUB_DIR"
+
+cat >"$PROBE" <<'EOF'
+#!/bin/sh
+[ -e "${LG_BUDDY_DEPENDENCIES_INSTALLED:?}" ]
+EOF
+
+cat >"$STUB_DIR/$PACKAGE_MANAGER" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >"${LG_BUDDY_PACKAGE_LOG:?}"
+printf '%s\n' package-manager >>"${LG_BUDDY_SEQUENCE_LOG:?}"
+if [ "${LG_BUDDY_FAKE_PACKAGE_MANAGER_FAIL:-0}" = "1" ]; then
+    exit 65
+fi
+if [ "${LG_BUDDY_FAKE_INSTALL_SATISFIES:-1}" = "1" ]; then
+    : >"${LG_BUDDY_DEPENDENCIES_INSTALLED:?}"
+fi
+EOF
+
+cat >"$STUB_DIR/systemctl" <<'EOF'
+#!/bin/sh
+case "$*" in
+    is-system-running|"--user is-system-running") printf '%s\n' running ;;
+esac
+exit 0
+EOF
+
+cat >"$STUB_DIR/systemd-tmpfiles" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$GUI_WRAPPER" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' gui-identity >>"${LG_BUDDY_SEQUENCE_LOG:?}"
+exec "${LG_BUDDY_REAL_GUI:?}" "$@"
+EOF
+
+chmod 755 "$PROBE" "$GUI_WRAPPER" "$STUB_DIR/$PACKAGE_MANAGER" \
+    "$STUB_DIR/systemctl" "$STUB_DIR/systemd-tmpfiles"
+
+run_fresh_install() {
+    local scenario="$1"
+    local output="$2"
+    local auto_install="$3"
+    local install_satisfies="$4"
+    local package_manager_fails="${5:-0}"
+    local root="$WORK_DIR/$scenario/root"
+    local home="$WORK_DIR/$scenario/home"
+
+    mkdir -p "$root" "$home/Desktop"
+    (
+        export PATH="$STUB_DIR:$PATH"
+        export HOME="$home"
+        export XDG_CONFIG_HOME="$home/.config"
+        export LG_BUDDY_INSTALL_ROOT="$root"
+        export LG_BUDDY_SUDO_CMD="none"
+        export LG_BUDDY_NONINTERACTIVE="1"
+        export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
+        export LG_BUDDY_SKIP_PIP_INSTALL="1"
+        export LG_BUDDY_TV_IP="192.0.2.10"
+        export LG_BUDDY_TV_MAC="02:00:00:00:00:10"
+        export LG_BUDDY_INPUT="HDMI_1"
+        export LG_BUDDY_TV_PLATFORM="bscpylgtv"
+        export LG_BUDDY_SCREEN_BACKEND="auto"
+        export LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY="enabled"
+        export LG_BUDDY_GUI_RUNTIME_PROBE="$PROBE"
+        export LG_BUDDY_DEPENDENCIES_INSTALLED="$DEPENDENCIES_INSTALLED"
+        export LG_BUDDY_PACKAGE_LOG="$PACKAGE_LOG"
+        export LG_BUDDY_SEQUENCE_LOG="$SEQUENCE_LOG"
+        export LG_BUDDY_REAL_GUI="$GUI_BINARY"
+        export LG_BUDDY_FAKE_INSTALL_SATISFIES="$install_satisfies"
+        export LG_BUDDY_FAKE_PACKAGE_MANAGER_FAIL="$package_manager_fails"
+        if [ "$auto_install" = "1" ]; then
+            export LG_BUDDY_AUTO_INSTALL_DEPS="yes"
+        else
+            unset LG_BUDDY_AUTO_INSTALL_DEPS
+        fi
+        cd "$(dirname "$INSTALL_SCRIPT")"
+        bash "$INSTALL_SCRIPT" \
+            --runtime-binary "$RUNTIME_BINARY" \
+            --gui-binary "$GUI_WRAPPER" >"$output" 2>&1
+    )
+}
+
+REFUSAL_OUTPUT="$WORK_DIR/refusal.output"
+if run_fresh_install refusal "$REFUSAL_OUTPUT" 0 1; then
+    echo "Noninteractive install unexpectedly installed missing GUI dependencies."
+    exit 1
+fi
+grep -F -q '  [MISSING] GTK 4.14 or newer' "$REFUSAL_OUTPUT"
+grep -F -q '  [MISSING] libadwaita 1.5 or newer' "$REFUSAL_OUTPUT"
+grep -F -q "$EXPECTED_MANUAL" "$REFUSAL_OUTPUT"
+[ ! -e "$PACKAGE_LOG" ] || {
+    echo "Refused dependency installation invoked $PACKAGE_MANAGER."
+    exit 1
+}
+[ ! -e "$SEQUENCE_LOG" ] || {
+    echo "Refused dependency installation executed the GUI candidate."
+    exit 1
+}
+[ -z "$(find "$WORK_DIR/refusal/root" -mindepth 1 -print -quit)" ] || {
+    echo "Refused dependency installation mutated the installation root."
+    exit 1
+}
+
+UNAVAILABLE_OUTPUT="$WORK_DIR/unavailable.output"
+rm -f "$PACKAGE_LOG" "$SEQUENCE_LOG" "$DEPENDENCIES_INSTALLED"
+if run_fresh_install unavailable "$UNAVAILABLE_OUTPUT" 1 0 1; then
+    echo "Install unexpectedly accepted an unavailable GUI runtime package."
+    exit 1
+fi
+[ "$(cat "$PACKAGE_LOG")" = "$EXPECTED_ARGS" ]
+grep -F -q 'Failed to install the missing packages.' "$UNAVAILABLE_OUTPUT"
+grep -F -q "$EXPECTED_MANUAL" "$UNAVAILABLE_OUTPUT"
+[ "$(cat "$SEQUENCE_LOG")" = "package-manager" ]
+[ -z "$(find "$WORK_DIR/unavailable/root" -mindepth 1 -print -quit)" ] || {
+    echo "Unavailable GUI runtime packages mutated the installation root."
+    exit 1
+}
+
+UNSATISFIED_OUTPUT="$WORK_DIR/unsatisfied.output"
+rm -f "$PACKAGE_LOG" "$SEQUENCE_LOG" "$DEPENDENCIES_INSTALLED"
+if run_fresh_install unsatisfied "$UNSATISFIED_OUTPUT" 1 0; then
+    echo "Install unexpectedly accepted insufficient GUI runtime versions."
+    exit 1
+fi
+[ "$(cat "$PACKAGE_LOG")" = "$EXPECTED_ARGS" ]
+grep -F -q 'The installed packages do not satisfy the GUI runtime requirements.' "$UNSATISFIED_OUTPUT"
+grep -F -q "$EXPECTED_MANUAL" "$UNSATISFIED_OUTPUT"
+[ "$(cat "$SEQUENCE_LOG")" = "package-manager" ]
+[ -z "$(find "$WORK_DIR/unsatisfied/root" -mindepth 1 -print -quit)" ] || {
+    echo "Insufficient GUI runtime versions mutated the installation root."
+    exit 1
+}
+
+SUCCESS_OUTPUT="$WORK_DIR/success.output"
+rm -f "$PACKAGE_LOG" "$SEQUENCE_LOG" "$DEPENDENCIES_INSTALLED"
+if ! run_fresh_install success "$SUCCESS_OUTPUT" 1 1; then
+    cat "$SUCCESS_OUTPUT"
+    echo "Fresh install failed after satisfying GUI runtime dependencies."
+    exit 1
+fi
+[ "$(cat "$PACKAGE_LOG")" = "$EXPECTED_ARGS" ]
+[ "$(sed -n '1p' "$SEQUENCE_LOG")" = "package-manager" ]
+[ "$(sed -n '2p' "$SEQUENCE_LOG")" = "gui-identity" ]
+[ "$(grep -F -c package-manager "$SEQUENCE_LOG")" -eq 1 ]
+[ -x "$WORK_DIR/success/root/usr/bin/lg-buddy" ]
+[ -x "$WORK_DIR/success/root/usr/bin/lg-buddy-gui" ]
+
+echo "$PACKAGE_MANAGER installer dependency smoke passed."

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -369,6 +369,8 @@ assert_executable "$BUNDLE_GUI"
     exit 1
 }
 bash "$SCRIPT_DIR/test-release-linkage.sh" "$BUNDLE_DIR/lg-buddy" "$BUNDLE_GUI"
+bash "$SCRIPT_DIR/test-installer-gui-dependencies.sh" \
+    "$BUNDLE_DIR/install.sh" "$BUNDLE_DIR/lg-buddy" "$BUNDLE_GUI" apt
 
 PAYLOAD_REFUSAL_ROOT="$WORK_DIR/payload-refusal-root"
 PAYLOAD_REFUSAL_HOME="$WORK_DIR/payload-refusal-home"
@@ -880,12 +882,31 @@ cmp -s "$NATIVE_ACCESS_TOKEN_SNAPSHOT" "$NATIVE_ACCESS_TOKEN_FILE"
 mkdir -p "$(dirname "$USER_DESKTOP_ENTRY")"
 printf 'stale user desktop launcher\n' >"$USER_DESKTOP_ENTRY"
 
+UPGRADE_DEPENDENCIES_INSTALLED="$WORK_DIR/upgrade-dependencies-installed"
+UPGRADE_PACKAGE_LOG="$WORK_DIR/upgrade-package-manager.log"
+UPGRADE_RUNTIME_PROBE="$INSTALLER_STUB_DIR/gui-runtime-probe"
+cat >"$UPGRADE_RUNTIME_PROBE" <<'EOF'
+#!/bin/sh
+[ -e "${LG_BUDDY_UPGRADE_DEPENDENCIES_INSTALLED:?}" ]
+EOF
+cat >"$INSTALLER_STUB_DIR/apt" <<'EOF'
+#!/bin/sh
+set -eu
+printf '%s\n' "$*" >"${LG_BUDDY_UPGRADE_PACKAGE_LOG:?}"
+: >"${LG_BUDDY_UPGRADE_DEPENDENCIES_INSTALLED:?}"
+EOF
+chmod 755 "$UPGRADE_RUNTIME_PROBE" "$INSTALLER_STUB_DIR/apt"
+
 UPGRADE_STATUS=0
 if (
     export PATH="$INSTALLER_STUB_DIR:$PATH"
     export LG_BUDDY_CONFIGURE_MARKER="$CONFIGURE_MARKER"
     export LG_BUDDY_SERVICE_ACTION_LOG="$SERVICE_ACTION_LOG"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="0"
+    export LG_BUDDY_AUTO_INSTALL_DEPS="yes"
+    export LG_BUDDY_GUI_RUNTIME_PROBE="$UPGRADE_RUNTIME_PROBE"
+    export LG_BUDDY_UPGRADE_DEPENDENCIES_INSTALLED="$UPGRADE_DEPENDENCIES_INSTALLED"
+    export LG_BUDDY_UPGRADE_PACKAGE_LOG="$UPGRADE_PACKAGE_LOG"
     cd "$BUNDLE_DIR"
     bash ./install.sh --upgrade >"$UPGRADE_OUTPUT" 2>&1
 ); then
@@ -905,6 +926,7 @@ fi
     exit 1
 }
 grep -F -q 'Upgrade complete!' "$UPGRADE_OUTPUT"
+[ "$(cat "$UPGRADE_PACKAGE_LOG")" = 'install -y libgtk-4-1 libadwaita-1-0' ]
 cat >"$EXPECTED_SERVICE_ACTION_LOG" <<EOF
 systemctl is-system-running
 systemctl --user is-system-running

--- a/scripts/test_publish_release_assets.py
+++ b/scripts/test_publish_release_assets.py
@@ -6,7 +6,6 @@ import hashlib
 import io
 import json
 import os
-import shutil
 import subprocess
 import tarfile
 import tempfile
@@ -26,6 +25,7 @@ VERSION = "9.8.7-beta.1"
 TAG = f"v{VERSION}"
 TARGET = "x86_64-unknown-linux-musl"
 GUI_TARGET = "x86_64-unknown-linux-gnu"
+PLACEHOLDER_NOTES = "Release notes pending maintainer review."
 
 
 FAKE_GH = r"""#!/usr/bin/env python3
@@ -48,6 +48,11 @@ state = json.loads(state_path.read_text(encoding="utf-8"))
 
 def save():
     state_path.write_text(json.dumps(state), encoding="utf-8")
+
+def option_value(arguments, option, default=None):
+    if option not in arguments:
+        return default
+    return arguments[arguments.index(option) + 1]
 
 if len(args) < 3 or args[0] != "release":
     sys.exit("unsupported fake gh invocation")
@@ -80,6 +85,8 @@ if command == "view":
         print(json.dumps({
             "isDraft": state["draft"],
             "isPrerelease": state["prerelease"],
+            "body": state["body"],
+            "name": state["title"],
         }))
     sys.exit(0)
 
@@ -90,6 +97,8 @@ if command == "create":
         "exists": True,
         "draft": "--draft" in rest,
         "prerelease": "--prerelease" in rest,
+        "body": option_value(rest, "--notes", ""),
+        "title": option_value(rest, "--title", ""),
         "assets": [],
     })
     save()
@@ -114,19 +123,18 @@ if command == "upload":
     save()
     sys.exit(0)
 
-if command == "download":
-    pattern = rest[rest.index("--pattern") + 1]
-    destination = Path(rest[rest.index("--dir") + 1])
-    destination.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(asset_dir / pattern, destination / pattern)
-    sys.exit(0)
-
 if command == "edit":
     for argument in rest:
         if argument.startswith("--draft="):
             state["draft"] = argument.split("=", 1)[1] == "true"
         elif argument.startswith("--prerelease="):
             state["prerelease"] = argument.split("=", 1)[1] == "true"
+    notes = option_value(rest, "--notes")
+    title = option_value(rest, "--title")
+    if notes is not None:
+        state["body"] = notes
+    if title is not None:
+        state["title"] = title
     save()
     sys.exit(0)
 
@@ -219,10 +227,14 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         exists: bool = False,
         draft: bool = True,
         prerelease: bool = True,
+        body: str = "Reviewed release notes",
+        title: str = "Reviewed release title",
         assets: dict[str, bytes] | None = None,
     ) -> None:
         asset_values = assets or {}
         self.remote_assets.mkdir(parents=True, exist_ok=True)
+        for existing in self.remote_assets.iterdir():
+            existing.unlink()
         for name, content in asset_values.items():
             (self.remote_assets / name).write_bytes(content)
         self.state_path.write_text(
@@ -231,6 +243,8 @@ class PublishReleaseAssetsTests(unittest.TestCase):
                     "exists": exists,
                     "draft": draft,
                     "prerelease": prerelease,
+                    "body": body,
+                    "title": title,
                     "assets": list(asset_values),
                 }
             ),
@@ -239,6 +253,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
 
     def run_publisher(
         self,
+        mode: str = "stage-draft",
         *,
         fail_upload: str | None = None,
         corrupt_upload: str | None = None,
@@ -252,6 +267,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
             [
                 "bash",
                 self.publisher,
+                mode,
                 "--dist-dir",
                 self.dist,
                 "--tag",
@@ -287,24 +303,22 @@ class PublishReleaseAssetsTests(unittest.TestCase):
             self.checksums.name: self.checksums.read_bytes(),
         }
 
-    def test_new_release_is_published_only_after_assets_are_uploaded(self) -> None:
+    def test_new_release_is_staged_as_a_complete_draft(self) -> None:
         result = self.run_publisher()
 
         self.assertEqual(result.returncode, 0, result.stdout)
         self.assertEqual(set(self.state()["assets"]), set(self.complete_assets()))
-        self.assertFalse(self.state()["draft"])
+        self.assertTrue(self.state()["draft"])
+        self.assertEqual(self.state()["body"], PLACEHOLDER_NOTES)
         create = self.mutations("create")
         uploads = self.mutations("upload")
-        edit = self.mutations("edit")
         self.assertEqual(len(create), 1)
         self.assertIn("--draft", create[0])
         self.assertEqual(len(uploads), 2)
-        self.assertEqual(len(edit), 1)
-        self.assertIn("--draft=false", edit[0])
+        self.assertEqual(self.mutations("edit"), [])
         self.assertLess(self.calls().index(create[0]), self.calls().index(uploads[0]))
-        self.assertLess(self.calls().index(uploads[-1]), self.calls().index(edit[0]))
 
-    def test_retry_resumes_a_partially_uploaded_draft(self) -> None:
+    def test_staging_retry_resumes_a_partially_uploaded_draft(self) -> None:
         first = self.run_publisher(fail_upload=self.checksums.name)
         self.assertNotEqual(first.returncode, 0)
         self.assertTrue(self.state()["draft"])
@@ -312,15 +326,32 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         second = self.run_publisher()
 
         self.assertEqual(second.returncode, 0, second.stdout)
-        self.assertFalse(self.state()["draft"])
+        self.assertTrue(self.state()["draft"])
         self.assertEqual(len(self.mutations("create")), 1)
         archive_uploads = [
             call for call in self.mutations("upload") if call[-1] == str(self.archive)
         ]
         self.assertEqual(len(archive_uploads), 1)
-        self.assertEqual(len(self.mutations("edit")), 1)
+        self.assertEqual(self.mutations("edit"), [])
 
-    def test_unexpected_draft_asset_blocks_publication_without_mutation(self) -> None:
+    def test_staging_preserves_existing_reviewed_title_and_notes(self) -> None:
+        self.write_state(
+            exists=True,
+            body="Carefully reviewed notes\n",
+            title="Custom title",
+            assets=self.complete_assets(),
+        )
+
+        result = self.run_publisher()
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.state()["body"], "Carefully reviewed notes\n")
+        self.assertEqual(self.state()["title"], "Custom title")
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_unexpected_draft_asset_blocks_staging_without_mutation(self) -> None:
         self.write_state(exists=True, assets={"unexpected.txt": b"unexpected"})
 
         result = self.run_publisher()
@@ -345,11 +376,8 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertEqual(self.mutations("upload"), [])
         self.assertEqual(self.mutations("edit"), [])
 
-    def test_mismatched_draft_asset_blocks_publication(self) -> None:
-        self.write_state(
-            exists=True,
-            assets={self.archive.name: b"different archive"},
-        )
+    def test_mismatched_draft_asset_blocks_staging(self) -> None:
+        self.write_state(exists=True, assets={self.archive.name: b"different archive"})
 
         result = self.run_publisher()
 
@@ -358,7 +386,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertTrue(self.state()["draft"])
         self.assertEqual(self.mutations("edit"), [])
 
-    def test_successful_but_corrupted_upload_blocks_publication(self) -> None:
+    def test_successful_but_corrupted_upload_blocks_staging(self) -> None:
         result = self.run_publisher(corrupt_upload=self.checksums.name)
 
         self.assertNotEqual(result.returncode, 0)
@@ -366,7 +394,7 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertTrue(self.state()["draft"])
         self.assertEqual(self.mutations("edit"), [])
 
-    def test_complete_published_release_is_verification_only(self) -> None:
+    def test_complete_published_release_is_staging_verification_only(self) -> None:
         self.write_state(exists=True, draft=False, assets=self.complete_assets())
 
         result = self.run_publisher()
@@ -375,6 +403,100 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertEqual(self.mutations("create"), [])
         self.assertEqual(self.mutations("upload"), [])
         self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_requires_an_existing_draft(self) -> None:
+        result = self.run_publisher("publish-draft")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not exist", result.stdout)
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_rejects_missing_assets_without_uploading(self) -> None:
+        self.write_state(
+            exists=True,
+            assets={self.archive.name: self.archive.read_bytes()},
+        )
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is missing required asset", result.stdout)
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_rejects_mismatched_draft_classification(self) -> None:
+        self.write_state(
+            exists=True,
+            prerelease=False,
+            assets=self.complete_assets(),
+        )
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("wrong prerelease classification", result.stdout)
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_publication_preserves_reviewed_title_and_notes(self) -> None:
+        self.write_state(
+            exists=True,
+            body="Reviewed notes\nwith details.\n",
+            title="Custom reviewed title",
+            assets=self.complete_assets(),
+        )
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertFalse(self.state()["draft"])
+        self.assertEqual(self.state()["body"], "Reviewed notes\nwith details.\n")
+        self.assertEqual(self.state()["title"], "Custom reviewed title")
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        edits = self.mutations("edit")
+        self.assertEqual(len(edits), 1)
+        self.assertEqual(edits[0][3:], ["--draft=false"])
+
+    def test_empty_or_placeholder_notes_block_publication(self) -> None:
+        for notes in ("", " \n\t", PLACEHOLDER_NOTES):
+            with self.subTest(notes=notes):
+                self.write_state(
+                    exists=True,
+                    body=notes,
+                    assets=self.complete_assets(),
+                )
+                if self.log_path.exists():
+                    self.log_path.unlink()
+
+                result = self.run_publisher("publish-draft")
+
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("empty or placeholder release notes", result.stdout)
+                self.assertTrue(self.state()["draft"])
+                self.assertEqual(self.mutations("edit"), [])
+
+    def test_complete_published_release_is_publication_verification_only(self) -> None:
+        self.write_state(exists=True, draft=False, assets=self.complete_assets())
+
+        result = self.run_publisher("publish-draft")
+
+        self.assertEqual(result.returncode, 0, result.stdout)
+        self.assertEqual(self.mutations("create"), [])
+        self.assertEqual(self.mutations("upload"), [])
+        self.assertEqual(self.mutations("edit"), [])
+
+    def test_invalid_local_checksum_blocks_before_github_access(self) -> None:
+        self.checksums.write_text(
+            f"{'0' * 64}  {self.archive.name}\n", encoding="utf-8"
+        )
+
+        result = self.run_publisher()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(self.calls(), [])
 
 
 if __name__ == "__main__":

--- a/scripts/test_publish_release_assets.py
+++ b/scripts/test_publish_release_assets.py
@@ -461,7 +461,13 @@ class PublishReleaseAssetsTests(unittest.TestCase):
         self.assertEqual(edits[0][3:], ["--draft=false"])
 
     def test_empty_or_placeholder_notes_block_publication(self) -> None:
-        for notes in ("", " \n\t", PLACEHOLDER_NOTES):
+        for notes in (
+            "",
+            " \n\t",
+            PLACEHOLDER_NOTES,
+            f" \n{PLACEHOLDER_NOTES}\t\n",
+            PLACEHOLDER_NOTES.replace(" ", "\n"),
+        ):
             with self.subTest(notes=notes):
                 self.write_state(
                     exists=True,

--- a/scripts/test_release_promotion.py
+++ b/scripts/test_release_promotion.py
@@ -259,7 +259,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("prerelease", merged, base)
 
-        self.assertTrue(result["publish"])
+        self.assertTrue(result["prepare"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["source_sha"], source)
         self.assertEqual(result["tag"], "v1.4.0-beta.1")
@@ -275,7 +275,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("main", merged, base)
 
-        self.assertTrue(result["publish"])
+        self.assertTrue(result["prepare"])
         self.assertEqual(result["source_sha"], source)
         self.assertEqual(result["tag"], "v1.4.0")
         self.assertEqual(result["channel"], "stable")
@@ -286,7 +286,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("main", merged, base)
 
-        self.assertTrue(result["publish"])
+        self.assertTrue(result["prepare"])
         self.assertEqual(result["source_sha"], source)
         self.assertEqual(result["tag"], "v1.4.0")
         self.assertEqual(result["channel"], "stable")
@@ -302,7 +302,7 @@ class PromotionTests(unittest.TestCase):
 
         result = self.repository.validate_merged("prerelease", merged, prerelease)
 
-        self.assertFalse(result["publish"])
+        self.assertFalse(result["prepare"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["base_sha"], prerelease)
         self.assertEqual(result["channel"], "stable")
@@ -318,7 +318,7 @@ class PromotionTests(unittest.TestCase):
             "prerelease", merged, self.repository.stable_sha
         )
 
-        self.assertFalse(result["publish"])
+        self.assertFalse(result["prepare"])
         self.assertEqual(result["head_sha"], merged)
         self.assertEqual(result["base_sha"], self.repository.stable_sha)
         self.assertEqual(result["channel"], "stable")


### PR DESCRIPTION
## Release

Promote the exact current `dev` commit as LG Buddy 1.5.1 stable.

## User-facing fixes

- install required GTK 4.14 and libadwaita 1.5 runtime dependencies through supported release-bundle installations and upgrades (#165)
- ignore incidental desktop and gamepad activity for one second after session lock so disengaging input does not immediately restore the screen (#166)

## Release infrastructure

- stage verified releases as drafts for notes and asset review before publication (#167)
- reduce redundant GitHub Actions execution while retaining PR validation (#169)

## Promotion contract

- source: same-repository `dev` branch
- target: `main`
- version: `1.5.1` in both package manifests and `Cargo.lock`
- prerelease promotion: intentionally skipped; direct stable promotion runs the same required validation
- tag: derived as `v1.5.1` and currently absent

## Local validation

- live release-promotion validation for exact `dev` and `main` SHAs
- 24 promotion tests
- 22 manifest tests
- 15 publication tests
- version-preparation PR checks passed on Ubuntu, Fedora, and Arch