### PR TITLE
Pair the first TV from the TVs blank state

### DIFF
--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-adw = { package = "libadwaita", version = "0.9.2", features = ["gtk_v4_10", "v1_4"] }
+adw = { package = "libadwaita", version = "0.9.2", features = ["gtk_v4_10", "v1_5"] }
 gtk = { package = "gtk4", version = "0.11.4", features = ["v4_10"] }
 lg-buddy = { path = "../lg-buddy" }
 

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -12,26 +12,22 @@ use std::time::Duration;
 
 use gtk::glib;
 use gtk::prelude::*;
-use lg_buddy::audio::{AudioWriteError, AudioWriteFailure, AudioWriteOutcome};
+use lg_buddy::application::{Application, ApplicationTransition, OverviewCompletion};
+use lg_buddy::audio::{AudioWriteError, AudioWriteFailure};
 use lg_buddy::brightness::{
     BrightnessReadError, BrightnessReadFailure, BrightnessWriteError, BrightnessWriteFailure,
-    BrightnessWriteOutcome,
 };
 use lg_buddy::navigation::{ApplicationPage, Navigation};
 use lg_buddy::overview::{
-    EnvironmentOverviewBackend, OverviewApplication, OverviewAudioReadOperation,
-    OverviewAudioWriteOperation, OverviewBackend, OverviewBrightnessReadOperation,
-    OverviewBrightnessWriteOperation, OverviewFrontendUpdate, OverviewIntent, OverviewOperation,
-    OverviewSummaryError, OverviewSummaryOperation, OverviewTransition, OverviewTvIdentity,
+    EnvironmentOverviewBackend, OverviewBackend, OverviewFrontendUpdate, OverviewIntent,
+    OverviewOperation, OverviewSummaryError, OverviewTransition,
 };
 use lg_buddy::pairing::{
-    EnvironmentPairingBackend, PairingBackend, PairingError, PairingFailure, PairingOperation,
-    PairingStage,
+    EnvironmentPairingBackend, PairingBackend, PairingError, PairingOperation, PairingStage,
 };
-use lg_buddy::tv::{AudioStatus, OledBrightness};
 use lg_buddy::tvs::{
-    EnvironmentTvsBackend, TvsApplication, TvsBackend, TvsIntent, TvsModelReadOperation,
-    TvsReadError, TvsReadOperation, TvsTransition,
+    EnvironmentTvsBackend, TvsBackend, TvsIntent, TvsModelReadOperation, TvsReadError,
+    TvsReadOperation, TvsTransition,
 };
 
 pub const APPLICATION_ID: &str = "io.github.staphylococcus.LGBuddy";
@@ -144,34 +140,10 @@ fn install_application_actions(
     application.set_accels_for_action("app.escape", &["Escape"]);
 }
 
-enum WorkerResult {
-    Summary(
-        OverviewSummaryOperation,
-        Result<OverviewTvIdentity, OverviewSummaryError>,
-    ),
-    BrightnessRead(
-        OverviewBrightnessReadOperation,
-        Result<OledBrightness, BrightnessReadError>,
-    ),
-    AudioRead(
-        OverviewAudioReadOperation,
-        Result<AudioStatus, lg_buddy::overview::AudioReadError>,
-    ),
-    BrightnessWrite(
-        OverviewBrightnessWriteOperation,
-        Result<BrightnessWriteOutcome, BrightnessWriteError>,
-    ),
-    AudioWrite(
-        OverviewAudioWriteOperation,
-        Result<AudioWriteOutcome, AudioWriteError>,
-    ),
-}
-
 struct ApplicationController {
-    application: RefCell<OverviewApplication>,
+    application: RefCell<Application>,
     gtk_application: adw::Application,
     window: window::ApplicationWindow,
-    tvs: RefCell<TvsApplication>,
     tvs_backend: Arc<dyn TvsBackend>,
     pairing_backend: Arc<dyn PairingBackend>,
     navigation: RefCell<Navigation>,
@@ -184,7 +156,7 @@ impl ApplicationController {
         gtk_application: &adw::Application,
         backend: Arc<dyn OverviewBackend>,
         tvs_backend: Arc<dyn TvsBackend>,
-    ) -> (Rc<Self>, OverviewTransition, TvsTransition) {
+    ) -> (Rc<Self>, ApplicationTransition) {
         Self::with_pairing_backend(
             gtk_application,
             backend,
@@ -198,9 +170,8 @@ impl ApplicationController {
         backend: Arc<dyn OverviewBackend>,
         tvs_backend: Arc<dyn TvsBackend>,
         pairing_backend: Arc<dyn PairingBackend>,
-    ) -> (Rc<Self>, OverviewTransition, TvsTransition) {
-        let (application, opening) = OverviewApplication::open();
-        let (tvs, tvs_opening) = TvsApplication::open();
+    ) -> (Rc<Self>, ApplicationTransition) {
+        let (application, opening) = Application::open();
         let controller = Rc::new_cyclic(|controller| {
             let on_intent: overview::IntentHandler = Rc::new({
                 let controller = controller.clone();
@@ -227,7 +198,6 @@ impl ApplicationController {
                 }
             });
             Self {
-                tvs: RefCell::new(tvs),
                 tvs_backend,
                 pairing_backend,
                 navigation: RefCell::new(Navigation::default()),
@@ -243,7 +213,7 @@ impl ApplicationController {
                 closed: Cell::new(false),
             }
         });
-        (controller, opening, tvs_opening)
+        (controller, opening)
     }
 
     fn present(&self) {
@@ -253,13 +223,25 @@ impl ApplicationController {
     }
 
     fn handle_intent(controller: &Rc<Self>, intent: OverviewIntent) {
-        let transition = controller.application.borrow_mut().handle_intent(intent);
+        let transition = controller
+            .application
+            .borrow_mut()
+            .handle_overview_intent(intent);
         if let Some(transition) = transition {
             Self::apply_transition(controller, transition);
         }
     }
 
-    fn apply_transition(controller: &Rc<Self>, transition: OverviewTransition) {
+    fn apply_transition(controller: &Rc<Self>, transition: ApplicationTransition) {
+        if let Some(tvs) = transition.tvs() {
+            Self::render_tvs_transition(controller, tvs);
+        }
+        if let Some(overview) = transition.overview() {
+            Self::render_overview_transition(controller, overview);
+        }
+    }
+
+    fn render_overview_transition(controller: &Rc<Self>, transition: &OverviewTransition) {
         if let Some(diagnostic) = transition.diagnostic() {
             eprintln!("LG Buddy GUI: {diagnostic}");
         }
@@ -269,7 +251,6 @@ impl ApplicationController {
             }
             OverviewFrontendUpdate::Close => {
                 controller.closed.set(true);
-                controller.tvs.borrow_mut().shutdown();
                 controller.window.close();
             }
         }
@@ -286,13 +267,16 @@ impl ApplicationController {
     }
 
     fn handle_tvs_intent(controller: &Rc<Self>, intent: TvsIntent) {
-        let transition = controller.tvs.borrow_mut().handle_intent(intent);
+        let transition = controller
+            .application
+            .borrow_mut()
+            .handle_tvs_intent(intent);
         if let Some(transition) = transition {
-            Self::apply_tvs_transition(controller, transition);
+            Self::apply_transition(controller, transition);
         }
     }
 
-    fn apply_tvs_transition(controller: &Rc<Self>, transition: TvsTransition) {
+    fn render_tvs_transition(controller: &Rc<Self>, transition: &TvsTransition) {
         if let Some(diagnostic) = transition.diagnostic() {
             eprintln!("LG Buddy GUI: {diagnostic}");
         }
@@ -309,18 +293,13 @@ impl ApplicationController {
         if let Some(operation) = transition.pairing_operation() {
             Self::start_pairing(controller, operation.clone());
         }
-        if transition.profile_created() {
-            let overview = controller.application.borrow_mut().profile_created();
-            if let Some(overview) = overview {
-                Self::apply_transition(controller, overview);
-            }
-        }
     }
 
     fn start_pairing(controller: &Rc<Self>, operation: PairingOperation) {
         enum Update {
             Progress(PairingStage),
             Done(Result<lg_buddy::tvs::TvProfile, PairingError>),
+            Stopped,
         }
         let backend = Arc::clone(&controller.pairing_backend);
         let worker_operation = operation.clone();
@@ -338,24 +317,26 @@ impl ApplicationController {
             let update = match receiver.try_recv() {
                 Ok(update) => update,
                 Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
-                Err(mpsc::TryRecvError::Disconnected) => {
-                    Update::Done(Err(PairingError::new(PairingFailure::Connection)))
-                }
+                Err(mpsc::TryRecvError::Disconnected) => Update::Stopped,
             };
-            let done = matches!(update, Update::Done(_));
+            let done = matches!(update, Update::Done(_) | Update::Stopped);
             if let Some(controller) = controller.upgrade() {
                 let transition = match update {
                     Update::Progress(stage) => controller
-                        .tvs
+                        .application
                         .borrow_mut()
                         .pairing_progress(&operation, stage),
                     Update::Done(result) => controller
-                        .tvs
+                        .application
                         .borrow_mut()
                         .complete_pairing(&operation, result),
+                    Update::Stopped => controller
+                        .application
+                        .borrow_mut()
+                        .pairing_worker_stopped(&operation),
                 };
                 if let Some(transition) = transition {
-                    Self::apply_tvs_transition(&controller, transition);
+                    Self::apply_transition(&controller, transition);
                 }
             }
             if done {
@@ -383,11 +364,11 @@ impl ApplicationController {
             };
             if let Some(controller) = controller.upgrade() {
                 let transition = controller
-                    .tvs
+                    .application
                     .borrow_mut()
-                    .complete_model_read(operation.clone(), result);
+                    .complete_tvs_model_read(operation.clone(), result);
                 if let Some(transition) = transition {
-                    Self::apply_tvs_transition(&controller, transition);
+                    Self::apply_transition(&controller, transition);
                 }
             }
             glib::ControlFlow::Break
@@ -410,9 +391,12 @@ impl ApplicationController {
                 )),
             };
             if let Some(controller) = controller.upgrade() {
-                let transition = controller.tvs.borrow_mut().complete_read(operation, result);
+                let transition = controller
+                    .application
+                    .borrow_mut()
+                    .complete_tvs_read(operation, result);
                 if let Some(transition) = transition {
-                    Self::apply_tvs_transition(&controller, transition);
+                    Self::apply_transition(&controller, transition);
                 }
             }
             glib::ControlFlow::Break
@@ -432,21 +416,24 @@ impl ApplicationController {
         thread::spawn(move || {
             let result = match operation {
                 OverviewOperation::ReadSummary(operation) => {
-                    WorkerResult::Summary(operation, backend.read_summary())
+                    OverviewCompletion::Summary(operation, backend.read_summary())
                 }
                 OverviewOperation::ReadBrightness(operation) => {
-                    WorkerResult::BrightnessRead(operation, backend.read_brightness())
+                    OverviewCompletion::BrightnessRead(operation, backend.read_brightness())
                 }
                 OverviewOperation::ReadAudio(operation) => {
-                    WorkerResult::AudioRead(operation, backend.read_audio())
+                    OverviewCompletion::AudioRead(operation, backend.read_audio())
                 }
-                OverviewOperation::WriteBrightness(operation) => WorkerResult::BrightnessWrite(
+                OverviewOperation::WriteBrightness(operation) => {
+                    OverviewCompletion::BrightnessWrite(
+                        operation,
+                        backend.write_brightness(operation.brightness()),
+                    )
+                }
+                OverviewOperation::WriteAudio(operation) => OverviewCompletion::AudioWrite(
                     operation,
-                    backend.write_brightness(operation.brightness()),
+                    backend.write_audio(operation.operation()),
                 ),
-                OverviewOperation::WriteAudio(operation) => {
-                    WorkerResult::AudioWrite(operation, backend.write_audio(operation.operation()))
-                }
             };
             let _ = sender.send(result);
         });
@@ -473,38 +460,38 @@ impl ApplicationController {
         });
     }
 
-    fn disconnected_result(operation: OverviewOperation) -> WorkerResult {
+    fn disconnected_result(operation: OverviewOperation) -> OverviewCompletion {
         let message = "the Overview operation stopped before returning a result";
         match operation {
-            OverviewOperation::ReadSummary(operation) => WorkerResult::Summary(
+            OverviewOperation::ReadSummary(operation) => OverviewCompletion::Summary(
                 operation,
                 Err(OverviewSummaryError::new(
                     lg_buddy::overview::OverviewSummaryFailure::Internal,
                     message,
                 )),
             ),
-            OverviewOperation::ReadBrightness(operation) => WorkerResult::BrightnessRead(
+            OverviewOperation::ReadBrightness(operation) => OverviewCompletion::BrightnessRead(
                 operation,
                 Err(BrightnessReadError::new(
                     BrightnessReadFailure::Internal,
                     message,
                 )),
             ),
-            OverviewOperation::ReadAudio(operation) => WorkerResult::AudioRead(
+            OverviewOperation::ReadAudio(operation) => OverviewCompletion::AudioRead(
                 operation,
                 Err(lg_buddy::overview::AudioReadError::new(
                     lg_buddy::overview::AudioReadFailure::Internal,
                     message,
                 )),
             ),
-            OverviewOperation::WriteBrightness(operation) => WorkerResult::BrightnessWrite(
+            OverviewOperation::WriteBrightness(operation) => OverviewCompletion::BrightnessWrite(
                 operation,
                 Err(BrightnessWriteError::new(
                     BrightnessWriteFailure::Internal,
                     message,
                 )),
             ),
-            OverviewOperation::WriteAudio(operation) => WorkerResult::AudioWrite(
+            OverviewOperation::WriteAudio(operation) => OverviewCompletion::AudioWrite(
                 operation,
                 Err(AudioWriteError::new(
                     AudioWriteFailure::Internal,
@@ -515,29 +502,11 @@ impl ApplicationController {
         }
     }
 
-    fn complete(controller: &Rc<Self>, result: WorkerResult) {
-        let transition = match result {
-            WorkerResult::Summary(operation, result) => controller
-                .application
-                .borrow_mut()
-                .complete_summary(operation, result),
-            WorkerResult::BrightnessRead(operation, result) => controller
-                .application
-                .borrow_mut()
-                .complete_brightness_read(operation, result),
-            WorkerResult::AudioRead(operation, result) => controller
-                .application
-                .borrow_mut()
-                .complete_audio_read(operation, result),
-            WorkerResult::BrightnessWrite(operation, result) => controller
-                .application
-                .borrow_mut()
-                .complete_brightness_write(operation, result),
-            WorkerResult::AudioWrite(operation, result) => controller
-                .application
-                .borrow_mut()
-                .complete_audio_write(operation, result),
-        };
+    fn complete(controller: &Rc<Self>, result: OverviewCompletion) {
+        let transition = controller
+            .application
+            .borrow_mut()
+            .complete_overview(result);
         if let Some(transition) = transition {
             Self::apply_transition(controller, transition);
         }
@@ -545,7 +514,6 @@ impl ApplicationController {
 
     fn shutdown(&self) {
         self.application.borrow_mut().shutdown();
-        self.tvs.borrow_mut().shutdown();
     }
 }
 
@@ -564,14 +532,13 @@ fn connect_application(
                 controller.present();
                 return;
             }
-            let (overview, opening, tvs_opening) = ApplicationController::new(
+            let (overview, opening) = ApplicationController::new(
                 application,
                 Arc::clone(&backend),
                 Arc::clone(&tvs_backend),
             );
             controller.replace(Some(Rc::clone(&overview)));
             ApplicationController::apply_transition(&overview, opening);
-            ApplicationController::apply_tvs_transition(&overview, tvs_opening);
             overview.present();
         }
     });
@@ -876,7 +843,7 @@ pub(crate) mod controller_test_support {
         let application = test_application("Blocking");
         let (profiles_tx, profiles_rx) = mpsc::channel();
         let (model_tx, model_rx) = mpsc::channel();
-        let (controller, opening, tvs_opening) = ApplicationController::new(
+        let (controller, opening) = ApplicationController::new(
             &application,
             Arc::new(backend),
             Arc::new(BlockingTvsBackend {
@@ -885,7 +852,6 @@ pub(crate) mod controller_test_support {
             }),
         );
         ApplicationController::apply_transition(&controller, opening.clone());
-        ApplicationController::apply_tvs_transition(&controller, tvs_opening);
         let native_window = controller.window.window();
         controller.present();
         controller.present();
@@ -1004,11 +970,12 @@ pub(crate) mod controller_test_support {
         heartbeat_source.remove();
 
         let panic_application = test_application("Panic");
-        let (panic_controller, panic_opening, _) = ApplicationController::new(
+        let (panic_controller, panic_opening) = ApplicationController::new(
             &panic_application,
             Arc::new(PanicBackend),
             Arc::new(EmptyTvsBackend),
         );
+        let panic_opening = panic_opening.overview().unwrap();
         let initial = match panic_opening.update() {
             super::OverviewFrontendUpdate::Present(presentation) => presentation.clone(),
             super::OverviewFrontendUpdate::Close => panic!("opening must present"),
@@ -1037,6 +1004,7 @@ pub(crate) mod controller_test_support {
         struct PairingMock {
             release: Mutex<mpsc::Receiver<()>>,
             reject: bool,
+            panic: bool,
         }
         impl PairingBackend for PairingMock {
             fn pair(
@@ -1050,6 +1018,7 @@ pub(crate) mod controller_test_support {
                 if operation.is_cancelled() {
                     return Err(PairingError::new(PairingFailure::Cancelled));
                 }
+                assert!(!self.panic, "injected pairing worker failure");
                 if self.reject {
                     return Err(PairingError::new(PairingFailure::Rejected));
                 }
@@ -1078,24 +1047,26 @@ pub(crate) mod controller_test_support {
                 Ok("Test OLED".into())
             }
         }
-        for (cancel, reject, name) in [
-            (false, false, "PairSuccess"),
-            (true, false, "PairCancel"),
-            (false, true, "PairRejected"),
+        for (cancel, reject, panic, name) in [
+            (false, false, false, "PairSuccess"),
+            (true, false, false, "PairCancel"),
+            (false, true, false, "PairRejected"),
+            (false, false, true, "PairWorkerStopped"),
         ] {
             let application = test_application(name);
             let (backend, controls) = BlockingBackend::new();
             let (release, receiver) = mpsc::channel();
-            let (controller, _, opening) = ApplicationController::with_pairing_backend(
+            let (controller, opening) = ApplicationController::with_pairing_backend(
                 &application,
                 Arc::new(backend),
                 Arc::new(TvsMock),
                 Arc::new(PairingMock {
                     release: Mutex::new(receiver),
                     reject,
+                    panic,
                 }),
             );
-            ApplicationController::apply_tvs_transition(&controller, opening);
+            ApplicationController::render_tvs_transition(&controller, opening.tvs().unwrap());
             controller.present();
             controller.navigate(lg_buddy::navigation::ApplicationPage::Tvs);
             pump_until(|| {
@@ -1124,8 +1095,8 @@ pub(crate) mod controller_test_support {
                 assert!(!controller.closed.get());
                 release.send(()).unwrap();
                 pump_for(Duration::from_millis(60));
-                assert!(!controller.tvs.borrow().is_pairing());
-            } else if reject {
+                assert!(!controller.application.borrow().is_pairing());
+            } else if reject || panic {
                 release.send(()).unwrap();
                 pump_until(|| {
                     widget_contains_text(
@@ -1133,7 +1104,17 @@ pub(crate) mod controller_test_support {
                         "Could Not Pair TV",
                     )
                 });
-                assert!(controller.tvs.borrow().is_pairing());
+                assert!(controller.application.borrow().is_pairing());
+                if panic {
+                    assert!(widget_contains_text(
+                        controller.window.window().upcast_ref(),
+                        "Pairing stopped unexpectedly",
+                    ));
+                    assert!(!widget_contains_text(
+                        controller.window.window().upcast_ref(),
+                        "Check the IP address",
+                    ));
+                }
             } else {
                 release.send(()).unwrap();
                 controls
@@ -1158,7 +1139,7 @@ pub(crate) mod controller_test_support {
                 pump_until(|| {
                     widget_contains_text(controller.window.window().upcast_ref(), "Test OLED")
                 });
-                assert!(!controller.tvs.borrow().is_pairing());
+                assert!(!controller.application.borrow().is_pairing());
                 assert_eq!(
                     controller.navigation.borrow().selected(),
                     lg_buddy::navigation::ApplicationPage::Tvs
@@ -1169,7 +1150,7 @@ pub(crate) mod controller_test_support {
                     controller.window.window().upcast_ref(),
                     "TV paired successfully",
                 ),
-                !cancel && !reject,
+                !cancel && !reject && !panic,
                 "only successful pairing should show the confirmation toast",
             );
             ApplicationController::handle_intent(&controller, OverviewIntent::Cancel);

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1,4 +1,5 @@
 mod overview;
+mod pairing;
 mod tvs;
 mod window;
 
@@ -22,6 +23,10 @@ use lg_buddy::overview::{
     OverviewAudioWriteOperation, OverviewBackend, OverviewBrightnessReadOperation,
     OverviewBrightnessWriteOperation, OverviewFrontendUpdate, OverviewIntent, OverviewOperation,
     OverviewSummaryError, OverviewSummaryOperation, OverviewTransition, OverviewTvIdentity,
+};
+use lg_buddy::pairing::{
+    EnvironmentPairingBackend, PairingBackend, PairingError, PairingFailure, PairingOperation,
+    PairingStage,
 };
 use lg_buddy::tv::{AudioStatus, OledBrightness};
 use lg_buddy::tvs::{
@@ -113,6 +118,7 @@ fn install_application_actions(
     let quit = gtk::gio::SimpleAction::new("quit", None);
     let application_for_quit = application.clone();
     quit.connect_activate({
+        let controller = Rc::clone(&controller);
         move |_, _| {
             if let Some(controller) = controller.borrow().as_ref() {
                 ApplicationController::handle_intent(controller, OverviewIntent::Cancel);
@@ -122,7 +128,20 @@ fn install_application_actions(
         }
     });
     application.add_action(&quit);
-    application.set_accels_for_action("app.quit", &["<Primary>q", "Escape"]);
+    application.set_accels_for_action("app.quit", &["<Primary>q"]);
+    let escape = gtk::gio::SimpleAction::new("escape", None);
+    let application_for_escape = application.clone();
+    escape.connect_activate(move |_, _| {
+        if let Some(controller) = controller.borrow().as_ref() {
+            if !controller.window.dismiss_dialog() {
+                ApplicationController::handle_intent(controller, OverviewIntent::Cancel);
+            }
+        } else {
+            application_for_escape.quit();
+        }
+    });
+    application.add_action(&escape);
+    application.set_accels_for_action("app.escape", &["Escape"]);
 }
 
 enum WorkerResult {
@@ -154,6 +173,7 @@ struct ApplicationController {
     window: window::ApplicationWindow,
     tvs: RefCell<TvsApplication>,
     tvs_backend: Arc<dyn TvsBackend>,
+    pairing_backend: Arc<dyn PairingBackend>,
     navigation: RefCell<Navigation>,
     backend: Arc<dyn OverviewBackend>,
     closed: Cell<bool>,
@@ -164,6 +184,20 @@ impl ApplicationController {
         gtk_application: &adw::Application,
         backend: Arc<dyn OverviewBackend>,
         tvs_backend: Arc<dyn TvsBackend>,
+    ) -> (Rc<Self>, OverviewTransition, TvsTransition) {
+        Self::with_pairing_backend(
+            gtk_application,
+            backend,
+            tvs_backend,
+            Arc::new(EnvironmentPairingBackend),
+        )
+    }
+
+    fn with_pairing_backend(
+        gtk_application: &adw::Application,
+        backend: Arc<dyn OverviewBackend>,
+        tvs_backend: Arc<dyn TvsBackend>,
+        pairing_backend: Arc<dyn PairingBackend>,
     ) -> (Rc<Self>, OverviewTransition, TvsTransition) {
         let (application, opening) = OverviewApplication::open();
         let (tvs, tvs_opening) = TvsApplication::open();
@@ -195,6 +229,7 @@ impl ApplicationController {
             Self {
                 tvs: RefCell::new(tvs),
                 tvs_backend,
+                pairing_backend,
                 navigation: RefCell::new(Navigation::default()),
                 application: RefCell::new(application),
                 gtk_application: gtk_application.clone(),
@@ -262,12 +297,72 @@ impl ApplicationController {
             eprintln!("LG Buddy GUI: {diagnostic}");
         }
         controller.window.render_tvs(transition.presentation());
+        if let Some(message) = transition.toast_message() {
+            controller.window.show_toast(message);
+        }
         if let Some(operation) = transition.read_operation() {
             Self::start_tvs_read(controller, operation);
         }
         if let Some(operation) = transition.model_read_operation() {
             Self::start_tvs_model_read(controller, operation.clone());
         }
+        if let Some(operation) = transition.pairing_operation() {
+            Self::start_pairing(controller, operation.clone());
+        }
+        if transition.profile_created() {
+            let overview = controller.application.borrow_mut().profile_created();
+            if let Some(overview) = overview {
+                Self::apply_transition(controller, overview);
+            }
+        }
+    }
+
+    fn start_pairing(controller: &Rc<Self>, operation: PairingOperation) {
+        enum Update {
+            Progress(PairingStage),
+            Done(Result<lg_buddy::tvs::TvProfile, PairingError>),
+        }
+        let backend = Arc::clone(&controller.pairing_backend);
+        let worker_operation = operation.clone();
+        let (sender, receiver) = mpsc::channel();
+        // A started publication must finish even if the window closes.
+        let mut application_hold = Some(controller.gtk_application.hold());
+        thread::spawn(move || {
+            let result = backend.pair(&worker_operation, &mut |stage| {
+                let _ = sender.send(Update::Progress(stage));
+            });
+            let _ = sender.send(Update::Done(result));
+        });
+        let controller = Rc::downgrade(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || loop {
+            let update = match receiver.try_recv() {
+                Ok(update) => update,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    Update::Done(Err(PairingError::new(PairingFailure::Connection)))
+                }
+            };
+            let done = matches!(update, Update::Done(_));
+            if let Some(controller) = controller.upgrade() {
+                let transition = match update {
+                    Update::Progress(stage) => controller
+                        .tvs
+                        .borrow_mut()
+                        .pairing_progress(&operation, stage),
+                    Update::Done(result) => controller
+                        .tvs
+                        .borrow_mut()
+                        .complete_pairing(&operation, result),
+                };
+                if let Some(transition) = transition {
+                    Self::apply_tvs_transition(&controller, transition);
+                }
+            }
+            if done {
+                drop(application_hold.take());
+                return glib::ControlFlow::Break;
+            }
+        });
     }
 
     fn start_tvs_model_read(controller: &Rc<Self>, operation: TvsModelReadOperation) {
@@ -775,6 +870,7 @@ pub(crate) mod controller_test_support {
             gtk::is_initialized(),
             "renderer test must initialize GTK first"
         );
+        run_pairing_scenario();
 
         let (backend, controls) = BlockingBackend::new();
         let application = test_application("Blocking");
@@ -930,6 +1026,155 @@ pub(crate) mod controller_test_support {
         });
         panic_controller.window.close();
         assert_cancel_waits_for_write_in_application_loop();
+    }
+
+    fn run_pairing_scenario() {
+        use lg_buddy::pairing::{
+            PairingBackend, PairingError, PairingFailure, PairingIntent, PairingOperation,
+            PairingStage,
+        };
+        use lg_buddy::tvs::{TvCredentialState, TvId, TvProfile, TvsIntent};
+        struct PairingMock {
+            release: Mutex<mpsc::Receiver<()>>,
+            reject: bool,
+        }
+        impl PairingBackend for PairingMock {
+            fn pair(
+                &self,
+                operation: &PairingOperation,
+                progress: &mut dyn FnMut(PairingStage),
+            ) -> Result<TvProfile, PairingError> {
+                assert!(!gtk::is_initialized_main_thread());
+                progress(PairingStage::WaitingForConfirmation);
+                self.release.lock().unwrap().recv().unwrap();
+                if operation.is_cancelled() {
+                    return Err(PairingError::new(PairingFailure::Cancelled));
+                }
+                if self.reject {
+                    return Err(PairingError::new(PairingFailure::Rejected));
+                }
+                progress(PairingStage::Verifying);
+                let request = operation.request();
+                Ok(TvProfile::new(
+                    TvId::primary(),
+                    "Primary TV",
+                    request.address(),
+                    request.mac(),
+                    request.input(),
+                    TvPlatform::LgWebOs,
+                    TvCredentialState::Stored,
+                ))
+            }
+        }
+        struct TvsMock;
+        impl lg_buddy::tvs::TvsBackend for TvsMock {
+            fn read_profiles(&self) -> Result<Vec<TvProfile>, lg_buddy::tvs::TvsReadError> {
+                Ok(vec![])
+            }
+            fn read_model_name(
+                &self,
+                _: &TvProfile,
+            ) -> Result<String, lg_buddy::tvs::TvsReadError> {
+                Ok("Test OLED".into())
+            }
+        }
+        for (cancel, reject, name) in [
+            (false, false, "PairSuccess"),
+            (true, false, "PairCancel"),
+            (false, true, "PairRejected"),
+        ] {
+            let application = test_application(name);
+            let (backend, controls) = BlockingBackend::new();
+            let (release, receiver) = mpsc::channel();
+            let (controller, _, opening) = ApplicationController::with_pairing_backend(
+                &application,
+                Arc::new(backend),
+                Arc::new(TvsMock),
+                Arc::new(PairingMock {
+                    release: Mutex::new(receiver),
+                    reject,
+                }),
+            );
+            ApplicationController::apply_tvs_transition(&controller, opening);
+            controller.present();
+            controller.navigate(lg_buddy::navigation::ApplicationPage::Tvs);
+            pump_until(|| {
+                widget_contains_text(controller.window.window().upcast_ref(), "No TV configured")
+            });
+            for intent in [
+                TvsIntent::PairTv,
+                TvsIntent::Pairing(PairingIntent::SetAddress("192.0.2.10".into())),
+                TvsIntent::Pairing(PairingIntent::SetMac("02:11:22:33:44:55".into())),
+                TvsIntent::Pairing(PairingIntent::Submit),
+            ] {
+                ApplicationController::handle_tvs_intent(&controller, intent);
+            }
+            pump_until(|| {
+                widget_contains_text(
+                    controller.window.window().upcast_ref(),
+                    "Confirm on Your TV",
+                )
+            });
+            assert!(!widget_contains_text(
+                controller.window.window().upcast_ref(),
+                "TV paired successfully",
+            ));
+            if cancel {
+                assert!(controller.window.dismiss_dialog());
+                assert!(!controller.closed.get());
+                release.send(()).unwrap();
+                pump_for(Duration::from_millis(60));
+                assert!(!controller.tvs.borrow().is_pairing());
+            } else if reject {
+                release.send(()).unwrap();
+                pump_until(|| {
+                    widget_contains_text(
+                        controller.window.window().upcast_ref(),
+                        "Could Not Pair TV",
+                    )
+                });
+                assert!(controller.tvs.borrow().is_pairing());
+            } else {
+                release.send(()).unwrap();
+                controls
+                    .summary
+                    .send(Ok(OverviewTvIdentity::new(
+                        "192.0.2.10".parse().unwrap(),
+                        HdmiInput::Hdmi1,
+                        TvPlatform::LgWebOs,
+                    )))
+                    .unwrap();
+                controls
+                    .brightness
+                    .send(Ok(OledBrightness::new(50).unwrap()))
+                    .unwrap();
+                controls
+                    .audio
+                    .send(Ok(AudioStatus::new(
+                        CurrentVolume::Level(VolumeLevel::new(25).unwrap()),
+                        false,
+                    )))
+                    .unwrap();
+                pump_until(|| {
+                    widget_contains_text(controller.window.window().upcast_ref(), "Test OLED")
+                });
+                assert!(!controller.tvs.borrow().is_pairing());
+                assert_eq!(
+                    controller.navigation.borrow().selected(),
+                    lg_buddy::navigation::ApplicationPage::Tvs
+                );
+            }
+            assert_eq!(
+                widget_contains_text(
+                    controller.window.window().upcast_ref(),
+                    "TV paired successfully",
+                ),
+                !cancel && !reject,
+                "only successful pairing should show the confirmation toast",
+            );
+            ApplicationController::handle_intent(&controller, OverviewIntent::Cancel);
+            assert!(controller.closed.get());
+        }
     }
 
     fn assert_cancel_waits_for_write_in_application_loop() {

--- a/crates/lg-buddy-gui/src/pairing.rs
+++ b/crates/lg-buddy-gui/src/pairing.rs
@@ -1,0 +1,562 @@
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use adw::prelude::*;
+use lg_buddy::config::HdmiInput;
+use lg_buddy::pairing::PairingIntent;
+use lg_buddy::presentation::brightness::UserFacingError;
+use lg_buddy::presentation::pairing::PairingPresentation;
+use lg_buddy::tvs::TvsIntent;
+
+#[cfg(test)]
+const TV_ICON_NAME: &str = "video-display-symbolic";
+
+type IntentHandler = Rc<dyn Fn(TvsIntent)>;
+
+/// GTK realization of the application-owned first-TV pairing presentation.
+///
+/// The renderer keeps the form values only as widget state. Every edit and
+/// action is forwarded as a semantic pairing intent; validation and the
+/// pairing workflow remain in the application layer.
+pub(crate) struct PairingView {
+    dialog: adw::Dialog,
+    description: gtk::Label,
+    address: adw::EntryRow,
+    mac: adw::EntryRow,
+    input: adw::ComboRow,
+    status: gtk::Label,
+    pair: gtk::Button,
+    progress: gtk::ProgressBar,
+    cancel: gtk::Button,
+    toasts: adw::ToastOverlay,
+    error_toast: RefCell<Option<adw::Toast>>,
+    suppress: Rc<Cell<bool>>,
+    presented: Cell<bool>,
+}
+
+impl PairingView {
+    pub(crate) fn new(on_intent: IntentHandler) -> Self {
+        let suppress = Rc::new(Cell::new(false));
+
+        let description = gtk::Label::builder()
+            .xalign(0.0)
+            .wrap(true)
+            .hexpand(true)
+            .build();
+        description.set_accessible_role(gtk::AccessibleRole::Status);
+        description.add_css_class("dim-label");
+
+        let address = adw::EntryRow::builder()
+            .title("TV address")
+            .activates_default(true)
+            .build();
+        address.set_input_purpose(gtk::InputPurpose::FreeForm);
+        connect_text_intent(
+            &address,
+            Rc::clone(&suppress),
+            Rc::clone(&on_intent),
+            PairingIntent::SetAddress,
+        );
+
+        let mac = adw::EntryRow::builder()
+            .title("MAC address")
+            .activates_default(true)
+            .build();
+        mac.set_input_purpose(gtk::InputPurpose::FreeForm);
+        connect_text_intent(
+            &mac,
+            Rc::clone(&suppress),
+            Rc::clone(&on_intent),
+            PairingIntent::SetMac,
+        );
+
+        let input_model = gtk::StringList::new(&["HDMI 1", "HDMI 2", "HDMI 3", "HDMI 4"]);
+        let input = adw::ComboRow::builder()
+            .title("HDMI input")
+            .model(&input_model)
+            .build();
+        input.set_selected(0);
+        {
+            let suppress = Rc::clone(&suppress);
+            let on_intent = Rc::clone(&on_intent);
+            input.connect_selected_notify(move |row| {
+                if suppress.get() {
+                    return;
+                }
+                if let Some(input) = hdmi_input(row.selected()) {
+                    on_intent(TvsIntent::Pairing(PairingIntent::SetInput(input)));
+                }
+            });
+        }
+
+        let status = gtk::Label::builder()
+            .xalign(0.0)
+            .wrap(true)
+            .hexpand(true)
+            .visible(false)
+            .build();
+        status.set_accessible_role(gtk::AccessibleRole::Alert);
+
+        let pair = gtk::Button::with_label("Pair");
+        pair.add_css_class("suggested-action");
+        pair.connect_clicked({
+            let on_intent = Rc::clone(&on_intent);
+            move |_| on_intent(TvsIntent::Pairing(PairingIntent::Submit))
+        });
+
+        let cancel = gtk::Button::with_label("Cancel");
+        cancel.connect_clicked({
+            let on_intent = Rc::clone(&on_intent);
+            move |_| on_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+        });
+
+        let form = adw::PreferencesGroup::builder()
+            .title("TV connection")
+            .build();
+        form.add(&address);
+        form.add(&mac);
+        form.add(&input);
+
+        let content = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(12)
+            .margin_top(20)
+            .margin_bottom(20)
+            .build();
+        content.append(&description);
+        content.append(&status);
+        content.append(&form);
+
+        let clamp = adw::Clamp::builder()
+            .maximum_size(600)
+            .tightening_threshold(400)
+            .margin_start(20)
+            .margin_end(20)
+            .child(&content)
+            .build();
+        let scroller = gtk::ScrolledWindow::builder()
+            .vexpand(true)
+            .min_content_height(0)
+            .propagate_natural_height(false)
+            .child(&clamp)
+            .build();
+        let header = adw::HeaderBar::builder()
+            .show_start_title_buttons(false)
+            .show_end_title_buttons(false)
+            .build();
+        header.pack_start(&cancel);
+        header.pack_end(&pair);
+        let progress = gtk::ProgressBar::builder()
+            .valign(gtk::Align::Start)
+            .can_target(false)
+            .visible(false)
+            .build();
+        progress.add_css_class("osd");
+        let progress_overlay = gtk::Overlay::builder().child(&scroller).build();
+        progress_overlay.add_overlay(&progress);
+        let toasts = adw::ToastOverlay::new();
+        toasts.set_child(Some(&progress_overlay));
+        let toolbar = adw::ToolbarView::builder().content(&toasts).build();
+        toolbar.add_top_bar(&header);
+        let dialog = adw::Dialog::builder()
+            .title("Pair a TV")
+            .content_width(480)
+            .content_height(480)
+            .child(&toolbar)
+            // Ask the application before dismissing: a worker may have begun
+            // saving before its progress event reaches the main loop.
+            .can_close(false)
+            .build();
+        dialog.connect_close_attempt({
+            let on_intent = Rc::clone(&on_intent);
+            let cancel = cancel.clone();
+            move |_| {
+                if cancel.is_sensitive() {
+                    on_intent(TvsIntent::Pairing(PairingIntent::Cancel));
+                }
+            }
+        });
+
+        // Activating either text row submits the declared operation. The
+        // button remains an ordinary action so Enter is not claimed globally.
+        connect_submit_on_activate(&address, Rc::clone(&on_intent));
+        connect_submit_on_activate(&mac, on_intent);
+
+        Self {
+            dialog,
+            description,
+            address,
+            mac,
+            input,
+            status,
+            pair,
+            progress,
+            cancel,
+            toasts,
+            error_toast: RefCell::new(None),
+            suppress,
+            presented: Cell::new(false),
+        }
+    }
+
+    pub(crate) fn render(
+        &self,
+        parent: &adw::ApplicationWindow,
+        presentation: Option<&PairingPresentation>,
+    ) {
+        let Some(presentation) = presentation else {
+            self.clear_toast();
+            self.progress.set_visible(false);
+            if self.presented.replace(false) {
+                self.dialog.force_close();
+            }
+            return;
+        };
+        self.suppress.set(true);
+        self.dialog.set_title(presentation.title());
+        self.description.set_text(presentation.description());
+        set_entry_text_preserving_selection(&self.address, presentation.address());
+        set_entry_text_preserving_selection(&self.mac, presentation.mac());
+        if let Some(index) = hdmi_index(presentation.input()) {
+            self.input.set_selected(index);
+        }
+
+        let editable = presentation.can_submit();
+        self.address.set_sensitive(editable);
+        self.mac.set_sensitive(editable);
+        self.input.set_sensitive(editable);
+        self.pair.set_sensitive(presentation.can_submit());
+        self.progress
+            .set_fraction(presentation.progress_fraction().unwrap_or(0.0));
+        self.progress
+            .set_visible(presentation.progress_fraction().is_some());
+        self.progress
+            .update_property(&[gtk::accessible::Property::Label(presentation.title())]);
+        self.cancel.set_sensitive(presentation.can_cancel());
+
+        if let Some(error) = presentation.error() {
+            self.status.set_text(&error_text(error));
+            self.status.add_css_class("error");
+        } else {
+            self.clear_toast();
+            self.status.set_text("");
+            self.status.remove_css_class("error");
+        }
+        self.status.set_visible(presentation.error().is_some());
+        self.suppress.set(false);
+
+        if !self.presented.replace(true) {
+            self.dialog.present(Some(parent));
+            self.address.grab_focus();
+        }
+    }
+
+    pub(crate) fn show_toast(&self, message: &str) -> bool {
+        if !self.presented.get() {
+            return false;
+        }
+        self.clear_toast();
+        let toast = adw::Toast::new(message);
+        self.error_toast.replace(Some(toast.clone()));
+        self.toasts.add_toast(toast);
+        true
+    }
+
+    fn clear_toast(&self) {
+        if let Some(toast) = self.error_toast.take() {
+            toast.dismiss();
+        }
+    }
+}
+
+fn connect_text_intent<F>(
+    row: &adw::EntryRow,
+    suppress: Rc<Cell<bool>>,
+    on_intent: IntentHandler,
+    intent: F,
+) where
+    F: Fn(String) -> PairingIntent + 'static,
+{
+    row.connect_changed(move |row| {
+        if !suppress.get() {
+            let text = row.text().to_string();
+            on_intent(TvsIntent::Pairing(intent(text)));
+        }
+    });
+}
+
+fn connect_submit_on_activate(row: &adw::EntryRow, on_intent: IntentHandler) {
+    row.connect_entry_activated(move |_| {
+        on_intent(TvsIntent::Pairing(PairingIntent::Submit));
+    });
+}
+
+fn set_entry_text_preserving_selection(row: &adw::EntryRow, text: &str) {
+    if row.text().as_str() == text {
+        return;
+    }
+    let position = row.position();
+    let selection = row.selection_bounds();
+    row.set_text(text);
+    let length = text.chars().count() as i32;
+    if let Some((start, end)) = selection {
+        row.select_region(start.min(length), end.min(length));
+    } else {
+        row.set_position(position.min(length));
+    }
+}
+
+fn hdmi_input(index: u32) -> Option<HdmiInput> {
+    match index {
+        0 => Some(HdmiInput::Hdmi1),
+        1 => Some(HdmiInput::Hdmi2),
+        2 => Some(HdmiInput::Hdmi3),
+        3 => Some(HdmiInput::Hdmi4),
+        _ => None,
+    }
+}
+
+fn hdmi_index(input: HdmiInput) -> Option<u32> {
+    match input {
+        HdmiInput::Hdmi1 => Some(0),
+        HdmiInput::Hdmi2 => Some(1),
+        HdmiInput::Hdmi3 => Some(2),
+        HdmiInput::Hdmi4 => Some(3),
+    }
+}
+
+fn error_text(error: &UserFacingError) -> String {
+    format!("{} {}", error.summary(), error.detail())
+}
+
+#[cfg(test)]
+pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
+    use std::cell::RefCell;
+
+    use lg_buddy::config::HdmiInput;
+    use lg_buddy::pairing::{PairingError, PairingFailure, PairingStage};
+    use lg_buddy::tvs::TvsApplication;
+
+    fn pump() {
+        let context = gtk::glib::MainContext::default();
+        while context.pending() {
+            context.iteration(false);
+        }
+    }
+
+    let intents: Rc<RefCell<Vec<TvsIntent>>> = Rc::new(RefCell::new(Vec::new()));
+    let view = PairingView::new(Rc::new({
+        let intents = Rc::clone(&intents);
+        move |intent| intents.borrow_mut().push(intent)
+    }));
+    let window = adw::ApplicationWindow::builder()
+        .application(application)
+        .default_width(600)
+        .default_height(420)
+        .build();
+    window.present();
+
+    let (mut app, opening) = TvsApplication::open();
+    let empty = app
+        .complete_read(
+            opening.read_operation().expect("TV read operation"),
+            Ok(Vec::new()),
+        )
+        .expect("empty TVs transition");
+    let pairing_opened = app
+        .handle_intent(TvsIntent::PairTv)
+        .expect("pairing transition");
+    let presentation = pairing_opened
+        .presentation()
+        .pairing()
+        .expect("pairing form");
+    view.render(&window, Some(presentation));
+    pump();
+    assert_eq!(view.dialog.title(), "Pair a TV");
+    assert_eq!(window.visible_dialog().as_ref(), Some(&view.dialog));
+    assert_eq!(view.dialog.accessible_role(), gtk::AccessibleRole::Dialog);
+    assert!(gtk::prelude::GtkWindowExt::focus(&window)
+        .is_some_and(|focus| focus.is_ancestor(&view.address)));
+    assert!(view.pair.is_sensitive());
+    assert_eq!(view.pair.label().as_deref(), Some("Pair"));
+    assert!(!view.progress.is_visible());
+    assert!(view.cancel.is_sensitive());
+    assert_eq!(
+        gtk::prelude::GtkWindowExt::focus(&window)
+            .unwrap()
+            .accessible_role(),
+        gtk::AccessibleRole::TextBox
+    );
+    assert_eq!(view.pair.accessible_role(), gtk::AccessibleRole::Button);
+
+    view.address.set_text("192.0.2.42");
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::Pairing(PairingIntent::SetAddress(
+            "192.0.2.42".to_string()
+        )))
+    );
+    view.mac.set_text("02:11:22:33:44:55");
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::Pairing(PairingIntent::SetMac(
+            "02:11:22:33:44:55".to_string()
+        )))
+    );
+    view.input.set_selected(1);
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::Pairing(PairingIntent::SetInput(
+            HdmiInput::Hdmi2
+        )))
+    );
+
+    let editing = app
+        .handle_intent(TvsIntent::Pairing(PairingIntent::SetAddress(
+            "192.0.2.42".to_string(),
+        )))
+        .expect("address edit");
+    view.render(
+        &window,
+        Some(editing.presentation().pairing().expect("editing form")),
+    );
+    let editing = app
+        .handle_intent(TvsIntent::Pairing(PairingIntent::SetMac(
+            "02:11:22:33:44:55".to_string(),
+        )))
+        .expect("MAC edit");
+    view.render(
+        &window,
+        Some(editing.presentation().pairing().expect("editing form")),
+    );
+    let editing = app
+        .handle_intent(TvsIntent::Pairing(PairingIntent::SetInput(
+            HdmiInput::Hdmi2,
+        )))
+        .expect("input edit");
+    view.render(
+        &window,
+        Some(editing.presentation().pairing().expect("editing form")),
+    );
+
+    view.pair.emit_clicked();
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::Pairing(PairingIntent::Submit))
+    );
+    let connecting = app
+        .handle_intent(TvsIntent::Pairing(PairingIntent::Submit))
+        .expect("pairing start");
+    let operation = connecting
+        .pairing_operation()
+        .expect("pairing operation")
+        .clone();
+    view.render(
+        &window,
+        Some(connecting.presentation().pairing().expect("connecting")),
+    );
+    assert_eq!(view.dialog.title(), "Connecting to TV");
+    assert!(!view.address.is_sensitive());
+    assert!(!view.pair.is_sensitive());
+    assert!(view.progress.is_visible());
+
+    let waiting = app
+        .pairing_progress(&operation, PairingStage::WaitingForConfirmation)
+        .expect("confirmation transition");
+    view.render(
+        &window,
+        Some(waiting.presentation().pairing().expect("confirmation")),
+    );
+    assert_eq!(view.dialog.title(), "Confirm on Your TV");
+    assert_eq!(view.progress.fraction(), 0.25);
+    assert!(view.progress.is_visible());
+    assert!(view.description.label().contains("remote"));
+    // Escape and sheet dismissal use the same intent as the header's Cancel.
+    assert!(!view.dialog.close());
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::Pairing(PairingIntent::Cancel))
+    );
+    let verifying = app
+        .pairing_progress(&operation, PairingStage::Verifying)
+        .expect("verification transition");
+    view.render(
+        &window,
+        Some(verifying.presentation().pairing().expect("verification")),
+    );
+
+    let saving = app
+        .pairing_progress(&operation, PairingStage::Saving)
+        .expect("saving transition");
+    view.render(&window, saving.presentation().pairing());
+    assert_eq!(view.progress.fraction(), 0.75);
+    assert!(view.progress.is_visible());
+    assert!(!view.cancel.is_sensitive());
+    intents.borrow_mut().clear();
+    assert!(!view.dialog.close());
+    assert!(intents.borrow().is_empty(), "saving cannot be dismissed");
+
+    let failed = app
+        .complete_pairing(&operation, Err(PairingError::new(PairingFailure::Rejected)))
+        .expect("failed pairing transition");
+    view.render(
+        &window,
+        Some(failed.presentation().pairing().expect("failed pairing")),
+    );
+    assert_eq!(view.dialog.title(), "Could Not Pair TV");
+    assert!(!view.progress.is_visible());
+    assert!(view.show_toast(failed.toast_message().expect("failure toast")));
+    assert_eq!(
+        view.error_toast
+            .borrow()
+            .as_ref()
+            .unwrap()
+            .title()
+            .as_deref(),
+        Some("Connection declined on TV")
+    );
+    assert!(view.status.is_visible());
+    assert_eq!(view.status.accessible_role(), gtk::AccessibleRole::Alert);
+    assert!(view.pair.is_sensitive());
+
+    let editing = app
+        .handle_intent(TvsIntent::Pairing(PairingIntent::SetAddress(
+            "192.0.2.43".into(),
+        )))
+        .unwrap();
+    view.render(&window, editing.presentation().pairing());
+    assert!(view.error_toast.borrow().is_none());
+    assert!(!view.status.is_visible());
+
+    view.cancel.emit_clicked();
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::Pairing(PairingIntent::Cancel))
+    );
+    let cancelled = app
+        .handle_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+        .expect("pairing cancellation");
+    assert!(cancelled.presentation().pairing().is_none());
+    view.render(&window, cancelled.presentation().pairing());
+    assert!(!view.presented.get());
+    assert!(view.error_toast.borrow().is_none());
+    assert!(!view.progress.is_visible());
+    assert!(
+        intents.borrow().is_empty(),
+        "closing must not send a new intent"
+    );
+
+    let reopened = app.handle_intent(TvsIntent::PairTv).unwrap();
+    view.render(&window, reopened.presentation().pairing());
+    pump();
+    assert!(view.presented.get());
+    assert!(view.address.text().is_empty());
+    assert_eq!(window.visible_dialog().as_ref(), Some(&view.dialog));
+    view.render(&window, None);
+
+    // The empty presentation owns the CTA; pairing owns the form instead.
+    assert!(empty.presentation().pair_action().is_some());
+    assert!(pairing_opened.presentation().pair_action().is_none());
+    assert!(gtk::IconTheme::for_display(&view.dialog.display()).has_icon(TV_ICON_NAME));
+    window.close();
+}

--- a/crates/lg-buddy-gui/src/pairing.rs
+++ b/crates/lg-buddy-gui/src/pairing.rs
@@ -162,6 +162,7 @@ impl PairingView {
             .title("Pair a TV")
             .content_width(480)
             .content_height(480)
+            .accessible_role(gtk::AccessibleRole::Dialog)
             .child(&toolbar)
             // Ask the application before dismissing: a worker may have begun
             // saving before its progress event reaches the main loop.

--- a/crates/lg-buddy-gui/src/pairing.rs
+++ b/crates/lg-buddy-gui/src/pairing.rs
@@ -162,7 +162,6 @@ impl PairingView {
             .title("Pair a TV")
             .content_width(480)
             .content_height(480)
-            .accessible_role(gtk::AccessibleRole::Dialog)
             .child(&toolbar)
             // Ask the application before dismissing: a worker may have begun
             // saving before its progress event reaches the main loop.
@@ -375,7 +374,8 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     pump();
     assert_eq!(view.dialog.title(), "Pair a TV");
     assert_eq!(window.visible_dialog().as_ref(), Some(&view.dialog));
-    assert_eq!(view.dialog.accessible_role(), gtk::AccessibleRole::Dialog);
+    // libadwaita 1.5.0 exposes the dialog role on an internal sheet.
+    // The installed AT-SPI smoke checks the effective dialog and its controls.
     assert!(gtk::prelude::GtkWindowExt::focus(&window)
         .is_some_and(|focus| focus.is_ancestor(&view.address)));
     assert!(view.pair.is_sensitive());

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -33,6 +33,8 @@ pub(crate) struct TvsView {
 struct TvsMode {
     stack: gtk::Stack,
     status: adw::StatusPage,
+    status_error: gtk::Label,
+    pair: PairButton,
     details: adw::PreferencesGroup,
     address: adw::ActionRow,
     mac: adw::ActionRow,
@@ -51,7 +53,18 @@ impl TvsMode {
             .vexpand(true)
             .build();
         let retry = RetryButton::new(on_intent);
-        status.set_child(Some(&retry.button));
+        let pair = PairButton::new(on_intent);
+        let status_actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        status_actions.set_halign(gtk::Align::Center);
+        status_actions.append(&retry.button);
+        status_actions.append(&pair.button);
+        let status_error = gtk::Label::builder().wrap(true).visible(false).build();
+        status_error.set_accessible_role(gtk::AccessibleRole::Alert);
+        status_error.add_css_class("error");
+        let status_content = gtk::Box::new(gtk::Orientation::Vertical, 8);
+        status_content.append(&status_error);
+        status_content.append(&status_actions);
+        status.set_child(Some(&status_content));
 
         let details = adw::PreferencesGroup::builder().title("TV details").build();
         let address = detail_row("Address");
@@ -101,6 +114,8 @@ impl TvsMode {
         Self {
             stack,
             status,
+            status_error,
+            pair,
             details,
             address,
             mac,
@@ -114,13 +129,15 @@ impl TvsMode {
 
     fn show_status(&self, title: &str, description: Option<&str>, error: bool) {
         self.status.set_title(title);
-        self.status.set_description(description);
+        self.status
+            .set_description(if error { None } else { description });
         self.status.set_icon_name(Some(TV_ICON_NAME));
-        self.status.set_accessible_role(if error {
-            gtk::AccessibleRole::Alert
+        self.status_error.set_text(if error {
+            description.unwrap_or(title)
         } else {
-            gtk::AccessibleRole::Status
+            ""
         });
+        self.status_error.set_visible(error);
         self.stack.set_visible_child_name("status");
     }
 
@@ -260,8 +277,11 @@ impl TvsView {
             self.sidebar.unselect_all();
         }
 
-        self.render_mode(&self.single, presentation);
-        self.render_mode(&self.multiple, presentation);
+        if is_multiple {
+            self.render_mode(&self.multiple, presentation);
+        } else {
+            self.render_mode(&self.single, presentation);
+        }
         self.suppress.set(false);
     }
 
@@ -316,6 +336,7 @@ impl TvsView {
 
     fn render_mode(&self, mode: &TvsMode, presentation: &TvsPresentation) {
         mode.retry.render(presentation.retry_action());
+        mode.pair.render(presentation.pair_action());
         match presentation.status() {
             TvsStatus::Loading { message } => mode.show_status(message, None, false),
             TvsStatus::Empty { title, description } => {
@@ -341,6 +362,59 @@ impl TvsView {
 struct RetryButton {
     button: gtk::Button,
     intent: Rc<RefCell<Option<TvsIntent>>>,
+}
+
+struct PairButton {
+    button: gtk::Button,
+    intent: Rc<RefCell<Option<TvsIntent>>>,
+}
+
+impl PairButton {
+    fn new(on_intent: &IntentHandler) -> Self {
+        let button = gtk::Button::with_label("Pair a TV");
+        button.add_css_class("suggested-action");
+        button.add_css_class("pill");
+        button.set_visible(false);
+        button.set_sensitive(false);
+        let intent = Rc::new(RefCell::new(None));
+        button.connect_clicked({
+            let on_intent = Rc::clone(on_intent);
+            let intent = Rc::clone(&intent);
+            move |_| {
+                let intent = intent.borrow().clone();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
+        Self { button, intent }
+    }
+
+    fn render(&self, action: Option<&TvsAction>) {
+        self.intent.replace(
+            action
+                .filter(|action| action.enabled())
+                .map(TvsAction::intent),
+        );
+        self.button.set_visible(action.is_some());
+        self.button
+            .set_sensitive(action.is_some_and(TvsAction::enabled));
+        self.button
+            .set_label(action.map_or("Pair a TV", TvsAction::label));
+        self.button.set_tooltip_text(action.map(TvsAction::label));
+        self.button
+            .update_property(&[gtk::accessible::Property::Label(
+                action.map_or("Pair a TV", TvsAction::label),
+            )]);
+        if action.is_some() && !self.button.has_focus() {
+            let button = self.button.clone();
+            gtk::glib::idle_add_local_once(move || {
+                if button.is_mapped() && button.is_visible() && button.is_sensitive() {
+                    button.grab_focus();
+                }
+            });
+        }
+    }
 }
 
 impl RetryButton {
@@ -471,8 +545,38 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     assert_eq!(view.single.status.title().as_str(), "No TV configured");
     assert_eq!(
         view.single.status.description().as_deref(),
-        Some("Configure a TV to see its details here.")
+        Some("Pair your TV to control it with LG Buddy.")
     );
+    assert!(view.single.pair.button.is_visible());
+    assert!(view.single.pair.button.is_sensitive());
+    assert_eq!(
+        view.single.pair.button.label().as_deref(),
+        Some("Pair a TV")
+    );
+    pump();
+    assert!(view.single.pair.button.has_focus());
+
+    view.single.pair.button.emit_clicked();
+    assert_eq!(intents.borrow_mut().pop(), Some(TvsIntent::PairTv));
+    let pairing = app
+        .handle_intent(TvsIntent::PairTv)
+        .expect("pairing transition");
+    view.render(pairing.presentation());
+    assert_eq!(
+        view.single.stack.visible_child_name().as_deref(),
+        Some("status")
+    );
+    assert!(!view.single.pair.button.is_visible());
+    let blank = app
+        .handle_intent(TvsIntent::Pairing(lg_buddy::pairing::PairingIntent::Cancel))
+        .expect("blank transition");
+    view.render(blank.presentation());
+    pump();
+    assert_eq!(
+        view.single.stack.visible_child_name().as_deref(),
+        Some("status")
+    );
+    assert!(view.single.pair.button.has_focus());
 
     let one = profile("primary", "Primary TV", "192.0.2.10");
     let (mut app, opening) = TvsApplication::open();
@@ -615,4 +719,5 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     assert!(view.split_bin.current_breakpoint().is_some());
     assert!(view.split.is_collapsed());
     window.close();
+    crate::pairing::run_renderer_scenarios(application);
 }

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -12,6 +12,8 @@ pub(crate) struct ApplicationWindow {
     window: adw::ApplicationWindow,
     overview: crate::overview::OverviewView,
     tvs: crate::tvs::TvsView,
+    pairing: crate::pairing::PairingView,
+    toasts: adw::ToastOverlay,
     stack: adw::ViewStack,
     suppress_navigation: Rc<Cell<bool>>,
     allow_close: Rc<Cell<bool>>,
@@ -35,7 +37,8 @@ impl ApplicationWindow {
             .height_request(240)
             .build();
         let overview = crate::overview::OverviewView::new(&window, Rc::clone(&on_overview));
-        let tvs = crate::tvs::TvsView::new(on_tvs);
+        let tvs = crate::tvs::TvsView::new(Rc::clone(&on_tvs));
+        let pairing = crate::pairing::PairingView::new(on_tvs);
         let stack = adw::ViewStack::new();
         stack.set_hhomogeneous(false);
         stack.set_vhomogeneous(false);
@@ -66,7 +69,9 @@ impl ApplicationWindow {
             .build();
         let header = adw::HeaderBar::builder().title_widget(&switcher).build();
         let switcher_bar = adw::ViewSwitcherBar::builder().stack(&stack).build();
-        let toolbar = adw::ToolbarView::builder().content(&stack).build();
+        let toasts = adw::ToastOverlay::new();
+        toasts.set_child(Some(&stack));
+        let toolbar = adw::ToolbarView::builder().content(&toasts).build();
         toolbar.add_top_bar(&header);
         toolbar.add_bottom_bar(&switcher_bar);
         window.set_content(Some(&toolbar));
@@ -106,6 +111,8 @@ impl ApplicationWindow {
             window,
             overview,
             tvs,
+            pairing,
+            toasts,
             stack,
             suppress_navigation,
             allow_close,
@@ -119,6 +126,22 @@ impl ApplicationWindow {
 
     pub(crate) fn render_tvs(&self, presentation: &TvsPresentation) {
         self.tvs.render(presentation);
+        self.pairing.render(&self.window, presentation.pairing());
+    }
+
+    pub(crate) fn dismiss_dialog(&self) -> bool {
+        if let Some(dialog) = self.window.visible_dialog() {
+            dialog.close();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn show_toast(&self, message: &str) {
+        if !self.pairing.show_toast(message) {
+            self.toasts.add_toast(adw::Toast::new(message));
+        }
     }
 
     pub(crate) fn navigate(&self, page: ApplicationPage) {

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -1,0 +1,334 @@
+//! Toolkit-independent coordination between the desktop application's views.
+//! Hosts execute the declared operations and return completions; cross-view
+//! workflow decisions stay here alongside the individual application models.
+
+use crate::audio::{AudioWriteError, AudioWriteOutcome};
+use crate::brightness::{BrightnessReadError, BrightnessWriteError, BrightnessWriteOutcome};
+use crate::overview::{
+    AudioReadError, OverviewApplication, OverviewAudioReadOperation, OverviewAudioWriteOperation,
+    OverviewBrightnessReadOperation, OverviewBrightnessWriteOperation, OverviewFrontendUpdate,
+    OverviewIntent, OverviewSummaryError, OverviewSummaryOperation, OverviewTransition,
+    OverviewTvIdentity,
+};
+use crate::pairing::{PairingError, PairingFailure, PairingOperation, PairingStage};
+use crate::tv::{AudioStatus, OledBrightness};
+use crate::tvs::{
+    TvProfile, TvsApplication, TvsIntent, TvsModelReadOperation, TvsReadError, TvsReadOperation,
+    TvsTransition,
+};
+
+pub enum OverviewCompletion {
+    Summary(
+        OverviewSummaryOperation,
+        Result<OverviewTvIdentity, OverviewSummaryError>,
+    ),
+    BrightnessRead(
+        OverviewBrightnessReadOperation,
+        Result<OledBrightness, BrightnessReadError>,
+    ),
+    AudioRead(
+        OverviewAudioReadOperation,
+        Result<AudioStatus, AudioReadError>,
+    ),
+    BrightnessWrite(
+        OverviewBrightnessWriteOperation,
+        Result<BrightnessWriteOutcome, BrightnessWriteError>,
+    ),
+    AudioWrite(
+        OverviewAudioWriteOperation,
+        Result<AudioWriteOutcome, AudioWriteError>,
+    ),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ApplicationTransition {
+    overview: Option<OverviewTransition>,
+    tvs: Option<TvsTransition>,
+}
+
+impl ApplicationTransition {
+    pub fn overview(&self) -> Option<&OverviewTransition> {
+        self.overview.as_ref()
+    }
+
+    pub fn tvs(&self) -> Option<&TvsTransition> {
+        self.tvs.as_ref()
+    }
+}
+
+pub struct Application {
+    overview: OverviewApplication,
+    tvs: TvsApplication,
+}
+
+impl Application {
+    pub fn open() -> (Self, ApplicationTransition) {
+        let (overview, overview_opening) = OverviewApplication::open();
+        let (tvs, tvs_opening) = TvsApplication::open();
+        (
+            Self { overview, tvs },
+            ApplicationTransition {
+                overview: Some(overview_opening),
+                tvs: Some(tvs_opening),
+            },
+        )
+    }
+
+    pub fn handle_overview_intent(
+        &mut self,
+        intent: OverviewIntent,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.overview.handle_intent(intent)?;
+        Some(self.overview_transition(transition))
+    }
+
+    pub fn handle_tvs_intent(&mut self, intent: TvsIntent) -> Option<ApplicationTransition> {
+        let transition = self.tvs.handle_intent(intent)?;
+        Some(self.tvs_transition(transition))
+    }
+
+    pub fn complete_overview(
+        &mut self,
+        completion: OverviewCompletion,
+    ) -> Option<ApplicationTransition> {
+        let transition = match completion {
+            OverviewCompletion::Summary(operation, result) => {
+                self.overview.complete_summary(operation, result)
+            }
+            OverviewCompletion::BrightnessRead(operation, result) => {
+                self.overview.complete_brightness_read(operation, result)
+            }
+            OverviewCompletion::AudioRead(operation, result) => {
+                self.overview.complete_audio_read(operation, result)
+            }
+            OverviewCompletion::BrightnessWrite(operation, result) => {
+                self.overview.complete_brightness_write(operation, result)
+            }
+            OverviewCompletion::AudioWrite(operation, result) => {
+                self.overview.complete_audio_write(operation, result)
+            }
+        }?;
+        Some(self.overview_transition(transition))
+    }
+
+    pub fn complete_tvs_read(
+        &mut self,
+        operation: TvsReadOperation,
+        result: Result<Vec<TvProfile>, TvsReadError>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.tvs.complete_read(operation, result)?;
+        Some(self.tvs_transition(transition))
+    }
+
+    pub fn complete_tvs_model_read(
+        &mut self,
+        operation: TvsModelReadOperation,
+        result: Result<String, TvsReadError>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.tvs.complete_model_read(operation, result)?;
+        Some(self.tvs_transition(transition))
+    }
+
+    pub fn pairing_progress(
+        &mut self,
+        operation: &PairingOperation,
+        stage: PairingStage,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.tvs.pairing_progress(operation, stage)?;
+        Some(self.tvs_transition(transition))
+    }
+
+    pub fn complete_pairing(
+        &mut self,
+        operation: &PairingOperation,
+        result: Result<TvProfile, PairingError>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.tvs.complete_pairing(operation, result)?;
+        Some(self.tvs_transition(transition))
+    }
+
+    pub fn pairing_worker_stopped(
+        &mut self,
+        operation: &PairingOperation,
+    ) -> Option<ApplicationTransition> {
+        self.complete_pairing(operation, Err(PairingError::new(PairingFailure::Internal)))
+    }
+
+    pub fn is_pairing(&self) -> bool {
+        self.tvs.is_pairing()
+    }
+
+    pub fn shutdown(&mut self) {
+        self.overview.shutdown();
+        self.tvs.shutdown();
+    }
+
+    fn overview_transition(&mut self, transition: OverviewTransition) -> ApplicationTransition {
+        if matches!(transition.update(), OverviewFrontendUpdate::Close) {
+            self.tvs.shutdown();
+        }
+        ApplicationTransition {
+            overview: Some(transition),
+            tvs: None,
+        }
+    }
+
+    fn tvs_transition(&mut self, transition: TvsTransition) -> ApplicationTransition {
+        let overview = if transition.profile_created() {
+            self.overview.profile_created()
+        } else {
+            None
+        };
+        ApplicationTransition {
+            overview,
+            tvs: Some(transition),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{HdmiInput, TvPlatform};
+    use crate::overview::{OverviewOperation, OverviewSummaryFailure};
+    use crate::pairing::PairingIntent;
+    use crate::tvs::{TvCredentialState, TvId};
+
+    fn pairing() -> (Application, ApplicationTransition, PairingOperation) {
+        let (mut application, opening) = Application::open();
+        application
+            .complete_tvs_read(opening.tvs().unwrap().read_operation().unwrap(), Ok(vec![]))
+            .unwrap();
+        for intent in [
+            TvsIntent::PairTv,
+            TvsIntent::Pairing(PairingIntent::SetAddress("192.0.2.10".into())),
+            TvsIntent::Pairing(PairingIntent::SetMac("02:11:22:33:44:55".into())),
+        ] {
+            application.handle_tvs_intent(intent).unwrap();
+        }
+        let start = application
+            .handle_tvs_intent(TvsIntent::Pairing(PairingIntent::Submit))
+            .unwrap();
+        let operation = start.tvs().unwrap().pairing_operation().unwrap().clone();
+        (application, opening, operation)
+    }
+
+    fn profile(operation: &PairingOperation) -> TvProfile {
+        let request = operation.request();
+        TvProfile::new(
+            TvId::primary(),
+            "Primary TV",
+            request.address(),
+            request.mac(),
+            HdmiInput::Hdmi1,
+            TvPlatform::LgWebOs,
+            TvCredentialState::Stored,
+        )
+    }
+
+    #[test]
+    fn pairing_success_refreshes_overview_and_rejects_previous_results() {
+        let (mut application, opening, operation) = pairing();
+        let completed = application
+            .complete_pairing(&operation, Ok(profile(&operation)))
+            .unwrap();
+        let tvs = completed.tvs().unwrap();
+        assert_eq!(tvs.presentation().profiles(), &[profile(&operation)]);
+        assert!(tvs.presentation().pairing().is_none());
+        assert_eq!(tvs.toast_message(), Some("TV paired successfully"));
+        let refreshed = completed
+            .overview()
+            .expect("pairing must refresh Overview without a renderer");
+        assert!(matches!(
+            refreshed.operations(),
+            [
+                OverviewOperation::ReadSummary(_),
+                OverviewOperation::ReadBrightness(_),
+                OverviewOperation::ReadAudio(_)
+            ]
+        ));
+        for old in opening.overview().unwrap().operations() {
+            assert!(!refreshed.operations().contains(old));
+            let result = match *old {
+                OverviewOperation::ReadSummary(op) => OverviewCompletion::Summary(
+                    op,
+                    Err(OverviewSummaryError::new(
+                        OverviewSummaryFailure::NotConfigured,
+                        "old configuration",
+                    )),
+                ),
+                OverviewOperation::ReadBrightness(op) => {
+                    OverviewCompletion::BrightnessRead(op, Ok(OledBrightness::new(30).unwrap()))
+                }
+                OverviewOperation::ReadAudio(op) => OverviewCompletion::AudioRead(
+                    op,
+                    Ok(AudioStatus::new(crate::tv::CurrentVolume::Unknown, false)),
+                ),
+                _ => unreachable!(),
+            };
+            assert!(application.complete_overview(result).is_none());
+        }
+    }
+
+    #[test]
+    fn worker_loss_reports_an_internal_failure_without_refreshing_overview() {
+        let (mut application, _, operation) = pairing();
+        let failed = application.pairing_worker_stopped(&operation).unwrap();
+        assert!(failed.overview().is_none());
+        let tvs = failed.tvs().unwrap();
+        assert_eq!(tvs.toast_message(), Some("Pairing stopped unexpectedly"));
+        assert!(tvs.presentation().profiles().is_empty());
+        let pairing = tvs.presentation().pairing().unwrap();
+        assert_eq!(pairing.address(), "192.0.2.10");
+        assert!(pairing
+            .error()
+            .unwrap()
+            .detail()
+            .contains("Restart LG Buddy"));
+        assert!(!pairing.error().unwrap().detail().contains("IP address"));
+        assert!(!pairing
+            .description()
+            .contains("No TV configuration was saved"));
+        assert!(pairing.can_cancel());
+        assert!(application
+            .handle_tvs_intent(TvsIntent::Pairing(PairingIntent::Submit))
+            .unwrap()
+            .tvs()
+            .unwrap()
+            .pairing_operation()
+            .is_some());
+    }
+
+    #[test]
+    fn cancellation_and_application_close_reject_late_pairing_results() {
+        let (mut application, _, operation) = pairing();
+        let cancelled = application
+            .handle_tvs_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+            .unwrap();
+        assert!(cancelled.overview().is_none());
+        assert!(cancelled.tvs().unwrap().presentation().pairing().is_none());
+        assert!(operation.is_cancelled());
+        assert!(application
+            .complete_pairing(&operation, Ok(profile(&operation)))
+            .is_none());
+        assert!(application.pairing_worker_stopped(&operation).is_none());
+
+        let (mut application, _, operation) = pairing();
+        let closed = application
+            .handle_overview_intent(OverviewIntent::Cancel)
+            .unwrap();
+        assert!(matches!(
+            closed.overview().unwrap().update(),
+            OverviewFrontendUpdate::Close
+        ));
+        assert!(operation.is_cancelled());
+        assert!(!application.is_pairing());
+        assert!(application
+            .pairing_progress(&operation, PairingStage::Verifying)
+            .is_none());
+        assert!(application
+            .complete_pairing(&operation, Ok(profile(&operation)))
+            .is_none());
+        assert!(application.handle_tvs_intent(TvsIntent::PairTv).is_none());
+    }
+}

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -11,6 +11,8 @@ pub mod lifecycle;
 pub mod navigation;
 pub mod notifications;
 pub mod overview;
+pub mod pairing;
+mod pairing_store;
 pub mod platform_access_token;
 pub mod policy;
 pub mod presentation;

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -1,5 +1,6 @@
 mod dev;
 
+pub mod application;
 pub mod audio;
 pub mod auth;
 pub mod backend;

--- a/crates/lg-buddy/src/overview.rs
+++ b/crates/lg-buddy/src/overview.rs
@@ -430,6 +430,31 @@ impl OverviewApplication {
         }
     }
 
+    /// Reload after the first primary profile has been saved. Preserve the
+    /// operation sequence so late results from the empty state stay stale.
+    pub fn profile_created(&mut self) -> Option<OverviewTransition> {
+        if self.is_closed()
+            || matches!(self.brightness, BrightnessState::Applying { .. })
+            || matches!(self.audio, AudioState::Applying { .. })
+        {
+            return None;
+        }
+        let summary = self.new_summary();
+        let brightness = OverviewBrightnessReadOperation::new(self.next_id);
+        self.next_id += 1;
+        self.brightness = BrightnessState::Loading(brightness);
+        self.brightness_presentation = BrightnessPresentation::loading();
+        let audio = self.new_audio_read();
+        Some(self.transition(
+            vec![
+                OverviewOperation::ReadSummary(summary),
+                OverviewOperation::ReadBrightness(brightness),
+                OverviewOperation::ReadAudio(audio),
+            ],
+            None,
+        ))
+    }
+
     pub fn complete_summary(
         &mut self,
         operation: OverviewSummaryOperation,
@@ -1149,6 +1174,37 @@ mod tests {
     use crate::audio::AudioWriteFailure;
     use crate::presentation::brightness::BrightnessStatus;
     use crate::presentation::overview::AudioStatus;
+
+    #[test]
+    fn first_profile_reload_rejects_results_from_the_empty_state() {
+        let (mut app, original) = OverviewApplication::open();
+        let refreshed = app.profile_created().unwrap();
+        assert_eq!(refreshed.operations().len(), 3);
+        for operation in original.operations() {
+            assert!(!refreshed.operations().contains(operation));
+            let stale = match *operation {
+                OverviewOperation::ReadSummary(op) => app.complete_summary(
+                    op,
+                    Err(OverviewSummaryError::new(
+                        OverviewSummaryFailure::NotConfigured,
+                        "old config",
+                    )),
+                ),
+                OverviewOperation::ReadBrightness(op) => {
+                    app.complete_brightness_read(op, Ok(OledBrightness::new(30).unwrap()))
+                }
+                OverviewOperation::ReadAudio(op) => app.complete_audio_read(
+                    op,
+                    Ok(crate::tv::AudioStatus::new(
+                        CurrentVolume::Level(VolumeLevel::new(20).unwrap()),
+                        false,
+                    )),
+                ),
+                _ => unreachable!(),
+            };
+            assert!(stale.is_none());
+        }
+    }
 
     fn ready_application() -> OverviewApplication {
         let (mut app, opening) = OverviewApplication::open();

--- a/crates/lg-buddy/src/overview.rs
+++ b/crates/lg-buddy/src/overview.rs
@@ -432,7 +432,7 @@ impl OverviewApplication {
 
     /// Reload after the first primary profile has been saved. Preserve the
     /// operation sequence so late results from the empty state stay stale.
-    pub fn profile_created(&mut self) -> Option<OverviewTransition> {
+    pub(crate) fn profile_created(&mut self) -> Option<OverviewTransition> {
         if self.is_closed()
             || matches!(self.brightness, BrightnessState::Applying { .. })
             || matches!(self.audio, AudioState::Applying { .. })

--- a/crates/lg-buddy/src/pairing.rs
+++ b/crates/lg-buddy/src/pairing.rs
@@ -1,0 +1,728 @@
+//! Foreground first-TV pairing. The application validates the draft and owns
+//! cancellation; its worker pairs and verifies before publishing any profile.
+
+use std::net::Ipv4Addr;
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+use crate::config::{HdmiInput, MacAddress, TvPlatform};
+use crate::pairing_store::PairingStore;
+use crate::presentation::{brightness::UserFacingError, pairing::PairingPresentation};
+use crate::settings::ConfigPathResolver;
+use crate::tvs::{TvCredentialState, TvId, TvProfile};
+use crate::web_os::{WebOsClient, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PairingIntent {
+    SetAddress(String),
+    SetMac(String),
+    SetInput(HdmiInput),
+    Submit,
+    Cancel,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairingStage {
+    Editing,
+    Connecting,
+    WaitingForConfirmation,
+    Verifying,
+    Saving,
+    Failed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PairingDraft {
+    pub address: String,
+    pub mac: String,
+    pub input: HdmiInput,
+}
+
+impl Default for PairingDraft {
+    fn default() -> Self {
+        Self {
+            address: String::new(),
+            mac: String::new(),
+            input: HdmiInput::Hdmi1,
+        }
+    }
+}
+
+/// Validated primary-profile fields. Platform is deliberately native webOS.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PairingRequest {
+    address: Ipv4Addr,
+    mac: MacAddress,
+    input: HdmiInput,
+}
+
+impl PairingRequest {
+    pub fn address(&self) -> Ipv4Addr {
+        self.address
+    }
+    pub fn mac(&self) -> MacAddress {
+        self.mac
+    }
+    pub fn input(&self) -> HdmiInput {
+        self.input
+    }
+}
+
+// Exactly one side wins the cancellation/commit boundary. The UI never waits
+// for a filesystem lock: cancellation is accepted until publication starts.
+const ACTIVE: u8 = 0;
+const CANCELLED: u8 = 1;
+const SAVING: u8 = 2;
+
+#[derive(Debug, Clone)]
+pub struct PairingOperation {
+    id: u64,
+    request: PairingRequest,
+    gate: Arc<AtomicU8>,
+}
+
+impl PartialEq for PairingOperation {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && Arc::ptr_eq(&self.gate, &other.gate)
+    }
+}
+impl Eq for PairingOperation {}
+
+impl PairingOperation {
+    pub fn request(&self) -> PairingRequest {
+        self.request
+    }
+    pub fn is_cancelled(&self) -> bool {
+        self.gate.load(Ordering::Acquire) == CANCELLED
+    }
+    fn cancel(&self) -> bool {
+        self.gate
+            .compare_exchange(ACTIVE, CANCELLED, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+            || self.is_cancelled()
+    }
+    fn begin_save(&self) -> bool {
+        self.gate
+            .compare_exchange(ACTIVE, SAVING, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PairingFailure {
+    Cancelled,
+    Rejected,
+    Timeout,
+    Verification,
+    Connection,
+    Persistence,
+}
+
+/// Contains only application-owned guidance, never a server frame or token.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingError {
+    failure: PairingFailure,
+}
+
+impl PairingError {
+    pub fn new(failure: PairingFailure) -> Self {
+        Self { failure }
+    }
+    pub fn failure(&self) -> PairingFailure {
+        self.failure
+    }
+    fn presentation(&self) -> UserFacingError {
+        let (title, detail) = match self.failure {
+            PairingFailure::Cancelled => ("Pairing cancelled", "No TV was saved."),
+            PairingFailure::Rejected => ("Connection declined on TV", "Start pairing again and use the TV remote to allow the connection request."),
+            PairingFailure::Timeout => ("The TV did not respond in time", "Check that the TV is on and reachable, then try again. Accept the connection request on the TV when it appears."),
+            PairingFailure::Verification => ("TV access could not be verified", "Check that this TV supports LG Buddy’s power, sound, and OLED brightness controls, then try again."),
+            PairingFailure::Connection => ("Could not connect to the TV", "Check the IP address, turn the TV on, and make sure it is on the same network."),
+            PairingFailure::Persistence => ("Could not save the TV", "Run LG Buddy as your normal user. Check that its configuration folder is writable and that another setup has not already configured a TV."),
+        };
+        UserFacingError::new(title, detail)
+    }
+}
+
+pub trait PairingBackend: Send + Sync + 'static {
+    fn pair(
+        &self,
+        operation: &PairingOperation,
+        progress: &mut dyn FnMut(PairingStage),
+    ) -> Result<TvProfile, PairingError>;
+}
+
+#[derive(Debug, Default)]
+pub struct EnvironmentPairingBackend;
+
+impl PairingBackend for EnvironmentPairingBackend {
+    fn pair(
+        &self,
+        operation: &PairingOperation,
+        progress: &mut dyn FnMut(PairingStage),
+    ) -> Result<TvProfile, PairingError> {
+        let path = ConfigPathResolver::resolve_from_env()
+            .map_err(|_| PairingError::new(PairingFailure::Persistence))?;
+        pair_and_save(operation, &path, progress, |progress| {
+            WebOsClient::pair_in_memory(
+                WebOsEndpoint::wss(operation.request.address),
+                Duration::from_secs(3),
+                Duration::from_secs(60),
+                &|| operation.is_cancelled(),
+                &mut |event| {
+                    progress(match event {
+                        WebOsPairingEvent::WaitingForConfirmation => {
+                            PairingStage::WaitingForConfirmation
+                        }
+                        WebOsPairingEvent::Verifying => PairingStage::Verifying,
+                    })
+                },
+            )
+            .map_err(|error| {
+                PairingError::new(match error {
+                    WebOsPairingError::Cancelled => PairingFailure::Cancelled,
+                    WebOsPairingError::Rejected => PairingFailure::Rejected,
+                    WebOsPairingError::Timeout => PairingFailure::Timeout,
+                    WebOsPairingError::VerificationFailed => PairingFailure::Verification,
+                    WebOsPairingError::Failed => PairingFailure::Connection,
+                })
+            })
+            .map(|(_client, token)| token)
+        })
+    }
+}
+
+fn pair_and_save(
+    operation: &PairingOperation,
+    path: &std::path::Path,
+    progress: &mut dyn FnMut(PairingStage),
+    authenticate: impl FnOnce(
+        &mut dyn FnMut(PairingStage),
+    )
+        -> Result<crate::platform_access_token::PlatformAccessToken, PairingError>,
+) -> Result<TvProfile, PairingError> {
+    if operation.is_cancelled() {
+        return Err(PairingError::new(PairingFailure::Cancelled));
+    }
+    let persistence_error = || PairingError::new(PairingFailure::Persistence);
+    let store = PairingStore::prepare(path).map_err(|_| persistence_error())?;
+    let token = authenticate(progress)?;
+    if !operation.begin_save() {
+        return Err(PairingError::new(PairingFailure::Cancelled));
+    }
+    progress(PairingStage::Saving);
+    let request = operation.request;
+    store
+        .commit(request.address, request.mac, request.input, &token)
+        .map_err(|_| persistence_error())?;
+    Ok(TvProfile::new(
+        TvId::primary(),
+        "Primary TV",
+        request.address,
+        request.mac,
+        request.input,
+        TvPlatform::LgWebOs,
+        TvCredentialState::Stored,
+    ))
+}
+
+#[derive(Debug)]
+pub(crate) struct PairingApplication {
+    draft: PairingDraft,
+    stage: PairingStage,
+    error: Option<UserFacingError>,
+    active: Option<PairingOperation>,
+}
+
+pub(crate) enum PairingUpdate {
+    Changed,
+    Start(PairingOperation),
+    Cancelled,
+}
+
+impl PairingApplication {
+    pub fn new() -> Self {
+        Self {
+            draft: PairingDraft::default(),
+            stage: PairingStage::Editing,
+            error: None,
+            active: None,
+        }
+    }
+
+    pub fn presentation(&self) -> PairingPresentation {
+        PairingPresentation::new(self.draft.clone(), self.stage, self.error.clone())
+    }
+
+    pub fn handle_intent(
+        &mut self,
+        intent: PairingIntent,
+        operation_id: u64,
+    ) -> Option<PairingUpdate> {
+        if intent == PairingIntent::Cancel {
+            if self.active.as_ref().is_none_or(PairingOperation::cancel) {
+                return Some(PairingUpdate::Cancelled);
+            }
+            self.stage = PairingStage::Saving;
+            return Some(PairingUpdate::Changed);
+        }
+        if self.active.is_some() {
+            return None;
+        }
+        match intent {
+            PairingIntent::SetAddress(value) => self.draft.address = value,
+            PairingIntent::SetMac(value) => self.draft.mac = value,
+            PairingIntent::SetInput(value) => self.draft.input = value,
+            PairingIntent::Submit => {
+                let request = match validate(&self.draft) {
+                    Ok(request) => request,
+                    Err(error) => {
+                        self.error = Some(error);
+                        self.stage = PairingStage::Failed;
+                        return Some(PairingUpdate::Changed);
+                    }
+                };
+                let operation = PairingOperation {
+                    id: operation_id,
+                    request,
+                    gate: Arc::new(AtomicU8::new(ACTIVE)),
+                };
+                self.active = Some(operation.clone());
+                self.error = None;
+                self.stage = PairingStage::Connecting;
+                return Some(PairingUpdate::Start(operation));
+            }
+            PairingIntent::Cancel => unreachable!(),
+        }
+        self.error = None;
+        self.stage = PairingStage::Editing;
+        Some(PairingUpdate::Changed)
+    }
+
+    pub fn progress(&mut self, operation: &PairingOperation, stage: PairingStage) -> bool {
+        if self.active.as_ref() != Some(operation) {
+            return false;
+        }
+        let valid = matches!(
+            (self.stage, stage),
+            (
+                PairingStage::Connecting,
+                PairingStage::WaitingForConfirmation | PairingStage::Verifying
+            ) | (
+                PairingStage::WaitingForConfirmation,
+                PairingStage::Verifying
+            ) | (PairingStage::Verifying, PairingStage::Saving)
+        );
+        if valid {
+            self.stage = stage;
+        }
+        valid
+    }
+
+    pub fn complete(
+        &mut self,
+        operation: &PairingOperation,
+        result: &Result<TvProfile, PairingError>,
+    ) -> bool {
+        if self.active.as_ref() != Some(operation) {
+            return false;
+        }
+        self.active = None;
+        if let Err(error) = result {
+            self.stage = PairingStage::Failed;
+            self.error = Some(error.presentation());
+        }
+        true
+    }
+
+    pub fn shutdown(&self) {
+        if let Some(operation) = &self.active {
+            operation.cancel();
+        }
+    }
+}
+
+fn validate(draft: &PairingDraft) -> Result<PairingRequest, UserFacingError> {
+    let address = draft
+        .address
+        .trim()
+        .parse::<Ipv4Addr>()
+        .ok()
+        .filter(|address| {
+            !address.is_unspecified() && !address.is_multicast() && !address.is_broadcast()
+        })
+        .ok_or_else(|| {
+            UserFacingError::new(
+                "Enter the TV’s IP address",
+                "Use an IPv4 address such as 192.168.1.50.",
+            )
+        })?;
+    let mac = draft.mac.trim().parse::<MacAddress>().ok()
+        .filter(|mac| mac.octets() != [0; 6] && mac.octets()[0] & 1 == 0)
+        .ok_or_else(|| UserFacingError::new("Enter the TV’s MAC address", "Use six pairs of hexadecimal digits, such as 02:11:22:33:44:55. Use the address of the TV’s network connection."))?;
+    Ok(PairingRequest {
+        address,
+        mac,
+        input: draft.input,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::presentation::tvs::TvsStatus;
+    use crate::tvs::{TvsApplication, TvsIntent, TvsTransition};
+
+    #[test]
+    fn workflow_publishes_only_verified_uncancelled_profiles() {
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        use crate::platform_access_token::{PlatformAccessToken, PlatformAccessTokenStore};
+        use crate::settings::SettingsStore;
+        use std::fs;
+        let root =
+            std::env::temp_dir().join(format!("lg-buddy-pairing-workflow-{}", std::process::id()));
+        fs::create_dir_all(&root).unwrap();
+        for (index, outcome) in [
+            Some(PairingFailure::Rejected),
+            Some(PairingFailure::Timeout),
+            Some(PairingFailure::Verification),
+            Some(PairingFailure::Cancelled),
+            None,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let path = root.join(index.to_string()).join("config.env");
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let original = b"# Preserve unrelated settings\nscreen_idle_timeout=42\n";
+            fs::write(&path, original).unwrap();
+            let (mut app, _) = blank();
+            let operation = submit(&mut app);
+            let mut stages = Vec::new();
+            let result = pair_and_save(
+                &operation,
+                &path,
+                &mut |stage| stages.push(stage),
+                |progress| {
+                    assert_eq!(fs::read(&path).unwrap(), original);
+                    assert!(!path
+                        .parent()
+                        .unwrap()
+                        .join("tvs/primary/access-token.json")
+                        .exists());
+                    progress(PairingStage::WaitingForConfirmation);
+                    progress(PairingStage::Verifying);
+                    match outcome {
+                        Some(PairingFailure::Cancelled) => {
+                            assert!(operation.cancel());
+                        }
+                        Some(failure) => return Err(PairingError::new(failure)),
+                        None => {}
+                    }
+                    Ok(PlatformAccessToken::new("test-client-key").unwrap())
+                },
+            );
+            match outcome {
+                Some(failure) => {
+                    assert_eq!(result.unwrap_err().failure(), failure);
+                    assert_eq!(fs::read(&path).unwrap(), original);
+                    assert!(!path
+                        .parent()
+                        .unwrap()
+                        .join("tvs/primary/access-token.json")
+                        .exists());
+                    assert!(!stages.contains(&PairingStage::Saving));
+                }
+                None => {
+                    let result = result.unwrap();
+                    let settings = SettingsStore::load(&path).unwrap();
+                    assert_eq!(
+                        settings.raw_storage_value("tvs_primary_ip"),
+                        Some("192.0.2.10")
+                    );
+                    assert_eq!(
+                        settings.raw_storage_value("tvs_primary_platform"),
+                        Some("lg_webos")
+                    );
+                    let token_store = PlatformAccessTokenStore::for_primary_profile(
+                        &path,
+                        crate::auth::resolve_config_owner(&path).unwrap(),
+                    )
+                    .unwrap();
+                    assert_eq!(
+                        token_store.load().unwrap(),
+                        Some(PlatformAccessToken::new("test-client-key").unwrap())
+                    );
+                    let complete = app.complete_pairing(&operation, Ok(result)).unwrap();
+                    assert!(complete.profile_created());
+                    assert_eq!(stages.last(), Some(&PairingStage::Saving));
+                    let retry = pair_and_save(&operation, &path, &mut |_| {}, |_| {
+                        panic!("existing profile must refuse before connecting")
+                    });
+                    assert_eq!(retry.unwrap_err().failure(), PairingFailure::Persistence);
+                }
+            }
+        }
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    fn blank() -> (TvsApplication, TvsTransition) {
+        let (mut app, opening) = TvsApplication::open();
+        assert!(opening.presentation().pair_action().is_none());
+        let transition = app
+            .complete_read(opening.read_operation().unwrap(), Ok(vec![]))
+            .unwrap();
+        (app, transition)
+    }
+
+    fn submit(app: &mut TvsApplication) -> PairingOperation {
+        app.handle_intent(TvsIntent::PairTv).unwrap();
+        app.handle_intent(TvsIntent::Pairing(PairingIntent::SetAddress(
+            "192.0.2.10".into(),
+        )))
+        .unwrap();
+        app.handle_intent(TvsIntent::Pairing(PairingIntent::SetMac(
+            "02:11:22:33:44:55".into(),
+        )))
+        .unwrap();
+        app.handle_intent(TvsIntent::Pairing(PairingIntent::SetInput(
+            HdmiInput::Hdmi3,
+        )))
+        .unwrap();
+        let transition = app
+            .handle_intent(TvsIntent::Pairing(PairingIntent::Submit))
+            .unwrap();
+        assert!(transition.presentation().pair_action().is_none());
+        assert_eq!(
+            transition.presentation().pairing().unwrap().stage(),
+            PairingStage::Connecting
+        );
+        transition.pairing_operation().unwrap().clone()
+    }
+
+    fn profile(operation: &PairingOperation) -> TvProfile {
+        let request = operation.request();
+        TvProfile::new(
+            TvId::primary(),
+            "Primary TV",
+            request.address(),
+            request.mac(),
+            request.input(),
+            TvPlatform::LgWebOs,
+            TvCredentialState::Stored,
+        )
+    }
+
+    #[test]
+    fn first_tv_moves_from_blank_state_through_confirmation_to_details() {
+        let (mut app, empty) = blank();
+        assert_eq!(
+            empty.presentation().pair_action().unwrap().intent(),
+            TvsIntent::PairTv
+        );
+        let operation = submit(&mut app);
+        for (stage, fraction) in [
+            (PairingStage::WaitingForConfirmation, 0.25),
+            (PairingStage::Verifying, 0.5),
+        ] {
+            let update = app.pairing_progress(&operation, stage).unwrap();
+            assert_eq!(update.presentation().pairing().unwrap().stage(), stage);
+            assert_eq!(
+                update.presentation().pairing().unwrap().progress_fraction(),
+                Some(fraction)
+            );
+            assert!(update.toast_message().is_none());
+        }
+        assert!(operation.begin_save());
+        let saving = app
+            .pairing_progress(&operation, PairingStage::Saving)
+            .unwrap();
+        assert!(!saving.presentation().pairing().unwrap().can_cancel());
+        let saved = app
+            .complete_pairing(&operation, Ok(profile(&operation)))
+            .unwrap();
+        assert!(saved.profile_created());
+        assert_eq!(saved.toast_message(), Some("TV paired successfully"));
+        assert_eq!(saved.presentation().profiles().len(), 1);
+        assert_eq!(
+            saved.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi3
+        );
+        assert!(saved.presentation().pairing().is_none());
+        assert!(saved.presentation().pair_action().is_none());
+        assert!(app.handle_intent(TvsIntent::PairTv).is_none());
+    }
+
+    #[test]
+    fn cancel_at_each_network_stage_returns_to_blank_and_rejects_late_results() {
+        for stage in [
+            PairingStage::Connecting,
+            PairingStage::WaitingForConfirmation,
+            PairingStage::Verifying,
+        ] {
+            let (mut app, _) = blank();
+            let operation = submit(&mut app);
+            if stage != PairingStage::Connecting {
+                app.pairing_progress(&operation, stage);
+            }
+            let cancelled = app
+                .handle_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+                .unwrap();
+            assert!(operation.is_cancelled());
+            assert!(!operation.begin_save());
+            assert!(matches!(
+                cancelled.presentation().status(),
+                TvsStatus::Empty { .. }
+            ));
+            assert!(cancelled.presentation().pair_action().is_some());
+            assert!(cancelled.toast_message().is_none());
+            assert!(app
+                .pairing_progress(&operation, PairingStage::Verifying)
+                .is_none());
+            assert!(app
+                .complete_pairing(&operation, Ok(profile(&operation)))
+                .is_none());
+            let second = submit(&mut app);
+            assert_ne!(second, operation);
+            assert!(app
+                .complete_pairing(&operation, Ok(profile(&operation)))
+                .is_none());
+        }
+    }
+
+    #[test]
+    fn failures_retain_editable_details_but_no_profile() {
+        for failure in [
+            PairingFailure::Rejected,
+            PairingFailure::Timeout,
+            PairingFailure::Verification,
+            PairingFailure::Connection,
+            PairingFailure::Persistence,
+        ] {
+            let (mut app, _) = blank();
+            let operation = submit(&mut app);
+            let failed = app
+                .complete_pairing(&operation, Err(PairingError::new(failure)))
+                .unwrap();
+            let presentation = failed.presentation().pairing().unwrap();
+            assert_eq!(presentation.stage(), PairingStage::Failed);
+            assert_eq!(presentation.address(), "192.0.2.10");
+            assert!(presentation.error().is_some());
+            assert!(presentation.can_submit());
+            assert!(failed.presentation().profiles().is_empty());
+            assert!(!failed.profile_created());
+            assert_eq!(
+                failed.toast_message(),
+                Some(presentation.error().unwrap().summary())
+            );
+            assert!(presentation.progress_fraction().is_none());
+            let retry = app
+                .handle_intent(TvsIntent::Pairing(PairingIntent::Submit))
+                .unwrap();
+            assert!(retry.pairing_operation().is_some());
+            assert!(retry.toast_message().is_none());
+        }
+    }
+
+    #[test]
+    fn malformed_form_never_starts_io_and_cancellation_discards_draft() {
+        let (mut app, _) = blank();
+        app.handle_intent(TvsIntent::PairTv).unwrap();
+        let invalid = app
+            .handle_intent(TvsIntent::Pairing(PairingIntent::Submit))
+            .unwrap();
+        assert!(invalid.pairing_operation().is_none());
+        assert!(invalid.toast_message().is_none());
+        assert!(invalid
+            .presentation()
+            .pairing()
+            .unwrap()
+            .error()
+            .unwrap()
+            .summary()
+            .contains("IP"));
+        app.handle_intent(TvsIntent::Pairing(PairingIntent::SetAddress(
+            "192.0.2.10".into(),
+        )))
+        .unwrap();
+        let invalid = app
+            .handle_intent(TvsIntent::Pairing(PairingIntent::Submit))
+            .unwrap();
+        assert!(invalid.pairing_operation().is_none());
+        assert!(invalid
+            .presentation()
+            .pairing()
+            .unwrap()
+            .error()
+            .unwrap()
+            .summary()
+            .contains("MAC"));
+        app.handle_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+            .unwrap();
+        let fresh = app.handle_intent(TvsIntent::PairTv).unwrap();
+        assert!(fresh.presentation().pairing().unwrap().address().is_empty());
+    }
+
+    #[test]
+    fn saving_wins_late_cancel_and_shutdown_cancels_only_uncommitted_work() {
+        let (mut app, _) = blank();
+        let operation = submit(&mut app);
+        assert!(operation.begin_save());
+        let cancel = app
+            .handle_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+            .unwrap();
+        assert_eq!(
+            cancel.presentation().pairing().unwrap().stage(),
+            PairingStage::Saving
+        );
+        assert!(!operation.is_cancelled());
+        assert!(app
+            .complete_pairing(&operation, Ok(profile(&operation)))
+            .unwrap()
+            .profile_created());
+
+        let (mut app, _) = blank();
+        let operation = submit(&mut app);
+        assert!(app
+            .handle_intent(TvsIntent::Pairing(PairingIntent::Submit))
+            .is_none());
+        app.shutdown();
+        assert!(operation.is_cancelled());
+        assert!(app
+            .complete_pairing(&operation, Ok(profile(&operation)))
+            .is_none());
+        assert!(app.handle_intent(TvsIntent::PairTv).is_none());
+    }
+
+    #[test]
+    fn validate_unicast_addresses_and_normalize_whitespace() {
+        let mut draft = PairingDraft {
+            address: " 192.0.2.10 ".into(),
+            mac: " 02:11:22:33:44:FF ".into(),
+            input: HdmiInput::Hdmi1,
+        };
+        assert_eq!(
+            validate(&draft).unwrap().mac.to_string(),
+            "02:11:22:33:44:ff"
+        );
+        for address in ["0.0.0.0", "255.255.255.255", "224.0.0.1", "not-an-ip"] {
+            draft.address = address.into();
+            assert!(validate(&draft).is_err());
+        }
+        draft.address = "192.0.2.10".into();
+        for mac in [
+            "00:00:00:00:00:00",
+            "ff:ff:ff:ff:ff:ff",
+            "01:11:22:33:44:55",
+            "bad",
+        ] {
+            draft.mac = mac.into();
+            assert!(validate(&draft).is_err());
+        }
+    }
+}

--- a/crates/lg-buddy/src/pairing.rs
+++ b/crates/lg-buddy/src/pairing.rs
@@ -13,7 +13,9 @@ use crate::pairing_store::PairingStore;
 use crate::presentation::{brightness::UserFacingError, pairing::PairingPresentation};
 use crate::settings::ConfigPathResolver;
 use crate::tvs::{TvCredentialState, TvId, TvProfile};
-use crate::web_os::{WebOsClient, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent};
+use crate::web_os::{
+    WebOsClient, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent, WebOsPairingReadError,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PairingIntent {
@@ -119,6 +121,7 @@ pub enum PairingFailure {
     Verification,
     Connection,
     Persistence,
+    Internal,
 }
 
 /// Contains only application-owned guidance, never a server frame or token.
@@ -142,6 +145,7 @@ impl PairingError {
             PairingFailure::Verification => ("TV access could not be verified", "Check that this TV supports LG Buddy’s power, sound, and OLED brightness controls, then try again."),
             PairingFailure::Connection => ("Could not connect to the TV", "Check the IP address, turn the TV on, and make sure it is on the same network."),
             PairingFailure::Persistence => ("Could not save the TV", "Run LG Buddy as your normal user. Check that its configuration folder is writable and that another setup has not already configured a TV."),
+            PairingFailure::Internal => ("Pairing stopped unexpectedly", "Restart LG Buddy to check whether the TV was saved before trying again."),
         };
         UserFacingError::new(title, detail)
     }
@@ -166,33 +170,68 @@ impl PairingBackend for EnvironmentPairingBackend {
     ) -> Result<TvProfile, PairingError> {
         let path = ConfigPathResolver::resolve_from_env()
             .map_err(|_| PairingError::new(PairingFailure::Persistence))?;
-        pair_and_save(operation, &path, progress, |progress| {
-            WebOsClient::pair_in_memory(
-                WebOsEndpoint::wss(operation.request.address),
-                Duration::from_secs(3),
-                Duration::from_secs(60),
-                &|| operation.is_cancelled(),
-                &mut |event| {
-                    progress(match event {
-                        WebOsPairingEvent::WaitingForConfirmation => {
-                            PairingStage::WaitingForConfirmation
-                        }
-                        WebOsPairingEvent::Verifying => PairingStage::Verifying,
-                    })
-                },
-            )
-            .map_err(|error| {
-                PairingError::new(match error {
-                    WebOsPairingError::Cancelled => PairingFailure::Cancelled,
-                    WebOsPairingError::Rejected => PairingFailure::Rejected,
-                    WebOsPairingError::Timeout => PairingFailure::Timeout,
-                    WebOsPairingError::VerificationFailed => PairingFailure::Verification,
-                    WebOsPairingError::Failed => PairingFailure::Connection,
-                })
-            })
-            .map(|(_client, token)| token)
-        })
+        pair_and_save_webos(
+            operation,
+            &path,
+            WebOsEndpoint::wss(operation.request.address),
+            progress,
+        )
     }
+}
+
+fn pair_and_save_webos(
+    operation: &PairingOperation,
+    path: &std::path::Path,
+    endpoint: WebOsEndpoint,
+    progress: &mut dyn FnMut(PairingStage),
+) -> Result<TvProfile, PairingError> {
+    pair_and_save(operation, path, progress, |progress| {
+        let (mut client, token) = WebOsClient::pair_in_memory(
+            endpoint,
+            Duration::from_secs(3),
+            Duration::from_secs(60),
+            &|| operation.is_cancelled(),
+            &mut |event| match event {
+                WebOsPairingEvent::WaitingForConfirmation => {
+                    progress(PairingStage::WaitingForConfirmation)
+                }
+            },
+        )
+        .map_err(|error| {
+            PairingError::new(match error {
+                WebOsPairingError::Cancelled => PairingFailure::Cancelled,
+                WebOsPairingError::Rejected => PairingFailure::Rejected,
+                WebOsPairingError::Timeout => PairingFailure::Timeout,
+                WebOsPairingError::Failed => PairingFailure::Connection,
+            })
+        })?;
+
+        progress(PairingStage::Verifying);
+        const VERIFICATION_TIMEOUT: Duration = Duration::from_secs(3);
+        client
+            .power_state_with_cancellation(VERIFICATION_TIMEOUT, &|| operation.is_cancelled())
+            .map_err(map_pairing_read_error)?;
+        client
+            .audio_status_with_cancellation(VERIFICATION_TIMEOUT, &|| operation.is_cancelled())
+            .map_err(map_pairing_read_error)?;
+        client
+            .backlight_brightness_with_cancellation(VERIFICATION_TIMEOUT, &|| {
+                operation.is_cancelled()
+            })
+            .map_err(map_pairing_read_error)?;
+        if operation.is_cancelled() {
+            return Err(PairingError::new(PairingFailure::Cancelled));
+        }
+        Ok(token)
+    })
+}
+
+fn map_pairing_read_error(error: WebOsPairingReadError) -> PairingError {
+    PairingError::new(match error {
+        WebOsPairingReadError::Cancelled => PairingFailure::Cancelled,
+        WebOsPairingReadError::Timeout => PairingFailure::Timeout,
+        WebOsPairingReadError::Failed => PairingFailure::Verification,
+    })
 }
 
 fn pair_and_save(
@@ -375,6 +414,167 @@ mod tests {
     use super::*;
     use crate::presentation::tvs::TvsStatus;
     use crate::tvs::{TvsApplication, TvsIntent, TvsTransition};
+    use crate::web_os::test_support::{WebOsTestScenario, WebOsTestServer, WebOsTestVersion};
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn pairing_test_path(label: &str) -> std::path::PathBuf {
+        let sequence = TEST_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "lg-buddy-pairing-verification-{label}-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&root).unwrap();
+        root.join("config.env")
+    }
+
+    fn skip_pairing_tests_as_root() -> bool {
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    #[test]
+    fn environment_pairing_verifies_capabilities_before_saving() {
+        if skip_pairing_tests_as_root() {
+            return;
+        }
+        use crate::auth::resolve_config_owner;
+        use crate::platform_access_token::PlatformAccessTokenStore;
+        use crate::settings::SettingsStore;
+        use std::fs;
+
+        let path = pairing_test_path("success");
+        let original = b"# Preserve unrelated settings\nscreen_idle_timeout=42\n";
+        fs::write(&path, original).unwrap();
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StatefulTv,
+        );
+        let (mut app, _) = blank();
+        let operation = submit(&mut app);
+        let mut stages = Vec::new();
+
+        let profile = pair_and_save_webos(&operation, &path, server.endpoint(), &mut |stage| {
+            stages.push(stage);
+            assert_eq!(fs::read(&path).unwrap(), original);
+            assert!(!path
+                .parent()
+                .unwrap()
+                .join("tvs/primary/access-token.json")
+                .exists());
+        })
+        .expect("pairing should verify before saving");
+
+        assert_eq!(profile.address(), operation.request().address());
+        assert_eq!(
+            stages,
+            vec![
+                PairingStage::WaitingForConfirmation,
+                PairingStage::Verifying,
+                PairingStage::Saving,
+            ]
+        );
+        assert_eq!(
+            SettingsStore::load(&path)
+                .unwrap()
+                .raw_storage_value("tvs_primary_ip"),
+            Some("192.0.2.10")
+        );
+        let token_store = PlatformAccessTokenStore::for_primary_profile(
+            &path,
+            resolve_config_owner(&path).unwrap(),
+        )
+        .unwrap();
+        assert!(token_store.load().unwrap().is_some());
+        server.finish();
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn environment_pairing_verification_failure_does_not_save() {
+        if skip_pairing_tests_as_root() {
+            return;
+        }
+        use std::fs;
+
+        let path = pairing_test_path("verification-failure");
+        let original = b"# Preserve unrelated settings\nscreen_idle_timeout=42\n";
+        fs::write(&path, original).unwrap();
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PowerStatePermissionDenied,
+        );
+        let (mut app, _) = blank();
+        let operation = submit(&mut app);
+        let mut stages = Vec::new();
+
+        let error = pair_and_save_webos(&operation, &path, server.endpoint(), &mut |stage| {
+            stages.push(stage)
+        })
+        .expect_err("capability denial must prevent saving");
+
+        assert_eq!(error.failure(), PairingFailure::Verification);
+        assert_eq!(
+            stages,
+            vec![
+                PairingStage::WaitingForConfirmation,
+                PairingStage::Verifying,
+            ]
+        );
+        assert_eq!(fs::read(&path).unwrap(), original);
+        assert!(!path
+            .parent()
+            .unwrap()
+            .join("tvs/primary/access-token.json")
+            .exists());
+        server.finish();
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
+
+    #[test]
+    fn cancellation_at_verifying_skips_capability_requests_and_save() {
+        if skip_pairing_tests_as_root() {
+            return;
+        }
+        use std::fs;
+
+        let path = pairing_test_path("cancel-verifying");
+        let original = b"# Preserve unrelated settings\nscreen_idle_timeout=42\n";
+        fs::write(&path, original).unwrap();
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PowerStatePermissionDenied,
+        );
+        let (mut app, _) = blank();
+        let operation = submit(&mut app);
+        let operation_for_progress = operation.clone();
+        let mut stages = Vec::new();
+
+        let error = pair_and_save_webos(&operation, &path, server.endpoint(), &mut |stage| {
+            stages.push(stage);
+            if stage == PairingStage::Verifying {
+                assert!(operation_for_progress.cancel());
+            }
+        })
+        .expect_err("cancellation must stop before the first capability read");
+
+        assert_eq!(error.failure(), PairingFailure::Cancelled);
+        assert_eq!(
+            stages,
+            vec![
+                PairingStage::WaitingForConfirmation,
+                PairingStage::Verifying,
+            ]
+        );
+        assert_eq!(fs::read(&path).unwrap(), original);
+        assert!(!path
+            .parent()
+            .unwrap()
+            .join("tvs/primary/access-token.json")
+            .exists());
+        server.finish();
+        fs::remove_dir_all(path.parent().unwrap()).unwrap();
+    }
 
     #[test]
     fn workflow_publishes_only_verified_uncancelled_profiles() {

--- a/crates/lg-buddy/src/pairing_store.rs
+++ b/crates/lg-buddy/src/pairing_store.rs
@@ -1,0 +1,999 @@
+//! First-TV pairing persistence.
+//!
+//! Pairing has two durable outputs: the native webOS access token and the
+//! primary-TV settings in `config.env`.  This module keeps the workflow
+//! reversible until the config file is published.  There is still an
+//! unavoidable crash window between those two filesystem operations; callers
+//! should therefore treat a successfully returned commit as the completion
+//! boundary and repair an interrupted pairing on the next attempt.
+
+use crate::auth::{resolve_config_owner, AuthContextError, SystemUser};
+use crate::config::{parse_config_entries, HdmiInput, MacAddress};
+use crate::platform_access_token::{
+    PlatformAccessToken, PlatformAccessTokenStore, PlatformAccessTokenStoreError,
+};
+use std::error::Error;
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::net::Ipv4Addr;
+use std::path::{Path, PathBuf};
+use std::process;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+
+const LOCK_FILE_SUFFIX: &str = ".pairing.lock";
+const TV_KEYS: &[&str] = &[
+    "tvs_primary_ip",
+    "tv_ip",
+    "tvs_primary_mac",
+    "tv_mac",
+    "tvs_primary_input",
+    "input",
+    "tvs_primary_platform",
+];
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A prepared, exclusive first-TV pairing transaction.
+///
+/// Preparing one takes a narrow lock which remains held until this value is
+/// committed or dropped. Dropping it releases the kernel lock; the inert
+/// marker remains so every process locks the same inode, including after a crash.
+pub(crate) struct PairingStore {
+    config_path: PathBuf,
+    snapshot: Option<Vec<u8>>,
+    owner: SystemUser,
+    token_store: PlatformAccessTokenStore,
+    token_before: Option<TokenBefore>,
+    profile_dir_existed: bool,
+    tvs_dir_existed: bool,
+    _lock: PairingLock,
+}
+
+impl PairingStore {
+    /// Prepare a first-primary-TV transaction before starting network pairing.
+    pub(crate) fn prepare(config_path: &Path) -> Result<Self, PairingStoreError> {
+        prepare_with_euid(config_path, current_euid())
+    }
+
+    /// Persist the verified native webOS pairing result.
+    pub(crate) fn commit(
+        self,
+        address: Ipv4Addr,
+        mac: MacAddress,
+        input: HdmiInput,
+        token: &PlatformAccessToken,
+    ) -> Result<(), PairingStoreError> {
+        if current_euid() == 0 {
+            return Err(PairingStoreError::RunningAsRoot);
+        }
+
+        let current = read_config_snapshot(&self.config_path)?;
+        if current != self.snapshot {
+            return Err(PairingStoreError::ConfigChanged {
+                path: self.config_path.clone(),
+            });
+        }
+
+        let token_path = self.token_store.token_path().to_path_buf();
+        if let Err(source) = self.token_store.persist(token) {
+            let cleanup = self.cleanup_created_dirs();
+            let error = PairingStoreError::TokenWrite {
+                path: token_path,
+                source,
+            };
+            return match cleanup {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(PairingStoreError::Rollback {
+                    operation: Box::new(error),
+                    rollback: Box::new(rollback),
+                }),
+            };
+        }
+
+        let result = (|| {
+            let current = read_config_snapshot(&self.config_path)?;
+            if current != self.snapshot {
+                return Err(PairingStoreError::ConfigChanged {
+                    path: self.config_path.clone(),
+                });
+            }
+
+            let original = self.snapshot.as_deref().unwrap_or_default();
+            let contents = render_first_primary_config(original, address, mac, input);
+            atomic_write_config(
+                &self.config_path,
+                &contents,
+                &self.owner,
+                self.snapshot.is_some(),
+            )
+        })();
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => match self.restore_token() {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(PairingStoreError::Rollback {
+                    operation: Box::new(error),
+                    rollback: Box::new(rollback),
+                }),
+            },
+        }
+    }
+
+    fn restore_token(&self) -> Result<(), PairingStoreError> {
+        let token_path = self.token_store.token_path();
+        match &self.token_before {
+            Some(before) => {
+                atomic_write_bytes(token_path, &before.contents, before.mode).map_err(|source| {
+                    PairingStoreError::TokenRollback {
+                        path: token_path.to_path_buf(),
+                        source,
+                    }
+                })
+            }
+            None => {
+                match fs::symlink_metadata(token_path) {
+                    Ok(metadata) if metadata.file_type().is_file() => {
+                        fs::remove_file(token_path).map_err(|source| {
+                            PairingStoreError::TokenRollback {
+                                path: token_path.to_path_buf(),
+                                source,
+                            }
+                        })?;
+                    }
+                    Ok(_) => {
+                        return Err(PairingStoreError::TokenRollback {
+                            path: token_path.to_path_buf(),
+                            source: io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "credential path changed into a non-file",
+                            ),
+                        });
+                    }
+                    Err(source) if source.kind() == io::ErrorKind::NotFound => {}
+                    Err(source) => {
+                        return Err(PairingStoreError::TokenRollback {
+                            path: token_path.to_path_buf(),
+                            source,
+                        });
+                    }
+                }
+
+                self.cleanup_created_dirs()
+            }
+        }
+    }
+
+    fn cleanup_created_dirs(&self) -> Result<(), PairingStoreError> {
+        let token_path = self.token_store.token_path();
+        if !self.profile_dir_existed {
+            let profile = token_path
+                .parent()
+                .expect("derived token path always has a profile directory");
+            remove_empty_dir(profile)?;
+        }
+        if !self.tvs_dir_existed {
+            let tvs = token_path
+                .parent()
+                .and_then(Path::parent)
+                .expect("derived token path always has a TVs directory");
+            remove_empty_dir(tvs)?;
+        }
+        Ok(())
+    }
+}
+
+fn prepare_with_euid(config_path: &Path, euid: u32) -> Result<PairingStore, PairingStoreError> {
+    if euid == 0 {
+        return Err(PairingStoreError::RunningAsRoot);
+    }
+
+    let parent = config_path
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+        .ok_or_else(|| PairingStoreError::ConfigPathHasNoParent {
+            path: config_path.to_path_buf(),
+        })?;
+
+    let lock_path = config_path.with_file_name(format!(
+        ".{}{}",
+        config_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("config.env"),
+        LOCK_FILE_SUFFIX
+    ));
+    let lock = PairingLock::acquire(lock_path, parent.to_path_buf())?;
+
+    let snapshot = read_config_snapshot(config_path)?;
+    let config_contents =
+        std::str::from_utf8(snapshot.as_deref().unwrap_or_default()).map_err(|source| {
+            PairingStoreError::ConfigRead {
+                path: config_path.to_path_buf(),
+                source: io::Error::new(io::ErrorKind::InvalidData, source),
+            }
+        })?;
+    let entries = parse_config_entries(config_contents);
+    if let Some(key) = TV_KEYS.iter().find(|key| entries.contains_key(**key)) {
+        return Err(PairingStoreError::PrimaryAlreadyConfigured {
+            key: (*key).to_string(),
+        });
+    }
+
+    let owner = resolve_owner(config_path, snapshot.is_some(), euid)?;
+    if owner.uid() == 0 {
+        return Err(PairingStoreError::ConfigOwnedByRoot {
+            path: config_path.to_path_buf(),
+        });
+    }
+    if owner.uid() != euid {
+        return Err(PairingStoreError::ConfigOwnerMismatch {
+            path: config_path.to_path_buf(),
+            owner_uid: owner.uid(),
+            euid,
+        });
+    }
+    let token_store = PlatformAccessTokenStore::for_primary_profile(config_path, owner.clone())
+        .map_err(PairingStoreError::TokenPath)?;
+    let token_path = token_store.token_path().to_path_buf();
+    let token_before = read_existing_token(&token_path)?;
+    let profile_dir = token_path
+        .parent()
+        .expect("derived token path always has a profile directory");
+    let tvs_dir = profile_dir
+        .parent()
+        .expect("derived profile path always has a TVs directory");
+
+    Ok(PairingStore {
+        config_path: config_path.to_path_buf(),
+        snapshot,
+        owner,
+        token_store,
+        token_before,
+        profile_dir_existed: fs::symlink_metadata(profile_dir).is_ok(),
+        tvs_dir_existed: fs::symlink_metadata(tvs_dir).is_ok(),
+        _lock: lock,
+    })
+}
+
+fn resolve_owner(
+    config_path: &Path,
+    config_exists: bool,
+    euid: u32,
+) -> Result<SystemUser, PairingStoreError> {
+    if config_exists {
+        return resolve_config_owner(config_path).map_err(PairingStoreError::Owner);
+    }
+
+    #[cfg(unix)]
+    {
+        let gid = unsafe { libc::getegid() };
+        let username = std::env::var("USER").unwrap_or_else(|_| "unknown".to_string());
+        Ok(SystemUser::new(username, euid, gid, PathBuf::new()))
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (config_path, euid);
+        Err(PairingStoreError::Lock {
+            path: config_path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::Unsupported,
+                format!("native pairing is unsupported on this platform (uid {euid})"),
+            ),
+        })
+    }
+}
+
+fn current_euid() -> u32 {
+    #[cfg(unix)]
+    {
+        unsafe { libc::geteuid() }
+    }
+    #[cfg(not(unix))]
+    {
+        u32::MAX
+    }
+}
+
+fn read_config_snapshot(path: &Path) -> Result<Option<Vec<u8>>, PairingStoreError> {
+    if let Ok(metadata) = fs::symlink_metadata(path) {
+        if metadata.file_type().is_symlink() {
+            return Err(PairingStoreError::ConfigSymlink {
+                path: path.to_path_buf(),
+            });
+        }
+    }
+    match fs::read(path) {
+        Ok(contents) => Ok(Some(contents)),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(source) => Err(PairingStoreError::ConfigRead {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn read_existing_token(path: &Path) -> Result<Option<TokenBefore>, PairingStoreError> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => {
+            return Err(PairingStoreError::TokenRead {
+                path: path.to_path_buf(),
+                source,
+            })
+        }
+    };
+    if !metadata.file_type().is_file() {
+        return Err(PairingStoreError::TokenRead {
+            path: path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::InvalidData,
+                "credential path is not a regular file",
+            ),
+        });
+    }
+
+    let mut options = OpenOptions::new();
+    options.read(true);
+    #[cfg(unix)]
+    options.custom_flags(libc::O_NOFOLLOW);
+    let mut file = options
+        .open(path)
+        .map_err(|source| PairingStoreError::TokenRead {
+            path: path.to_path_buf(),
+            source,
+        })?;
+    let mut contents = Vec::new();
+    file.read_to_end(&mut contents)
+        .map_err(|source| PairingStoreError::TokenRead {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
+    #[cfg(unix)]
+    let mode = metadata.mode();
+    #[cfg(not(unix))]
+    let mode = 0;
+    Ok(Some(TokenBefore { contents, mode }))
+}
+
+fn remove_empty_dir(path: &Path) -> Result<(), PairingStoreError> {
+    match fs::remove_dir(path) {
+        Ok(()) => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(source) if source.kind() == io::ErrorKind::DirectoryNotEmpty => Ok(()),
+        Err(source) => Err(PairingStoreError::TokenRollback {
+            path: path.to_path_buf(),
+            source,
+        }),
+    }
+}
+
+fn render_first_primary_config(
+    original: &[u8],
+    address: Ipv4Addr,
+    mac: MacAddress,
+    input: HdmiInput,
+) -> Vec<u8> {
+    let mut contents = original.to_vec();
+    if !contents.is_empty() && !contents.ends_with(b"\n") {
+        contents.push(b'\n');
+    }
+    contents.extend_from_slice(format!("tvs_primary_ip={address}\n").as_bytes());
+    contents.extend_from_slice(format!("tvs_primary_mac={mac}\n").as_bytes());
+    contents.extend_from_slice(format!("tvs_primary_input={}\n", input.as_str()).as_bytes());
+    contents.extend_from_slice(b"tvs_primary_platform=lg_webos\n");
+    contents
+}
+
+fn atomic_write_config(
+    path: &Path,
+    contents: &[u8],
+    owner: &SystemUser,
+    existed: bool,
+) -> Result<(), PairingStoreError> {
+    let mode = if existed {
+        #[cfg(unix)]
+        {
+            fs::metadata(path)
+                .map_err(|source| PairingStoreError::ConfigWrite {
+                    path: path.to_path_buf(),
+                    source,
+                })?
+                .permissions()
+                .mode()
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            0o600
+        }
+    } else {
+        0o600
+    };
+    let temp = temporary_path(path);
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(mode & 0o7777).custom_flags(libc::O_NOFOLLOW);
+    let mut file = options
+        .open(&temp)
+        .map_err(|source| PairingStoreError::ConfigWrite {
+            path: temp.clone(),
+            source,
+        })?;
+
+    let result = (|| {
+        file.write_all(contents)
+            .map_err(|source| PairingStoreError::ConfigWrite {
+                path: temp.clone(),
+                source,
+            })?;
+        file.flush()
+            .map_err(|source| PairingStoreError::ConfigWrite {
+                path: temp.clone(),
+                source,
+            })?;
+        #[cfg(unix)]
+        {
+            file.set_permissions(fs::Permissions::from_mode(mode & 0o7777))
+                .map_err(|source| PairingStoreError::ConfigWrite {
+                    path: temp.clone(),
+                    source,
+                })?;
+            set_owner(&file, owner).map_err(|source| PairingStoreError::ConfigWrite {
+                path: temp.clone(),
+                source,
+            })?;
+        }
+        file.sync_all()
+            .map_err(|source| PairingStoreError::ConfigWrite {
+                path: temp.clone(),
+                source,
+            })?;
+        drop(file);
+        fs::rename(&temp, path).map_err(|source| PairingStoreError::ConfigWrite {
+            path: path.to_path_buf(),
+            source,
+        })
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+fn atomic_write_bytes(path: &Path, contents: &[u8], mode: u32) -> io::Result<()> {
+    let temp = temporary_path(path);
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(mode & 0o7777).custom_flags(libc::O_NOFOLLOW);
+    let mut file = options.open(&temp)?;
+    let result = (|| {
+        file.write_all(contents)?;
+        file.flush()?;
+        #[cfg(unix)]
+        {
+            file.set_permissions(fs::Permissions::from_mode(mode & 0o7777))?;
+        }
+        file.sync_all()?;
+        drop(file);
+        fs::rename(&temp, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp);
+    }
+    result
+}
+
+fn temporary_path(path: &Path) -> PathBuf {
+    let counter = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("file");
+    path.with_file_name(format!(".{name}.{}.{}.tmp", process::id(), counter))
+}
+
+#[cfg(unix)]
+fn set_owner(file: &File, owner: &SystemUser) -> io::Result<()> {
+    set_owner_ids(file, owner.uid(), owner.gid())
+}
+
+#[cfg(unix)]
+fn set_owner_ids(file: &File, uid: u32, gid: u32) -> io::Result<()> {
+    let result = unsafe { libc::fchown(file.as_raw_fd(), uid, gid) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+struct TokenBefore {
+    contents: Vec<u8>,
+    mode: u32,
+}
+
+#[derive(Debug)]
+struct PairingLock {
+    file: File,
+}
+
+impl PairingLock {
+    fn acquire(path: PathBuf, parent: PathBuf) -> Result<Self, PairingStoreError> {
+        let created_parents = ensure_lock_parent(&parent)?;
+        let mut options = OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        let mut file = match options.open(&path) {
+            Ok(file) => file,
+            Err(source) => {
+                remove_created_parents(&created_parents);
+                return Err(PairingStoreError::Lock { path, source });
+            }
+        };
+        #[cfg(unix)]
+        {
+            let result = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+            if result != 0 {
+                let source = io::Error::last_os_error();
+                remove_created_parents(&created_parents);
+                if source.kind() == io::ErrorKind::WouldBlock {
+                    return Err(PairingStoreError::PairingInProgress { path });
+                }
+                return Err(PairingStoreError::Lock { path, source });
+            }
+        }
+        let _ = writeln!(file, "pid={}", process::id());
+        Ok(Self { file })
+    }
+}
+
+impl Drop for PairingLock {
+    fn drop(&mut self) {
+        let _ = self.file.sync_all();
+    }
+}
+
+fn ensure_lock_parent(parent: &Path) -> Result<Vec<PathBuf>, PairingStoreError> {
+    if parent.is_dir() {
+        return Ok(Vec::new());
+    }
+    if parent.exists() {
+        return Err(PairingStoreError::Lock {
+            path: parent.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "config parent is not a directory",
+            ),
+        });
+    }
+
+    let mut created = Vec::new();
+    let mut current = parent;
+    while !current.exists() {
+        created.push(current.to_path_buf());
+        current = current.parent().ok_or_else(|| PairingStoreError::Lock {
+            path: parent.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::NotFound,
+                "config parent has no existing ancestor",
+            ),
+        })?;
+    }
+    fs::create_dir_all(parent).map_err(|source| PairingStoreError::Lock {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+    #[cfg(unix)]
+    for path in &created {
+        let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+    }
+    Ok(created)
+}
+
+fn remove_created_parents(created: &[PathBuf]) {
+    for path in created {
+        let _ = fs::remove_dir(path);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum PairingStoreError {
+    RunningAsRoot,
+    ConfigPathHasNoParent {
+        path: PathBuf,
+    },
+    PairingInProgress {
+        path: PathBuf,
+    },
+    Lock {
+        path: PathBuf,
+        source: io::Error,
+    },
+    ConfigRead {
+        path: PathBuf,
+        source: io::Error,
+    },
+    ConfigChanged {
+        path: PathBuf,
+    },
+    PrimaryAlreadyConfigured {
+        key: String,
+    },
+    ConfigOwnedByRoot {
+        path: PathBuf,
+    },
+    ConfigOwnerMismatch {
+        path: PathBuf,
+        owner_uid: u32,
+        euid: u32,
+    },
+    ConfigSymlink {
+        path: PathBuf,
+    },
+    Owner(AuthContextError),
+    TokenPath(PlatformAccessTokenStoreError),
+    TokenRead {
+        path: PathBuf,
+        source: io::Error,
+    },
+    TokenWrite {
+        path: PathBuf,
+        source: PlatformAccessTokenStoreError,
+    },
+    ConfigWrite {
+        path: PathBuf,
+        source: io::Error,
+    },
+    TokenRollback {
+        path: PathBuf,
+        source: io::Error,
+    },
+    Rollback {
+        operation: Box<Self>,
+        rollback: Box<Self>,
+    },
+}
+
+impl fmt::Display for PairingStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RunningAsRoot => write!(f, "native TV pairing cannot run as root"),
+            Self::ConfigPathHasNoParent { path } => {
+                write!(
+                    f,
+                    "config path `{}` has no parent directory",
+                    path.display()
+                )
+            }
+            Self::PairingInProgress { path } => {
+                write!(
+                    f,
+                    "another TV pairing is already in progress ({})",
+                    path.display()
+                )
+            }
+            Self::Lock { path, source } => {
+                write!(f, "could not lock `{}`: {source}", path.display())
+            }
+            Self::ConfigRead { path, source } => {
+                write!(f, "could not read config `{}`: {source}", path.display())
+            }
+            Self::ConfigChanged { path } => {
+                write!(f, "config `{}` changed during pairing", path.display())
+            }
+            Self::PrimaryAlreadyConfigured { key } => {
+                write!(f, "primary TV is already configured ({key})")
+            }
+            Self::ConfigOwnedByRoot { path } => {
+                write!(f, "config `{}` is owned by root", path.display())
+            }
+            Self::ConfigOwnerMismatch {
+                path,
+                owner_uid,
+                euid,
+            } => write!(
+                f,
+                "config `{}` is owned by uid {owner_uid}, current uid is {euid}",
+                path.display()
+            ),
+            Self::ConfigSymlink { path } => {
+                write!(f, "config `{}` is a symlink", path.display())
+            }
+            Self::Owner(source) => write!(f, "could not resolve config owner: {source}"),
+            Self::TokenPath(source) => {
+                write!(f, "could not derive native credential path: {source}")
+            }
+            Self::TokenRead { path, source } => write!(
+                f,
+                "could not read native credential `{}`: {source}",
+                path.display()
+            ),
+            Self::TokenWrite { path, source } => write!(
+                f,
+                "could not write native credential `{}`: {source}",
+                path.display()
+            ),
+            Self::ConfigWrite { path, source } => {
+                write!(f, "could not publish config `{}`: {source}", path.display())
+            }
+            Self::TokenRollback { path, source } => write!(
+                f,
+                "could not roll back native credential `{}`: {source}",
+                path.display()
+            ),
+            Self::Rollback {
+                operation,
+                rollback,
+            } => write!(f, "{operation}; rollback also failed: {rollback}"),
+        }
+    }
+}
+
+impl Error for PairingStoreError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Lock { source, .. }
+            | Self::ConfigRead { source, .. }
+            | Self::TokenRead { source, .. }
+            | Self::ConfigWrite { source, .. }
+            | Self::TokenRollback { source, .. } => Some(source),
+            Self::Owner(source) => Some(source),
+            Self::TokenPath(source) => Some(source),
+            Self::TokenWrite { source, .. } => Some(source),
+            Self::Rollback { operation, .. } => Some(operation),
+            Self::RunningAsRoot
+            | Self::ConfigPathHasNoParent { .. }
+            | Self::PairingInProgress { .. }
+            | Self::ConfigChanged { .. }
+            | Self::PrimaryAlreadyConfigured { .. }
+            | Self::ConfigOwnedByRoot { .. }
+            | Self::ConfigOwnerMismatch { .. }
+            | Self::ConfigSymlink { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TestDir(PathBuf);
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let id = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir()
+                .join(format!("lg-buddy-pairing-{name}-{}-{id}", process::id()));
+            fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+
+        fn config(&self) -> PathBuf {
+            self.0.join("config.env")
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn token(value: &str) -> PlatformAccessToken {
+        PlatformAccessToken::new(value).unwrap()
+    }
+
+    fn mac() -> MacAddress {
+        "aa:bb:cc:dd:ee:ff".parse().unwrap()
+    }
+
+    #[test]
+    fn prepare_refuses_root_before_creating_lock() {
+        let dir = TestDir::new("root");
+        let error = prepare_with_euid(&dir.config(), 0)
+            .err()
+            .expect("root guard should reject preparation");
+        assert!(matches!(error, PairingStoreError::RunningAsRoot));
+        assert!(!dir
+            .config()
+            .with_file_name(".config.env.pairing.lock")
+            .exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn prepare_rejects_symlinked_config_without_following_or_replacing_it() {
+        let dir = TestDir::new("symlink");
+        let target = dir.0.join("real-config.env");
+        fs::write(&target, "screen_backend=gnome\n").unwrap();
+        std::os::unix::fs::symlink(&target, dir.config()).unwrap();
+
+        let error = PairingStore::prepare(&dir.config())
+            .err()
+            .expect("symlink config should be rejected");
+        assert!(matches!(error, PairingStoreError::ConfigSymlink { .. }));
+        assert_eq!(
+            fs::read_to_string(target).unwrap(),
+            "screen_backend=gnome\n"
+        );
+        assert!(fs::symlink_metadata(dir.config())
+            .unwrap()
+            .file_type()
+            .is_symlink());
+    }
+
+    #[test]
+    fn successful_commit_preserves_unrelated_config_and_writes_native_profile() {
+        let dir = TestDir::new("success");
+        fs::write(dir.config(), "# keep\nscreen_backend=gnome\n").unwrap();
+        let store = PairingStore::prepare(&dir.config()).unwrap();
+        store
+            .commit(
+                "192.0.2.42".parse().unwrap(),
+                mac(),
+                HdmiInput::Hdmi2,
+                &token("secret"),
+            )
+            .unwrap();
+
+        let config = fs::read_to_string(dir.config()).unwrap();
+        assert!(config.starts_with("# keep\nscreen_backend=gnome\n"));
+        assert!(config.contains("tvs_primary_ip=192.0.2.42\n"));
+        assert!(config.contains("tvs_primary_mac=aa:bb:cc:dd:ee:ff\n"));
+        assert!(config.contains("tvs_primary_input=HDMI_2\n"));
+        assert!(config.contains("tvs_primary_platform=lg_webos\n"));
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        let token: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(token_path).unwrap()).unwrap();
+        assert_eq!(token["access_token"], "secret");
+        assert!(dir
+            .config()
+            .with_file_name(".config.env.pairing.lock")
+            .exists());
+    }
+
+    #[test]
+    fn dropping_prepared_store_cancels_without_durable_changes() {
+        let dir = TestDir::new("cancel");
+        fs::write(dir.config(), "screen_backend=gnome\n").unwrap();
+        {
+            let _store = PairingStore::prepare(&dir.config()).unwrap();
+        }
+        assert_eq!(
+            fs::read_to_string(dir.config()).unwrap(),
+            "screen_backend=gnome\n"
+        );
+        assert!(dir
+            .config()
+            .with_file_name(".config.env.pairing.lock")
+            .exists());
+        assert!(!dir.0.join("tvs").exists());
+    }
+
+    #[test]
+    fn second_primary_is_refused_after_success() {
+        let dir = TestDir::new("second");
+        fs::write(dir.config(), "screen_backend=gnome\n").unwrap();
+        let store = PairingStore::prepare(&dir.config()).unwrap();
+        store
+            .commit(
+                "192.0.2.42".parse().unwrap(),
+                mac(),
+                HdmiInput::Hdmi1,
+                &token("secret"),
+            )
+            .unwrap();
+        assert!(matches!(
+            PairingStore::prepare(&dir.config()),
+            Err(PairingStoreError::PrimaryAlreadyConfigured { .. })
+        ));
+    }
+
+    #[test]
+    fn concurrent_config_mutation_is_rejected_without_writing_token() {
+        let dir = TestDir::new("concurrent");
+        fs::write(dir.config(), "screen_backend=gnome\n").unwrap();
+        let store = PairingStore::prepare(&dir.config()).unwrap();
+        fs::write(dir.config(), "screen_backend=wayland\n").unwrap();
+        let error = store
+            .commit(
+                "192.0.2.42".parse().unwrap(),
+                mac(),
+                HdmiInput::Hdmi1,
+                &token("secret"),
+            )
+            .unwrap_err();
+        assert!(matches!(error, PairingStoreError::ConfigChanged { .. }));
+        assert!(!dir.0.join("tvs").exists());
+    }
+
+    #[test]
+    fn preexisting_orphan_token_is_unchanged_when_prepare_is_cancelled() {
+        let dir = TestDir::new("orphan");
+        fs::write(dir.config(), "screen_backend=gnome\n").unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        let original = b"{\n  \"access_token\": \"orphan\"\n}\n";
+        fs::write(&token_path, original).unwrap();
+        {
+            let _store = PairingStore::prepare(&dir.config()).unwrap();
+        }
+        assert_eq!(fs::read(token_path).unwrap(), original);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dropping_lock_releases_flock_without_replacing_marker_inode() {
+        let dir = TestDir::new("lock-lifecycle");
+        let lock_path = dir.config().with_file_name(".config.env.pairing.lock");
+        let first = PairingLock::acquire(lock_path.clone(), dir.0.clone()).unwrap();
+        let before = fs::metadata(&lock_path).unwrap().ino();
+        drop(first);
+        let after = fs::metadata(&lock_path).unwrap().ino();
+        assert_eq!(before, after);
+
+        let second = PairingLock::acquire(lock_path.clone(), dir.0.clone()).unwrap();
+        drop(second);
+        assert_eq!(fs::metadata(lock_path).unwrap().ino(), before);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_failure_rolls_back_new_token() {
+        let dir = TestDir::new("rollback");
+        fs::write(dir.config(), "screen_backend=gnome\n").unwrap();
+        fs::create_dir_all(dir.0.join("tvs/primary")).unwrap();
+        let store = PairingStore::prepare(&dir.config()).unwrap();
+        fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o500)).unwrap();
+        let result = store.commit(
+            "192.0.2.42".parse().unwrap(),
+            mac(),
+            HdmiInput::Hdmi1,
+            &token("secret"),
+        );
+        fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result.is_err());
+        assert!(!dir.0.join("tvs/primary/access-token.json").exists());
+        assert_eq!(
+            fs::read_to_string(dir.config()).unwrap(),
+            "screen_backend=gnome\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_failure_restores_preexisting_orphan_token_bytes() {
+        let dir = TestDir::new("rollback-orphan");
+        fs::write(dir.config(), "screen_backend=gnome\n").unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        let original = b"orphan bytes that must survive exactly\n";
+        fs::write(&token_path, original).unwrap();
+        let store = PairingStore::prepare(&dir.config()).unwrap();
+        fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o500)).unwrap();
+        let result = store.commit(
+            "192.0.2.42".parse().unwrap(),
+            mac(),
+            HdmiInput::Hdmi1,
+            &token("secret"),
+        );
+        fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(result.is_err());
+        assert_eq!(fs::read(token_path).unwrap(), original);
+    }
+}

--- a/crates/lg-buddy/src/pairing_store.rs
+++ b/crates/lg-buddy/src/pairing_store.rs
@@ -561,7 +561,10 @@ impl PairingLock {
 
 impl Drop for PairingLock {
     fn drop(&mut self) {
-        let _ = self.file.sync_all();
+        // Closing only our descriptor can leave the lock held by a child
+        // between fork and exec. Release the shared open-file-description lock.
+        #[cfg(unix)]
+        let _ = unsafe { libc::flock(self.file.as_raw_fd(), libc::LOCK_UN) };
     }
 }
 
@@ -942,12 +945,23 @@ mod tests {
         let dir = TestDir::new("lock-lifecycle");
         let lock_path = dir.config().with_file_name(".config.env.pairing.lock");
         let first = PairingLock::acquire(lock_path.clone(), dir.0.clone()).unwrap();
+        // A forked child can retain this open file description until exec.
+        let inherited = first.file.try_clone().unwrap();
         let before = fs::metadata(&lock_path).unwrap().ino();
+        assert!(matches!(
+            PairingLock::acquire(lock_path.clone(), dir.0.clone()),
+            Err(PairingStoreError::PairingInProgress { .. })
+        ));
         drop(first);
         let after = fs::metadata(&lock_path).unwrap().ino();
         assert_eq!(before, after);
 
         let second = PairingLock::acquire(lock_path.clone(), dir.0.clone()).unwrap();
+        drop(inherited);
+        assert!(matches!(
+            PairingLock::acquire(lock_path.clone(), dir.0.clone()),
+            Err(PairingStoreError::PairingInProgress { .. })
+        ));
         drop(second);
         assert_eq!(fs::metadata(lock_path).unwrap().ino(), before);
     }

--- a/crates/lg-buddy/src/presentation/mod.rs
+++ b/crates/lg-buddy/src/presentation/mod.rs
@@ -1,3 +1,4 @@
 pub mod brightness;
 pub mod overview;
+pub mod pairing;
 pub mod tvs;

--- a/crates/lg-buddy/src/presentation/pairing.rs
+++ b/crates/lg-buddy/src/presentation/pairing.rs
@@ -75,7 +75,7 @@ impl PairingPresentation {
             PairingStage::WaitingForConfirmation => "Use your TV remote to allow LG Buddy’s connection request. You have one minute to respond.",
             PairingStage::Verifying => "Checking that LG Buddy can read the TV’s power, sound, and brightness controls.",
             PairingStage::Saving => "Saving the verified TV and its access token.",
-            PairingStage::Failed => "No TV configuration was saved. Check the details below and try again.",
+            PairingStage::Failed => "Check the details below for how to continue.",
         }
     }
 }

--- a/crates/lg-buddy/src/presentation/pairing.rs
+++ b/crates/lg-buddy/src/presentation/pairing.rs
@@ -1,0 +1,81 @@
+use super::brightness::UserFacingError;
+use crate::config::HdmiInput;
+use crate::pairing::{PairingDraft, PairingStage};
+
+/// A pairing form or foreground operation, without credentials or I/O policy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PairingPresentation {
+    draft: PairingDraft,
+    stage: PairingStage,
+    error: Option<UserFacingError>,
+}
+
+impl PairingPresentation {
+    pub(crate) fn new(
+        draft: PairingDraft,
+        stage: PairingStage,
+        error: Option<UserFacingError>,
+    ) -> Self {
+        Self {
+            draft,
+            stage,
+            error,
+        }
+    }
+
+    pub fn stage(&self) -> PairingStage {
+        self.stage
+    }
+    pub fn address(&self) -> &str {
+        &self.draft.address
+    }
+    pub fn mac(&self) -> &str {
+        &self.draft.mac
+    }
+    pub fn input(&self) -> HdmiInput {
+        self.draft.input
+    }
+    pub fn error(&self) -> Option<&UserFacingError> {
+        self.error.as_ref()
+    }
+    pub fn can_submit(&self) -> bool {
+        matches!(self.stage, PairingStage::Editing | PairingStage::Failed)
+    }
+    pub fn can_cancel(&self) -> bool {
+        self.stage != PairingStage::Saving
+    }
+
+    /// Completed workflow phases, not an estimate of elapsed or remaining time.
+    /// Successful completion closes pairing and is confirmed by the success toast.
+    pub fn progress_fraction(&self) -> Option<f64> {
+        match self.stage {
+            PairingStage::Editing | PairingStage::Failed => None,
+            PairingStage::Connecting => Some(0.0),
+            PairingStage::WaitingForConfirmation => Some(0.25),
+            PairingStage::Verifying => Some(0.5),
+            PairingStage::Saving => Some(0.75),
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        match self.stage {
+            PairingStage::Editing => "Pair a TV",
+            PairingStage::Connecting => "Connecting to TV",
+            PairingStage::WaitingForConfirmation => "Confirm on Your TV",
+            PairingStage::Verifying => "Verifying TV Access",
+            PairingStage::Saving => "Saving TV",
+            PairingStage::Failed => "Could Not Pair TV",
+        }
+    }
+
+    pub fn description(&self) -> &str {
+        match self.stage {
+            PairingStage::Editing => "Turn on your TV and connect it to the same network. Find its IP and MAC addresses in the TV’s network settings.\n\nRequired: Enable TV On With Mobile / Wake-on-LAN.\nStrongly recommended: Use a static IP address and enable Always Ready.",
+            PairingStage::Connecting => "Keep the TV on while LG Buddy connects.",
+            PairingStage::WaitingForConfirmation => "Use your TV remote to allow LG Buddy’s connection request. You have one minute to respond.",
+            PairingStage::Verifying => "Checking that LG Buddy can read the TV’s power, sound, and brightness controls.",
+            PairingStage::Saving => "Saving the verified TV and its access token.",
+            PairingStage::Failed => "No TV configuration was saved. Check the details below and try again.",
+        }
+    }
+}

--- a/crates/lg-buddy/src/presentation/tvs.rs
+++ b/crates/lg-buddy/src/presentation/tvs.rs
@@ -8,6 +8,8 @@ pub struct TvsPresentation {
     profiles: Vec<TvProfile>,
     selected_id: Option<TvId>,
     retry_action: Option<TvsAction>,
+    pair_action: Option<TvsAction>,
+    pairing: Option<super::pairing::PairingPresentation>,
 }
 
 /// The state a renderer can show without interpreting application policy.
@@ -37,6 +39,8 @@ impl TvsPresentation {
             profiles: Vec::new(),
             selected_id: None,
             retry_action: None,
+            pair_action: None,
+            pairing: None,
         }
     }
 
@@ -45,11 +49,13 @@ impl TvsPresentation {
             title: "TVs".to_string(),
             status: TvsStatus::Empty {
                 title: "No TV configured".to_string(),
-                description: "Configure a TV to see its details here.".to_string(),
+                description: "Pair your TV to control it with LG Buddy.".to_string(),
             },
             profiles: Vec::new(),
             selected_id: None,
             retry_action: None,
+            pair_action: Some(TvsAction::new("Pair a TV", true, TvsIntent::PairTv)),
+            pairing: None,
         }
     }
 
@@ -60,6 +66,8 @@ impl TvsPresentation {
             profiles,
             selected_id: Some(selected_id),
             retry_action: None,
+            pair_action: None,
+            pairing: None,
         }
     }
 
@@ -70,6 +78,8 @@ impl TvsPresentation {
             profiles: Vec::new(),
             selected_id: None,
             retry_action: Some(TvsAction::new("Retry", true, TvsIntent::Retry)),
+            pair_action: None,
+            pairing: None,
         }
     }
 
@@ -97,6 +107,19 @@ impl TvsPresentation {
 
     pub fn retry_action(&self) -> Option<&TvsAction> {
         self.retry_action.as_ref()
+    }
+
+    pub fn pair_action(&self) -> Option<&TvsAction> {
+        self.pair_action.as_ref()
+    }
+
+    pub fn pairing(&self) -> Option<&super::pairing::PairingPresentation> {
+        self.pairing.as_ref()
+    }
+
+    pub(crate) fn set_pairing(&mut self, pairing: super::pairing::PairingPresentation) {
+        self.pair_action = None;
+        self.pairing = Some(pairing);
     }
 }
 
@@ -143,7 +166,7 @@ mod tests {
         assert_eq!(TvCredentialState::Stored.label(), "Stored locally");
         assert!(TvCredentialState::Stored
             .description()
-            .contains("not verified"));
+            .contains("does not establish current access"));
         assert_eq!(
             TvCredentialState::LocalFile.description(),
             "A legacy credential file is present locally; authentication is not verified."

--- a/crates/lg-buddy/src/tvs.rs
+++ b/crates/lg-buddy/src/tvs.rs
@@ -1,9 +1,9 @@
-//! Application-owned, read-only TV profile collection.
+//! Application-owned TV profile collection and first-TV pairing entry point.
 //!
 //! The current durable configuration has one `primary` profile.  The
 //! collection shape is intentional: it lets the renderer exercise selection
 //! and adaptive multi-TV layouts without adding a second-TV storage format or
-//! any pairing workflow to production.
+//! a second-TV pairing workflow to production.
 
 use std::error::Error;
 use std::fmt;
@@ -13,6 +13,10 @@ use std::time::Duration;
 
 use crate::auth::{resolve_bscpylgtv_auth_context_from_env, resolve_config_owner};
 use crate::config::{HdmiInput, MacAddress, TvPlatform};
+use crate::pairing::{
+    PairingApplication, PairingError, PairingFailure, PairingIntent, PairingOperation,
+    PairingStage, PairingUpdate,
+};
 use crate::platform_access_token::{PlatformAccessTokenStore, PlatformAccessTokenStoreError};
 use crate::presentation::brightness::UserFacingError;
 use crate::presentation::tvs::TvsPresentation;
@@ -190,7 +194,7 @@ impl TvCredentialState {
     pub fn description(self) -> &'static str {
         match self {
             Self::Stored => {
-                "A native access token is stored locally; pairing and validity are not verified."
+                "A native access token is stored locally; this does not establish current access to the TV."
             }
             Self::Missing => "No local credential was found.",
             Self::LocalFile => {
@@ -212,6 +216,8 @@ impl TvCredentialState {
 pub enum TvsIntent {
     Select(TvId),
     Retry,
+    PairTv,
+    Pairing(PairingIntent),
 }
 
 /// Opaque identity for one asynchronous profile read.
@@ -243,6 +249,9 @@ pub struct TvsTransition {
     presentation: TvsPresentation,
     read_operation: Option<TvsReadOperation>,
     model_read_operation: Option<TvsModelReadOperation>,
+    pairing_operation: Option<PairingOperation>,
+    profile_created: bool,
+    toast_message: Option<String>,
     diagnostic: Option<String>,
 }
 
@@ -261,6 +270,20 @@ impl TvsTransition {
 
     pub fn diagnostic(&self) -> Option<&str> {
         self.diagnostic.as_deref()
+    }
+
+    pub fn pairing_operation(&self) -> Option<&PairingOperation> {
+        self.pairing_operation.as_ref()
+    }
+
+    /// The durable profile changed, so other application views can reload it.
+    pub fn profile_created(&self) -> bool {
+        self.profile_created
+    }
+
+    /// One-time feedback for this transition, separate from persistent view state.
+    pub fn toast_message(&self) -> Option<&str> {
+        self.toast_message.as_deref()
     }
 }
 
@@ -396,6 +419,7 @@ pub struct TvsApplication {
     state: TvsState,
     next_operation_id: u64,
     pending_model: Option<TvsModelReadOperation>,
+    pairing: Option<PairingApplication>,
 }
 
 impl TvsApplication {
@@ -405,6 +429,7 @@ impl TvsApplication {
             state: TvsState::Loading(operation),
             next_operation_id: 1,
             pending_model: None,
+            pairing: None,
         };
         let transition = application.transition(Some(operation), None);
         (application, transition)
@@ -412,6 +437,32 @@ impl TvsApplication {
 
     pub fn handle_intent(&mut self, intent: TvsIntent) -> Option<TvsTransition> {
         match intent {
+            TvsIntent::PairTv => {
+                if !matches!(self.state, TvsState::Empty) || self.pairing.is_some() {
+                    return None;
+                }
+                self.pairing = Some(PairingApplication::new());
+                Some(self.transition(None, None))
+            }
+            TvsIntent::Pairing(intent) => {
+                let update = self
+                    .pairing
+                    .as_mut()?
+                    .handle_intent(intent, self.next_operation_id)?;
+                match update {
+                    PairingUpdate::Changed => Some(self.transition(None, None)),
+                    PairingUpdate::Cancelled => {
+                        self.pairing = None;
+                        Some(self.transition(None, None))
+                    }
+                    PairingUpdate::Start(operation) => {
+                        self.next_operation_id += 1;
+                        let mut transition = self.transition(None, None);
+                        transition.pairing_operation = Some(operation);
+                        Some(transition)
+                    }
+                }
+            }
             TvsIntent::Retry => {
                 if !matches!(self.state, TvsState::Failed(_)) {
                     return None;
@@ -495,8 +546,62 @@ impl TvsApplication {
     }
 
     pub fn shutdown(&mut self) {
+        if let Some(pairing) = &self.pairing {
+            pairing.shutdown();
+        }
+        self.pairing = None;
         self.state = TvsState::Closed;
         self.pending_model = None;
+    }
+
+    pub fn pairing_progress(
+        &mut self,
+        operation: &PairingOperation,
+        stage: PairingStage,
+    ) -> Option<TvsTransition> {
+        self.pairing
+            .as_mut()?
+            .progress(operation, stage)
+            .then(|| self.transition(None, None))
+    }
+
+    pub fn complete_pairing(
+        &mut self,
+        operation: &PairingOperation,
+        result: Result<TvProfile, PairingError>,
+    ) -> Option<TvsTransition> {
+        if !self.pairing.as_mut()?.complete(operation, &result) {
+            return None;
+        }
+        match result {
+            Ok(profile) => {
+                self.pairing = None;
+                self.state = TvsState::Ready {
+                    selected_id: profile.id().clone(),
+                    profiles: vec![profile],
+                };
+                let mut transition = self.transition_with_model_read();
+                transition.profile_created = true;
+                transition.toast_message = Some("TV paired successfully".into());
+                Some(transition)
+            }
+            Err(error) => {
+                if error.failure() == PairingFailure::Cancelled {
+                    self.pairing = None;
+                }
+                let mut transition = self.transition(None, None);
+                transition.toast_message = transition
+                    .presentation()
+                    .pairing()
+                    .and_then(|pairing| pairing.error())
+                    .map(|error| error.summary().to_owned());
+                Some(transition)
+            }
+        }
+    }
+
+    pub fn is_pairing(&self) -> bool {
+        self.pairing.is_some()
     }
 
     fn transition_with_model_read(&mut self) -> TvsTransition {
@@ -533,12 +638,15 @@ impl TvsApplication {
             presentation: self.presentation(),
             read_operation,
             model_read_operation: None,
+            pairing_operation: None,
+            profile_created: false,
+            toast_message: None,
             diagnostic,
         }
     }
 
     fn presentation(&self) -> TvsPresentation {
-        match &self.state {
+        let mut presentation = match &self.state {
             TvsState::Loading(_) => TvsPresentation::loading(),
             TvsState::Empty => TvsPresentation::empty(),
             TvsState::Ready {
@@ -547,7 +655,11 @@ impl TvsApplication {
             } => TvsPresentation::ready(profiles.clone(), selected_id.clone()),
             TvsState::Failed(error) => TvsPresentation::failed(error.clone()),
             TvsState::Closed => TvsPresentation::loading(),
+        };
+        if let Some(pairing) = &self.pairing {
+            presentation.set_pairing(pairing.presentation());
         }
+        presentation
     }
 }
 
@@ -971,7 +1083,7 @@ mod tests {
         );
         assert!(TvCredentialState::Stored
             .description()
-            .contains("not verified"));
+            .contains("does not establish current access"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/tvs.rs
+++ b/crates/lg-buddy/src/tvs.rs
@@ -277,7 +277,7 @@ impl TvsTransition {
     }
 
     /// The durable profile changed, so other application views can reload it.
-    pub fn profile_created(&self) -> bool {
+    pub(crate) fn profile_created(&self) -> bool {
         self.profile_created
     }
 

--- a/crates/lg-buddy/src/web_os/audio.rs
+++ b/crates/lg-buddy/src/web_os/audio.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::error::Error;
 use std::fmt;
 
-const GET_AUDIO_STATUS_URI: &str = "ssap://audio/getStatus";
+pub(crate) const GET_AUDIO_STATUS_URI: &str = "ssap://audio/getStatus";
 const SET_AUDIO_VOLUME_URI: &str = "ssap://audio/setVolume";
 const AUDIO_VOLUME_UP_URI: &str = "ssap://audio/volumeUp";
 const AUDIO_VOLUME_DOWN_URI: &str = "ssap://audio/volumeDown";
@@ -141,7 +141,7 @@ impl WebOsClient {
     }
 }
 
-fn parse_audio_status_response(
+pub(crate) fn parse_audio_status_response(
     response: &Value,
 ) -> Result<WebOsAudioStatus, WebOsAudioStatusError> {
     let payload = match response.get("payload") {

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -17,6 +17,8 @@ use tungstenite::{client_tls_with_config, Connector, HandshakeError, Message, We
 
 const WEBOS_WS_PORT: u16 = 3000;
 const WEBOS_WSS_PORT: u16 = 3001;
+const PAIRING_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
+const PAIRING_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(3);
 
 type WebOsSocket = WebSocket<MaybeTlsStream<TcpStream>>;
 
@@ -84,7 +86,78 @@ pub struct WebOsClient {
     response_timeout: Duration,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebOsPairingEvent {
+    WaitingForConfirmation,
+    Verifying,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WebOsPairingError {
+    Cancelled,
+    Rejected,
+    Timeout,
+    VerificationFailed,
+    Failed,
+}
+
+impl fmt::Display for WebOsPairingError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cancelled => write!(f, "webOS pairing was cancelled"),
+            Self::Rejected => write!(f, "webOS pairing was rejected"),
+            Self::Timeout => write!(f, "webOS pairing timed out"),
+            Self::VerificationFailed => write!(f, "webOS pairing verification failed"),
+            Self::Failed => write!(f, "webOS pairing failed"),
+        }
+    }
+}
+
+impl Error for WebOsPairingError {}
+
 impl WebOsClient {
+    /// Pairs a fresh native webOS client without reading or writing a token
+    /// store. The returned token is owned by the caller and remains in memory
+    /// until it is explicitly persisted by the surrounding profile workflow.
+    pub fn pair_in_memory(
+        endpoint: WebOsEndpoint,
+        connect_timeout: Duration,
+        response_timeout: Duration,
+        cancelled: &dyn Fn() -> bool,
+        on_event: &mut dyn FnMut(WebOsPairingEvent),
+    ) -> Result<(WebOsClient, PlatformAccessToken), WebOsPairingError> {
+        ensure_pairing_uid_not_root(effective_uid())?;
+        if cancelled() {
+            return Err(WebOsPairingError::Cancelled);
+        }
+
+        let mut client = Self::connect(endpoint, connect_timeout, response_timeout)
+            .map_err(|_source| WebOsPairingError::Failed)?;
+        let pairing_deadline = Instant::now()
+            .checked_add(response_timeout)
+            .ok_or(WebOsPairingError::Failed)?;
+
+        let token = client
+            .registration()
+            .register_for_pairing(pairing_deadline, cancelled, on_event)
+            .map_err(pairing_registration_error)?;
+
+        if cancelled() {
+            return Err(WebOsPairingError::Cancelled);
+        }
+        on_event(WebOsPairingEvent::Verifying);
+
+        // Confirmation may reasonably take a minute, while capability reads
+        // should never inherit that long deadline after pairing succeeds.
+        client.response_timeout = response_timeout.min(PAIRING_VERIFICATION_TIMEOUT);
+        client.verify_pairing_capabilities(cancelled)?;
+        if cancelled() {
+            return Err(WebOsPairingError::Cancelled);
+        }
+
+        Ok((client, token))
+    }
+
     /// Connects and authenticates using the stored token only.
     ///
     /// This is the authentication path for background operations. It loads
@@ -196,6 +269,82 @@ impl WebOsClient {
         WebOsClientRegistration { client: self }
     }
 
+    fn verify_pairing_capabilities(
+        &mut self,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<(), WebOsPairingError> {
+        self.verify_pairing_capability(
+            super::power::GET_POWER_STATE_URI,
+            json!({}),
+            cancelled,
+            |response| super::power::parse_power_state_response(response).map(|_| ()),
+        )?;
+        self.verify_pairing_capability(
+            super::audio::GET_AUDIO_STATUS_URI,
+            json!({}),
+            cancelled,
+            |response| super::audio::parse_audio_status_response(response).map(|_| ()),
+        )?;
+        self.verify_pairing_capability(
+            super::picture::GET_SYSTEM_SETTINGS_URI,
+            json!({
+                "category": "picture",
+                "keys": ["backlight"],
+            }),
+            cancelled,
+            |response| super::picture::parse_backlight_brightness_response(response).map(|_| ()),
+        )?;
+        Ok(())
+    }
+
+    fn verify_pairing_capability<F, E>(
+        &mut self,
+        uri: &str,
+        payload: Value,
+        cancelled: &dyn Fn() -> bool,
+        parse: F,
+    ) -> Result<(), WebOsPairingError>
+    where
+        F: FnOnce(&Value) -> Result<(), E>,
+        E: fmt::Display,
+    {
+        if cancelled() {
+            return Err(WebOsPairingError::Cancelled);
+        }
+        let response = self
+            .send_pairing_request(uri, payload, cancelled)
+            .map_err(pairing_verification_transport_error)?;
+        parse(&response).map_err(|_error| WebOsPairingError::VerificationFailed)
+    }
+
+    fn send_pairing_request(
+        &mut self,
+        uri: &str,
+        payload: Value,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Value, PairingTransportError> {
+        set_write_timeout(&mut self.socket, self.response_timeout)
+            .map_err(|_source| PairingTransportError::Failed)?;
+        let request_id = self
+            .next_request_id()
+            .map_err(|_source| PairingTransportError::Failed)?;
+        let request = json!({
+            "id": request_id,
+            "type": "request",
+            "uri": uri,
+            "payload": payload,
+        });
+        self.send_message(request)
+            .map_err(|_source| PairingTransportError::Failed)?;
+        let deadline = Instant::now()
+            .checked_add(self.response_timeout)
+            .ok_or(PairingTransportError::Failed)?;
+        let response = self
+            .receive_correlated_until(&request_id, deadline, cancelled)
+            .map_err(pairing_receive_error)?;
+        validate_response_message(response).map_err(pairing_transport_error_from_client)
+    }
+
     pub(crate) fn send_request(
         &mut self,
         uri: &str,
@@ -295,6 +444,141 @@ impl WebOsClient {
             }
         }
     }
+
+    fn receive_correlated_until(
+        &mut self,
+        request_id: &str,
+        deadline: Instant,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<Value, PairingReceiveError> {
+        loop {
+            if cancelled() {
+                return Err(PairingReceiveError::Cancelled);
+            }
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .ok_or(PairingReceiveError::Timeout)?;
+            if remaining.is_zero() {
+                return Err(PairingReceiveError::Timeout);
+            }
+            set_read_timeout(
+                &mut self.socket,
+                remaining.min(PAIRING_CANCEL_POLL_INTERVAL),
+            )
+            .map_err(|source| {
+                PairingReceiveError::Failed(WebOsClientError::ConfigureSocket { source })
+            })?;
+
+            let message = match self.socket.read() {
+                Ok(message) => message,
+                Err(tungstenite::Error::Io(source))
+                    if matches!(
+                        source.kind(),
+                        io::ErrorKind::TimedOut | io::ErrorKind::WouldBlock
+                    ) =>
+                {
+                    continue
+                }
+                Err(tungstenite::Error::ConnectionClosed | tungstenite::Error::AlreadyClosed) => {
+                    return Err(PairingReceiveError::Failed(
+                        WebOsClientError::ConnectionClosed {
+                            request_id: request_id.to_string(),
+                        },
+                    ))
+                }
+                Err(source) => {
+                    return Err(PairingReceiveError::Failed(WebOsClientError::Receive {
+                        source,
+                    }))
+                }
+            };
+
+            match message {
+                Message::Text(text) => {
+                    if let Some(response) = parse_correlated_frame(request_id, text.as_str())
+                        .map_err(PairingReceiveError::Failed)?
+                    {
+                        return Ok(response);
+                    }
+                }
+                Message::Ping(_) | Message::Pong(_) => {}
+                Message::Close(_) => {
+                    return Err(PairingReceiveError::Failed(
+                        WebOsClientError::ConnectionClosed {
+                            request_id: request_id.to_string(),
+                        },
+                    ))
+                }
+                Message::Binary(_) => {
+                    return Err(PairingReceiveError::Failed(
+                        WebOsClientError::UnexpectedBinaryFrame,
+                    ))
+                }
+                Message::Frame(_) => {
+                    return Err(PairingReceiveError::Failed(
+                        WebOsClientError::UnexpectedRawFrame,
+                    ))
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum PairingTransportError {
+    Cancelled,
+    Timeout,
+    Failed,
+}
+
+#[derive(Debug)]
+enum PairingReceiveError {
+    Cancelled,
+    Timeout,
+    Failed(WebOsClientError),
+}
+
+fn pairing_receive_error(error: PairingReceiveError) -> PairingTransportError {
+    match error {
+        PairingReceiveError::Cancelled => PairingTransportError::Cancelled,
+        PairingReceiveError::Timeout => PairingTransportError::Timeout,
+        PairingReceiveError::Failed(_source) => PairingTransportError::Failed,
+    }
+}
+
+fn pairing_transport_error_from_client(source: WebOsClientError) -> PairingTransportError {
+    match source {
+        WebOsClientError::Timeout { .. } => PairingTransportError::Timeout,
+        _ => PairingTransportError::Failed,
+    }
+}
+
+fn pairing_verification_transport_error(error: PairingTransportError) -> WebOsPairingError {
+    match error {
+        PairingTransportError::Cancelled => WebOsPairingError::Cancelled,
+        PairingTransportError::Timeout => WebOsPairingError::Timeout,
+        PairingTransportError::Failed => WebOsPairingError::VerificationFailed,
+    }
+}
+
+fn effective_uid() -> u32 {
+    #[cfg(unix)]
+    {
+        // SAFETY: geteuid has no preconditions and does not mutate process state.
+        unsafe { libc::geteuid() }
+    }
+    #[cfg(not(unix))]
+    {
+        1
+    }
+}
+
+fn ensure_pairing_uid_not_root(uid: u32) -> Result<(), WebOsPairingError> {
+    if uid == 0 {
+        Err(WebOsPairingError::Failed)
+    } else {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -309,6 +593,52 @@ pub(crate) struct WebOsClientRegistration<'client> {
 }
 
 impl WebOsClientRegistration<'_> {
+    fn register_for_pairing(
+        &mut self,
+        deadline: Instant,
+        cancelled: &dyn Fn() -> bool,
+        on_event: &mut dyn FnMut(WebOsPairingEvent),
+    ) -> Result<PlatformAccessToken, PairingRegistrationError> {
+        if cancelled() {
+            return Err(PairingRegistrationError::Cancelled);
+        }
+        let request_id = self
+            .client
+            .next_request_id()
+            .map_err(|_source| PairingRegistrationError::Failed)?;
+        let request = WebOsRegistrationRequest::new(&request_id, None)
+            .map_err(|_source| PairingRegistrationError::Failed)?;
+        self.client
+            .send_message(request.to_json_value())
+            .map_err(|_source| PairingRegistrationError::Failed)?;
+
+        loop {
+            let response = self
+                .client
+                .receive_correlated_until(&request_id, deadline, cancelled)
+                .map_err(|error| match error {
+                    PairingReceiveError::Cancelled => PairingRegistrationError::Cancelled,
+                    PairingReceiveError::Timeout => PairingRegistrationError::Timeout,
+                    PairingReceiveError::Failed(_source) => PairingRegistrationError::Failed,
+                })?;
+            let event = parse_registration_message(&request_id, &response.to_string()).map_err(
+                |source| match source {
+                    WebOsRegistrationError::PairingRejected { .. } => {
+                        PairingRegistrationError::Rejected
+                    }
+                    _ => PairingRegistrationError::Failed,
+                },
+            )?;
+
+            match event {
+                WebOsRegistrationEvent::PairingPrompt => {
+                    on_event(WebOsPairingEvent::WaitingForConfirmation);
+                }
+                WebOsRegistrationEvent::Registered { access_token } => return Ok(access_token),
+            }
+        }
+    }
+
     pub(crate) fn register<F>(
         &mut self,
         access_token: Option<&PlatformAccessToken>,
@@ -349,6 +679,23 @@ impl WebOsClientRegistration<'_> {
                 WebOsRegistrationEvent::Registered { access_token } => return Ok(access_token),
             }
         }
+    }
+}
+
+#[derive(Debug)]
+enum PairingRegistrationError {
+    Cancelled,
+    Rejected,
+    Timeout,
+    Failed,
+}
+
+fn pairing_registration_error(error: PairingRegistrationError) -> WebOsPairingError {
+    match error {
+        PairingRegistrationError::Cancelled => WebOsPairingError::Cancelled,
+        PairingRegistrationError::Rejected => WebOsPairingError::Rejected,
+        PairingRegistrationError::Timeout => WebOsPairingError::Timeout,
+        PairingRegistrationError::Failed => WebOsPairingError::Failed,
     }
 }
 
@@ -564,6 +911,20 @@ fn set_read_timeout(socket: &mut WebOsSocket, timeout: Duration) -> io::Result<(
     stream.set_read_timeout(Some(timeout))
 }
 
+fn set_write_timeout(socket: &mut WebOsSocket, timeout: Duration) -> io::Result<()> {
+    let stream = match socket.get_mut() {
+        MaybeTlsStream::Plain(stream) => stream,
+        MaybeTlsStream::Rustls(stream) => &mut stream.sock,
+        _ => {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "unsupported webOS TLS stream",
+            ))
+        }
+    };
+    stream.set_write_timeout(Some(timeout))
+}
+
 fn parse_correlated_frame(
     expected_request_id: &str,
     raw_message: &str,
@@ -628,7 +989,7 @@ fn parse_webos_error(message: &serde_json::Map<String, Value>) -> WebOsClientErr
 mod tests {
     use super::{
         WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
-        WebOsClientRegistrationError, WebOsEndpoint,
+        WebOsClientRegistrationError, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent,
     };
     use crate::auth::SystemUser;
     use crate::platform_access_token::{
@@ -643,8 +1004,10 @@ mod tests {
     use std::fs;
     use std::net::TcpListener;
     use std::path::{Path, PathBuf};
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::Duration;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::{Duration, Instant};
 
     const CONNECT_TIMEOUT: Duration = Duration::from_secs(1);
     const RESPONSE_TIMEOUT: Duration = Duration::from_millis(200);
@@ -691,6 +1054,207 @@ mod tests {
 
         PlatformAccessTokenStore::for_primary_profile(&dir.path().join("config.env"), owner)
             .expect("derive test token store")
+    }
+
+    fn pairing_error(
+        result: Result<(WebOsClient, PlatformAccessToken), WebOsPairingError>,
+    ) -> WebOsPairingError {
+        match result {
+            Ok(_) => panic!("pairing unexpectedly succeeded"),
+            Err(error) => error,
+        }
+    }
+
+    #[test]
+    fn pair_in_memory_accepts_and_verifies_without_persisting_token() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StatefulTv,
+        );
+        let mut events = Vec::new();
+        let (mut client, access_token) = WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &|| false,
+            &mut |event| events.push(event),
+        )
+        .expect("pair and verify native webOS client");
+
+        assert_eq!(access_token.as_secret_str(), "webos-test-access-token");
+        assert_eq!(
+            events,
+            vec![
+                WebOsPairingEvent::WaitingForConfirmation,
+                WebOsPairingEvent::Verifying,
+            ]
+        );
+        assert_eq!(
+            server.snapshot().registration_tokens,
+            vec![None],
+            "pairing must register without a stored client key"
+        );
+        assert_eq!(
+            client
+                .power_state()
+                .expect("returned client remains authenticated"),
+            super::super::WebOsPowerState::Active
+        );
+        drop(client);
+        server.finish();
+    }
+
+    #[test]
+    fn pair_in_memory_reports_rejection_without_exposing_credentials() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PairingRejected,
+        );
+        let error = pairing_error(WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &|| false,
+            &mut |_| {},
+        ));
+
+        assert_eq!(error, WebOsPairingError::Rejected);
+        assert!(!format!("{error:?}").contains("webos-test-access-token"));
+        server.finish();
+    }
+
+    #[test]
+    fn pair_in_memory_times_out_waiting_for_confirmation() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::RegistrationTimeout,
+        );
+        let error = pairing_error(WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            Duration::from_millis(80),
+            &|| false,
+            &mut |_| {},
+        ));
+
+        assert_eq!(error, WebOsPairingError::Timeout);
+        server.finish();
+    }
+
+    #[test]
+    fn pair_in_memory_cancellation_interrupts_prompt_wait() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::RegistrationTimeout,
+        );
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancel_after = Arc::clone(&cancelled);
+        let setter = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(80));
+            cancel_after.store(true, Ordering::Release);
+        });
+        let started = Instant::now();
+        let error = pairing_error(WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            Duration::from_secs(2),
+            &|| cancelled.load(Ordering::Acquire),
+            &mut |_| {},
+        ));
+        let elapsed = started.elapsed();
+        setter.join().expect("cancellation setter");
+
+        assert_eq!(error, WebOsPairingError::Cancelled);
+        assert!(
+            elapsed < Duration::from_millis(500),
+            "cancel took {elapsed:?}"
+        );
+        server.finish();
+    }
+
+    #[test]
+    fn cancelling_during_connection_does_not_send_a_pairing_request() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StatefulTv,
+        );
+        let checks = std::cell::Cell::new(0);
+        let error = pairing_error(WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &|| {
+                let previous = checks.get();
+                checks.set(previous + 1);
+                previous > 0
+            },
+            &mut |_| panic!("a cancelled connection must not begin pairing"),
+        ));
+        assert_eq!(error, WebOsPairingError::Cancelled);
+        assert!(server.snapshot().registration_tokens.is_empty());
+        server.finish();
+    }
+
+    #[test]
+    fn pair_in_memory_cancellation_from_prompt_event_skips_verification() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::StatefulTv,
+        );
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancel_on_prompt = Arc::clone(&cancelled);
+        let mut events = Vec::new();
+        let error = pairing_error(WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &|| cancelled.load(Ordering::Acquire),
+            &mut |event| {
+                events.push(event);
+                if event == WebOsPairingEvent::WaitingForConfirmation {
+                    cancel_on_prompt.store(true, Ordering::Release);
+                }
+            },
+        ));
+
+        assert_eq!(error, WebOsPairingError::Cancelled);
+        assert_eq!(events, vec![WebOsPairingEvent::WaitingForConfirmation]);
+        server.finish();
+    }
+
+    #[test]
+    fn pair_in_memory_reports_capability_verification_failure() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PowerStatePermissionDenied,
+        );
+        let mut events = Vec::new();
+        let error = pairing_error(WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &|| false,
+            &mut |event| events.push(event),
+        ));
+
+        assert_eq!(error, WebOsPairingError::VerificationFailed);
+        assert_eq!(
+            events,
+            vec![
+                WebOsPairingEvent::WaitingForConfirmation,
+                WebOsPairingEvent::Verifying,
+            ]
+        );
+        server.finish();
+    }
+
+    #[test]
+    fn pairing_root_guard_rejects_before_network() {
+        assert_eq!(
+            super::ensure_pairing_uid_not_root(0),
+            Err(WebOsPairingError::Failed)
+        );
+        assert!(super::ensure_pairing_uid_not_root(1000).is_ok());
     }
 
     #[test]

--- a/crates/lg-buddy/src/web_os/client.rs
+++ b/crates/lg-buddy/src/web_os/client.rs
@@ -18,7 +18,6 @@ use tungstenite::{client_tls_with_config, Connector, HandshakeError, Message, We
 const WEBOS_WS_PORT: u16 = 3000;
 const WEBOS_WSS_PORT: u16 = 3001;
 const PAIRING_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(50);
-const PAIRING_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(3);
 
 type WebOsSocket = WebSocket<MaybeTlsStream<TcpStream>>;
 
@@ -89,7 +88,6 @@ pub struct WebOsClient {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WebOsPairingEvent {
     WaitingForConfirmation,
-    Verifying,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -97,9 +95,30 @@ pub enum WebOsPairingError {
     Cancelled,
     Rejected,
     Timeout,
-    VerificationFailed,
     Failed,
 }
+
+/// Failure while a caller performs a cancellable typed read after pairing.
+/// The protocol layer deliberately does not choose which reads constitute
+/// verification; the application owns that policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebOsPairingReadError {
+    Cancelled,
+    Timeout,
+    Failed,
+}
+
+impl fmt::Display for WebOsPairingReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cancelled => write!(f, "webOS pairing read was cancelled"),
+            Self::Timeout => write!(f, "webOS pairing read timed out"),
+            Self::Failed => write!(f, "webOS pairing read failed"),
+        }
+    }
+}
+
+impl Error for WebOsPairingReadError {}
 
 impl fmt::Display for WebOsPairingError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -107,7 +126,6 @@ impl fmt::Display for WebOsPairingError {
             Self::Cancelled => write!(f, "webOS pairing was cancelled"),
             Self::Rejected => write!(f, "webOS pairing was rejected"),
             Self::Timeout => write!(f, "webOS pairing timed out"),
-            Self::VerificationFailed => write!(f, "webOS pairing verification failed"),
             Self::Failed => write!(f, "webOS pairing failed"),
         }
     }
@@ -142,15 +160,6 @@ impl WebOsClient {
             .register_for_pairing(pairing_deadline, cancelled, on_event)
             .map_err(pairing_registration_error)?;
 
-        if cancelled() {
-            return Err(WebOsPairingError::Cancelled);
-        }
-        on_event(WebOsPairingEvent::Verifying);
-
-        // Confirmation may reasonably take a minute, while capability reads
-        // should never inherit that long deadline after pairing succeeds.
-        client.response_timeout = response_timeout.min(PAIRING_VERIFICATION_TIMEOUT);
-        client.verify_pairing_capabilities(cancelled)?;
         if cancelled() {
             return Err(WebOsPairingError::Cancelled);
         }
@@ -269,61 +278,83 @@ impl WebOsClient {
         WebOsClientRegistration { client: self }
     }
 
-    fn verify_pairing_capabilities(
+    /// Reads the typed power state for application-owned pairing checks.
+    pub fn power_state_with_cancellation(
         &mut self,
+        response_timeout: Duration,
         cancelled: &dyn Fn() -> bool,
-    ) -> Result<(), WebOsPairingError> {
-        self.verify_pairing_capability(
+    ) -> Result<super::power::WebOsPowerState, WebOsPairingReadError> {
+        self.pairing_read(
             super::power::GET_POWER_STATE_URI,
             json!({}),
+            response_timeout,
             cancelled,
-            |response| super::power::parse_power_state_response(response).map(|_| ()),
-        )?;
-        self.verify_pairing_capability(
+            super::power::parse_power_state_response,
+        )
+    }
+
+    /// Reads the typed audio status for application-owned pairing checks.
+    pub fn audio_status_with_cancellation(
+        &mut self,
+        response_timeout: Duration,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<super::audio::WebOsAudioStatus, WebOsPairingReadError> {
+        self.pairing_read(
             super::audio::GET_AUDIO_STATUS_URI,
             json!({}),
+            response_timeout,
             cancelled,
-            |response| super::audio::parse_audio_status_response(response).map(|_| ()),
-        )?;
-        self.verify_pairing_capability(
+            super::audio::parse_audio_status_response,
+        )
+    }
+
+    /// Reads the typed OLED backlight brightness for application-owned
+    /// pairing checks.
+    pub fn backlight_brightness_with_cancellation(
+        &mut self,
+        response_timeout: Duration,
+        cancelled: &dyn Fn() -> bool,
+    ) -> Result<super::picture::WebOsBacklightBrightness, WebOsPairingReadError> {
+        self.pairing_read(
             super::picture::GET_SYSTEM_SETTINGS_URI,
             json!({
                 "category": "picture",
                 "keys": ["backlight"],
             }),
+            response_timeout,
             cancelled,
-            |response| super::picture::parse_backlight_brightness_response(response).map(|_| ()),
-        )?;
-        Ok(())
+            super::picture::parse_backlight_brightness_response,
+        )
     }
 
-    fn verify_pairing_capability<F, E>(
+    fn pairing_read<T, E>(
         &mut self,
         uri: &str,
         payload: Value,
+        response_timeout: Duration,
         cancelled: &dyn Fn() -> bool,
-        parse: F,
-    ) -> Result<(), WebOsPairingError>
-    where
-        F: FnOnce(&Value) -> Result<(), E>,
-        E: fmt::Display,
-    {
+        parse: impl FnOnce(&Value) -> Result<T, E>,
+    ) -> Result<T, WebOsPairingReadError> {
         if cancelled() {
-            return Err(WebOsPairingError::Cancelled);
+            return Err(WebOsPairingReadError::Cancelled);
         }
         let response = self
-            .send_pairing_request(uri, payload, cancelled)
-            .map_err(pairing_verification_transport_error)?;
-        parse(&response).map_err(|_error| WebOsPairingError::VerificationFailed)
+            .send_pairing_request(uri, payload, response_timeout, cancelled)
+            .map_err(pairing_read_transport_error)?;
+        parse(&response).map_err(|_error| WebOsPairingReadError::Failed)
     }
 
     fn send_pairing_request(
         &mut self,
         uri: &str,
         payload: Value,
+        response_timeout: Duration,
         cancelled: &dyn Fn() -> bool,
     ) -> Result<Value, PairingTransportError> {
-        set_write_timeout(&mut self.socket, self.response_timeout)
+        if response_timeout.is_zero() {
+            return Err(PairingTransportError::Failed);
+        }
+        set_write_timeout(&mut self.socket, response_timeout)
             .map_err(|_source| PairingTransportError::Failed)?;
         let request_id = self
             .next_request_id()
@@ -337,7 +368,7 @@ impl WebOsClient {
         self.send_message(request)
             .map_err(|_source| PairingTransportError::Failed)?;
         let deadline = Instant::now()
-            .checked_add(self.response_timeout)
+            .checked_add(response_timeout)
             .ok_or(PairingTransportError::Failed)?;
         let response = self
             .receive_correlated_until(&request_id, deadline, cancelled)
@@ -553,11 +584,11 @@ fn pairing_transport_error_from_client(source: WebOsClientError) -> PairingTrans
     }
 }
 
-fn pairing_verification_transport_error(error: PairingTransportError) -> WebOsPairingError {
+fn pairing_read_transport_error(error: PairingTransportError) -> WebOsPairingReadError {
     match error {
-        PairingTransportError::Cancelled => WebOsPairingError::Cancelled,
-        PairingTransportError::Timeout => WebOsPairingError::Timeout,
-        PairingTransportError::Failed => WebOsPairingError::VerificationFailed,
+        PairingTransportError::Cancelled => WebOsPairingReadError::Cancelled,
+        PairingTransportError::Timeout => WebOsPairingReadError::Timeout,
+        PairingTransportError::Failed => WebOsPairingReadError::Failed,
     }
 }
 
@@ -990,6 +1021,7 @@ mod tests {
     use super::{
         WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
         WebOsClientRegistrationError, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent,
+        WebOsPairingReadError,
     };
     use crate::auth::SystemUser;
     use crate::platform_access_token::{
@@ -999,7 +1031,7 @@ mod tests {
     use crate::web_os::test_support::{
         WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
     };
-    use crate::web_os::{WebOsPowerStateError, WebOsRegistrationError};
+    use crate::web_os::{WebOsAudioVolume, WebOsPowerStateError, WebOsRegistrationError};
     use serde_json::json;
     use std::fs;
     use std::net::TcpListener;
@@ -1066,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn pair_in_memory_accepts_and_verifies_without_persisting_token() {
+    fn pair_in_memory_accepts_without_choosing_verification_checks() {
         let server = WebOsTestServer::for_scenario(
             WebOsTestVersion::WebOs24Version92261,
             WebOsTestScenario::StatefulTv,
@@ -1079,16 +1111,10 @@ mod tests {
             &|| false,
             &mut |event| events.push(event),
         )
-        .expect("pair and verify native webOS client");
+        .expect("pair native webOS client");
 
         assert_eq!(access_token.as_secret_str(), "webos-test-access-token");
-        assert_eq!(
-            events,
-            vec![
-                WebOsPairingEvent::WaitingForConfirmation,
-                WebOsPairingEvent::Verifying,
-            ]
-        );
+        assert_eq!(events, vec![WebOsPairingEvent::WaitingForConfirmation,]);
         assert_eq!(
             server.snapshot().registration_tokens,
             vec![None],
@@ -1096,11 +1122,45 @@ mod tests {
         );
         assert_eq!(
             client
-                .power_state()
+                .power_state_with_cancellation(RESPONSE_TIMEOUT, &|| false)
                 .expect("returned client remains authenticated"),
             super::super::WebOsPowerState::Active
         );
+        assert_eq!(
+            client
+                .audio_status_with_cancellation(RESPONSE_TIMEOUT, &|| false)
+                .expect("typed audio read")
+                .volume(),
+            WebOsAudioVolume::Known(20)
+        );
+        assert_eq!(
+            client
+                .backlight_brightness_with_cancellation(RESPONSE_TIMEOUT, &|| false)
+                .expect("typed backlight read")
+                .as_percent(),
+            100
+        );
         drop(client);
+        server.finish();
+    }
+
+    #[test]
+    fn pair_in_memory_does_not_verify_capabilities_before_returning() {
+        let server = WebOsTestServer::for_scenario(
+            WebOsTestVersion::WebOs24Version92261,
+            WebOsTestScenario::PowerStatePermissionDenied,
+        );
+        let result = WebOsClient::pair_in_memory(
+            server.endpoint(),
+            CONNECT_TIMEOUT,
+            RESPONSE_TIMEOUT,
+            &|| false,
+            &mut |_| {},
+        );
+
+        // This scenario rejects the first power read. A successful pair proves
+        // that capability verification starts only when the caller asks.
+        assert!(result.is_ok());
         server.finish();
     }
 
@@ -1223,27 +1283,23 @@ mod tests {
     }
 
     #[test]
-    fn pair_in_memory_reports_capability_verification_failure() {
+    fn cancellable_typed_pairing_read_reports_protocol_failure() {
         let server = WebOsTestServer::for_scenario(
             WebOsTestVersion::WebOs24Version92261,
             WebOsTestScenario::PowerStatePermissionDenied,
         );
-        let mut events = Vec::new();
-        let error = pairing_error(WebOsClient::pair_in_memory(
+        let (mut client, _) = WebOsClient::pair_in_memory(
             server.endpoint(),
             CONNECT_TIMEOUT,
             RESPONSE_TIMEOUT,
             &|| false,
-            &mut |event| events.push(event),
-        ));
+            &mut |_| {},
+        )
+        .expect("pairing should finish before capability checks");
 
-        assert_eq!(error, WebOsPairingError::VerificationFailed);
         assert_eq!(
-            events,
-            vec![
-                WebOsPairingEvent::WaitingForConfirmation,
-                WebOsPairingEvent::Verifying,
-            ]
+            client.power_state_with_cancellation(RESPONSE_TIMEOUT, &|| false),
+            Err(WebOsPairingReadError::Failed)
         );
         server.finish();
     }

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -13,7 +13,7 @@ mod registration;
 mod screen;
 mod system_info;
 #[cfg(test)]
-mod test_support;
+pub(crate) mod test_support;
 mod tls;
 
 pub(crate) use adapter::WebOsPairingPolicy;
@@ -23,6 +23,7 @@ pub(crate) use client::WebOsClientRegistration;
 pub use client::{
     WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
     WebOsClientRegistrationError, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent,
+    WebOsPairingReadError,
 };
 pub use control::WebOsControlError;
 pub use input::{WebOsForegroundApp, WebOsForegroundAppError, WebOsInputId, WebOsInputIdError};

--- a/crates/lg-buddy/src/web_os/mod.rs
+++ b/crates/lg-buddy/src/web_os/mod.rs
@@ -22,7 +22,7 @@ pub use audio::{WebOsAudioStatus, WebOsAudioStatusError, WebOsAudioVolume};
 pub(crate) use client::WebOsClientRegistration;
 pub use client::{
     WebOsAuthenticatedClientError, WebOsAuthenticationEvent, WebOsClient, WebOsClientError,
-    WebOsClientRegistrationError, WebOsEndpoint,
+    WebOsClientRegistrationError, WebOsEndpoint, WebOsPairingError, WebOsPairingEvent,
 };
 pub use control::WebOsControlError;
 pub use input::{WebOsForegroundApp, WebOsForegroundAppError, WebOsInputId, WebOsInputIdError};

--- a/crates/lg-buddy/src/web_os/picture.rs
+++ b/crates/lg-buddy/src/web_os/picture.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::thread;
 use std::time::Duration;
 
-const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
+pub(crate) const GET_SYSTEM_SETTINGS_URI: &str = "ssap://settings/getSystemSettings";
 const CREATE_ALERT_URI: &str = "ssap://system.notifications/createAlert";
 const CLOSE_ALERT_URI: &str = "ssap://system.notifications/closeAlert";
 const SET_SYSTEM_SETTINGS_LUNA_URI: &str = "luna://com.webos.settingsservice/setSystemSettings";
@@ -316,7 +316,7 @@ fn close_alert_id(
     Ok(format!("{ALERT_ID_CLOSE_PREFIX}{sequence}"))
 }
 
-fn parse_backlight_brightness_response(
+pub(crate) fn parse_backlight_brightness_response(
     response: &Value,
 ) -> Result<WebOsBacklightBrightness, WebOsBacklightBrightnessError> {
     let payload = match response.get("payload") {

--- a/crates/lg-buddy/src/web_os/power.rs
+++ b/crates/lg-buddy/src/web_os/power.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use std::error::Error;
 use std::fmt;
 
-const GET_POWER_STATE_URI: &str = "ssap://com.webos.service.tvpower/power/getPowerState";
+pub(crate) const GET_POWER_STATE_URI: &str = "ssap://com.webos.service.tvpower/power/getPowerState";
 const POWER_OFF_URI: &str = "ssap://system/turnOff";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -120,7 +120,9 @@ impl WebOsClient {
     }
 }
 
-fn parse_power_state_response(response: &Value) -> Result<WebOsPowerState, WebOsPowerStateError> {
+pub(crate) fn parse_power_state_response(
+    response: &Value,
+) -> Result<WebOsPowerState, WebOsPowerStateError> {
     let payload = match response.get("payload") {
         Some(Value::Object(payload)) => payload,
         Some(_) => return Err(WebOsPowerStateError::InvalidPayload),

--- a/crates/lg-buddy/src/web_os/test_support.rs
+++ b/crates/lg-buddy/src/web_os/test_support.rs
@@ -1,5 +1,4 @@
 mod test_server;
 
-pub(super) use test_server::{
-    TestAccessTokenStore, WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
-};
+pub(super) use test_server::{TestAccessTokenStore, WebOsTestInput};
+pub(crate) use test_server::{WebOsTestScenario, WebOsTestServer, WebOsTestVersion};

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -60,7 +60,7 @@ static TEST_DIR_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 static WRITE_SETTINGS_SIGNED_ENVELOPE: OnceLock<Value> = OnceLock::new();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::web_os) enum WebOsTestScenario {
+pub(crate) enum WebOsTestScenario {
     StatefulTv,
     ProtocolEcho,
     UnrelatedFrameBeforeResponse,
@@ -83,7 +83,7 @@ pub(in crate::web_os) enum WebOsTestScenario {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::web_os) enum WebOsTestVersion {
+pub(crate) enum WebOsTestVersion {
     // Local hardware baseline: webOS24 / 9.2.2-61.
     WebOs24Version92261,
     // External hardware observation: webOS26 firmware 43.21.60.
@@ -97,7 +97,7 @@ enum WebOsTestTransport {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(in crate::web_os) enum WebOsTestInput {
+pub(crate) enum WebOsTestInput {
     Hdmi2,
     Hdmi3,
 }
@@ -570,7 +570,7 @@ struct WebOsTestRuntime {
     restore_session_interruption_injected: bool,
 }
 
-pub(in crate::web_os) struct WebOsTestServer {
+pub(crate) struct WebOsTestServer {
     endpoint: WebOsEndpoint,
     address: std::net::SocketAddr,
     runtime: Arc<Mutex<WebOsTestRuntime>>,
@@ -600,10 +600,7 @@ impl WebOsTestServer {
         )
     }
 
-    pub(in crate::web_os) fn for_scenario(
-        version: WebOsTestVersion,
-        scenario: WebOsTestScenario,
-    ) -> Self {
+    pub(crate) fn for_scenario(version: WebOsTestVersion, scenario: WebOsTestScenario) -> Self {
         Self::spawn(
             version,
             WebOsPowerState::Active,
@@ -742,7 +739,7 @@ impl WebOsTestServer {
         )
     }
 
-    pub(in crate::web_os) fn endpoint(&self) -> WebOsEndpoint {
+    pub(crate) fn endpoint(&self) -> WebOsEndpoint {
         self.endpoint
     }
 
@@ -799,7 +796,7 @@ impl WebOsTestServer {
         }
     }
 
-    pub(in crate::web_os) fn finish(mut self) {
+    pub(crate) fn finish(mut self) {
         self.stop_and_join().expect("webOS test server thread");
     }
 

--- a/crates/lg-buddy/tests/tvs_profiles.rs
+++ b/crates/lg-buddy/tests/tvs_profiles.rs
@@ -46,7 +46,7 @@ fn environment_backend_reads_primary_profile_and_only_local_token_metadata() {
     assert_eq!(profile.credentials(), TvCredentialState::Stored);
     assert!(TvCredentialState::Stored
         .description()
-        .contains("not verified"));
+        .contains("does not establish current access"));
     assert_eq!(
         fs::read(config.path()).expect("config after read"),
         original

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -502,8 +502,11 @@ persistence remain in the core. Pairing is refused as root. The access token
 stays in memory until verification succeeds; the primary profile is published
 last, with credential rollback on a failed save. Accepted cancellation prevents
 publication. Once saving begins, it finishes even if the window closes.
-Success opens the new TV details and refreshes Overview with fresh operation
-identities. This does not install or activate services.
+The toolkit-independent application coordinator opens the new TV details and
+refreshes Overview with fresh operation identities after success. The application
+backend selects the capability checks; the webOS client supplies authentication
+and cancellable reads. GTK forwards unexpected worker termination to the core
+as an internal failure. This does not install or activate services.
 The `volume` family uses the TV audio abstraction for typed volume and mute
 operations. Setting or stepping volume explicitly unmutes after the volume
 operation; mute toggle reads the current state before writing its inverse.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -494,6 +494,16 @@ produces a blank state, one TV opens directly to details, and only multi-profile
 renderer fixtures expose the TV-selection sidebar. Production storage remains
 limited to one primary profile. Tab changes retain pending Overview operations
 and do not initiate TV writes or pairing.
+The zero-TV blank state offers first-TV pairing through a separate foreground
+application workflow. GTK forwards the native webOS form and cancellation
+intents, and worker progress describes connecting, TV confirmation, verification,
+and saving. Validation, protocol authentication, capability checks, and credential
+persistence remain in the core. Pairing is refused as root. The access token
+stays in memory until verification succeeds; the primary profile is published
+last, with credential rollback on a failed save. Accepted cancellation prevents
+publication. Once saving begins, it finishes even if the window closes.
+Success opens the new TV details and refreshes Overview with fresh operation
+identities. This does not install or activate services.
 The `volume` family uses the TV audio abstraction for typed volume and mute
 operations. Setting or stepping volume explicitly unmutes after the volume
 operation; mute toggle reads the current state before writing its inverse.

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ Compiling the Rust runtime requires:
 Compiling and testing the GTK frontend additionally requires:
 
 - GTK 4.10 or newer development files
-- libadwaita 1.4 or newer development files
+- libadwaita 1.5 or newer development files
 - `pkg-config`
 - a graphical session or virtual display for renderer tests
 - `xdotool` for the executable launch smoke test

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -606,8 +606,10 @@ owns field validation, connecting, confirmation guidance, capability verificatio
 failure recovery, and cancellation. GTK declares no network or persistence
 policy and never shells out to the CLI.
 
-The foreground worker pairs into memory and verifies power, audio, and OLED
-brightness reads before saving. Both pairing and profile persistence refuse
+The foreground application backend pairs into memory, then chooses and sequences
+power, audio, and OLED brightness verification before saving. The webOS client
+provides authentication and cancellable typed reads; it does not decide which
+capabilities the pairing workflow requires. Both pairing and profile persistence refuse
 root execution. The existing `tvs/primary/access-token.json` location is used,
 and the configuration file is published atomically after the token. A failed
 configuration save restores the prior credential state. A process crash between
@@ -619,7 +621,11 @@ progress and results from cancelled attempts. Once publication starts, dialog
 dismissal is disabled; the worker is allowed to finish on application
 window close. Success shows the new TV details and reloads Overview without
 accepting its earlier empty-state
-results. No second-TV flow, discovery, legacy-platform pairing, or service setup
+results. A toolkit-independent application coordinator owns this cross-view
+refresh and coordinates application close with pairing cancellation. GTK only
+executes declared operations and renders updates. An unexpected worker exit is
+reported to the coordinator as an internal failure, not as a TV connection error.
+No second-TV flow, discovery, legacy-platform pairing, or service setup
 is included.
 
 Headless workflow tests cover validation, confirmation, rejection, timeout,

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -140,7 +140,7 @@ The headless binary retains its static `x86_64-unknown-linux-musl` release
 target. The GTK binary is a separate dynamically linked
 `x86_64-unknown-linux-gnu` artifact. Ubuntu 24.04 is the oldest release-bundle
 build and runtime baseline: GTK 4.14, libadwaita 1.5, and GLIBC 2.39. The source
-contract remains limited to GTK 4.10 APIs and libadwaita 1.4, but compatibility
+contract remains limited to GTK 4.10 APIs and libadwaita 1.5, but compatibility
 below the tested bundle baseline is not claimed. Fedora 43 and current Arch
 validate the same built artifact on newer supported userspaces. The release
 manifest and embedded ELF identities verify both artifacts, so the GUI does
@@ -581,7 +581,52 @@ The renderer accepts multi-profile fixtures and shows an adaptive
 `AdwNavigationSplitView` only for more than one presented TV. Selection remains
 an application intent. Production storage still yields zero or one primary
 profile; this increment adds no schema, pairing, repair, or configuration writes.
-Pairing and the empty-state action follow in #174.
+
+## First-TV Pairing Increment
+
+[#174](https://github.com/Staphylococcus/LG_Buddy/issues/174) adds **Pair a TV**
+only to the zero-TV blank state. It opens an adaptive `AdwDialog` with a grouped
+form for the IPv4 address, MAC address, and managed HDMI input; this flow uses
+native webOS. Its action-dialog header contains Cancel, a centered title, and
+Pair; it has no separate close button or footer actions. The dialog keeps
+navigation behind the modal, adapts to smaller windows, and routes Cancel,
+Escape, and native dismissal through the same application intent. Successful
+pairing closes the dialog to reveal TV details and shows a “TV paired successfully”
+toast after verification and saving.
+During pairing, a thin progress bar beneath the header shows completed workflow
+phases: connecting at 0%, TV confirmation at 25%, verification at 50%, and saving
+at 75%. These milestones are not time estimates; success closes the dialog.
+The form and Pair button stay disabled until the attempt ends. General failures
+produce a toast inside the dialog; recovery guidance remains visible in the
+form. Editing, retrying, or dismissing the form clears the failure toast.
+Validation errors remain inline and do not generate toasts.
+The setup guidance marks TV On With Mobile / Wake-on-LAN as required, and a
+static IP address and Always Ready as strongly recommended. The application
+owns field validation, connecting, confirmation guidance, capability verification,
+failure recovery, and cancellation. GTK declares no network or persistence
+policy and never shells out to the CLI.
+
+The foreground worker pairs into memory and verifies power, audio, and OLED
+brightness reads before saving. Both pairing and profile persistence refuse
+root execution. The existing `tvs/primary/access-token.json` location is used,
+and the configuration file is published atomically after the token. A failed
+configuration save restores the prior credential state. A process crash between
+the two publications can leave an orphan token, but no partial TV configuration;
+a subsequent pairing attempt replaces that orphan after verification.
+
+Cancellation is accepted until saving begins. Operation identities reject late
+progress and results from cancelled attempts. Once publication starts, dialog
+dismissal is disabled; the worker is allowed to finish on application
+window close. Success shows the new TV details and reloads Overview without
+accepting its earlier empty-state
+results. No second-TV flow, discovery, legacy-platform pairing, or service setup
+is included.
+
+Headless workflow tests cover validation, confirmation, rejection, timeout,
+verification failure, cancellation, and persistence. Protocol fixtures exercise
+the native webOS exchange; GTK fixtures cover the form and intent mapping, and
+the installed accessibility check covers the blank-state CTA, modal form,
+validation feedback, and dismissal through Escape and the header's Cancel button.
 
 ## Evolution Rules
 

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -18,9 +18,8 @@ DEFAULT_TIMEOUT_SECONDS = 10
 MAX_ACCESSIBLES = 256
 
 
-def accessible_tree() -> list[object]:
-    desktop = pyatspi.Registry.getDesktop(0)
-    pending = [desktop]
+def accessible_tree(root: object | None = None) -> list[object]:
+    pending = [root if root is not None else pyatspi.Registry.getDesktop(0)]
     observed: list[object] = []
     while pending and len(observed) < MAX_ACCESSIBLES:
         accessible = pending.pop()
@@ -99,7 +98,7 @@ def parse_args() -> argparse.Namespace:
         help=f"maximum observation time in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
     )
     parser.add_argument("--select-page", choices=("Overview", "TVs"))
-    parser.add_argument("--expected-tvs-state", choices=("empty", "configured"))
+    parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid"))
     parser.add_argument("--expected-tv-address")
     parser.add_argument("--expected-tv-name", default="Primary TV")
     parser.add_argument("--focus-control", help="focus a control using native Tab navigation")
@@ -117,7 +116,8 @@ def observed_contract(expected_state: str, expected_slider_value: float | None):
     accessibles = accessible_tree()
     if not any(name(item) == WINDOW_TITLE for item in accessibles):
         return None
-    if any(normalized_name(item) in ("Apply", "Apply Volume", "Cancel") for item in accessibles):
+    if any(normalized_name(item) in ("Apply", "Apply Volume", "Cancel")
+           and item.getState().contains(pyatspi.STATE_SHOWING) for item in accessibles):
         raise SystemExit("Overview still exposes a removed action")
     slider = next((item for item in accessibles
         if role(item) == pyatspi.ROLE_SLIDER and name(item) == CONTROL_NAME), None)
@@ -186,10 +186,29 @@ def tvs_contract(expected_state: str, address: str | None, tv_name: str):
         except Exception:
             continue
     names = {normalized_name(item) for item in visible}
-    if any(value in names for value in ("Add TV", "Pair a TV", "Pair a TV…")):
-        raise SystemExit("TVs exposed an action outside the read-only slice")
+    dialogs = [item for item in visible if role(item) == pyatspi.ROLE_DIALOG]
+    if expected_state in ("pairing", "pairing-invalid"):
+        if len(dialogs) != 1 or not {"TV address", "MAC address", "HDMI input", "Cancel", "Pair"} <= names:
+            return None
+        dialog_names = {normalized_name(item) for item in accessible_tree(dialogs[0])}
+        if "Close" in dialog_names:
+            raise SystemExit("Pairing exposed a close button alongside Cancel")
+        if expected_state == "pairing-invalid":
+            if not any(role(item) == pyatspi.ROLE_ALERT and "address" in name(item).lower()
+                       for item in visible):
+                return None
+        elif not any(role(item) == pyatspi.ROLE_TEXT
+                     and item.getState().contains(pyatspi.STATE_FOCUSED) for item in visible):
+            return None
+        return accessibles, None
+    if dialogs:
+        return None
+    if "Add TV" in names:
+        raise SystemExit("TVs exposed an unsupported second-TV action")
     if expected_state == "empty":
-        return (accessibles, None) if "No TV configured" in names else None
+        return (accessibles, None) if {"No TV configured", "Pair a TV"} <= names else None
+    if any(value in names for value in ("Pair a TV", "Pair a TV…")):
+        raise SystemExit("A configured TV exposed the first-TV pairing action")
     if tv_name not in names or (address and address not in names):
         return None
     return accessibles, None
@@ -222,8 +241,14 @@ def main() -> int:
             time.sleep(0.1)
         raise SystemExit(f"could not focus {args.focus_control} through Tab navigation")
     if args.activate_control:
-        for item in accessible_tree():
-            if name(item) == args.activate_control:
+        accessibles = accessible_tree()
+        dialog = next((item for item in accessibles if role(item) == pyatspi.ROLE_DIALOG
+                       and item.getState().contains(pyatspi.STATE_SHOWING)), None)
+        for item in accessible_tree(dialog) if dialog is not None else accessibles:
+            if (name(item) == args.activate_control
+                    and role(item) in (pyatspi.ROLE_PUSH_BUTTON, pyatspi.ROLE_TOGGLE_BUTTON)
+                    and item.getState().contains(pyatspi.STATE_SHOWING)
+                    and item.getState().contains(pyatspi.STATE_SENSITIVE)):
                 if item.queryAction().doAction(0):
                     return 0
         raise SystemExit(f"could not activate {args.activate_control}")
@@ -254,7 +279,7 @@ def main() -> int:
                 print(f"  {role_name(item)}: {name(item)} [{', '.join(flags)}]", file=sys.stderr)
             except Exception:
                 continue
-        expected = f" {args.expected_state} state"
+        expected = f" {args.expected_tvs_state or args.expected_state} state"
         if args.expected_slider_value is not None:
             expected += f" at slider value {args.expected_slider_value:g}"
         raise SystemExit(
@@ -267,7 +292,7 @@ def main() -> int:
         {(role_name(item), name(item)) for item in accessibles if name(item)}
     )
     print("AT-SPI accessibility contract verified:")
-    print(f"  presentation state: {args.expected_state}")
+    print(f"  presentation state: {args.expected_tvs_state or args.expected_state}")
     if slider_value is not None:
         print(f"  slider value: {slider_value:g}")
     for observed_role, accessible_name in observed:

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -277,6 +277,8 @@ def main() -> int:
                     (pyatspi.STATE_CHECKED, "checked"),
                 ) if states.contains(state)]
                 print(f"  {role_name(item)}: {name(item)} [{', '.join(flags)}]", file=sys.stderr)
+                if role(item) == pyatspi.ROLE_SLIDER:
+                    print(f"    value: {item.queryValue().currentValue}", file=sys.stderr)
             except Exception:
                 continue
         expected = f" {args.expected_tvs_state or args.expected_state} state"

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -66,6 +66,12 @@ chmod 755 "$MOCK_COMMAND"
 export LG_BUDDY_CONFIG="$CONFIG_FILE"
 export LG_BUDDY_BSCPYLGTV_COMMAND="$MOCK_COMMAND"
 
+reset_tv_state() {
+    # Cancelled reads may still finish after the GUI exits. Serialize resets
+    # with their writes so an old snapshot cannot replace the next scenario.
+    flock "$STATE_FILE.lock" tee "$STATE_FILE" >/dev/null
+}
+
 start_gui() {
     local accessibility="${1:-disabled}"
     local color_scheme="${2:-}"
@@ -205,7 +211,7 @@ observe_gui_state() {
 
 # Read current state, edit the initially focused brightness slider through the
 # keyboard. Movement submits automatically and keeps Overview open.
-printf '%s\n' '{"backlight":50,"volume":20,"muted":true,"calls":[],"plan":{}}' >"$STATE_FILE"
+printf '%s\n' '{"backlight":50,"volume":20,"muted":true,"calls":[],"plan":{}}' | reset_tv_state
 start_accessibility_bus
 start_gui enabled
 wait_for_calls get_picture_settings 1
@@ -270,7 +276,7 @@ cmp -s "$STATE_FILE" "$WORK_DIR/before-empty.json" || fail "Empty profile perfor
 export LG_BUDDY_CONFIG="$CONFIG_FILE"
 
 # A failed optional model read retains the local TV details.
-printf '%s\n' '{"backlight":50,"calls":[],"plan":{"get_system_info":[{"result":"error","status":1,"stderr":"planned model read failure"}]}}' >"$STATE_FILE"
+printf '%s\n' '{"backlight":50,"calls":[],"plan":{"get_system_info":[{"result":"error","status":1,"stderr":"planned model read failure"}]}}' | reset_tv_state
 start_gui enabled
 wait_for_calls get_system_info 1
 observe_gui_state --select-page TVs
@@ -279,7 +285,7 @@ send_closing_mnemonic Escape
 finish_gui "unavailable TV model"
 
 # A slow write must not disable the slider or discard subsequent movement.
-printf '%s\n' '{"backlight":50,"volume":20,"muted":false,"calls":[],"plan":{"set_settings":[{"result":"success","delay_seconds":0.5,"state_update":{"backlight":55}}]}}' >"$STATE_FILE"
+printf '%s\n' '{"backlight":50,"volume":20,"muted":false,"calls":[],"plan":{"set_settings":[{"result":"success","delay_seconds":0.5,"state_update":{"backlight":55}}]}}' | reset_tv_state
 start_gui enabled
 xdotool windowfocus --sync "$WINDOW_ID"
 observe_gui_state --expected-slider-value 50 --expected-volume 20 --require-brightness-focus
@@ -299,7 +305,7 @@ PY
 
 # A failed read stays visible and Retry performs a fresh read. Observe each
 # rendered presentation before sending the action that depends on it.
-printf '%s\n' '{"backlight":64,"calls":[],"plan":{"get_picture_settings":[{"result":"error","status":1,"stderr":"planned read failure"},{"result":"success","stdout":"{\u0027backlight\u0027: 64}"}]}}' >"$STATE_FILE"
+printf '%s\n' '{"backlight":64,"calls":[],"plan":{"get_picture_settings":[{"result":"error","status":1,"stderr":"planned read failure"},{"result":"success","stdout":"{\u0027backlight\u0027: 64}"}]}}' | reset_tv_state
 start_gui enabled
 wait_for_calls get_picture_settings 1
 observe_gui_state --expected-state read-failed --expected-volume 20 --expected-muted false
@@ -318,7 +324,7 @@ finish_gui "read-failure cancellation"
 
 # Volume succeeded but unmuting failed: show the changed level and recover the
 # remaining mute operation without repeating the successful volume write.
-printf '%s\n' '{"backlight":50,"volume":20,"muted":true,"calls":[],"plan":{"set_mute":[{"result":"error","status":1,"stderr":"planned unmute failure"}]}}' >"$STATE_FILE"
+printf '%s\n' '{"backlight":50,"volume":20,"muted":true,"calls":[],"plan":{"set_mute":[{"result":"error","status":1,"stderr":"planned unmute failure"}]}}' | reset_tv_state
 start_gui enabled
 observe_gui_state --expected-volume 20 --expected-muted true
 xdotool windowfocus --sync "$WINDOW_ID"
@@ -341,13 +347,13 @@ assert sum(call["command"] == "set_volume" for call in state["calls"]) == 1, sta
 PY
 
 # Cancelling the loading window never writes a value.
-printf '%s\n' '{"backlight":37,"calls":[],"plan":{"get_picture_settings":[{"result":"success","stdout":"{\u0027backlight\u0027: 37}","delay_seconds":2}]}}' >"$STATE_FILE"
+printf '%s\n' '{"backlight":37,"calls":[],"plan":{"get_picture_settings":[{"result":"success","stdout":"{\u0027backlight\u0027: 37}","delay_seconds":2}]}}' | reset_tv_state
 start_gui
 xdotool windowfocus --sync "$WINDOW_ID"
 send_closing_mnemonic Escape
 finish_gui "loading cancellation"
-# The read-only subprocess may finish after its window closes. Let this mock
-# finish before reusing its state file for the next scenario.
+# Wait for the delayed brightness read before checking for writes. Other read
+# workers may still be finishing when the next scenario resets the state.
 wait_for_calls get_picture_settings 1
 python3 - "$STATE_FILE" <<'PY'
 import json
@@ -370,7 +376,7 @@ if [ "${LG_BUDDY_TEST_PLATFORM_CONTRACT:-0}" = "1" ]; then
         local geometry=""
         local screenshot="$WORK_DIR/$label.xwd"
 
-        printf '%s\n' '{"backlight":50,"calls":[],"plan":{}}' >"$STATE_FILE"
+        printf '%s\n' '{"backlight":50,"calls":[],"plan":{}}' | reset_tv_state
         start_gui enabled "$color_scheme" "$scale"
         wait_for_calls get_picture_settings 1
         observe_gui_state --expected-state ready --expected-slider-value 50

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -253,6 +253,17 @@ cp "$STATE_FILE" "$WORK_DIR/before-empty.json"
 start_gui enabled
 observe_gui_state --select-page TVs
 observe_gui_state --expected-tvs-state empty
+observe_gui_state --activate-control "Pair a TV"
+observe_gui_state --expected-tvs-state pairing
+xdotool key --window "$WINDOW_ID" Return
+observe_gui_state --expected-tvs-state pairing-invalid
+xdotool key --window "$WINDOW_ID" Escape
+observe_gui_state --expected-tvs-state empty
+# A second opening starts with a fresh form and uses the header's Cancel button.
+observe_gui_state --activate-control "Pair a TV"
+observe_gui_state --expected-tvs-state pairing
+observe_gui_state --activate-control Cancel
+observe_gui_state --expected-tvs-state empty
 send_closing_mnemonic Escape
 finish_gui "empty TVs view"
 cmp -s "$STATE_FILE" "$WORK_DIR/before-empty.json" || fail "Empty profile performed a TV operation."


### PR DESCRIPTION
## Summary

Users with no configured TV can now pair their first TV from the TVs blank state. The core application owns validation, native webOS authentication, capability verification, cancellation, and persistence; GTK renders typed state and forwards semantic intents.

A toolkit-independent coordinator refreshes Overview after pairing and handles interrupted workers. The application selects and sequences capability checks using the webOS client's cancellable typed reads.

Credentials remain in memory until verification succeeds. Saving writes the token before atomically publishing the primary profile, with credential rollback if the profile save fails. Accepted cancellation prevents publication, and pairing refuses root execution.

Pairing explicitly releases its transaction lock on completion or cancellation, including when a child process has inherited its descriptor.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

This slice supports one primary TV using native webOS. Discovery, additional TVs, pairing repair, and service setup remain outside its scope.

## User-Visible Behavior

- **Pair a TV** opens an adaptive action dialog for the TV's IP address, MAC address, and managed HDMI input, with the required and recommended TV setup guidance.
- Pairing shows confirmation instructions and a thin progress bar for workflow phases. Validation stays inline; general failures show a toast and persistent recovery guidance. Cancellation is available until saving begins.
- Success closes the dialog, shows the new TV details and a confirmation toast, and refreshes Overview.
- Unexpected worker failure provides recovery guidance without reporting a TV connection error. The pairing dialog retains libadwaita's native accessibility structure, verified through AT-SPI.

The frontend now requires libadwaita 1.5, matching the existing release-bundle baseline.

## Validation

- Full core Rust suite: 866 unit tests passed (1 ignored), 42 integration tests passed, and all 134 acceptance scenarios passed.
- GTK renderer/controller tests and installed GUI behavior/accessibility smoke tests under a private D-Bus session and Xvfb.
- Arch packaged GUI smoke with the CI-built bundle, both normally and with a forced late mock read. Scenario resets now share the mock's file lock so cancelled reads cannot overwrite the next scenario's state.
- Workspace Clippy with warnings denied, formatting check, shell/Python syntax checks, and `git diff --check`.

Real-TV pairing was not exercised. The documented crash window between token and configuration publication can leave an orphan token, which a subsequent pairing attempt replaces after verification.

## Related Issue

Fixes #174
