### PR TITLE
feat(gui): manage paired TV input and unpairing

### DIFF
--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -293,6 +293,43 @@ impl ApplicationController {
         if let Some(operation) = transition.pairing_operation() {
             Self::start_pairing(controller, operation.clone());
         }
+        if let Some(operation) = transition.management_operation() {
+            Self::start_tvs_management(controller, operation.clone());
+        }
+    }
+
+    fn start_tvs_management(
+        controller: &Rc<Self>,
+        operation: lg_buddy::tvs::TvsManagementOperation,
+    ) {
+        let backend = Arc::clone(&controller.tvs_backend);
+        let worker_operation = operation.clone();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let mut application_hold = Some(controller.gtk_application.hold());
+        thread::spawn(move || {
+            let _ = sender.send(backend.manage(&worker_operation));
+        });
+        let controller = Rc::downgrade(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || {
+            let result = match receiver.try_recv() {
+                Ok(result) => result,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    Err(lg_buddy::tvs::TvsManagementError::stopped())
+                }
+            };
+            if let Some(controller) = controller.upgrade() {
+                let transition = controller
+                    .application
+                    .borrow_mut()
+                    .complete_tvs_management(&operation, result);
+                if let Some(transition) = transition {
+                    Self::apply_transition(&controller, transition);
+                }
+            }
+            drop(application_hold.take());
+            glib::ControlFlow::Break
+        });
     }
 
     fn start_pairing(controller: &Rc<Self>, operation: PairingOperation) {

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -804,7 +804,7 @@ pub(crate) mod controller_test_support {
         application
     }
 
-    fn pump_until(mut ready: impl FnMut() -> bool) {
+    pub(crate) fn pump_until(mut ready: impl FnMut() -> bool) {
         let context = glib::MainContext::default();
         let deadline = Instant::now() + Duration::from_secs(3);
         while !ready() {

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -4,6 +4,7 @@ use std::net::Ipv4Addr;
 use std::rc::Rc;
 
 use adw::prelude::*;
+use lg_buddy::config::HdmiInput;
 use lg_buddy::presentation::tvs::{TvsAction, TvsPresentation, TvsStatus};
 use lg_buddy::tvs::{TvId, TvProfile, TvsIntent};
 
@@ -28,6 +29,11 @@ pub(crate) struct TvsView {
     sidebar_rows: RefCell<Vec<adw::ActionRow>>,
     rendered_selected: RefCell<Option<TvId>>,
     suppress: Rc<Cell<bool>>,
+    unpair_dialog: adw::AlertDialog,
+    unpair_dialog_visible: Cell<bool>,
+    unpair_confirm_intent: Rc<RefCell<Option<TvsIntent>>>,
+    unpair_cancel_intent: Rc<RefCell<Option<TvsIntent>>>,
+    restore_focus: RefCell<Option<gtk::Widget>>,
 }
 
 struct TvsMode {
@@ -38,15 +44,19 @@ struct TvsMode {
     details: adw::PreferencesGroup,
     address: adw::ActionRow,
     mac: adw::ActionRow,
-    input: adw::ActionRow,
+    input: adw::ComboRow,
     platform: adw::ActionRow,
     credentials: adw::ActionRow,
     credential_description: gtk::Label,
+    unpair: ActionButton,
+    management_error: gtk::Label,
+    management_actions: gtk::Box,
+    management_retry: RetryButton,
     retry: RetryButton,
 }
 
 impl TvsMode {
-    fn new(on_intent: &IntentHandler) -> Self {
+    fn new(on_intent: &IntentHandler, suppress: &Rc<Cell<bool>>) -> Self {
         let status = adw::StatusPage::builder()
             .icon_name(TV_ICON_NAME)
             .title("Loading TVs")
@@ -69,12 +79,31 @@ impl TvsMode {
         let details = adw::PreferencesGroup::builder().title("TV details").build();
         let address = detail_row("Address");
         let mac = detail_row("MAC address");
-        let input = detail_row("HDMI input");
+        let input_model = gtk::StringList::new(&["HDMI 1", "HDMI 2", "HDMI 3", "HDMI 4"]);
+        let input = adw::ComboRow::builder()
+            .title("HDMI input")
+            .model(&input_model)
+            .build();
+        input.set_selected(0);
+        {
+            let suppress = Rc::clone(suppress);
+            let on_intent = Rc::clone(on_intent);
+            input.connect_selected_notify(move |row| {
+                if suppress.get() {
+                    return;
+                }
+                if let Some(input) = hdmi_input(row.selected()) {
+                    on_intent(TvsIntent::SetInput(input));
+                }
+            });
+        }
         let platform = detail_row("Platform");
         let credentials = detail_row("Credentials");
-        for row in [&address, &mac, &input, &platform, &credentials] {
-            details.add(row);
-        }
+        details.add(&address);
+        details.add(&mac);
+        details.add(&input);
+        details.add(&platform);
+        details.add(&credentials);
         let credential_description = gtk::Label::builder()
             .xalign(0.0)
             .wrap(true)
@@ -82,14 +111,35 @@ impl TvsMode {
             .margin_end(12)
             .build();
         credential_description.add_css_class("dim-label");
+        let unpair = ActionButton::new(on_intent);
+        unpair.button.add_css_class("destructive-action");
+        let unpair_row = adw::ActionRow::builder()
+            .activatable(false)
+            .selectable(false)
+            .build();
+        unpair_row.add_suffix(&unpair.button);
+        let management_error = gtk::Label::builder()
+            .xalign(0.0)
+            .wrap(true)
+            .hexpand(true)
+            .visible(false)
+            .build();
+        management_error.set_accessible_role(gtk::AccessibleRole::Alert);
+        management_error.add_css_class("error");
+        let management_retry = RetryButton::new(on_intent);
+        let management_actions = gtk::Box::new(gtk::Orientation::Horizontal, 8);
+        management_actions.append(&management_error);
+        management_actions.append(&management_retry.button);
         let details_box = gtk::Box::builder()
             .orientation(gtk::Orientation::Vertical)
             .spacing(12)
             .margin_top(16)
             .margin_bottom(20)
             .build();
+        details_box.append(&management_actions);
         details_box.append(&details);
         details_box.append(&credential_description);
+        details.add(&unpair_row);
         let clamp = adw::Clamp::builder()
             .maximum_size(600)
             .tightening_threshold(400)
@@ -123,6 +173,10 @@ impl TvsMode {
             platform,
             credentials,
             credential_description,
+            unpair,
+            management_error,
+            management_actions,
+            management_retry,
             retry,
         }
     }
@@ -145,7 +199,6 @@ impl TvsMode {
         self.details.set_title(profile.display_name());
         self.address.set_subtitle(&profile.address().to_string());
         self.mac.set_subtitle(&profile.mac().to_string());
-        self.input.set_subtitle(profile.input_label());
         self.platform.set_subtitle(profile.platform_label());
         self.credentials.set_subtitle(profile.credentials().label());
         self.credential_description
@@ -195,7 +248,7 @@ impl TvsView {
             .title("TVs")
             .child(&sidebar_toolbar)
             .build();
-        let multiple = TvsMode::new(&on_intent);
+        let multiple = TvsMode::new(&on_intent, &suppress);
         let multiple_toolbar = toolbar_page("TV details", &multiple.stack, true);
         let content_page = adw::NavigationPage::builder()
             .title("TV details")
@@ -235,7 +288,7 @@ impl TvsView {
             split_for_activation.set_show_content(true);
         });
 
-        let single = TvsMode::new(&on_intent);
+        let single = TvsMode::new(&on_intent, &suppress);
         let root = gtk::Stack::new();
         root.set_vexpand(true);
         root.set_hexpand(true);
@@ -244,6 +297,31 @@ impl TvsView {
         root.add_named(&single.stack, Some("single"));
         root.add_named(&split_bin, Some("multiple"));
         root.set_visible_child_name("single");
+
+        let unpair_dialog = adw::AlertDialog::builder()
+            .can_close(true)
+            .default_response("cancel")
+            .close_response("cancel")
+            .build();
+        unpair_dialog.add_responses(&[("cancel", ""), ("confirm", "")]);
+        unpair_dialog.set_response_appearance("confirm", adw::ResponseAppearance::Destructive);
+        let unpair_confirm_intent = Rc::new(RefCell::new(None));
+        let unpair_cancel_intent = Rc::new(RefCell::new(None));
+        unpair_dialog.connect_response(None, {
+            let on_intent = Rc::clone(&on_intent);
+            let unpair_confirm_intent = unpair_confirm_intent.clone();
+            let unpair_cancel_intent = unpair_cancel_intent.clone();
+            move |_, response| {
+                let intent = match response {
+                    "confirm" => unpair_confirm_intent.borrow().clone(),
+                    "cancel" => unpair_cancel_intent.borrow().clone(),
+                    _ => None,
+                };
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
 
         Self {
             root,
@@ -257,6 +335,11 @@ impl TvsView {
             sidebar_rows: RefCell::new(Vec::new()),
             rendered_selected: RefCell::new(None),
             suppress,
+            unpair_dialog,
+            unpair_dialog_visible: Cell::new(false),
+            unpair_confirm_intent,
+            unpair_cancel_intent,
+            restore_focus: RefCell::new(None),
         }
     }
 
@@ -264,7 +347,11 @@ impl TvsView {
         self.root.upcast_ref()
     }
 
-    pub(crate) fn render(&self, presentation: &TvsPresentation) {
+    pub(crate) fn render(&self, parent: &adw::ApplicationWindow, presentation: &TvsPresentation) {
+        if presentation.unpair_confirmation().is_some() && !self.unpair_dialog_visible.get() {
+            self.restore_focus
+                .replace(gtk::prelude::GtkWindowExt::focus(parent));
+        }
         self.suppress.set(true);
         let profiles = presentation.profiles();
         let is_multiple = profiles.len() > 1;
@@ -282,6 +369,7 @@ impl TvsView {
         } else {
             self.render_mode(&self.single, presentation);
         }
+        self.render_unpair_dialog(parent, presentation);
         self.suppress.set(false);
     }
 
@@ -337,6 +425,19 @@ impl TvsView {
     fn render_mode(&self, mode: &TvsMode, presentation: &TvsPresentation) {
         mode.retry.render(presentation.retry_action());
         mode.pair.render(presentation.pair_action());
+        mode.unpair.render(presentation.unpair_action());
+        mode.management_retry
+            .render(presentation.retry_apply_action());
+        let management_error = presentation.management_error();
+        if let Some(error) = management_error {
+            mode.management_error.set_text(&error_text(error));
+        } else {
+            mode.management_error.set_text("");
+        }
+        mode.management_error
+            .set_visible(management_error.is_some());
+        mode.management_actions
+            .set_visible(management_error.is_some() || presentation.retry_apply_action().is_some());
         match presentation.status() {
             TvsStatus::Loading { message } => mode.show_status(message, None, false),
             TvsStatus::Empty { title, description } => {
@@ -346,7 +447,12 @@ impl TvsView {
                 mode.show_status(error.summary(), Some(error.detail()), true)
             }
             TvsStatus::Ready => match presentation.selected_profile() {
-                Some(profile) => mode.show_details(profile),
+                Some(profile) => {
+                    mode.input.set_sensitive(presentation.input_enabled());
+                    mode.input.set_selected(hdmi_index(profile.input()));
+                    mode.unpair.render(presentation.unpair_action());
+                    mode.show_details(profile)
+                }
                 None => {
                     debug_assert!(
                         false,
@@ -355,6 +461,43 @@ impl TvsView {
                     mode.stack.set_visible_child_name("details");
                 }
             },
+        }
+    }
+
+    fn render_unpair_dialog(
+        &self,
+        parent: &adw::ApplicationWindow,
+        presentation: &TvsPresentation,
+    ) {
+        let Some(confirmation) = presentation.unpair_confirmation() else {
+            self.unpair_confirm_intent.replace(None);
+            self.unpair_cancel_intent.replace(None);
+            if self.unpair_dialog_visible.replace(false) {
+                self.unpair_dialog.force_close();
+                if let Some(focus) = self.restore_focus.take() {
+                    let _ = focus.grab_focus();
+                }
+            }
+            return;
+        };
+
+        self.unpair_dialog.set_heading(Some(confirmation.title()));
+        self.unpair_dialog.set_body(confirmation.body());
+        self.unpair_dialog
+            .set_response_label("confirm", confirmation.confirm_action().label());
+        self.unpair_dialog
+            .set_response_label("cancel", confirmation.cancel_action().label());
+        self.unpair_dialog
+            .set_response_enabled("confirm", confirmation.confirm_action().enabled());
+        self.unpair_dialog
+            .set_response_enabled("cancel", confirmation.cancel_action().enabled());
+        self.unpair_confirm_intent
+            .replace(Some(confirmation.confirm_action().intent()));
+        self.unpair_cancel_intent
+            .replace(Some(confirmation.cancel_action().intent()));
+
+        if !self.unpair_dialog_visible.replace(true) {
+            self.unpair_dialog.present(Some(parent));
         }
     }
 }
@@ -367,6 +510,49 @@ struct RetryButton {
 struct PairButton {
     button: gtk::Button,
     intent: Rc<RefCell<Option<TvsIntent>>>,
+}
+
+struct ActionButton {
+    button: gtk::Button,
+    intent: Rc<RefCell<Option<TvsIntent>>>,
+}
+
+impl ActionButton {
+    fn new(on_intent: &IntentHandler) -> Self {
+        let button = gtk::Button::builder()
+            .visible(false)
+            .sensitive(false)
+            .build();
+        let intent = Rc::new(RefCell::new(None));
+        button.connect_clicked({
+            let on_intent = Rc::clone(on_intent);
+            let intent = Rc::clone(&intent);
+            move |_| {
+                let intent = intent.borrow().clone();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
+        Self { button, intent }
+    }
+
+    fn render(&self, action: Option<&TvsAction>) {
+        self.intent.replace(
+            action
+                .filter(|action| action.enabled())
+                .map(TvsAction::intent),
+        );
+        self.button.set_visible(action.is_some());
+        self.button
+            .set_sensitive(action.is_some_and(TvsAction::enabled));
+        self.button.set_label(action.map_or("", TvsAction::label));
+        self.button.set_tooltip_text(action.map(TvsAction::label));
+        self.button
+            .update_property(&[gtk::accessible::Property::Label(
+                action.map_or("", TvsAction::label),
+            )]);
+    }
 }
 
 impl PairButton {
@@ -465,6 +651,29 @@ fn detail_row(title: &str) -> adw::ActionRow {
         .build()
 }
 
+fn error_text(error: &lg_buddy::presentation::brightness::UserFacingError) -> String {
+    format!("{} {}", error.summary(), error.detail())
+}
+
+fn hdmi_input(index: u32) -> Option<HdmiInput> {
+    match index {
+        0 => Some(HdmiInput::Hdmi1),
+        1 => Some(HdmiInput::Hdmi2),
+        2 => Some(HdmiInput::Hdmi3),
+        3 => Some(HdmiInput::Hdmi4),
+        _ => None,
+    }
+}
+
+fn hdmi_index(input: HdmiInput) -> u32 {
+    match input {
+        HdmiInput::Hdmi1 => 0,
+        HdmiInput::Hdmi2 => 1,
+        HdmiInput::Hdmi3 => 2,
+        HdmiInput::Hdmi4 => 3,
+    }
+}
+
 fn sidebar_row(profile: &TvProfile) -> adw::ActionRow {
     adw::ActionRow::builder()
         .title(profile.display_name())
@@ -528,7 +737,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .build();
     window.present();
     let (mut app, opening) = TvsApplication::open();
-    view.render(opening.presentation());
+    view.render(&window, opening.presentation());
     assert_eq!(view.root.visible_child_name().as_deref(), Some("single"));
     assert_eq!(
         view.single.status.icon_name().as_deref(),
@@ -541,7 +750,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             Ok(Vec::new()),
         )
         .expect("empty transition");
-    view.render(empty.presentation());
+    view.render(&window, empty.presentation());
     assert_eq!(view.single.status.title().as_str(), "No TV configured");
     assert_eq!(
         view.single.status.description().as_deref(),
@@ -561,7 +770,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     let pairing = app
         .handle_intent(TvsIntent::PairTv)
         .expect("pairing transition");
-    view.render(pairing.presentation());
+    view.render(&window, pairing.presentation());
     assert_eq!(
         view.single.stack.visible_child_name().as_deref(),
         Some("status")
@@ -570,7 +779,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     let blank = app
         .handle_intent(TvsIntent::Pairing(lg_buddy::pairing::PairingIntent::Cancel))
         .expect("blank transition");
-    view.render(blank.presentation());
+    view.render(&window, blank.presentation());
     pump();
     assert_eq!(
         view.single.stack.visible_child_name().as_deref(),
@@ -586,7 +795,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             Ok(vec![one]),
         )
         .expect("one profile transition");
-    view.render(ready_one.presentation());
+    view.render(&window, ready_one.presentation());
     assert_eq!(view.root.visible_child_name().as_deref(), Some("single"));
     assert_eq!(
         view.single.stack.visible_child_name().as_deref(),
@@ -610,10 +819,23 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .credentials
         .subtitle()
         .is_some_and(|subtitle| subtitle.contains("Stored locally")));
+    assert_eq!(view.single.input.selected(), 1);
+    assert!(view.single.input.is_sensitive());
     assert!(
         intents.borrow().is_empty(),
         "rendering must not select a TV"
     );
+
+    // A user change is semantic input, while a later presentation update
+    // restores the optimistic/effective value without feeding back an intent.
+    view.single.input.set_selected(2);
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::SetInput(HdmiInput::Hdmi3))
+    );
+    view.render(&window, ready_one.presentation());
+    assert_eq!(view.single.input.selected(), 1);
+    assert!(intents.borrow().is_empty(), "render must not apply input");
 
     let model = app
         .complete_model_read(
@@ -624,12 +846,19 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             Ok("OLED42C2".to_string()),
         )
         .expect("model transition");
-    view.render(model.presentation());
+    view.render(&window, model.presentation());
     assert_eq!(view.single.details.title().as_str(), "OLED42C2");
     assert_eq!(
         view.single.address.subtitle().as_deref(),
         Some("192.0.2.10")
     );
+
+    let pending = app
+        .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+        .expect("input transition");
+    view.render(&window, pending.presentation());
+    assert!(!view.single.input.is_sensitive());
+    assert!(!view.single.unpair.button.is_sensitive());
 
     let (mut app, opening) = TvsApplication::open();
     let ready_multiple = app
@@ -641,7 +870,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             ]),
         )
         .expect("multiple profile transition");
-    view.render(ready_multiple.presentation());
+    view.render(&window, ready_multiple.presentation());
     assert_eq!(view.root.visible_child_name().as_deref(), Some("multiple"));
     assert_eq!(view.sidebar_rows.borrow().len(), 2);
     assert_eq!(view.sidebar.selected_row().map(|row| row.index()), Some(0));
@@ -657,7 +886,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     let selected = app
         .handle_intent(selected_intent)
         .expect("changed selection transition");
-    view.render(selected.presentation());
+    view.render(&window, selected.presentation());
     assert!(
         intents.borrow().is_empty(),
         "render must not feed back selection"
@@ -678,13 +907,49 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .expect("native Back action");
     assert!(!view.split.shows_content(), "Back opens the TV list");
     assert!(window.is_visible(), "Back must not close the application");
-    view.render(selected.presentation());
+    view.render(&window, selected.presentation());
     assert!(
         !view.split.shows_content(),
         "unchanged selection preserves list navigation"
     );
     selected_row.emit_activate();
     assert!(view.split.shows_content());
+
+    pump();
+    assert!(
+        view.multiple.unpair.button.grab_focus(),
+        "unpair action must be focusable"
+    );
+    view.multiple.unpair.button.emit_clicked();
+    assert_eq!(intents.borrow_mut().pop(), Some(TvsIntent::UnpairTv));
+    let confirming = app
+        .handle_intent(TvsIntent::UnpairTv)
+        .expect("confirmation transition");
+    view.render(&window, confirming.presentation());
+    assert_eq!(view.unpair_dialog.heading().as_deref(), Some("Unpair TV?"));
+    assert_eq!(
+        view.unpair_dialog.default_response().as_deref(),
+        Some("cancel")
+    );
+    assert_eq!(
+        window.visible_dialog().as_ref(),
+        Some(view.unpair_dialog.upcast_ref::<adw::Dialog>())
+    );
+    view.unpair_dialog.close();
+    pump();
+    assert_eq!(intents.borrow_mut().pop(), Some(TvsIntent::CancelUnpair));
+    let cancelled = app
+        .handle_intent(TvsIntent::CancelUnpair)
+        .expect("cancel transition");
+    view.render(&window, cancelled.presentation());
+    pump();
+    assert!(window.visible_dialog().is_none());
+    assert!(
+        gtk::prelude::GtkWindowExt::focus(&window).is_some_and(|focus| focus
+            == view.multiple.unpair.button.clone().upcast::<gtk::Widget>()
+            || focus.is_ancestor(&view.multiple.unpair.button)),
+        "cancel restores focus to the destructive action"
+    );
 
     let (mut app, opening) = TvsApplication::open();
     let failed = app
@@ -696,7 +961,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             )),
         )
         .expect("failure transition");
-    view.render(failed.presentation());
+    view.render(&window, failed.presentation());
     assert!(view.single.retry.button.is_visible());
     view.single.retry.button.emit_clicked();
     assert_eq!(intents.borrow_mut().pop(), Some(TvsIntent::Retry));
@@ -707,7 +972,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
 
     // The TVs-local breakpoint collapses the split at narrow sizes while the
     // top-level application breakpoint remains owned by the window shell.
-    view.render(ready_multiple.presentation());
+    view.render(&window, ready_multiple.presentation());
     pump();
     view.split.set_collapsed(false);
     view.split_bin.allocate(900, 420, -1, None);

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -702,6 +702,7 @@ fn toolbar_page(
 
 #[cfg(test)]
 pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
+    use crate::controller_test_support::pump_until;
     use lg_buddy::config::{HdmiInput, TvPlatform};
     use lg_buddy::tvs::{TvCredentialState, TvsApplication, TvsReadError, TvsReadFailure};
 
@@ -935,14 +936,21 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         window.visible_dialog().as_ref(),
         Some(view.unpair_dialog.upcast_ref::<adw::Dialog>())
     );
-    view.unpair_dialog.close();
-    pump();
+    // libadwaita 1.5 opens the sheet on frame-clock ticks. Closing it before
+    // its contents are mapped has no effect, even though visible_dialog is set.
+    pump_until(|| {
+        view.unpair_dialog
+            .child()
+            .is_some_and(|child| child.is_mapped())
+    });
+    assert!(view.unpair_dialog.close());
+    pump_until(|| !intents.borrow().is_empty());
     assert_eq!(intents.borrow_mut().pop(), Some(TvsIntent::CancelUnpair));
     let cancelled = app
         .handle_intent(TvsIntent::CancelUnpair)
         .expect("cancel transition");
     view.render(&window, cancelled.presentation());
-    pump();
+    pump_until(|| window.visible_dialog().is_none());
     assert!(window.visible_dialog().is_none());
     assert!(
         gtk::prelude::GtkWindowExt::focus(&window).is_some_and(|focus| focus

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -125,7 +125,7 @@ impl ApplicationWindow {
     }
 
     pub(crate) fn render_tvs(&self, presentation: &TvsPresentation) {
-        self.tvs.render(presentation);
+        self.tvs.render(&self.window, presentation);
         self.pairing.render(&self.window, presentation.pairing());
     }
 

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -13,8 +13,8 @@ use crate::overview::{
 use crate::pairing::{PairingError, PairingFailure, PairingOperation, PairingStage};
 use crate::tv::{AudioStatus, OledBrightness};
 use crate::tvs::{
-    TvProfile, TvsApplication, TvsIntent, TvsModelReadOperation, TvsReadError, TvsReadOperation,
-    TvsTransition,
+    TvProfile, TvsApplication, TvsIntent, TvsManagementError, TvsManagementOperation,
+    TvsManagementOutcome, TvsModelReadOperation, TvsReadError, TvsReadOperation, TvsTransition,
 };
 
 pub enum OverviewCompletion {
@@ -78,6 +78,9 @@ impl Application {
         &mut self,
         intent: OverviewIntent,
     ) -> Option<ApplicationTransition> {
+        if self.tvs.is_managing() && intent != OverviewIntent::Cancel {
+            return None;
+        }
         let transition = self.overview.handle_intent(intent)?;
         Some(self.overview_transition(transition))
     }
@@ -129,6 +132,15 @@ impl Application {
         Some(self.tvs_transition(transition))
     }
 
+    pub fn complete_tvs_management(
+        &mut self,
+        operation: &TvsManagementOperation,
+        result: Result<TvsManagementOutcome, TvsManagementError>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.tvs.complete_management(operation, result)?;
+        Some(self.tvs_transition(transition))
+    }
+
     pub fn pairing_progress(
         &mut self,
         operation: &PairingOperation,
@@ -167,15 +179,20 @@ impl Application {
         if matches!(transition.update(), OverviewFrontendUpdate::Close) {
             self.tvs.shutdown();
         }
+        let tvs = self
+            .tvs
+            .set_controls_available(!self.overview.has_pending_write());
         ApplicationTransition {
             overview: Some(transition),
-            tvs: None,
+            tvs,
         }
     }
 
     fn tvs_transition(&mut self, transition: TvsTransition) -> ApplicationTransition {
-        let overview = if transition.profile_created() {
-            self.overview.profile_created()
+        let overview = if transition.management_operation().is_some() {
+            self.overview.profile_change_started()
+        } else if transition.profile_changed() {
+            self.overview.profile_changed()
         } else {
             None
         };
@@ -330,5 +347,110 @@ mod tests {
             .complete_pairing(&operation, Ok(profile(&operation)))
             .is_none());
         assert!(application.handle_tvs_intent(TvsIntent::PairTv).is_none());
+    }
+}
+
+#[cfg(test)]
+mod management_tests {
+    use super::*;
+    use crate::brightness::BrightnessWriteOutcome;
+    use crate::config::{HdmiInput, TvPlatform};
+    use crate::overview::{OverviewIntent, OverviewOperation};
+    use crate::tvs::{TvCredentialState, TvId};
+
+    fn configured() -> (Application, ApplicationTransition) {
+        let (mut app, opening) = Application::open();
+        let profile = TvProfile::new(
+            TvId::primary(),
+            "TV",
+            "192.0.2.10".parse().unwrap(),
+            "02:11:22:33:44:55".parse().unwrap(),
+            HdmiInput::Hdmi1,
+            TvPlatform::LgWebOs,
+            TvCredentialState::Stored,
+        );
+        app.complete_tvs_read(
+            opening.tvs().unwrap().read_operation().unwrap(),
+            Ok(vec![profile]),
+        )
+        .unwrap();
+        (app, opening)
+    }
+
+    #[test]
+    fn profile_change_invalidates_overview_reads_and_blocks_new_writes_until_reload() {
+        let (mut app, opening) = configured();
+        let change = app
+            .handle_tvs_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+            .unwrap();
+        assert!(change.overview().unwrap().operations().is_empty());
+        assert!(app
+            .handle_overview_intent(OverviewIntent::SetBrightness(50))
+            .is_none());
+        for operation in opening.overview().unwrap().operations() {
+            if let OverviewOperation::ReadBrightness(read) = operation {
+                assert!(app
+                    .complete_overview(OverviewCompletion::BrightnessRead(
+                        *read,
+                        Ok(OledBrightness::new(50).unwrap())
+                    ))
+                    .is_none());
+            }
+        }
+        let done = app
+            .complete_tvs_management(
+                change.tvs().unwrap().management_operation().unwrap(),
+                Err(TvsManagementError::stopped()),
+            )
+            .unwrap();
+        assert_eq!(done.overview().unwrap().operations().len(), 3);
+        assert!(done.tvs().unwrap().presentation().input_enabled());
+    }
+
+    #[test]
+    fn active_overview_write_disables_profile_changes_until_it_finishes() {
+        let (mut app, opening) = configured();
+        for operation in opening.overview().unwrap().operations() {
+            if let OverviewOperation::ReadBrightness(read) = operation {
+                app.complete_overview(OverviewCompletion::BrightnessRead(
+                    *read,
+                    Ok(OledBrightness::new(50).unwrap()),
+                ))
+                .unwrap();
+            }
+        }
+        let writing = app
+            .handle_overview_intent(OverviewIntent::SetBrightness(60))
+            .unwrap();
+        assert!(!writing.tvs().unwrap().presentation().input_enabled());
+        assert!(!writing
+            .tvs()
+            .unwrap()
+            .presentation()
+            .unpair_action()
+            .unwrap()
+            .enabled());
+        assert!(app
+            .handle_tvs_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+            .is_none());
+        assert!(app.handle_tvs_intent(TvsIntent::UnpairTv).is_none());
+        let operation = writing
+            .overview()
+            .unwrap()
+            .operations()
+            .iter()
+            .find_map(|op| match op {
+                OverviewOperation::WriteBrightness(write) => Some(*write),
+                _ => None,
+            })
+            .unwrap();
+        let done = app
+            .complete_overview(OverviewCompletion::BrightnessWrite(
+                operation,
+                Ok(BrightnessWriteOutcome::applied()),
+            ))
+            .unwrap();
+        assert!(done.tvs().unwrap().presentation().input_enabled());
+        assert!(app.handle_tvs_intent(TvsIntent::UnpairTv).is_some());
     }
 }

--- a/crates/lg-buddy/src/overview.rs
+++ b/crates/lg-buddy/src/overview.rs
@@ -430,9 +430,20 @@ impl OverviewApplication {
         }
     }
 
-    /// Reload after the first primary profile has been saved. Preserve the
-    /// operation sequence so late results from the empty state stay stale.
-    pub(crate) fn profile_created(&mut self) -> Option<OverviewTransition> {
+    pub(crate) fn has_pending_write(&self) -> bool {
+        matches!(self.brightness, BrightnessState::Applying { .. })
+            || matches!(self.audio, AudioState::Applying { .. })
+    }
+
+    /// Invalidate previous reads and disable controls while the profile is changing.
+    pub(crate) fn profile_change_started(&mut self) -> Option<OverviewTransition> {
+        let mut transition = self.profile_changed()?;
+        transition.operations.clear();
+        Some(transition)
+    }
+
+    /// Reload a changed profile without accepting results from its previous configuration.
+    pub(crate) fn profile_changed(&mut self) -> Option<OverviewTransition> {
         if self.is_closed()
             || matches!(self.brightness, BrightnessState::Applying { .. })
             || matches!(self.audio, AudioState::Applying { .. })
@@ -1178,7 +1189,7 @@ mod tests {
     #[test]
     fn first_profile_reload_rejects_results_from_the_empty_state() {
         let (mut app, original) = OverviewApplication::open();
-        let refreshed = app.profile_created().unwrap();
+        let refreshed = app.profile_changed().unwrap();
         assert_eq!(refreshed.operations().len(), 3);
         for operation in original.operations() {
             assert!(!refreshed.operations().contains(operation));

--- a/crates/lg-buddy/src/pairing.rs
+++ b/crates/lg-buddy/src/pairing.rs
@@ -659,7 +659,7 @@ mod tests {
                         Some(PlatformAccessToken::new("test-client-key").unwrap())
                     );
                     let complete = app.complete_pairing(&operation, Ok(result)).unwrap();
-                    assert!(complete.profile_created());
+                    assert!(complete.profile_changed());
                     assert_eq!(stages.last(), Some(&PairingStage::Saving));
                     let retry = pair_and_save(&operation, &path, &mut |_| {}, |_| {
                         panic!("existing profile must refuse before connecting")
@@ -746,7 +746,7 @@ mod tests {
         let saved = app
             .complete_pairing(&operation, Ok(profile(&operation)))
             .unwrap();
-        assert!(saved.profile_created());
+        assert!(saved.profile_changed());
         assert_eq!(saved.toast_message(), Some("TV paired successfully"));
         assert_eq!(saved.presentation().profiles().len(), 1);
         assert_eq!(
@@ -815,7 +815,7 @@ mod tests {
             assert!(presentation.error().is_some());
             assert!(presentation.can_submit());
             assert!(failed.presentation().profiles().is_empty());
-            assert!(!failed.profile_created());
+            assert!(!failed.profile_changed());
             assert_eq!(
                 failed.toast_message(),
                 Some(presentation.error().unwrap().summary())
@@ -884,7 +884,7 @@ mod tests {
         assert!(app
             .complete_pairing(&operation, Ok(profile(&operation)))
             .unwrap()
-            .profile_created());
+            .profile_changed());
 
         let (mut app, _) = blank();
         let operation = submit(&mut app);

--- a/crates/lg-buddy/src/pairing_store.rs
+++ b/crates/lg-buddy/src/pairing_store.rs
@@ -39,6 +39,13 @@ const TV_KEYS: &[&str] = &[
 
 static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+pub(crate) fn unpair_primary(
+    config_path: &Path,
+    expected: &crate::tvs::TvProfile,
+) -> Result<(), PairingStoreError> {
+    PairingStore::unpair_primary(config_path, expected)
+}
+
 /// A prepared, exclusive first-TV pairing transaction.
 ///
 /// Preparing one takes a narrow lock which remains held until this value is
@@ -59,6 +66,61 @@ impl PairingStore {
     /// Prepare a first-primary-TV transaction before starting network pairing.
     pub(crate) fn prepare(config_path: &Path) -> Result<Self, PairingStoreError> {
         prepare_with_euid(config_path, current_euid())
+    }
+
+    /// Remove the configured primary-TV profile and its native credential.
+    ///
+    /// The same lock and snapshots used by pairing are held for the complete
+    /// operation.  The profile is checked again immediately before removing
+    /// the credential, so a stale caller cannot erase a newly selected TV.
+    pub(crate) fn unpair_primary(
+        config_path: &Path,
+        expected: &crate::tvs::TvProfile,
+    ) -> Result<(), PairingStoreError> {
+        let store = prepare_unpair_with_euid(config_path, current_euid())?;
+        store.unpair(expected)
+    }
+
+    fn unpair(self, expected: &crate::tvs::TvProfile) -> Result<(), PairingStoreError> {
+        self.check_unpair_preconditions(expected)?;
+        self.remove_token()?;
+
+        let result = (|| {
+            self.check_unpair_config_preconditions(expected)?;
+            match fs::symlink_metadata(self.token_store.token_path()) {
+                Ok(_) => {
+                    return Err(PairingStoreError::TokenChanged {
+                        path: self.token_store.token_path().to_path_buf(),
+                    });
+                }
+                Err(source) if source.kind() == io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(PairingStoreError::TokenRemove {
+                        path: self.token_store.token_path().to_path_buf(),
+                        source,
+                    });
+                }
+            }
+            let original = self.snapshot.as_deref().unwrap_or_default();
+            let contents = remove_primary_config_keys(original);
+            atomic_write_config(
+                &self.config_path,
+                &contents,
+                &self.owner,
+                self.snapshot.is_some(),
+            )
+        })();
+
+        match result {
+            Ok(()) => Ok(()),
+            Err(error) => match self.restore_unpaired_token() {
+                Ok(()) => Err(error),
+                Err(rollback) => Err(PairingStoreError::Rollback {
+                    operation: Box::new(error),
+                    rollback: Box::new(rollback),
+                }),
+            },
+        }
     }
 
     /// Persist the verified native webOS pairing result.
@@ -170,6 +232,110 @@ impl PairingStore {
         }
     }
 
+    fn restore_unpaired_token(&self) -> Result<(), PairingStoreError> {
+        let token_path = self.token_store.token_path();
+        match &self.token_before {
+            Some(before) => {
+                ensure_token_path_safe(token_path, &self.owner)?;
+                match read_existing_token(token_path)? {
+                    Some(current) if !same_token_snapshot(Some(before), Some(&current)) => {
+                        Err(PairingStoreError::TokenChanged {
+                            path: token_path.to_path_buf(),
+                        })
+                    }
+                    Some(_) => Ok(()),
+                    None => atomic_write_bytes(token_path, &before.contents, before.mode).map_err(
+                        |source| PairingStoreError::TokenRollback {
+                            path: token_path.to_path_buf(),
+                            source,
+                        },
+                    ),
+                }
+            }
+            None => match fs::symlink_metadata(token_path) {
+                Ok(metadata) if metadata.file_type().is_file() => {
+                    // A credential which appeared while the config was being
+                    // published belongs to whoever created it.  Leave it in
+                    // place instead of deleting a stale concurrent change.
+                    Ok(())
+                }
+                Ok(_) => Err(PairingStoreError::TokenRollback {
+                    path: token_path.to_path_buf(),
+                    source: io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "credential path changed into a non-file",
+                    ),
+                }),
+                Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(source) => Err(PairingStoreError::TokenRollback {
+                    path: token_path.to_path_buf(),
+                    source,
+                }),
+            },
+        }
+    }
+
+    fn check_unpair_preconditions(
+        &self,
+        expected: &crate::tvs::TvProfile,
+    ) -> Result<(), PairingStoreError> {
+        self.check_unpair_config_preconditions(expected)?;
+        ensure_token_path_safe(self.token_store.token_path(), &self.owner)?;
+        let current_token = read_existing_token(self.token_store.token_path())?;
+        if !same_token_snapshot(self.token_before.as_ref(), current_token.as_ref()) {
+            return Err(PairingStoreError::TokenChanged {
+                path: self.token_store.token_path().to_path_buf(),
+            });
+        }
+        Ok(())
+    }
+
+    fn check_unpair_config_preconditions(
+        &self,
+        expected: &crate::tvs::TvProfile,
+    ) -> Result<(), PairingStoreError> {
+        let current = read_config_snapshot(&self.config_path)?;
+        if current != self.snapshot {
+            return Err(PairingStoreError::ConfigChanged {
+                path: self.config_path.clone(),
+            });
+        }
+        ensure_config_owner(&self.config_path, &self.owner)?;
+        validate_primary_identity(&self.config_path, current.as_deref(), expected)?;
+        Ok(())
+    }
+
+    fn remove_token(&self) -> Result<(), PairingStoreError> {
+        let path = self.token_store.token_path();
+        ensure_token_path_safe(path, &self.owner)?;
+        let current = read_existing_token(path)?;
+        if !same_token_snapshot(self.token_before.as_ref(), current.as_ref()) {
+            return Err(PairingStoreError::TokenChanged {
+                path: path.to_path_buf(),
+            });
+        }
+        match fs::symlink_metadata(path) {
+            Ok(metadata) if metadata.file_type().is_file() => {
+                fs::remove_file(path).map_err(|source| PairingStoreError::TokenRemove {
+                    path: path.to_path_buf(),
+                    source,
+                })
+            }
+            Ok(_) => Err(PairingStoreError::TokenRead {
+                path: path.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "credential path is not a regular file",
+                ),
+            }),
+            Err(source) if source.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(PairingStoreError::TokenRemove {
+                path: path.to_path_buf(),
+                source,
+            }),
+        }
+    }
+
     fn cleanup_created_dirs(&self) -> Result<(), PairingStoreError> {
         let token_path = self.token_store.token_path();
         if !self.profile_dir_existed {
@@ -190,6 +356,21 @@ impl PairingStore {
 }
 
 fn prepare_with_euid(config_path: &Path, euid: u32) -> Result<PairingStore, PairingStoreError> {
+    prepare_transaction(config_path, euid, true)
+}
+
+fn prepare_unpair_with_euid(
+    config_path: &Path,
+    euid: u32,
+) -> Result<PairingStore, PairingStoreError> {
+    prepare_transaction(config_path, euid, false)
+}
+
+fn prepare_transaction(
+    config_path: &Path,
+    euid: u32,
+    require_unconfigured: bool,
+) -> Result<PairingStore, PairingStoreError> {
     if euid == 0 {
         return Err(PairingStoreError::RunningAsRoot);
     }
@@ -220,10 +401,12 @@ fn prepare_with_euid(config_path: &Path, euid: u32) -> Result<PairingStore, Pair
             }
         })?;
     let entries = parse_config_entries(config_contents);
-    if let Some(key) = TV_KEYS.iter().find(|key| entries.contains_key(**key)) {
-        return Err(PairingStoreError::PrimaryAlreadyConfigured {
-            key: (*key).to_string(),
-        });
+    if require_unconfigured {
+        if let Some(key) = TV_KEYS.iter().find(|key| entries.contains_key(**key)) {
+            return Err(PairingStoreError::PrimaryAlreadyConfigured {
+                key: (*key).to_string(),
+            });
+        }
     }
 
     let owner = resolve_owner(config_path, snapshot.is_some(), euid)?;
@@ -249,6 +432,10 @@ fn prepare_with_euid(config_path: &Path, euid: u32) -> Result<PairingStore, Pair
     let tvs_dir = profile_dir
         .parent()
         .expect("derived profile path always has a TVs directory");
+
+    if !require_unconfigured {
+        ensure_token_path_safe(&token_path, &owner)?;
+    }
 
     Ok(PairingStore {
         config_path: config_path.to_path_buf(),
@@ -362,6 +549,263 @@ fn read_existing_token(path: &Path) -> Result<Option<TokenBefore>, PairingStoreE
     #[cfg(not(unix))]
     let mode = 0;
     Ok(Some(TokenBefore { contents, mode }))
+}
+
+fn same_token_snapshot(before: Option<&TokenBefore>, current: Option<&TokenBefore>) -> bool {
+    match (before, current) {
+        (None, None) => true,
+        (Some(before), Some(current)) => {
+            before.contents == current.contents && before.mode == current.mode
+        }
+        _ => false,
+    }
+}
+
+fn ensure_config_owner(path: &Path, owner: &SystemUser) -> Result<(), PairingStoreError> {
+    let metadata = fs::symlink_metadata(path).map_err(|source| PairingStoreError::ConfigRead {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    if metadata.file_type().is_symlink() {
+        return Err(PairingStoreError::ConfigSymlink {
+            path: path.to_path_buf(),
+        });
+    }
+    if !metadata.file_type().is_file() {
+        return Err(PairingStoreError::ConfigRead {
+            path: path.to_path_buf(),
+            source: io::Error::new(
+                io::ErrorKind::InvalidData,
+                "config path is not a regular file",
+            ),
+        });
+    }
+    #[cfg(unix)]
+    {
+        if metadata.uid() == 0 {
+            return Err(PairingStoreError::ConfigOwnedByRoot {
+                path: path.to_path_buf(),
+            });
+        }
+        if metadata.uid() != owner.uid() {
+            return Err(PairingStoreError::ConfigOwnerMismatch {
+                path: path.to_path_buf(),
+                owner_uid: metadata.uid(),
+                euid: current_euid(),
+            });
+        }
+    }
+    Ok(())
+}
+
+fn ensure_token_path_safe(token_path: &Path, owner: &SystemUser) -> Result<(), PairingStoreError> {
+    let profile_dir = token_path
+        .parent()
+        .expect("derived token path always has a profile directory");
+    let tvs_dir = profile_dir
+        .parent()
+        .expect("derived profile path always has a TVs directory");
+
+    for directory in [tvs_dir, profile_dir] {
+        let metadata = match fs::symlink_metadata(directory) {
+            Ok(metadata) => metadata,
+            Err(source) if source.kind() == io::ErrorKind::NotFound => continue,
+            Err(source) => {
+                return Err(PairingStoreError::TokenRead {
+                    path: directory.to_path_buf(),
+                    source,
+                })
+            }
+        };
+        if metadata.file_type().is_symlink() {
+            return Err(PairingStoreError::TokenRead {
+                path: directory.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "credential directory is a symlink",
+                ),
+            });
+        }
+        if !metadata.file_type().is_dir() {
+            return Err(PairingStoreError::TokenRead {
+                path: directory.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "credential path is not a directory",
+                ),
+            });
+        }
+        #[cfg(unix)]
+        {
+            if metadata.uid() == 0 {
+                return Err(PairingStoreError::TokenRead {
+                    path: directory.to_path_buf(),
+                    source: io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "credential directory is owned by root",
+                    ),
+                });
+            }
+            if metadata.uid() != owner.uid() {
+                return Err(PairingStoreError::TokenRead {
+                    path: directory.to_path_buf(),
+                    source: io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        "credential directory has a different owner",
+                    ),
+                });
+            }
+        }
+    }
+
+    match fs::symlink_metadata(token_path) {
+        Ok(metadata) if metadata.file_type().is_file() => {
+            #[cfg(unix)]
+            {
+                if metadata.uid() == 0 {
+                    return Err(PairingStoreError::TokenRead {
+                        path: token_path.to_path_buf(),
+                        source: io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "credential file is owned by root",
+                        ),
+                    });
+                }
+                if metadata.uid() != owner.uid() {
+                    return Err(PairingStoreError::TokenRead {
+                        path: token_path.to_path_buf(),
+                        source: io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            "credential file has a different owner",
+                        ),
+                    });
+                }
+            }
+        }
+        Ok(_) => {
+            return Err(PairingStoreError::TokenRead {
+                path: token_path.to_path_buf(),
+                source: io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "credential path is not a regular file",
+                ),
+            });
+        }
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {}
+        Err(source) => {
+            return Err(PairingStoreError::TokenRead {
+                path: token_path.to_path_buf(),
+                source,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_primary_identity(
+    config_path: &Path,
+    contents: Option<&[u8]>,
+    expected: &crate::tvs::TvProfile,
+) -> Result<(), PairingStoreError> {
+    let contents = contents.ok_or_else(|| PairingStoreError::PrimaryIdentityMismatch {
+        path: config_path.to_path_buf(),
+        field: "profile",
+    })?;
+    let text = std::str::from_utf8(contents).map_err(|source| PairingStoreError::ConfigRead {
+        path: config_path.to_path_buf(),
+        source: io::Error::new(io::ErrorKind::InvalidData, source),
+    })?;
+    let entries = parse_config_entries(text);
+
+    let value = |primary: &str, fallback: &str| {
+        entries
+            .get(primary)
+            .or_else(|| entries.get(fallback))
+            .map(String::as_str)
+    };
+    let address = value("tvs_primary_ip", "tv_ip")
+        .and_then(|value| value.parse::<Ipv4Addr>().ok())
+        .ok_or_else(|| identity_mismatch(config_path, "ip"))?;
+    let mac = value("tvs_primary_mac", "tv_mac")
+        .and_then(|value| value.parse::<MacAddress>().ok())
+        .ok_or_else(|| identity_mismatch(config_path, "mac"))?;
+    let input = value("tvs_primary_input", "input")
+        .and_then(|value| value.parse::<HdmiInput>().ok())
+        .ok_or_else(|| identity_mismatch(config_path, "input"))?;
+    let platform = entries
+        .get("tvs_primary_platform")
+        .map(String::as_str)
+        .unwrap_or(crate::config::TvPlatform::DEFAULT.as_str())
+        .parse::<crate::config::TvPlatform>()
+        .map_err(|_| identity_mismatch(config_path, "platform"))?;
+
+    for (field, matches) in [
+        ("ip", address == expected.address()),
+        ("mac", mac == expected.mac()),
+        ("input", input == expected.input()),
+        ("platform", platform == expected.platform()),
+    ] {
+        if !matches {
+            return Err(identity_mismatch(config_path, field));
+        }
+    }
+    Ok(())
+}
+
+fn identity_mismatch(path: &Path, field: &'static str) -> PairingStoreError {
+    PairingStoreError::PrimaryIdentityMismatch {
+        path: path.to_path_buf(),
+        field,
+    }
+}
+
+fn remove_primary_config_keys(original: &[u8]) -> Vec<u8> {
+    let mut contents = Vec::with_capacity(original.len());
+    let mut start = 0;
+    for (index, byte) in original.iter().enumerate() {
+        if *byte != b'\n' {
+            continue;
+        }
+        let line = &original[start..=index];
+        if !is_primary_config_line(line) {
+            contents.extend_from_slice(line);
+        }
+        start = index + 1;
+    }
+    if start < original.len() {
+        let line = &original[start..];
+        if !is_primary_config_line(line) {
+            contents.extend_from_slice(line);
+        }
+    }
+    contents
+}
+
+fn is_primary_config_line(line: &[u8]) -> bool {
+    let line = trim_ascii_whitespace(line.strip_suffix(b"\n").unwrap_or(line));
+    let line = trim_ascii_whitespace(line.strip_suffix(b"\r").unwrap_or(line));
+    if line.is_empty() || line[0] == b'#' {
+        return false;
+    }
+    let Some(equal) = line.iter().position(|byte| *byte == b'=') else {
+        return false;
+    };
+    let key = trim_ascii_whitespace(&line[..equal]);
+    TV_KEYS.iter().any(|candidate| key == candidate.as_bytes())
+}
+
+fn trim_ascii_whitespace(value: &[u8]) -> &[u8] {
+    let start = value
+        .iter()
+        .position(|byte| !byte.is_ascii_whitespace())
+        .unwrap_or(value.len());
+    let end = value
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map(|index| index + 1)
+        .unwrap_or(start);
+    &value[start..end]
 }
 
 fn remove_empty_dir(path: &Path) -> Result<(), PairingStoreError> {
@@ -631,6 +1075,13 @@ pub(crate) enum PairingStoreError {
     ConfigChanged {
         path: PathBuf,
     },
+    TokenChanged {
+        path: PathBuf,
+    },
+    PrimaryIdentityMismatch {
+        path: PathBuf,
+        field: &'static str,
+    },
     PrimaryAlreadyConfigured {
         key: String,
     },
@@ -654,6 +1105,10 @@ pub(crate) enum PairingStoreError {
     TokenWrite {
         path: PathBuf,
         source: PlatformAccessTokenStoreError,
+    },
+    TokenRemove {
+        path: PathBuf,
+        source: io::Error,
     },
     ConfigWrite {
         path: PathBuf,
@@ -696,6 +1151,18 @@ impl fmt::Display for PairingStoreError {
             Self::ConfigChanged { path } => {
                 write!(f, "config `{}` changed during pairing", path.display())
             }
+            Self::TokenChanged { path } => {
+                write!(
+                    f,
+                    "native credential `{}` changed during unpairing",
+                    path.display()
+                )
+            }
+            Self::PrimaryIdentityMismatch { path, field } => write!(
+                f,
+                "configured primary TV {field} does not match the selected profile in `{}`",
+                path.display()
+            ),
             Self::PrimaryAlreadyConfigured { key } => {
                 write!(f, "primary TV is already configured ({key})")
             }
@@ -728,6 +1195,11 @@ impl fmt::Display for PairingStoreError {
                 "could not write native credential `{}`: {source}",
                 path.display()
             ),
+            Self::TokenRemove { path, source } => write!(
+                f,
+                "could not remove native credential `{}`: {source}",
+                path.display()
+            ),
             Self::ConfigWrite { path, source } => {
                 write!(f, "could not publish config `{}`: {source}", path.display())
             }
@@ -750,6 +1222,7 @@ impl Error for PairingStoreError {
             Self::Lock { source, .. }
             | Self::ConfigRead { source, .. }
             | Self::TokenRead { source, .. }
+            | Self::TokenRemove { source, .. }
             | Self::ConfigWrite { source, .. }
             | Self::TokenRollback { source, .. } => Some(source),
             Self::Owner(source) => Some(source),
@@ -760,6 +1233,8 @@ impl Error for PairingStoreError {
             | Self::ConfigPathHasNoParent { .. }
             | Self::PairingInProgress { .. }
             | Self::ConfigChanged { .. }
+            | Self::TokenChanged { .. }
+            | Self::PrimaryIdentityMismatch { .. }
             | Self::PrimaryAlreadyConfigured { .. }
             | Self::ConfigOwnedByRoot { .. }
             | Self::ConfigOwnerMismatch { .. }
@@ -771,6 +1246,8 @@ impl Error for PairingStoreError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::TvPlatform;
+    use crate::tvs::{TvCredentialState, TvId, TvProfile};
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -803,6 +1280,27 @@ mod tests {
 
     fn mac() -> MacAddress {
         "aa:bb:cc:dd:ee:ff".parse().unwrap()
+    }
+
+    fn profile(platform: TvPlatform) -> TvProfile {
+        TvProfile::new(
+            TvId::primary(),
+            "Primary TV",
+            "192.0.2.42".parse().unwrap(),
+            mac(),
+            HdmiInput::Hdmi2,
+            platform,
+            TvCredentialState::Stored,
+        )
+    }
+
+    fn native_config() -> &'static str {
+        "# keep this comment\n\
+         screen_backend=gnome\n\
+         tvs_primary_ip=192.0.2.42\n\
+         tvs_primary_mac=aa:bb:cc:dd:ee:ff\n\
+         tvs_primary_input=HDMI_2\n\
+         tvs_primary_platform=lg_webos\n"
     }
 
     #[test]
@@ -1009,5 +1507,153 @@ mod tests {
         fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o700)).unwrap();
         assert!(result.is_err());
         assert_eq!(fs::read(token_path).unwrap(), original);
+    }
+
+    #[test]
+    fn unpair_native_removes_all_primary_keys_and_native_token() {
+        let dir = TestDir::new("unpair-native");
+        fs::write(dir.config(), native_config()).unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        fs::write(&token_path, "{\"access_token\":\"native\"}\n").unwrap();
+        let legacy = dir.0.join(".aiopylgtv.sqlite");
+        fs::write(&legacy, b"legacy database").unwrap();
+
+        PairingStore::unpair_primary(&dir.config(), &profile(TvPlatform::LgWebOs)).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dir.config()).unwrap(),
+            "# keep this comment\nscreen_backend=gnome\n"
+        );
+        assert!(!token_path.exists());
+        assert_eq!(fs::read(legacy).unwrap(), b"legacy database");
+    }
+
+    #[test]
+    fn unpair_compatibility_removes_config_but_preserves_missing_native_token() {
+        let dir = TestDir::new("unpair-compatibility");
+        fs::write(
+            dir.config(),
+            "screen_backend=gnome\n\
+             tv_ip=192.0.2.42\n\
+             tv_mac=aa:bb:cc:dd:ee:ff\n\
+             input=HDMI_2\n",
+        )
+        .unwrap();
+        let legacy = dir.0.join(".aiopylgtv.sqlite");
+        fs::write(&legacy, b"legacy database").unwrap();
+
+        PairingStore::unpair_primary(&dir.config(), &profile(TvPlatform::Bscpylgtv)).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dir.config()).unwrap(),
+            "screen_backend=gnome\n"
+        );
+        assert!(!dir.0.join("tvs/primary/access-token.json").exists());
+        assert_eq!(fs::read(legacy).unwrap(), b"legacy database");
+    }
+
+    #[test]
+    fn dropping_unpair_transaction_is_cancellation_equivalent() {
+        let dir = TestDir::new("unpair-cancel");
+        fs::write(dir.config(), native_config()).unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        let original_token = b"malformed token bytes\n";
+        fs::write(&token_path, original_token).unwrap();
+
+        {
+            let _store = prepare_unpair_with_euid(&dir.config(), current_euid()).unwrap();
+        }
+
+        assert_eq!(fs::read_to_string(dir.config()).unwrap(), native_config());
+        assert_eq!(fs::read(token_path).unwrap(), original_token);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unpair_config_failure_restores_original_token_and_config() {
+        let dir = TestDir::new("unpair-rollback");
+        let original_config = native_config();
+        fs::write(dir.config(), original_config).unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        let original_token = b"malformed token bytes\n";
+        fs::write(&token_path, original_token).unwrap();
+        let store = prepare_unpair_with_euid(&dir.config(), current_euid()).unwrap();
+        fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = store.unpair(&profile(TvPlatform::LgWebOs));
+
+        fs::set_permissions(&dir.0, fs::Permissions::from_mode(0o700)).unwrap();
+        assert!(matches!(result, Err(PairingStoreError::ConfigWrite { .. })));
+        assert_eq!(fs::read_to_string(dir.config()).unwrap(), original_config);
+        assert_eq!(fs::read(token_path).unwrap(), original_token);
+    }
+
+    #[test]
+    fn unpair_refuses_stale_profile_before_removing_token() {
+        let dir = TestDir::new("unpair-stale");
+        fs::write(dir.config(), native_config()).unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        fs::write(&token_path, b"token").unwrap();
+
+        let stale = TvProfile::new(
+            TvId::primary(),
+            "Primary TV",
+            "192.0.2.99".parse().unwrap(),
+            mac(),
+            HdmiInput::Hdmi2,
+            TvPlatform::LgWebOs,
+            TvCredentialState::Stored,
+        );
+        let result = PairingStore::unpair_primary(&dir.config(), &stale);
+
+        assert!(matches!(
+            result,
+            Err(PairingStoreError::PrimaryIdentityMismatch { .. })
+        ));
+        assert_eq!(fs::read_to_string(dir.config()).unwrap(), native_config());
+        assert_eq!(fs::read(token_path).unwrap(), b"token");
+    }
+
+    #[test]
+    fn unpair_removes_malformed_regular_token() {
+        let dir = TestDir::new("unpair-malformed");
+        fs::write(dir.config(), native_config()).unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        fs::write(&token_path, b"not json").unwrap();
+
+        PairingStore::unpair_primary(&dir.config(), &profile(TvPlatform::LgWebOs)).unwrap();
+
+        assert!(!token_path.exists());
+        assert_eq!(
+            fs::read_to_string(dir.config()).unwrap(),
+            "# keep this comment\nscreen_backend=gnome\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unpair_refuses_unsafe_token_symlink() {
+        let dir = TestDir::new("unpair-token-symlink");
+        fs::write(dir.config(), native_config()).unwrap();
+        let token_path = dir.0.join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().unwrap()).unwrap();
+        let target = dir.0.join("outside-token");
+        fs::write(&target, b"must survive").unwrap();
+        std::os::unix::fs::symlink(&target, &token_path).unwrap();
+
+        assert!(
+            PairingStore::unpair_primary(&dir.config(), &profile(TvPlatform::LgWebOs)).is_err()
+        );
+        assert_eq!(fs::read(&target).unwrap(), b"must survive");
+        assert!(fs::symlink_metadata(token_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(fs::read_to_string(dir.config()).unwrap(), native_config());
     }
 }

--- a/crates/lg-buddy/src/presentation/tvs.rs
+++ b/crates/lg-buddy/src/presentation/tvs.rs
@@ -10,6 +10,11 @@ pub struct TvsPresentation {
     retry_action: Option<TvsAction>,
     pair_action: Option<TvsAction>,
     pairing: Option<super::pairing::PairingPresentation>,
+    input_enabled: bool,
+    unpair_action: Option<TvsAction>,
+    unpair_confirmation: Option<UnpairConfirmation>,
+    management_error: Option<super::brightness::UserFacingError>,
+    retry_apply_action: Option<TvsAction>,
 }
 
 /// The state a renderer can show without interpreting application policy.
@@ -29,6 +34,26 @@ pub struct TvsAction {
     intent: TvsIntent,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnpairConfirmation {
+    confirm: TvsAction,
+    cancel: TvsAction,
+}
+impl UnpairConfirmation {
+    pub fn title(&self) -> &str {
+        "Unpair TV?"
+    }
+    pub fn body(&self) -> &str {
+        "Remove this TV and its saved native credential from LG Buddy? You can pair a TV again afterwards. This does not remove LG Buddy’s authorization on the TV itself."
+    }
+    pub fn confirm_action(&self) -> &TvsAction {
+        &self.confirm
+    }
+    pub fn cancel_action(&self) -> &TvsAction {
+        &self.cancel
+    }
+}
+
 impl TvsPresentation {
     pub(crate) fn loading() -> Self {
         Self {
@@ -41,6 +66,11 @@ impl TvsPresentation {
             retry_action: None,
             pair_action: None,
             pairing: None,
+            input_enabled: false,
+            unpair_action: None,
+            unpair_confirmation: None,
+            management_error: None,
+            retry_apply_action: None,
         }
     }
 
@@ -56,6 +86,11 @@ impl TvsPresentation {
             retry_action: None,
             pair_action: Some(TvsAction::new("Pair a TV", true, TvsIntent::PairTv)),
             pairing: None,
+            input_enabled: false,
+            unpair_action: None,
+            unpair_confirmation: None,
+            management_error: None,
+            retry_apply_action: None,
         }
     }
 
@@ -68,6 +103,11 @@ impl TvsPresentation {
             retry_action: None,
             pair_action: None,
             pairing: None,
+            input_enabled: false,
+            unpair_action: None,
+            unpair_confirmation: None,
+            management_error: None,
+            retry_apply_action: None,
         }
     }
 
@@ -80,7 +120,59 @@ impl TvsPresentation {
             retry_action: Some(TvsAction::new("Retry", true, TvsIntent::Retry)),
             pair_action: None,
             pairing: None,
+            input_enabled: false,
+            unpair_action: None,
+            unpair_confirmation: None,
+            management_error: None,
+            retry_apply_action: None,
         }
+    }
+
+    pub fn input_enabled(&self) -> bool {
+        self.input_enabled
+    }
+    pub fn unpair_action(&self) -> Option<&TvsAction> {
+        self.unpair_action.as_ref()
+    }
+    pub fn unpair_confirmation(&self) -> Option<&UnpairConfirmation> {
+        self.unpair_confirmation.as_ref()
+    }
+    pub fn management_error(&self) -> Option<&super::brightness::UserFacingError> {
+        self.management_error.as_ref()
+    }
+    pub fn retry_apply_action(&self) -> Option<&TvsAction> {
+        self.retry_apply_action.as_ref()
+    }
+
+    pub(crate) fn set_input(&mut self, input: crate::config::HdmiInput) {
+        if let Some(profile) = self
+            .profiles
+            .iter_mut()
+            .find(|p| Some(p.id()) == self.selected_id.as_ref())
+        {
+            profile.set_input(input);
+        }
+    }
+
+    pub(crate) fn set_management(
+        &mut self,
+        enabled: bool,
+        confirming: bool,
+        confirmation_enabled: bool,
+        error: Option<super::brightness::UserFacingError>,
+        retry_apply: bool,
+    ) {
+        self.input_enabled = enabled;
+        self.unpair_action = self
+            .selected_profile()
+            .map(|_| TvsAction::new("Unpair TV…", enabled, TvsIntent::UnpairTv));
+        self.unpair_confirmation = confirming.then(|| UnpairConfirmation {
+            confirm: TvsAction::new("Unpair", confirmation_enabled, TvsIntent::ConfirmUnpair),
+            cancel: TvsAction::new("Cancel", true, TvsIntent::CancelUnpair),
+        });
+        self.management_error = error;
+        self.retry_apply_action =
+            retry_apply.then(|| TvsAction::new("Retry", enabled, TvsIntent::RetryInputApply));
     }
 
     pub fn title(&self) -> &str {

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -29,7 +29,7 @@ pub use tv::{PlatformPreflight, WebOsPlatformPreflight};
 
 #[cfg(test)]
 use formatter::format_effective_value;
-use store::persist_settings_mutation;
+pub(crate) use store::persist_settings_mutation;
 
 const READ_WRITE_OPERATIONS: &[SettingOperation] = &[
     SettingOperation::Get,

--- a/crates/lg-buddy/src/settings/store.rs
+++ b/crates/lg-buddy/src/settings/store.rs
@@ -1,7 +1,13 @@
 use std::collections::HashMap;
-use std::fs;
-use std::io;
+use std::fs::{self, OpenOptions};
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
 use crate::config::{
     parse_config_entries, resolve_config_path, resolve_config_path_from_env, ConfigPathSources,
@@ -10,6 +16,8 @@ use crate::config::{
 use super::{
     SettingDefinition, SettingKey, SettingOperation, SettingValue, SettingsError, SETTINGS_REGISTRY,
 };
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct ConfigEnvEditor {
@@ -80,9 +88,11 @@ impl ConfigEnvEditor {
             }
         }
 
-        fs::write(&self.path, self.render()).map_err(|err| SettingsError::WriteConfig {
-            path: self.path.clone(),
-            message: err.to_string(),
+        atomic_write_config(&self.path, self.render().as_bytes()).map_err(|err| {
+            SettingsError::WriteConfig {
+                path: self.path.clone(),
+                message: err.to_string(),
+            }
         })
     }
 
@@ -102,6 +112,66 @@ impl ConfigEnvEditor {
             .find(|(_, line)| config_line_key(line) == Some(storage_key))
             .map(|(index, _)| index)
     }
+}
+
+fn atomic_write_config(path: &Path, contents: &[u8]) -> io::Result<()> {
+    // Continue updating an existing symlink's target instead of replacing the
+    // link itself. A dangling link cannot be safely resolved for publication.
+    let path = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => fs::canonicalize(path)?,
+        Ok(_) => path.to_path_buf(),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => path.to_path_buf(),
+        Err(error) => return Err(error),
+    };
+    // Check the original file's write access without truncating it. Rename
+    // permission alone must not let a save replace a read-only configuration.
+    let metadata = match OpenOptions::new().write(true).open(&path) {
+        Ok(file) => Some(file.metadata()?),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error),
+    };
+    let name = path.file_name().ok_or_else(|| {
+        io::Error::new(io::ErrorKind::InvalidInput, "config path has no file name")
+    })?;
+    let mut temp_name = std::ffi::OsString::from(".");
+    temp_name.push(name);
+    temp_name.push(format!(
+        ".settings.{}.{}.tmp",
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let temp_path = path.with_file_name(temp_name);
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(if metadata.is_some() { 0o600 } else { 0o666 });
+    let mut file = options.open(&temp_path)?;
+    let result = (|| {
+        file.write_all(contents)?;
+        if let Some(metadata) = metadata {
+            #[cfg(unix)]
+            {
+                let created = file.metadata()?;
+                if (created.uid(), created.gid()) != (metadata.uid(), metadata.gid()) {
+                    let result =
+                        unsafe { libc::fchown(file.as_raw_fd(), metadata.uid(), metadata.gid()) };
+                    if result != 0 {
+                        return Err(io::Error::last_os_error());
+                    }
+                }
+            }
+            file.set_permissions(metadata.permissions())?;
+        }
+        file.sync_all()?;
+        drop(file);
+        // Publication is the final fallible step: errors leave the old bytes
+        // intact, and success means readers can see the complete new contents.
+        fs::rename(&temp_path, &path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -202,7 +272,7 @@ impl SettingsChange {
     }
 }
 
-pub(super) fn persist_settings_mutation(
+pub(crate) fn persist_settings_mutation(
     path: &Path,
     mutation: SettingsMutation,
 ) -> Result<SettingsChange, SettingsError> {

--- a/crates/lg-buddy/src/tvs.rs
+++ b/crates/lg-buddy/src/tvs.rs
@@ -5,6 +5,11 @@
 //! and adaptive multi-TV layouts without adding a second-TV storage format or
 //! a second-TV pairing workflow to production.
 
+mod management;
+pub use management::{
+    TvsManagementAction, TvsManagementError, TvsManagementOperation, TvsManagementOutcome,
+};
+
 use std::error::Error;
 use std::fmt;
 use std::fs;
@@ -136,6 +141,10 @@ impl TvProfile {
         self.mac
     }
 
+    pub(crate) fn set_input(&mut self, input: HdmiInput) {
+        self.input = input;
+    }
+
     pub fn input(&self) -> HdmiInput {
         self.input
     }
@@ -217,6 +226,11 @@ pub enum TvsIntent {
     Select(TvId),
     Retry,
     PairTv,
+    SetInput(HdmiInput),
+    UnpairTv,
+    ConfirmUnpair,
+    CancelUnpair,
+    RetryInputApply,
     Pairing(PairingIntent),
 }
 
@@ -250,7 +264,8 @@ pub struct TvsTransition {
     read_operation: Option<TvsReadOperation>,
     model_read_operation: Option<TvsModelReadOperation>,
     pairing_operation: Option<PairingOperation>,
-    profile_created: bool,
+    profile_changed: bool,
+    management_operation: Option<TvsManagementOperation>,
     toast_message: Option<String>,
     diagnostic: Option<String>,
 }
@@ -277,8 +292,12 @@ impl TvsTransition {
     }
 
     /// The durable profile changed, so other application views can reload it.
-    pub(crate) fn profile_created(&self) -> bool {
-        self.profile_created
+    pub(crate) fn profile_changed(&self) -> bool {
+        self.profile_changed
+    }
+
+    pub fn management_operation(&self) -> Option<&TvsManagementOperation> {
+        self.management_operation.as_ref()
     }
 
     /// One-time feedback for this transition, separate from persistent view state.
@@ -335,6 +354,12 @@ impl Error for TvsReadError {}
 pub trait TvsBackend: Send + Sync + 'static {
     fn read_profiles(&self) -> Result<Vec<TvProfile>, TvsReadError>;
     fn read_model_name(&self, profile: &TvProfile) -> Result<String, TvsReadError>;
+    fn manage(
+        &self,
+        _operation: &TvsManagementOperation,
+    ) -> Result<TvsManagementOutcome, TvsManagementError> {
+        Err(TvsManagementError::stopped())
+    }
 }
 
 /// Production reader for the existing primary profile.
@@ -347,6 +372,13 @@ pub trait TvsBackend: Send + Sync + 'static {
 pub struct EnvironmentTvsBackend;
 
 impl TvsBackend for EnvironmentTvsBackend {
+    fn manage(
+        &self,
+        operation: &TvsManagementOperation,
+    ) -> Result<TvsManagementOutcome, TvsManagementError> {
+        management::manage(operation)
+    }
+
     fn read_profiles(&self) -> Result<Vec<TvProfile>, TvsReadError> {
         let config_path = ConfigPathResolver::resolve_from_env()
             .map_err(|error| TvsReadError::new(TvsReadFailure::NotConfigured, error.to_string()))?;
@@ -420,6 +452,11 @@ pub struct TvsApplication {
     next_operation_id: u64,
     pending_model: Option<TvsModelReadOperation>,
     pairing: Option<PairingApplication>,
+    management: Option<TvsManagementOperation>,
+    confirming_unpair: bool,
+    controls_available: bool,
+    management_error: Option<UserFacingError>,
+    input_apply_failed: bool,
 }
 
 impl TvsApplication {
@@ -430,6 +467,11 @@ impl TvsApplication {
             next_operation_id: 1,
             pending_model: None,
             pairing: None,
+            management: None,
+            confirming_unpair: false,
+            controls_available: true,
+            management_error: None,
+            input_apply_failed: false,
         };
         let transition = application.transition(Some(operation), None);
         (application, transition)
@@ -437,6 +479,44 @@ impl TvsApplication {
 
     pub fn handle_intent(&mut self, intent: TvsIntent) -> Option<TvsTransition> {
         match intent {
+            TvsIntent::SetInput(input) => {
+                if !self.can_manage() || self.confirming_unpair {
+                    return None;
+                }
+                let profile = self.selected_profile()?;
+                if profile.input() == input {
+                    return None;
+                }
+                self.start_management(TvsManagementAction::SetInput(input))
+            }
+            TvsIntent::RetryInputApply => {
+                if !self.can_manage() || !self.input_apply_failed || self.confirming_unpair {
+                    return None;
+                }
+                self.start_management(TvsManagementAction::RetryInputApply)
+            }
+            TvsIntent::UnpairTv => {
+                if !self.can_manage() || self.confirming_unpair {
+                    return None;
+                }
+                self.confirming_unpair = true;
+                self.management_error = None;
+                Some(self.transition(None, None))
+            }
+            TvsIntent::ConfirmUnpair => {
+                if !self.can_manage() || !self.confirming_unpair {
+                    return None;
+                }
+                self.confirming_unpair = false;
+                self.start_management(TvsManagementAction::Unpair)
+            }
+            TvsIntent::CancelUnpair => {
+                if !self.confirming_unpair {
+                    return None;
+                }
+                self.confirming_unpair = false;
+                Some(self.transition(None, None))
+            }
             TvsIntent::PairTv => {
                 if !matches!(self.state, TvsState::Empty) || self.pairing.is_some() {
                     return None;
@@ -471,6 +551,9 @@ impl TvsApplication {
                 Some(self.transition(Some(operation), None))
             }
             TvsIntent::Select(id) => {
+                if self.is_managing() || self.confirming_unpair {
+                    return None;
+                }
                 let TvsState::Ready {
                     profiles,
                     selected_id,
@@ -550,6 +633,8 @@ impl TvsApplication {
             pairing.shutdown();
         }
         self.pairing = None;
+        self.management = None;
+        self.confirming_unpair = false;
         self.state = TvsState::Closed;
         self.pending_model = None;
     }
@@ -581,7 +666,7 @@ impl TvsApplication {
                     profiles: vec![profile],
                 };
                 let mut transition = self.transition_with_model_read();
-                transition.profile_created = true;
+                transition.profile_changed = true;
                 transition.toast_message = Some("TV paired successfully".into());
                 Some(transition)
             }
@@ -602,6 +687,96 @@ impl TvsApplication {
 
     pub fn is_pairing(&self) -> bool {
         self.pairing.is_some()
+    }
+
+    fn selected_profile(&self) -> Option<&TvProfile> {
+        match &self.state {
+            TvsState::Ready {
+                profiles,
+                selected_id,
+            } => profiles.iter().find(|p| p.id() == selected_id),
+            _ => None,
+        }
+    }
+
+    fn can_manage(&self) -> bool {
+        self.controls_available
+            && self.management.is_none()
+            && self.pairing.is_none()
+            && self.selected_profile().is_some()
+    }
+
+    pub fn is_managing(&self) -> bool {
+        self.management.is_some()
+    }
+
+    pub(crate) fn set_controls_available(&mut self, available: bool) -> Option<TvsTransition> {
+        if self.controls_available == available {
+            return None;
+        }
+        self.controls_available = available;
+        Some(self.transition(None, None))
+    }
+
+    fn start_management(&mut self, action: TvsManagementAction) -> Option<TvsTransition> {
+        let operation = TvsManagementOperation {
+            id: self.next_operation_id,
+            profile: self.selected_profile()?.clone(),
+            action,
+        };
+        self.next_operation_id += 1;
+        self.pending_model = None;
+        self.management_error = None;
+        self.management = Some(operation.clone());
+        let mut transition = self.transition(None, None);
+        transition.management_operation = Some(operation);
+        Some(transition)
+    }
+
+    pub fn complete_management(
+        &mut self,
+        operation: &TvsManagementOperation,
+        result: Result<TvsManagementOutcome, TvsManagementError>,
+    ) -> Option<TvsTransition> {
+        if self.management.as_ref() != Some(operation) {
+            return None;
+        }
+        self.management = None;
+        let toast = match result {
+            Ok(TvsManagementOutcome::Unpaired) => {
+                self.state = TvsState::Empty;
+                self.input_apply_failed = false;
+                Some("TV unpaired".to_string())
+            }
+            Ok(TvsManagementOutcome::InputChanged(profile)) => {
+                self.state = TvsState::Ready {
+                    selected_id: profile.id().clone(),
+                    profiles: vec![profile],
+                };
+                self.input_apply_failed = false;
+                Some("HDMI input updated".to_string())
+            }
+            Ok(TvsManagementOutcome::InputApplyFailed(profile)) => {
+                self.state = TvsState::Ready {
+                    selected_id: profile.id().clone(),
+                    profiles: vec![profile],
+                };
+                self.input_apply_failed = true;
+                self.management_error = Some(UserFacingError::new(
+                    "HDMI input saved",
+                    "The selection was saved, but could not be applied. Retry applying it.",
+                ));
+                None
+            }
+            Err(error) => {
+                self.management_error = Some(error.presentation().clone());
+                None
+            }
+        };
+        let mut transition = self.transition(None, None);
+        transition.profile_changed = true;
+        transition.toast_message = toast;
+        Some(transition)
     }
 
     fn transition_with_model_read(&mut self) -> TvsTransition {
@@ -639,7 +814,8 @@ impl TvsApplication {
             read_operation,
             model_read_operation: None,
             pairing_operation: None,
-            profile_created: false,
+            profile_changed: false,
+            management_operation: None,
             toast_message: None,
             diagnostic,
         }
@@ -656,6 +832,18 @@ impl TvsApplication {
             TvsState::Failed(error) => TvsPresentation::failed(error.clone()),
             TvsState::Closed => TvsPresentation::loading(),
         };
+        if let Some(operation) = &self.management {
+            if let TvsManagementAction::SetInput(input) = operation.action {
+                presentation.set_input(input);
+            }
+        }
+        presentation.set_management(
+            self.can_manage() && !self.confirming_unpair,
+            self.confirming_unpair,
+            self.controls_available,
+            self.management_error.clone(),
+            self.input_apply_failed,
+        );
         if let Some(pairing) = &self.pairing {
             presentation.set_pairing(pairing.presentation());
         }
@@ -1118,6 +1306,149 @@ mod tests {
         app.shutdown();
         assert!(app
             .complete_read(retry_operation, Ok(vec![profile("late", "192.0.2.8")]))
+            .is_none());
+    }
+}
+
+#[cfg(test)]
+mod management_tests {
+    use super::*;
+
+    fn configured() -> (TvsApplication, TvsTransition) {
+        let (mut app, opening) = TvsApplication::open();
+        let profile = TvProfile::new(
+            TvId::primary(),
+            "TV",
+            "192.0.2.10".parse().unwrap(),
+            "02:11:22:33:44:55".parse().unwrap(),
+            HdmiInput::Hdmi1,
+            TvPlatform::LgWebOs,
+            TvCredentialState::Stored,
+        );
+        let ready = app
+            .complete_read(opening.read_operation().unwrap(), Ok(vec![profile]))
+            .unwrap();
+        (app, ready)
+    }
+
+    #[test]
+    fn unpair_requires_confirmation_and_cancellation_keeps_profile() {
+        let (mut app, ready) = configured();
+        assert!(app.handle_intent(TvsIntent::ConfirmUnpair).is_none());
+        let confirmation = app.handle_intent(TvsIntent::UnpairTv).unwrap();
+        assert!(confirmation.presentation().unpair_confirmation().is_some());
+        assert!(confirmation.management_operation().is_none());
+        assert!(!confirmation.presentation().input_enabled());
+        let cancelled = app.handle_intent(TvsIntent::CancelUnpair).unwrap();
+        assert_eq!(
+            cancelled.presentation().profiles(),
+            ready.presentation().profiles()
+        );
+        assert!(cancelled.presentation().unpair_confirmation().is_none());
+        assert!(cancelled.management_operation().is_none());
+    }
+
+    #[test]
+    fn failed_unpair_preserves_profile_and_success_reuses_empty_pairing() {
+        let (mut app, ready) = configured();
+        app.handle_intent(TvsIntent::UnpairTv).unwrap();
+        let started = app.handle_intent(TvsIntent::ConfirmUnpair).unwrap();
+        let operation = started.management_operation().unwrap();
+        assert!(app.handle_intent(TvsIntent::ConfirmUnpair).is_none());
+        let failed = app
+            .complete_management(operation, Err(TvsManagementError::stopped()))
+            .unwrap();
+        assert_eq!(
+            failed.presentation().profiles(),
+            ready.presentation().profiles()
+        );
+        assert!(failed.presentation().management_error().is_some());
+        app.handle_intent(TvsIntent::UnpairTv).unwrap();
+        let started = app.handle_intent(TvsIntent::ConfirmUnpair).unwrap();
+        let operation = started.management_operation().unwrap();
+        let success = app
+            .complete_management(operation, Ok(TvsManagementOutcome::Unpaired))
+            .unwrap();
+        assert!(success.presentation().profiles().is_empty());
+        assert_eq!(
+            success.presentation().pair_action().unwrap().intent(),
+            TvsIntent::PairTv
+        );
+        assert_eq!(success.toast_message(), Some("TV unpaired"));
+        assert!(app
+            .complete_model_read(
+                ready.model_read_operation().unwrap().clone(),
+                Ok("stale TV".into())
+            )
+            .is_none());
+        assert!(app
+            .complete_management(operation, Ok(TvsManagementOutcome::Unpaired))
+            .is_none());
+        assert!(app
+            .handle_intent(TvsIntent::PairTv)
+            .unwrap()
+            .presentation()
+            .pairing()
+            .is_some());
+    }
+
+    #[test]
+    fn input_failure_restores_selection_and_apply_failure_retains_saved_selection() {
+        let (mut app, ready) = configured();
+        let started = app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+            .unwrap();
+        assert_eq!(
+            started.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi3
+        );
+        assert!(!started.presentation().input_enabled());
+        assert!(app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi4))
+            .is_none());
+        assert!(app.handle_intent(TvsIntent::UnpairTv).is_none());
+        let failed = app
+            .complete_management(
+                started.management_operation().unwrap(),
+                Err(TvsManagementError::stopped()),
+            )
+            .unwrap();
+        assert_eq!(
+            failed.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi1
+        );
+        assert!(failed.presentation().input_enabled());
+        let started = app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+            .unwrap();
+        let mut saved = ready.presentation().selected_profile().unwrap().clone();
+        saved.set_input(HdmiInput::Hdmi3);
+        let applied = app
+            .complete_management(
+                started.management_operation().unwrap(),
+                Ok(TvsManagementOutcome::InputApplyFailed(saved)),
+            )
+            .unwrap();
+        assert_eq!(
+            applied.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi3
+        );
+        assert!(applied.presentation().retry_apply_action().is_some());
+        let retry = app.handle_intent(TvsIntent::RetryInputApply).unwrap();
+        assert_eq!(
+            retry.management_operation().unwrap().action(),
+            TvsManagementAction::RetryInputApply
+        );
+        assert_eq!(
+            retry.management_operation().unwrap().profile().input(),
+            HdmiInput::Hdmi3
+        );
+        app.shutdown();
+        assert!(app
+            .complete_management(
+                retry.management_operation().unwrap(),
+                Err(TvsManagementError::stopped())
+            )
             .is_none());
     }
 }

--- a/crates/lg-buddy/src/tvs/management.rs
+++ b/crates/lg-buddy/src/tvs/management.rs
@@ -1,0 +1,129 @@
+//! Local changes to the configured TV, using the existing settings and pairing stores.
+
+use super::{read_profiles_from_store, TvProfile};
+use crate::config::HdmiInput;
+use crate::presentation::brightness::UserFacingError;
+use crate::settings::{
+    persist_settings_mutation, ConfigPathResolver, SettingsApplier, SettingsMutation, SettingsStore,
+};
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TvsManagementAction {
+    SetInput(HdmiInput),
+    RetryInputApply,
+    Unpair,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TvsManagementOperation {
+    pub(super) id: u64,
+    pub(super) profile: TvProfile,
+    pub(super) action: TvsManagementAction,
+}
+
+impl TvsManagementOperation {
+    pub fn profile(&self) -> &TvProfile {
+        &self.profile
+    }
+
+    pub fn action(&self) -> TvsManagementAction {
+        self.action
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TvsManagementOutcome {
+    InputChanged(TvProfile),
+    InputApplyFailed(TvProfile),
+    Unpaired,
+}
+
+/// Sanitized failure; storage paths, protocol responses and tokens never enter presentation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TvsManagementError(UserFacingError);
+
+impl TvsManagementError {
+    pub fn new(summary: &str, detail: &str) -> Self {
+        Self(UserFacingError::new(summary, detail))
+    }
+
+    pub fn stopped() -> Self {
+        Self::new(
+            "TV change stopped",
+            "Check the saved TV details before trying again.",
+        )
+    }
+
+    pub fn presentation(&self) -> &UserFacingError {
+        &self.0
+    }
+}
+
+pub(super) fn manage(
+    operation: &TvsManagementOperation,
+) -> Result<TvsManagementOutcome, TvsManagementError> {
+    let path = ConfigPathResolver::resolve_from_env().map_err(|_| configuration_changed())?;
+    manage_at(&path, operation)
+}
+
+fn configuration_changed() -> TvsManagementError {
+    TvsManagementError::new(
+        "TV configuration changed",
+        "Reopen LG Buddy to load the current TV before trying again.",
+    )
+}
+
+fn manage_at(
+    path: &Path,
+    operation: &TvsManagementOperation,
+) -> Result<TvsManagementOutcome, TvsManagementError> {
+    let store = SettingsStore::load(path).map_err(|_| configuration_changed())?;
+    let profiles = read_profiles_from_store(path, &store).map_err(|_| configuration_changed())?;
+    let mut profile = profiles
+        .into_iter()
+        .next()
+        .ok_or_else(configuration_changed)?;
+    if !same_configuration(&profile, operation.profile()) {
+        return Err(configuration_changed());
+    }
+    match operation.action {
+        TvsManagementAction::Unpair => {
+            crate::pairing_store::unpair_primary(path, &operation.profile).map_err(|_| {
+                TvsManagementError::new("Could not unpair TV", "LG Buddy could not remove its local connection. Check access to the configuration and credential files, then try again.")
+            })?;
+            Ok(TvsManagementOutcome::Unpaired)
+        }
+        TvsManagementAction::SetInput(_) | TvsManagementAction::RetryInputApply => {
+            // Retrying applies the already-persisted selection, never a stale draft value.
+            let input = match operation.action {
+                TvsManagementAction::SetInput(input) => input,
+                _ => profile.input(),
+            };
+            let mutation =
+                SettingsMutation::set(&store, "tv.input", input.as_str()).map_err(|_| {
+                    TvsManagementError::new(
+                        "Invalid HDMI input",
+                        "Choose an input from HDMI 1 to HDMI 4.",
+                    )
+                })?;
+            let change = persist_settings_mutation(path, mutation).map_err(|_| {
+                TvsManagementError::new("Could not save HDMI input", "The previous input is still selected. Check access to the configuration file and try again.")
+            })?;
+            profile.input = input;
+            profile.model_name = operation.profile.model_name.clone();
+            match SettingsApplier::from_env().apply(&change) {
+                Ok(_) => Ok(TvsManagementOutcome::InputChanged(profile)),
+                Err(_) => Ok(TvsManagementOutcome::InputApplyFailed(profile)),
+            }
+        }
+    }
+}
+
+pub(super) fn same_configuration(left: &TvProfile, right: &TvProfile) -> bool {
+    left.id() == right.id()
+        && left.address() == right.address()
+        && left.mac() == right.mac()
+        && left.input() == right.input()
+        && left.platform() == right.platform()
+}

--- a/crates/lg-buddy/tests/tvs_management.rs
+++ b/crates/lg-buddy/tests/tvs_management.rs
@@ -1,0 +1,234 @@
+mod support;
+
+use lg_buddy::config::HdmiInput;
+use lg_buddy::settings::{ConfigEnvEditor, SettingsCommand, SettingsCommandRunner, SettingsStore};
+use lg_buddy::tvs::{
+    EnvironmentTvsBackend, TvsApplication, TvsBackend, TvsIntent, TvsManagementOutcome,
+};
+use std::fs;
+use support::{TestConfigFile, TestEnv};
+
+#[test]
+fn input_edit_reuses_cli_persistence_without_pairing_or_tv_commands() {
+    let config = TestConfigFile::new("tvs-input-edit");
+    config.write_sample("HDMI_1");
+    let before = fs::read_to_string(config.path()).unwrap();
+    let cli_config = TestConfigFile::new("tvs-input-cli");
+    cli_config.write_contents(&before);
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    let backend = EnvironmentTvsBackend;
+    let (mut app, opening) = TvsApplication::open();
+    let profiles = backend.read_profiles().unwrap();
+    app.complete_read(opening.read_operation().unwrap(), Ok(profiles))
+        .unwrap();
+    let start = app
+        .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+        .unwrap();
+    let operation = start.management_operation().unwrap();
+    let outcome = backend.manage(operation).unwrap();
+    assert!(matches!(outcome, TvsManagementOutcome::InputChanged(_)));
+    let saved = app.complete_management(operation, Ok(outcome)).unwrap();
+    assert_eq!(
+        saved.presentation().selected_profile().unwrap().input(),
+        HdmiInput::Hdmi3
+    );
+    let runner = SettingsCommandRunner::new(SettingsStore::load(cli_config.path()).unwrap());
+    runner
+        .run(
+            SettingsCommand::Set {
+                key: "tv.input".into(),
+                value: "HDMI_3".into(),
+            },
+            &mut Vec::new(),
+        )
+        .unwrap();
+    assert_eq!(
+        fs::read(config.path()).unwrap(),
+        fs::read(cli_config.path()).unwrap()
+    );
+}
+
+#[test]
+fn input_edit_rejects_a_changed_profile_before_saving() {
+    let config = TestConfigFile::new("tvs-input-stale");
+    config.write_sample("HDMI_1");
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    let backend = EnvironmentTvsBackend;
+    let (mut app, opening) = TvsApplication::open();
+    app.complete_read(
+        opening.read_operation().unwrap(),
+        Ok(backend.read_profiles().unwrap()),
+    )
+    .unwrap();
+    let start = app
+        .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+        .unwrap();
+    config.set_value("tvs_primary_ip", "192.0.2.99");
+    let before = fs::read(config.path()).unwrap();
+    assert!(backend
+        .manage(start.management_operation().unwrap())
+        .is_err());
+    assert_eq!(fs::read(config.path()).unwrap(), before);
+}
+
+#[cfg(unix)]
+#[test]
+fn input_write_failure_preserves_configuration_and_selection() {
+    // Resource limits and signal dispositions affect the whole process, so
+    // exercise real short writes in a child running only this test.
+    const CHILD: &str = "LG_BUDDY_TEST_INPUT_SHORT_WRITE_CHILD";
+    if std::env::var_os(CHILD).is_none() {
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "input_write_failure_preserves_configuration_and_selection",
+                "--nocapture",
+            ])
+            .env(CHILD, "1")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "short-write test failed:\n{}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+
+    let config = TestConfigFile::new("tvs-input-short-write");
+    config.write_sample("HDMI_1");
+    config.append_line(&format!("# {}", "padding".repeat(250)));
+    config.append_line("updates_auto_check=disabled");
+    let before = fs::read(config.path()).unwrap();
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    let backend = EnvironmentTvsBackend;
+    let (mut app, opening) = TvsApplication::open();
+    app.complete_read(
+        opening.read_operation().unwrap(),
+        Ok(backend.read_profiles().unwrap()),
+    )
+    .unwrap();
+    let start = app
+        .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+        .unwrap();
+    let operation = start.management_operation().unwrap();
+    let runner = SettingsCommandRunner::new(SettingsStore::load(config.path()).unwrap());
+    unsafe {
+        // The first write can succeed partially; subsequent writes return EFBIG.
+        assert_ne!(libc::signal(libc::SIGXFSZ, libc::SIG_IGN), libc::SIG_ERR);
+        let mut limit = libc::rlimit {
+            rlim_cur: 0,
+            rlim_max: 0,
+        };
+        assert_eq!(libc::getrlimit(libc::RLIMIT_FSIZE, &mut limit), 0);
+        limit.rlim_cur = 512;
+        assert_eq!(libc::setrlimit(libc::RLIMIT_FSIZE, &limit), 0);
+    }
+
+    let error = backend.manage(operation).unwrap_err();
+    assert_eq!(error.presentation().summary(), "Could not save HDMI input");
+    let failed = app.complete_management(operation, Err(error)).unwrap();
+    assert_eq!(
+        failed.presentation().selected_profile().unwrap().input(),
+        HdmiInput::Hdmi1
+    );
+    assert!(failed.presentation().input_enabled());
+    assert!(failed.toast_message().is_none());
+    assert_eq!(fs::read(config.path()).unwrap(), before);
+    assert!(runner
+        .run(
+            SettingsCommand::Set {
+                key: "tv.input".into(),
+                value: "HDMI_3".into(),
+            },
+            &mut Vec::new(),
+        )
+        .is_err());
+    assert_eq!(fs::read(config.path()).unwrap(), before);
+    assert_eq!(
+        fs::read_dir(config.path().parent().unwrap())
+            .unwrap()
+            .count(),
+        1,
+        "failed saves must clean up their temporary files"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn input_edit_preserves_symlink_target_permissions_and_owner() {
+    use std::os::unix::fs::{symlink, MetadataExt, PermissionsExt};
+
+    let config = TestConfigFile::new("tvs-input-symlink");
+    config.write_sample("HDMI_1");
+    fs::set_permissions(config.path(), fs::Permissions::from_mode(0o640)).unwrap();
+    let before = fs::metadata(config.path()).unwrap();
+    let link = config.path().parent().unwrap().join("links/config.env");
+    fs::create_dir(link.parent().unwrap()).unwrap();
+    symlink("../config.env", &link).unwrap();
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", &link);
+    let backend = EnvironmentTvsBackend;
+    let (mut app, opening) = TvsApplication::open();
+    app.complete_read(
+        opening.read_operation().unwrap(),
+        Ok(backend.read_profiles().unwrap()),
+    )
+    .unwrap();
+    let start = app
+        .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+        .unwrap();
+    backend
+        .manage(start.management_operation().unwrap())
+        .unwrap();
+
+    assert_eq!(
+        fs::read_link(link).unwrap(),
+        std::path::Path::new("../config.env")
+    );
+    assert!(fs::read_to_string(config.path())
+        .unwrap()
+        .contains("tvs_primary_input=HDMI_3"));
+    let after = fs::metadata(config.path()).unwrap();
+    assert_eq!(after.mode(), before.mode());
+    assert_eq!((after.uid(), after.gid()), (before.uid(), before.gid()));
+}
+
+#[cfg(unix)]
+#[test]
+fn settings_save_does_not_replace_read_only_configuration() {
+    use std::os::unix::fs::PermissionsExt;
+
+    if unsafe { libc::geteuid() } == 0 {
+        return; // Root can write read-only files, including with the original writer.
+    }
+    let config = TestConfigFile::new("settings-read-only");
+    config.write_sample("HDMI_1");
+    let before = fs::read(config.path()).unwrap();
+    fs::set_permissions(config.path(), fs::Permissions::from_mode(0o400)).unwrap();
+    let runner = SettingsCommandRunner::new(SettingsStore::load(config.path()).unwrap());
+    assert!(runner
+        .run(
+            SettingsCommand::Set {
+                key: "tv.input".into(),
+                value: "HDMI_3".into(),
+            },
+            &mut Vec::new(),
+        )
+        .is_err());
+    assert_eq!(fs::read(config.path()).unwrap(), before);
+}
+
+#[test]
+fn settings_save_creates_missing_configuration_and_parent_directory() {
+    let config = TestConfigFile::new("settings-new-config");
+    let path = config.path().parent().unwrap().join("nested/config.env");
+    let contents = "updates_channel=prerelease\n";
+    ConfigEnvEditor::parse(&path, contents).save().unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), contents);
+    assert_eq!(fs::read_dir(path.parent().unwrap()).unwrap().count(), 1);
+}

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -494,6 +494,15 @@ produces a blank state, one TV opens directly to details, and only multi-profile
 renderer fixtures expose the TV-selection sidebar. Production storage remains
 limited to one primary profile. Tab changes retain pending Overview operations
 and do not initiate TV writes or pairing.
+The TVs application also declares immediate managed-input changes and confirmed
+local unpairing. Input edits reuse the settings registry, persistence, and apply
+strategy. Unpairing shares the pairing store’s lock and atomic config publication,
+removes only primary-profile keys and the local native token, and restores that
+token if config publication fails. Compatibility credential storage and unrelated
+settings are retained. A started change disables profile controls and suspends
+Overview operations; completion reloads Overview with new operation identities.
+Active Overview writes must finish before profile changes can begin. GTK only
+renders the input selection, confirmation, progress availability, and errors.
 The zero-TV blank state offers first-TV pairing through a separate foreground
 application workflow. GTK forwards the native webOS form and cancellation
 intents, and worker progress describes connecting, TV confirmation, verification,

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -28,10 +28,22 @@ appear alongside it.
 ### TVs
 
 The TVs tab shows the configured TV's address, MAC address, HDMI input, control
-platform, and credential status. These details are read-only. A saved credential
+platform, and credential status. In 1.6.0-beta.1 these details are read-only. A saved credential
 does not mean the TV is currently connected; check Overview for connection
 status. When available, the model reported by the TV replaces the generic
 profile heading. If it cannot be read, the saved details remain visible.
+
+Development builds also let you change **HDMI input** directly in TVs. The
+selection saves immediately and changes which input LG Buddy manages; it does
+not switch the TV’s current source. If saving fails, the previous selection is
+restored.
+
+To remove the connection or recover from pairing problems, choose **Unpair
+TV…** and confirm. This removes the saved TV profile and its local native
+credential, while keeping other settings. It does not revoke authorization on
+the TV or remove compatibility credential storage. Cancelling the confirmation
+keeps the connection. Once unpaired, use **Pair a TV** to reconnect through
+native webOS. Cancelling or failing this new pairing leaves no TV configured.
 
 With no TV configured, choose **Pair a TV** to get started.
 

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -98,7 +98,7 @@ def parse_args() -> argparse.Namespace:
         help=f"maximum observation time in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
     )
     parser.add_argument("--select-page", choices=("Overview", "TVs"))
-    parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid"))
+    parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid", "unpair"))
     parser.add_argument("--expected-tv-address")
     parser.add_argument("--expected-tv-name", default="Primary TV")
     parser.add_argument("--focus-control", help="focus a control using native Tab navigation")
@@ -187,6 +187,8 @@ def tvs_contract(expected_state: str, address: str | None, tv_name: str):
             continue
     names = {normalized_name(item) for item in visible}
     dialogs = [item for item in visible if role(item) == pyatspi.ROLE_DIALOG]
+    if expected_state == "unpair":
+        return (accessibles, None) if {"Unpair TV?", "Cancel", "Unpair"} <= names else None
     if expected_state in ("pairing", "pairing-invalid"):
         if len(dialogs) != 1 or not {"TV address", "MAC address", "HDMI input", "Cancel", "Pair"} <= names:
             return None

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -27,6 +27,10 @@ fail() {
 }
 
 cleanup() {
+    local status=$?
+    if [ "$status" -ne 0 ] && [ -f "$WORK_DIR/gui.output" ]; then
+        cat "$WORK_DIR/gui.output" >&2
+    fi
     if [ -n "$GUI_PID" ] && kill -0 "$GUI_PID" 2>/dev/null; then
         kill "$GUI_PID"
         wait "$GUI_PID" 2>/dev/null || true
@@ -232,7 +236,7 @@ observe_gui_state --expected-slider-value 55 --expected-volume 21 --expected-mut
 observe_gui_state --activate-control "Mute TV"
 wait_for_calls set_mute 2
 observe_gui_state --expected-slider-value 55 --expected-volume 21 --expected-muted true
-# Native tab navigation shows the read-only profile and preserves live controls.
+# Native tab navigation shows the configured profile and preserves live controls.
 observe_gui_state --select-page TVs
 TV_ADDRESS="$(sed -n 's/^tvs_primary_ip=//p' "$CONFIG_FILE" | tail -n1)"
 observe_gui_state --expected-tvs-state configured --expected-tv-address "$TV_ADDRESS" --expected-tv-name OLED42C2
@@ -252,6 +256,41 @@ assert state["volume"] == 21 and state["muted"] is True, state
 audio_calls = [call["command"] for call in state["calls"] if call["command"] in ("set_volume", "set_mute")]
 assert audio_calls == ["set_volume", "set_mute", "set_mute"], audio_calls
 PY
+
+# TV management uses native controls and the real local persistence backend.
+cp "$CONFIG_FILE" "$WORK_DIR/before-management.env"
+mkdir -p "$WORK_DIR/tvs/primary"
+printf '%s\n' '{"access_token":"management-smoke-token"}' > "$WORK_DIR/tvs/primary/access-token.json"
+chmod 600 "$WORK_DIR/tvs/primary/access-token.json"
+start_gui enabled
+observe_gui_state --select-page TVs
+observe_gui_state --expected-tvs-state configured --expected-tv-address "$TV_ADDRESS" --expected-tv-name OLED42C2
+observe_gui_state --focus-control "HDMI input" --window-id "$WINDOW_ID"
+xdotool key --window "$WINDOW_ID" --delay 60 space Home Down Down Return
+for ((attempt = 0; attempt < 100; attempt++)); do
+    [ "$("$RUNTIME_BINARY" settings get tv.input)" = "HDMI_3" ] && break
+    sleep 0.1
+done
+[ "$("$RUNTIME_BINARY" settings get tv.input)" = "HDMI_3" ] || fail "Input selection was not saved."
+cp "$CONFIG_FILE" "$WORK_DIR/before-unpair.env"
+observe_gui_state --activate-control "Unpair TV…"
+observe_gui_state --expected-tvs-state unpair
+xdotool key --window "$WINDOW_ID" Escape
+observe_gui_state --expected-tvs-state configured --expected-tv-address "$TV_ADDRESS" --expected-tv-name OLED42C2
+cmp -s "$CONFIG_FILE" "$WORK_DIR/before-unpair.env" || fail "Cancelling Unpair changed the configuration."
+[ -f "$WORK_DIR/tvs/primary/access-token.json" ] || fail "Cancelling Unpair removed the credential."
+observe_gui_state --activate-control "Unpair TV…"
+observe_gui_state --expected-tvs-state unpair
+observe_gui_state --activate-control Unpair
+observe_gui_state --expected-tvs-state empty
+[ ! -e "$WORK_DIR/tvs/primary/access-token.json" ] || fail "Unpair left the native credential."
+observe_gui_state --activate-control "Pair a TV"
+observe_gui_state --expected-tvs-state pairing
+observe_gui_state --activate-control Cancel
+observe_gui_state --expected-tvs-state empty
+send_closing_mnemonic Escape
+finish_gui "input editing and confirmed unpairing"
+cp "$WORK_DIR/before-management.env" "$CONFIG_FILE"
 
 # An absent profile has a standard empty state and never contacts the TV.
 export LG_BUDDY_CONFIG="$WORK_DIR/no-config.env"


### PR DESCRIPTION
## Summary

The TVs view now lets users change the managed HDMI input and recover from pairing problems through Unpair → Pair. Application-owned operations coordinate these changes with Overview and keep validation, persistence, and recovery out of GTK.

Settings saves publish atomically so a failed write preserves the original configuration and the previous selection. Unpairing removes the primary profile and native credential together, with credential rollback if configuration publication fails.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

- HDMI selection saves immediately and changes which input LG Buddy manages; it does not switch the TV’s current source.
- Unpair TV requires destructive confirmation. Success returns to the existing Pair a TV empty state, preserving unrelated settings and compatibility credentials. TV-side authorization is retained.
- Profile changes wait for active Overview writes, disable conflicting controls, and refresh Overview with fresh operation identities.
- Save failures retain the original configuration, including its permissions and ownership, and restore the previous selection.

## Validation

- `cargo test -p lg-buddy`: 878 unit tests, 48 integration tests, and 134 Cucumber scenarios passed; the optional hardware test remains ignored.
- A real short-write regression failed before the fix and passes for both GUI and CLI saves; coverage also checks cleanup, symlinks, permissions, ownership, read-only files, and new configuration files.
- GTK renderer/controller tests and installed GUI behavior smoke passed under Xvfb/AT-SPI with a mock TV and isolated installation.
- Clippy, formatting, shell/Python syntax checks, and `git diff --check` passed.

## Related Issue

Fixes #175
