### PR TITLE
Add read-only behavior Settings view

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ controls close at hand.
 ## 1.6 Beta Preview
 
 **1.6.0-beta.1** introduces Overview, the TVs view, and native first-TV pairing.
-This is an early preview of 1.6; GUI settings and credential repair are still
-being developed. The latest stable 1.5 release does not include this expanded
+This is an early preview of 1.6; further GUI work is still being developed.
+The development branch also includes TV input changes, local unpairing, and a
+read-only Settings tab. The latest stable 1.5 release does not include this expanded
 interface. See the [beta release notes](docs/releases/1.6.0-beta.1.md) for scope
 and installation details. Screenshots use sample TV data.
 

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1,5 +1,6 @@
 mod overview;
 mod pairing;
+mod settings;
 mod tvs;
 mod window;
 
@@ -24,6 +25,10 @@ use lg_buddy::overview::{
 };
 use lg_buddy::pairing::{
     EnvironmentPairingBackend, PairingBackend, PairingError, PairingOperation, PairingStage,
+};
+use lg_buddy::settings_view::{
+    EnvironmentSettingsBackend, SettingsBackend, SettingsIntent, SettingsReadError,
+    SettingsReadOperation, SettingsTransition,
 };
 use lg_buddy::tvs::{
     EnvironmentTvsBackend, TvsBackend, TvsIntent, TvsModelReadOperation, TvsReadError,
@@ -103,6 +108,7 @@ fn run_application() -> glib::ExitCode {
         Rc::clone(&controller),
         Arc::new(EnvironmentOverviewBackend),
         Arc::new(EnvironmentTvsBackend),
+        Arc::new(EnvironmentSettingsBackend),
     );
     application.run_with_args(&["lg-buddy-gui"])
 }
@@ -146,6 +152,7 @@ struct ApplicationController {
     window: window::ApplicationWindow,
     tvs_backend: Arc<dyn TvsBackend>,
     pairing_backend: Arc<dyn PairingBackend>,
+    settings_backend: Arc<dyn SettingsBackend>,
     navigation: RefCell<Navigation>,
     backend: Arc<dyn OverviewBackend>,
     closed: Cell<bool>,
@@ -156,20 +163,23 @@ impl ApplicationController {
         gtk_application: &adw::Application,
         backend: Arc<dyn OverviewBackend>,
         tvs_backend: Arc<dyn TvsBackend>,
+        settings_backend: Arc<dyn SettingsBackend>,
     ) -> (Rc<Self>, ApplicationTransition) {
-        Self::with_pairing_backend(
+        Self::with_backends(
             gtk_application,
             backend,
             tvs_backend,
             Arc::new(EnvironmentPairingBackend),
+            settings_backend,
         )
     }
 
-    fn with_pairing_backend(
+    fn with_backends(
         gtk_application: &adw::Application,
         backend: Arc<dyn OverviewBackend>,
         tvs_backend: Arc<dyn TvsBackend>,
         pairing_backend: Arc<dyn PairingBackend>,
+        settings_backend: Arc<dyn SettingsBackend>,
     ) -> (Rc<Self>, ApplicationTransition) {
         let (application, opening) = Application::open();
         let controller = Rc::new_cyclic(|controller| {
@@ -193,13 +203,22 @@ impl ApplicationController {
                 let controller = controller.clone();
                 move |page| {
                     if let Some(controller) = controller.upgrade() {
-                        controller.navigate(page);
+                        Self::navigate(&controller, page);
+                    }
+                }
+            });
+            let on_settings = Rc::new({
+                let controller = controller.clone();
+                move |intent| {
+                    if let Some(controller) = controller.upgrade() {
+                        Self::handle_settings_intent(&controller, intent);
                     }
                 }
             });
             Self {
                 tvs_backend,
                 pairing_backend,
+                settings_backend,
                 navigation: RefCell::new(Navigation::default()),
                 application: RefCell::new(application),
                 gtk_application: gtk_application.clone(),
@@ -207,6 +226,7 @@ impl ApplicationController {
                     gtk_application,
                     on_intent,
                     on_tvs,
+                    on_settings,
                     on_navigation,
                 ),
                 backend,
@@ -233,6 +253,9 @@ impl ApplicationController {
     }
 
     fn apply_transition(controller: &Rc<Self>, transition: ApplicationTransition) {
+        if let Some(settings) = transition.settings() {
+            Self::render_settings_transition(controller, settings);
+        }
         if let Some(tvs) = transition.tvs() {
             Self::render_tvs_transition(controller, tvs);
         }
@@ -259,11 +282,63 @@ impl ApplicationController {
         }
     }
 
-    fn navigate(&self, page: ApplicationPage) {
-        if !self.closed.get() {
-            self.navigation.borrow_mut().select(page);
-            self.window.navigate(self.navigation.borrow().selected());
+    fn navigate(controller: &Rc<Self>, page: ApplicationPage) {
+        if !controller.closed.get() {
+            controller.navigation.borrow_mut().select(page);
+            controller
+                .window
+                .navigate(controller.navigation.borrow().selected());
+            let transition = controller.application.borrow_mut().select_page(page);
+            if let Some(transition) = transition {
+                Self::apply_transition(controller, transition);
+            }
         }
+    }
+
+    fn handle_settings_intent(controller: &Rc<Self>, intent: SettingsIntent) {
+        let transition = controller
+            .application
+            .borrow_mut()
+            .handle_settings_intent(intent);
+        if let Some(transition) = transition {
+            Self::apply_transition(controller, transition);
+        }
+    }
+
+    fn render_settings_transition(controller: &Rc<Self>, transition: &SettingsTransition) {
+        if let Some(diagnostic) = transition.diagnostic() {
+            eprintln!("LG Buddy GUI: {diagnostic}");
+        }
+        controller.window.render_settings(transition.presentation());
+        if let Some(operation) = transition.read_operation() {
+            Self::start_settings_read(controller, operation);
+        }
+    }
+
+    fn start_settings_read(controller: &Rc<Self>, operation: SettingsReadOperation) {
+        let backend = Arc::clone(&controller.settings_backend);
+        let (sender, receiver) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let _ = sender.send(backend.read_settings());
+        });
+        let controller = Rc::downgrade(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || {
+            let result = match receiver.try_recv() {
+                Ok(result) => result,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => Err(SettingsReadError::stopped()),
+            };
+            if let Some(controller) = controller.upgrade() {
+                let transition = controller
+                    .application
+                    .borrow_mut()
+                    .complete_settings_read(operation, result);
+                if let Some(transition) = transition {
+                    Self::apply_transition(&controller, transition);
+                }
+            }
+            glib::ControlFlow::Break
+        });
     }
 
     fn handle_tvs_intent(controller: &Rc<Self>, intent: TvsIntent) {
@@ -559,11 +634,13 @@ fn connect_application(
     controller: Rc<RefCell<Option<Rc<ApplicationController>>>>,
     backend: Arc<dyn OverviewBackend>,
     tvs_backend: Arc<dyn TvsBackend>,
+    settings_backend: Arc<dyn SettingsBackend>,
 ) {
     application.connect_activate({
         let controller = Rc::clone(&controller);
         let backend = Arc::clone(&backend);
         let tvs_backend = Arc::clone(&tvs_backend);
+        let settings_backend = Arc::clone(&settings_backend);
         move |application| {
             if let Some(controller) = controller.borrow().as_ref() {
                 controller.present();
@@ -573,6 +650,7 @@ fn connect_application(
                 application,
                 Arc::clone(&backend),
                 Arc::clone(&tvs_backend),
+                Arc::clone(&settings_backend),
             );
             controller.replace(Some(Rc::clone(&overview)));
             ApplicationController::apply_transition(&overview, opening);
@@ -638,6 +716,25 @@ pub(crate) mod controller_test_support {
     use super::{ApplicationController, APPLICATION_ID};
 
     struct EmptyTvsBackend;
+    struct DefaultSettingsBackend;
+
+    impl lg_buddy::settings_view::SettingsBackend for DefaultSettingsBackend {
+        fn read_settings(
+            &self,
+        ) -> Result<
+            Vec<lg_buddy::presentation::settings::SettingsGroup>,
+            lg_buddy::settings_view::SettingsReadError,
+        > {
+            let store = lg_buddy::settings::ConfigEnvReader::parse("/unused/config.env", "");
+            Ok(
+                lg_buddy::presentation::settings::SettingsPresentation::from_store(
+                    &lg_buddy::settings::SettingsStore::from_reader(store),
+                )
+                .groups()
+                .to_vec(),
+            )
+        }
+    }
     impl lg_buddy::tvs::TvsBackend for EmptyTvsBackend {
         fn read_profiles(
             &self,
@@ -875,6 +972,7 @@ pub(crate) mod controller_test_support {
             "renderer test must initialize GTK first"
         );
         run_pairing_scenario();
+        run_settings_scenario();
 
         let (backend, controls) = BlockingBackend::new();
         let application = test_application("Blocking");
@@ -887,6 +985,7 @@ pub(crate) mod controller_test_support {
                 profiles: Mutex::new(profiles_rx),
                 model: Mutex::new(model_rx),
             }),
+            Arc::new(DefaultSettingsBackend),
         );
         ApplicationController::apply_transition(&controller, opening.clone());
         let native_window = controller.window.window();
@@ -1011,6 +1110,7 @@ pub(crate) mod controller_test_support {
             &panic_application,
             Arc::new(PanicBackend),
             Arc::new(EmptyTvsBackend),
+            Arc::new(DefaultSettingsBackend),
         );
         let panic_opening = panic_opening.overview().unwrap();
         let initial = match panic_opening.update() {
@@ -1030,6 +1130,87 @@ pub(crate) mod controller_test_support {
         });
         panic_controller.window.close();
         assert_cancel_waits_for_write_in_application_loop();
+    }
+
+    fn run_settings_scenario() {
+        use lg_buddy::presentation::settings::{SettingsGroup, SettingsPresentation};
+        use lg_buddy::settings::ConfigEnvReader;
+        use lg_buddy::settings_view::{SettingsBackend, SettingsReadError};
+
+        struct SettingsMock(
+            Mutex<std::collections::VecDeque<Result<Vec<SettingsGroup>, SettingsReadError>>>,
+        );
+        impl SettingsBackend for SettingsMock {
+            fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .pop_front()
+                    .expect("expected settings read")
+            }
+        }
+        fn settings(timeout: u32) -> Vec<SettingsGroup> {
+            let store = ConfigEnvReader::parse(
+                "/unused/config.env",
+                &format!("screen_idle_timeout={timeout}\n"),
+            )
+            .into_store();
+            SettingsPresentation::from_store(&store).groups().to_vec()
+        }
+        fn retry_button(widget: &gtk::Widget) -> Option<gtk::Button> {
+            if let Some(button) = widget.downcast_ref::<gtk::Button>() {
+                if button.label().as_deref() == Some("Retry") && button.is_visible() {
+                    return Some(button.clone());
+                }
+            }
+            let mut child = widget.first_child();
+            while let Some(current) = child {
+                if let Some(button) = retry_button(&current) {
+                    return Some(button);
+                }
+                child = current.next_sibling();
+            }
+            None
+        }
+
+        let application = test_application("Settings");
+        let backend = std::sync::Arc::new(SettingsMock(Mutex::new(
+            std::collections::VecDeque::from([
+                Err(SettingsReadError::unreadable("test settings read failure")),
+                Ok(settings(600)),
+                Ok(settings(120)),
+            ]),
+        )));
+        let (controller, opening) = ApplicationController::new(
+            &application,
+            Arc::new(PanicBackend),
+            Arc::new(EmptyTvsBackend),
+            backend,
+        );
+        ApplicationController::render_settings_transition(&controller, opening.settings().unwrap());
+        controller
+            .window
+            .choose_page(super::ApplicationPage::Settings);
+        controller.present();
+        let native = controller.window.window();
+        pump_until(|| {
+            widget_contains_text(native.upcast_ref(), "LG Buddy could not read its settings")
+        });
+        retry_button(native.upcast_ref())
+            .expect("visible Retry button")
+            .emit_clicked();
+        pump_until(|| widget_contains_text(native.upcast_ref(), "600 seconds"));
+        assert_eq!(
+            controller.navigation.borrow().selected(),
+            super::ApplicationPage::Settings
+        );
+        controller.window.choose_page(super::ApplicationPage::Tvs);
+        controller
+            .window
+            .choose_page(super::ApplicationPage::Settings);
+        pump_until(|| widget_contains_text(native.upcast_ref(), "120 seconds"));
+        controller.shutdown();
+        controller.window.close();
     }
 
     fn run_pairing_scenario() {
@@ -1093,7 +1274,7 @@ pub(crate) mod controller_test_support {
             let application = test_application(name);
             let (backend, controls) = BlockingBackend::new();
             let (release, receiver) = mpsc::channel();
-            let (controller, opening) = ApplicationController::with_pairing_backend(
+            let (controller, opening) = ApplicationController::with_backends(
                 &application,
                 Arc::new(backend),
                 Arc::new(TvsMock),
@@ -1102,10 +1283,14 @@ pub(crate) mod controller_test_support {
                     reject,
                     panic,
                 }),
+                Arc::new(DefaultSettingsBackend),
             );
             ApplicationController::render_tvs_transition(&controller, opening.tvs().unwrap());
             controller.present();
-            controller.navigate(lg_buddy::navigation::ApplicationPage::Tvs);
+            ApplicationController::navigate(
+                &controller,
+                lg_buddy::navigation::ApplicationPage::Tvs,
+            );
             pump_until(|| {
                 widget_contains_text(controller.window.window().upcast_ref(), "No TV configured")
             });
@@ -1208,6 +1393,7 @@ pub(crate) mod controller_test_support {
             Rc::clone(&controller),
             Arc::new(backend),
             Arc::new(EmptyTvsBackend),
+            Arc::new(DefaultSettingsBackend),
         );
         controls
             .summary

--- a/crates/lg-buddy-gui/src/overview.rs
+++ b/crates/lg-buddy-gui/src/overview.rs
@@ -720,6 +720,7 @@ mod tests {
         view.window.close();
         late_brightness_respects_focus(&application);
         crate::tvs::run_renderer_scenarios(&application);
+        crate::settings::run_renderer_scenarios(&application);
         crate::controller_test_support::run_scenario();
     }
 }

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -1,0 +1,283 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use adw::prelude::*;
+use lg_buddy::presentation::settings::{SettingsPresentation, SettingsRow, SettingsStatus};
+use lg_buddy::settings_view::SettingsIntent;
+
+/// Native preference rows for the application-owned, read-only Settings view.
+pub(crate) struct SettingsView {
+    root: gtk::Stack,
+    page: adw::PreferencesPage,
+    groups: RefCell<Vec<adw::PreferencesGroup>>,
+    status: adw::StatusPage,
+    retry: gtk::Button,
+    retry_intent: Rc<RefCell<Option<SettingsIntent>>>,
+}
+
+impl SettingsView {
+    pub(crate) fn new(on_intent: Rc<dyn Fn(SettingsIntent)>) -> Self {
+        let page = adw::PreferencesPage::new();
+        let status = adw::StatusPage::builder()
+            .icon_name("preferences-system-symbolic")
+            .vexpand(true)
+            .build();
+        let retry = gtk::Button::builder().halign(gtk::Align::Center).build();
+        retry.add_css_class("pill");
+        let retry_intent = Rc::new(RefCell::new(None));
+        retry.connect_clicked({
+            let intent = Rc::clone(&retry_intent);
+            move |_| {
+                let intent = *intent.borrow();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
+        status.set_child(Some(&retry));
+        let root = gtk::Stack::builder()
+            .hexpand(true)
+            .vexpand(true)
+            .hhomogeneous(false)
+            .vhomogeneous(false)
+            .build();
+        root.add_named(&status, Some("status"));
+        root.add_named(&page, Some("settings"));
+        root.set_visible_child_name("status");
+        Self {
+            root,
+            page,
+            groups: RefCell::new(Vec::new()),
+            status,
+            retry,
+            retry_intent,
+        }
+    }
+
+    pub(crate) fn widget(&self) -> &gtk::Stack {
+        &self.root
+    }
+
+    pub(crate) fn render(&self, presentation: &SettingsPresentation) {
+        let action = presentation.retry_action();
+        self.retry.set_visible(action.is_some());
+        self.retry
+            .set_sensitive(action.is_some_and(|action| action.enabled()));
+        self.retry
+            .set_label(action.map_or("", |action| action.label()));
+        self.retry_intent
+            .replace(action.map(|action| action.intent()));
+        match presentation.status() {
+            SettingsStatus::Loading { message } => {
+                self.status.set_title(message);
+                self.status.set_description(None);
+                self.root.set_visible_child_name("status");
+            }
+            SettingsStatus::Failed(error) => {
+                self.status.set_title(error.summary());
+                self.status.set_description(Some(error.detail()));
+                self.root.set_visible_child_name("status");
+            }
+            SettingsStatus::Ready => {
+                for group in self.groups.borrow_mut().drain(..) {
+                    self.page.remove(&group);
+                }
+                for group in presentation.groups() {
+                    let native = adw::PreferencesGroup::builder()
+                        .title(gtk::glib::markup_escape_text(group.title()))
+                        .description(gtk::glib::markup_escape_text(group.description()))
+                        .build();
+                    for row in group.rows() {
+                        native.add(&setting_row(row));
+                    }
+                    self.page.add(&native);
+                    self.groups.borrow_mut().push(native);
+                }
+                self.root.set_visible_child_name("settings");
+            }
+        }
+    }
+}
+
+fn setting_row(presentation: &SettingsRow) -> adw::ExpanderRow {
+    let row = adw::ExpanderRow::builder()
+        .use_markup(false)
+        .title_lines(0)
+        .subtitle_lines(0)
+        .build();
+    // Set text after construction so native child labels already use plain text.
+    row.set_title(presentation.title());
+    row.set_subtitle(presentation.description());
+    let value = gtk::Label::builder()
+        .label(presentation.value_label())
+        .wrap(true)
+        .wrap_mode(gtk::pango::WrapMode::Word)
+        .width_chars(12)
+        .max_width_chars(12)
+        .xalign(1.0)
+        .valign(gtk::Align::Center)
+        .build();
+    value.add_css_class("dim-label");
+    row.add_suffix(&value);
+    row.update_property(&[
+        gtk::accessible::Property::Label(presentation.title()),
+        gtk::accessible::Property::Description(&format!(
+            "{} {}",
+            presentation.description(),
+            presentation.value_label()
+        )),
+    ]);
+    if let Some(problem) = presentation.problem() {
+        let icon = gtk::Image::from_icon_name("dialog-warning-symbolic");
+        icon.add_css_class("error");
+        icon.set_tooltip_text(Some(problem));
+        row.add_prefix(&icon);
+        let error = detail_row("", problem);
+        error.add_css_class("error");
+        error.set_accessible_role(gtk::AccessibleRole::Alert);
+        error.update_property(&[gtk::accessible::Property::Label(problem)]);
+        row.add_row(&error);
+    }
+    for (title, value) in [
+        ("Source", presentation.source_label()),
+        ("Default", presentation.default_label()),
+        ("Accepted values", presentation.accepted_values_label()),
+    ] {
+        row.add_row(&detail_row(title, value));
+    }
+    row
+}
+
+fn detail_row(title: &str, value: &str) -> adw::ActionRow {
+    let row = adw::ActionRow::builder()
+        .use_markup(false)
+        .subtitle_lines(0)
+        .activatable(false)
+        .selectable(false)
+        .build();
+    row.set_title(title);
+    row.set_subtitle(value);
+    row
+}
+
+#[cfg(test)]
+pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
+    use crate::controller_test_support::pump_until;
+    use lg_buddy::settings::{ConfigEnvReader, SettingsStore};
+    use lg_buddy::settings_view::{SettingsApplication, SettingsReadError};
+
+    fn descendants(widget: &gtk::Widget) -> Vec<gtk::Widget> {
+        let mut found = vec![widget.clone()];
+        let mut child = widget.first_child();
+        while let Some(current) = child {
+            found.extend(descendants(&current));
+            child = current.next_sibling();
+        }
+        found
+    }
+
+    let intents = Rc::new(RefCell::new(Vec::new()));
+    let view = SettingsView::new(Rc::new({
+        let intents = Rc::clone(&intents);
+        move |intent| intents.borrow_mut().push(intent)
+    }));
+    let window = adw::ApplicationWindow::builder()
+        .application(application)
+        .default_width(1100)
+        .default_height(800)
+        .content(view.widget())
+        .build();
+    let (mut model, opening) = SettingsApplication::open();
+    view.render(opening.presentation());
+    window.present();
+    pump_until(|| view.status.is_mapped());
+    assert_eq!(view.root.visible_child_name().as_deref(), Some("status"));
+    assert!(!view.retry.is_visible());
+    let failed = model
+        .complete_read(
+            opening.read_operation().unwrap(),
+            Err(SettingsReadError::stopped()),
+        )
+        .unwrap();
+    view.render(failed.presentation());
+    assert!(view.retry.is_visible());
+    view.retry.emit_clicked();
+    assert_eq!(*intents.borrow(), vec![SettingsIntent::Retry]);
+
+    let store = SettingsStore::from_reader(ConfigEnvReader::parse(
+        "/unused/config.env",
+        "screen_idle_timeout=600\nupdates_channel=<invalid>&\n",
+    ));
+    let presentation = SettingsPresentation::from_store(&store);
+    view.render(&presentation);
+    pump_until(|| view.page.is_mapped() && view.groups.borrow()[0].width() > 0);
+    let widgets = descendants(view.widget().upcast_ref());
+    let rows: Vec<adw::ExpanderRow> = widgets
+        .iter()
+        .filter_map(|widget| widget.clone().downcast().ok())
+        .collect();
+    assert_eq!(view.groups.borrow().len(), 3);
+    assert_eq!(rows.len(), 7);
+    assert!(widgets
+        .iter()
+        .filter_map(|widget| widget.clone().downcast::<gtk::Label>().ok())
+        .any(|label| label.text() == "Sleep & Wake"));
+    assert!(
+        view.groups.borrow()[0].width() < 800,
+        "preference content must be clamped in wide windows"
+    );
+    for label in widgets
+        .iter()
+        .filter_map(|widget| widget.clone().downcast::<gtk::Label>().ok())
+        .filter(|label| {
+            matches!(
+                label.text().as_str(),
+                "Automatic" | "Enabled" | "Conservative"
+            )
+        })
+    {
+        assert_eq!(
+            label.layout().line_count(),
+            1,
+            "setting values must not wrap within a word"
+        );
+    }
+    for (row, declared) in rows
+        .iter()
+        .zip(presentation.groups().iter().flat_map(|group| group.rows()))
+    {
+        assert_eq!(row.title(), declared.title());
+        assert_eq!(row.subtitle(), declared.description());
+        assert!(!row.uses_markup());
+        assert!(!row.shows_enable_switch());
+    }
+    assert!(!widgets
+        .iter()
+        .any(|widget| widget.is::<gtk::Switch>() && widget.is_visible()));
+    assert!(!widgets
+        .iter()
+        .any(|widget| widget.is::<adw::ComboRow>() || widget.is::<gtk::Entry>()));
+    rows[0].set_expanded(true);
+    pump_until(|| rows[0].is_expanded());
+    let first_details = descendants(rows[0].upcast_ref());
+    assert!(first_details
+        .iter()
+        .filter_map(|widget| widget.clone().downcast::<adw::ActionRow>().ok())
+        .any(|row| row.title() == "Accepted values"));
+    assert!(widgets
+        .iter()
+        .any(|widget| widget.accessible_role() == gtk::AccessibleRole::Alert));
+    assert!(widgets
+        .iter()
+        .filter_map(|widget| widget.clone().downcast::<gtk::Label>().ok())
+        .any(|label| label.text().contains("<invalid>&")));
+
+    window.set_default_size(360, 600);
+    pump_until(|| window.width() <= 360);
+    let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
+    assert!(
+        minimum <= 360,
+        "settings rows must fit a narrow window: {minimum}"
+    );
+    window.close();
+}

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -5,13 +5,16 @@ use adw::prelude::*;
 use lg_buddy::navigation::ApplicationPage;
 use lg_buddy::overview::OverviewIntent;
 use lg_buddy::presentation::overview::OverviewPresentation;
+use lg_buddy::presentation::settings::SettingsPresentation;
 use lg_buddy::presentation::tvs::TvsPresentation;
+use lg_buddy::settings_view::SettingsIntent;
 use lg_buddy::tvs::TvsIntent;
 
 pub(crate) struct ApplicationWindow {
     window: adw::ApplicationWindow,
     overview: crate::overview::OverviewView,
     tvs: crate::tvs::TvsView,
+    settings: crate::settings::SettingsView,
     pairing: crate::pairing::PairingView,
     toasts: adw::ToastOverlay,
     stack: adw::ViewStack,
@@ -25,6 +28,7 @@ impl ApplicationWindow {
         application: &adw::Application,
         on_overview: crate::overview::IntentHandler,
         on_tvs: Rc<dyn Fn(TvsIntent)>,
+        on_settings: Rc<dyn Fn(SettingsIntent)>,
         on_navigation: Rc<dyn Fn(ApplicationPage)>,
     ) -> Self {
         let window = adw::ApplicationWindow::builder()
@@ -39,6 +43,7 @@ impl ApplicationWindow {
         let overview = crate::overview::OverviewView::new(&window, Rc::clone(&on_overview));
         let tvs = crate::tvs::TvsView::new(Rc::clone(&on_tvs));
         let pairing = crate::pairing::PairingView::new(on_tvs);
+        let settings = crate::settings::SettingsView::new(on_settings);
         let stack = adw::ViewStack::new();
         stack.set_hhomogeneous(false);
         stack.set_vhomogeneous(false);
@@ -46,6 +51,10 @@ impl ApplicationWindow {
             let (widget, icon): (&gtk::Widget, _) = match page {
                 ApplicationPage::Overview => (overview.widget().upcast_ref(), "view-grid-symbolic"),
                 ApplicationPage::Tvs => (tvs.widget().upcast_ref(), "video-display-symbolic"),
+                ApplicationPage::Settings => (
+                    settings.widget().upcast_ref(),
+                    "preferences-system-symbolic",
+                ),
             };
             stack.add_titled_with_icon(widget, Some(page_name(page)), page.title(), icon);
         }
@@ -58,6 +67,7 @@ impl ApplicationWindow {
                     match stack.visible_child_name().as_deref() {
                         Some("overview") => on_navigation(ApplicationPage::Overview),
                         Some("tvs") => on_navigation(ApplicationPage::Tvs),
+                        Some("settings") => on_navigation(ApplicationPage::Settings),
                         _ => {}
                     }
                 }
@@ -77,7 +87,7 @@ impl ApplicationWindow {
         window.set_content(Some(&toolbar));
         let narrow = adw::Breakpoint::new(adw::BreakpointCondition::new_length(
             adw::BreakpointConditionLengthType::MaxWidth,
-            400.0,
+            540.0,
             adw::LengthUnit::Sp,
         ));
         narrow.add_setter(
@@ -111,6 +121,7 @@ impl ApplicationWindow {
             window,
             overview,
             tvs,
+            settings,
             pairing,
             toasts,
             stack,
@@ -127,6 +138,10 @@ impl ApplicationWindow {
     pub(crate) fn render_tvs(&self, presentation: &TvsPresentation) {
         self.tvs.render(&self.window, presentation);
         self.pairing.render(&self.window, presentation.pairing());
+    }
+
+    pub(crate) fn render_settings(&self, presentation: &SettingsPresentation) {
+        self.settings.render(presentation);
     }
 
     pub(crate) fn dismiss_dialog(&self) -> bool {
@@ -179,5 +194,6 @@ fn page_name(page: ApplicationPage) -> &'static str {
     match page {
         ApplicationPage::Overview => "overview",
         ApplicationPage::Tvs => "tvs",
+        ApplicationPage::Settings => "settings",
     }
 }

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -11,6 +11,11 @@ use crate::overview::{
     OverviewTvIdentity,
 };
 use crate::pairing::{PairingError, PairingFailure, PairingOperation, PairingStage};
+use crate::presentation::settings::SettingsGroup;
+use crate::settings_view::{
+    SettingsApplication, SettingsIntent, SettingsReadError, SettingsReadOperation,
+    SettingsTransition,
+};
 use crate::tv::{AudioStatus, OledBrightness};
 use crate::tvs::{
     TvProfile, TvsApplication, TvsIntent, TvsManagementError, TvsManagementOperation,
@@ -44,6 +49,7 @@ pub enum OverviewCompletion {
 pub struct ApplicationTransition {
     overview: Option<OverviewTransition>,
     tvs: Option<TvsTransition>,
+    settings: Option<SettingsTransition>,
 }
 
 impl ApplicationTransition {
@@ -54,22 +60,33 @@ impl ApplicationTransition {
     pub fn tvs(&self) -> Option<&TvsTransition> {
         self.tvs.as_ref()
     }
+
+    pub fn settings(&self) -> Option<&SettingsTransition> {
+        self.settings.as_ref()
+    }
 }
 
 pub struct Application {
     overview: OverviewApplication,
     tvs: TvsApplication,
+    settings: SettingsApplication,
 }
 
 impl Application {
     pub fn open() -> (Self, ApplicationTransition) {
         let (overview, overview_opening) = OverviewApplication::open();
         let (tvs, tvs_opening) = TvsApplication::open();
+        let (settings, settings_opening) = SettingsApplication::open();
         (
-            Self { overview, tvs },
+            Self {
+                overview,
+                tvs,
+                settings,
+            },
             ApplicationTransition {
                 overview: Some(overview_opening),
                 tvs: Some(tvs_opening),
+                settings: Some(settings_opening),
             },
         )
     }
@@ -88,6 +105,45 @@ impl Application {
     pub fn handle_tvs_intent(&mut self, intent: TvsIntent) -> Option<ApplicationTransition> {
         let transition = self.tvs.handle_intent(intent)?;
         Some(self.tvs_transition(transition))
+    }
+
+    pub fn handle_settings_intent(
+        &mut self,
+        intent: SettingsIntent,
+    ) -> Option<ApplicationTransition> {
+        self.settings
+            .handle_intent(intent)
+            .map(Self::settings_transition)
+    }
+
+    pub fn select_page(
+        &mut self,
+        page: crate::navigation::ApplicationPage,
+    ) -> Option<ApplicationTransition> {
+        match page {
+            crate::navigation::ApplicationPage::Settings => {
+                self.handle_settings_intent(SettingsIntent::Refresh)
+            }
+            _ => None,
+        }
+    }
+
+    pub fn complete_settings_read(
+        &mut self,
+        operation: SettingsReadOperation,
+        result: Result<Vec<SettingsGroup>, SettingsReadError>,
+    ) -> Option<ApplicationTransition> {
+        self.settings
+            .complete_read(operation, result)
+            .map(Self::settings_transition)
+    }
+
+    fn settings_transition(transition: SettingsTransition) -> ApplicationTransition {
+        ApplicationTransition {
+            overview: None,
+            tvs: None,
+            settings: Some(transition),
+        }
     }
 
     pub fn complete_overview(
@@ -173,11 +229,13 @@ impl Application {
     pub fn shutdown(&mut self) {
         self.overview.shutdown();
         self.tvs.shutdown();
+        self.settings.shutdown();
     }
 
     fn overview_transition(&mut self, transition: OverviewTransition) -> ApplicationTransition {
         if matches!(transition.update(), OverviewFrontendUpdate::Close) {
             self.tvs.shutdown();
+            self.settings.shutdown();
         }
         let tvs = self
             .tvs
@@ -185,6 +243,7 @@ impl Application {
         ApplicationTransition {
             overview: Some(transition),
             tvs,
+            settings: None,
         }
     }
 
@@ -199,6 +258,7 @@ impl Application {
         ApplicationTransition {
             overview,
             tvs: Some(transition),
+            settings: None,
         }
     }
 }

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -24,6 +24,7 @@ pub mod session;
 pub mod session_bus;
 pub mod session_notifications;
 pub mod settings;
+pub mod settings_view;
 pub mod sources;
 pub mod state;
 pub mod tv;

--- a/crates/lg-buddy/src/navigation.rs
+++ b/crates/lg-buddy/src/navigation.rs
@@ -5,15 +5,17 @@ pub enum ApplicationPage {
     #[default]
     Overview,
     Tvs,
+    Settings,
 }
 
 impl ApplicationPage {
-    pub const ALL: [Self; 2] = [Self::Overview, Self::Tvs];
+    pub const ALL: [Self; 3] = [Self::Overview, Self::Tvs, Self::Settings];
 
     pub fn title(self) -> &'static str {
         match self {
             Self::Overview => "Overview",
             Self::Tvs => "TVs",
+            Self::Settings => "Settings",
         }
     }
 }

--- a/crates/lg-buddy/src/presentation/mod.rs
+++ b/crates/lg-buddy/src/presentation/mod.rs
@@ -1,4 +1,5 @@
 pub mod brightness;
 pub mod overview;
 pub mod pairing;
+pub mod settings;
 pub mod tvs;

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -1,0 +1,317 @@
+use crate::presentation::brightness::UserFacingError;
+use crate::settings::{EffectiveSetting, SettingSource, SettingType, SettingValue, SettingsStore};
+use crate::settings_view::SettingsIntent;
+
+/// The toolkit-neutral model rendered by the Settings view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsPresentation {
+    status: SettingsStatus,
+    groups: Vec<SettingsGroup>,
+    retry_action: Option<SettingsAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsStatus {
+    Loading { message: String },
+    Ready,
+    Failed(UserFacingError),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsGroup {
+    title: String,
+    description: String,
+    rows: Vec<SettingsRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsRow {
+    title: String,
+    description: String,
+    value_label: String,
+    source_label: String,
+    default_label: String,
+    accepted_values_label: String,
+    problem: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsAction {
+    label: String,
+    enabled: bool,
+    intent: SettingsIntent,
+}
+
+impl SettingsPresentation {
+    pub(crate) fn loading() -> Self {
+        Self {
+            status: SettingsStatus::Loading {
+                message: "Loading settings…".to_string(),
+            },
+            groups: Vec::new(),
+            retry_action: None,
+        }
+    }
+
+    pub(crate) fn ready(groups: Vec<SettingsGroup>) -> Self {
+        Self {
+            status: SettingsStatus::Ready,
+            groups,
+            retry_action: None,
+        }
+    }
+
+    pub(crate) fn failed(error: UserFacingError) -> Self {
+        Self {
+            status: SettingsStatus::Failed(error),
+            groups: Vec::new(),
+            retry_action: Some(SettingsAction::new("Retry", true, SettingsIntent::Retry)),
+        }
+    }
+
+    /// Build the Settings view from the same registry-backed store used by the
+    /// CLI. This is also useful to fixture presentation tests without GTK or a
+    /// live environment.
+    pub fn from_store(store: &SettingsStore) -> Self {
+        Self::ready(groups_from_store(store))
+    }
+
+    pub fn status(&self) -> &SettingsStatus {
+        &self.status
+    }
+
+    pub fn groups(&self) -> &[SettingsGroup] {
+        &self.groups
+    }
+
+    pub fn retry_action(&self) -> Option<&SettingsAction> {
+        self.retry_action.as_ref()
+    }
+}
+
+impl SettingsGroup {
+    pub(crate) fn new(
+        title: impl Into<String>,
+        description: impl Into<String>,
+        rows: Vec<SettingsRow>,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            description: description.into(),
+            rows,
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn rows(&self) -> &[SettingsRow] {
+        &self.rows
+    }
+}
+
+impl SettingsRow {
+    pub(crate) fn new(
+        title: impl Into<String>,
+        description: impl Into<String>,
+        value_label: impl Into<String>,
+        source_label: impl Into<String>,
+        default_label: impl Into<String>,
+        accepted_values_label: impl Into<String>,
+        problem: Option<impl Into<String>>,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            description: description.into(),
+            value_label: value_label.into(),
+            source_label: source_label.into(),
+            default_label: default_label.into(),
+            accepted_values_label: accepted_values_label.into(),
+            problem: problem.map(Into::into),
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn value_label(&self) -> &str {
+        &self.value_label
+    }
+
+    pub fn source_label(&self) -> &str {
+        &self.source_label
+    }
+
+    pub fn default_label(&self) -> &str {
+        &self.default_label
+    }
+
+    pub fn accepted_values_label(&self) -> &str {
+        &self.accepted_values_label
+    }
+
+    pub fn problem(&self) -> Option<&str> {
+        self.problem.as_deref()
+    }
+}
+
+impl SettingsAction {
+    pub(crate) fn new(label: impl Into<String>, enabled: bool, intent: SettingsIntent) -> Self {
+        Self {
+            label: label.into(),
+            enabled,
+            intent,
+        }
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    pub fn intent(&self) -> SettingsIntent {
+        self.intent
+    }
+}
+
+pub(crate) fn groups_from_store(store: &SettingsStore) -> Vec<SettingsGroup> {
+    let effective = store.all_effective();
+    let setting = |key: &str| {
+        effective
+            .iter()
+            .find(|item| item.key_name() == key)
+            .expect("settings registry contains every Settings view key")
+    };
+
+    vec![
+        SettingsGroup::new(
+            "Screen",
+            "Choose when LG Buddy blanks and restores your TV screen.",
+            vec![
+                row(setting("screen.backend")),
+                row(setting("screen.idle_blank")),
+                row(setting("screen.idle_timeout")),
+                row(setting("screen.restore_policy")),
+            ],
+        ),
+        SettingsGroup::new(
+            "Sleep & Wake",
+            "Coordinate your TV with the computer’s sleep and wake behavior.",
+            vec![row(setting("system.sleep_wake_policy"))],
+        ),
+        SettingsGroup::new(
+            "Updates",
+            "Choose how LG Buddy checks for new versions.",
+            vec![
+                row(setting("updates.auto_check")),
+                row(setting("updates.channel")),
+            ],
+        ),
+    ]
+}
+
+fn row(setting: &EffectiveSetting) -> SettingsRow {
+    let definition = setting.definition();
+    let accepted_values = accepted_values_label(setting.key_name(), definition.value_type());
+    let problem = setting.invalid_value().map(|invalid| {
+        format!("Invalid configured value \"{invalid}\". Accepted values: {accepted_values}.")
+    });
+
+    let current_value_label = setting
+        .value()
+        .map(|value| value_label(setting.key_name(), value))
+        .unwrap_or_else(|| {
+            setting
+                .invalid_value()
+                .map(|_| "Invalid value".to_string())
+                .unwrap_or_else(|| "Not configured".to_string())
+        });
+
+    SettingsRow::new(
+        setting_title(setting.key_name()),
+        definition.description(),
+        current_value_label,
+        source_label(setting.source()),
+        definition
+            .default_value()
+            .map(|value| value_label(setting.key_name(), value))
+            .unwrap_or_else(|| "Not configured".to_string()),
+        accepted_values,
+        problem,
+    )
+}
+
+fn setting_title(key: &str) -> &'static str {
+    match key {
+        "screen.backend" => "Desktop integration",
+        "screen.idle_blank" => "Idle blanking",
+        "screen.idle_timeout" => "Idle timeout",
+        "screen.restore_policy" => "Restore policy",
+        "system.sleep_wake_policy" => "TV sleep & wake",
+        "updates.auto_check" => "Automatic update checks",
+        "updates.channel" => "Update channel",
+        _ => "Setting",
+    }
+}
+
+fn value_label(key: &str, value: SettingValue) -> String {
+    match (key, value) {
+        ("screen.backend", SettingValue::Enum("auto")) => "Automatic".to_string(),
+        ("screen.backend", SettingValue::Enum("gnome")) => "GNOME".to_string(),
+        ("screen.backend", SettingValue::Enum("wayland")) => "Wayland".to_string(),
+        ("screen.backend", SettingValue::Enum("swayidle")) => "swayidle (deprecated)".to_string(),
+        (_, SettingValue::Enum("enabled")) => "Enabled".to_string(),
+        (_, SettingValue::Enum("disabled")) => "Disabled".to_string(),
+        ("screen.restore_policy", SettingValue::Enum("conservative")) => "Conservative".to_string(),
+        ("screen.restore_policy", SettingValue::Enum("aggressive")) => "Aggressive".to_string(),
+        ("updates.channel", SettingValue::Enum("stable")) => "Stable".to_string(),
+        ("updates.channel", SettingValue::Enum("prerelease")) => "Prerelease".to_string(),
+        ("screen.idle_timeout", SettingValue::Integer(seconds)) => {
+            format!("{seconds} seconds")
+        }
+        (_, value) => value.to_string(),
+    }
+}
+
+fn source_label(source: SettingSource) -> &'static str {
+    match source {
+        SettingSource::Default => "Default",
+        SettingSource::ConfigEnv => "Saved configuration",
+        SettingSource::LegacyConfigEnv => "Legacy configuration",
+        SettingSource::InvalidConfigEnv => "Invalid configuration",
+        SettingSource::InvalidLegacyConfigEnv => "Invalid legacy configuration",
+        SettingSource::Missing => "Not configured",
+    }
+}
+
+fn accepted_values_label(key: &str, value_type: SettingType) -> String {
+    match value_type {
+        SettingType::Enum(enum_type) => {
+            let values = enum_type
+                .values()
+                .iter()
+                .map(|value| value_label(key, SettingValue::Enum(value)))
+                .collect::<Vec<_>>()
+                .join(", ");
+            values
+        }
+        SettingType::Integer(integer_type) => {
+            format!("{}–{} seconds", integer_type.min(), integer_type.max())
+        }
+        SettingType::Ipv4 => "An IPv4 address".to_string(),
+        SettingType::MacAddress => "A MAC address like aa:bb:cc:dd:ee:ff".to_string(),
+    }
+}

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -306,13 +306,13 @@ mod tests {
                 "tv.mac | storage=tvs_primary_mac | fallbacks=tv_mac | type=mac-address | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=MAC address of the primary configured TV for Wake-on-LAN.",
                 "tv.input | storage=tvs_primary_input | fallbacks=input | type=enum values=HDMI_1,HDMI_2,HDMI_3,HDMI_4 aliases=(none) | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=HDMI input used by the primary configured TV.",
                 "tv.platform | storage=tvs_primary_platform | fallbacks=(none) | type=enum values=bscpylgtv,lg_webos aliases=(none) | default=bscpylgtv | mutability=read-write | ops=get,describe,set,unset | apply=no-runtime-apply-required | description=Control platform for the primary configured TV.",
-                "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,wayland,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Screen backend selection for user-session blanking and restore behavior.",
-                "screen.idle_blank | storage=screen_idle_blank | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Idle-driven blanking and restore behavior for the configured screen.",
-                "screen.idle_timeout | storage=screen_idle_timeout | fallbacks=(none) | type=integer range=1..=86400 | default=300 | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Idle timeout in seconds before LG Buddy blanks the configured screen.",
-                "screen.restore_policy | storage=screen_restore_policy | fallbacks=(none) | type=enum values=conservative,aggressive aliases=marker_only->conservative | default=conservative | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Screen restore policy after LG Buddy blanks the configured screen.",
-                "system.sleep_wake_policy | storage=system_sleep_wake_policy | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=runtime-policy-only | description=System sleep and wake policy for lifecycle hooks.",
-                "updates.auto_check | storage=updates_auto_check | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=manage-update-check-timer | description=Automatic background update checks and update notifications.",
-                "updates.channel | storage=updates_channel | fallbacks=(none) | type=enum values=stable,prerelease aliases=(none) | default=stable | mutability=read-write | ops=get,describe,set,unset | apply=runtime-policy-only | description=Release channel used by all update operations.",
+                "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,wayland,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration.",
+                "screen.idle_blank | storage=screen_idle_blank | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Blank the TV screen when the computer is idle or locked, and restore it when activity resumes.",
+                "screen.idle_timeout | storage=screen_idle_timeout | fallbacks=(none) | type=integer range=1..=86400 | default=300 | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Seconds of user inactivity before LG Buddy blanks the configured screen.",
+                "screen.restore_policy | storage=screen_restore_policy | fallbacks=(none) | type=enum values=conservative,aggressive aliases=marker_only->conservative | default=conservative | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Conservative restores the TV only after LG Buddy blanked or powered it off. Aggressive also attempts to restore it without a prior LG Buddy action.",
+                "system.sleep_wake_policy | storage=system_sleep_wake_policy | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=runtime-policy-only | description=Power off the TV before the computer sleeps and restore it after waking.",
+                "updates.auto_check | storage=updates_auto_check | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=manage-update-check-timer | description=Periodically check for new LG Buddy versions and notify you when an update is available.",
+                "updates.channel | storage=updates_channel | fallbacks=(none) | type=enum values=stable,prerelease aliases=(none) | default=stable | mutability=read-write | ops=get,describe,set,unset | apply=runtime-policy-only | description=Choose stable releases or include prerelease versions in update checks and installation.",
             ]
         );
     }
@@ -495,7 +495,7 @@ screen.backend
   supported operations: get, describe, set, unset
   allowed values: auto, gnome, wayland, swayidle (deprecated compatibility backend)
   apply: restart-user-screen-service
-  description: Screen backend selection for user-session blanking and restore behavior.
+  description: Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration.
 
 screen.idle_blank
   storage key: screen_idle_blank
@@ -507,7 +507,7 @@ screen.idle_blank
   supported operations: get, describe, set, unset
   allowed values: enabled, disabled
   apply: restart-user-screen-service
-  description: Idle-driven blanking and restore behavior for the configured screen.
+  description: Blank the TV screen when the computer is idle or locked, and restore it when activity resumes.
 
 screen.idle_timeout
   storage key: screen_idle_timeout
@@ -519,7 +519,7 @@ screen.idle_timeout
   supported operations: get, describe, set, unset
   range: 1..=86400
   apply: restart-user-screen-service
-  description: Idle timeout in seconds before LG Buddy blanks the configured screen.
+  description: Seconds of user inactivity before LG Buddy blanks the configured screen.
 
 screen.restore_policy
   storage key: screen_restore_policy
@@ -532,7 +532,7 @@ screen.restore_policy
   allowed values: conservative, aggressive
   aliases: marker_only -> conservative
   apply: restart-user-screen-service
-  description: Screen restore policy after LG Buddy blanks the configured screen.
+  description: Conservative restores the TV only after LG Buddy blanked or powered it off. Aggressive also attempts to restore it without a prior LG Buddy action.
 
 system.sleep_wake_policy
   storage key: system_sleep_wake_policy
@@ -544,7 +544,7 @@ system.sleep_wake_policy
   supported operations: get, describe, set, unset
   allowed values: enabled, disabled
   apply: runtime-policy-only
-  description: System sleep and wake policy for lifecycle hooks.
+  description: Power off the TV before the computer sleeps and restore it after waking.
 
 updates.auto_check
   storage key: updates_auto_check
@@ -556,7 +556,7 @@ updates.auto_check
   supported operations: get, describe, set, unset
   allowed values: enabled, disabled
   apply: manage-update-check-timer
-  description: Automatic background update checks and update notifications.
+  description: Periodically check for new LG Buddy versions and notify you when an update is available.
 
 updates.channel
   storage key: updates_channel
@@ -568,7 +568,7 @@ updates.channel
   supported operations: get, describe, set, unset
   allowed values: stable, prerelease
   apply: runtime-policy-only
-  description: Release channel used by all update operations.
+  description: Choose stable releases or include prerelease versions in update checks and installation.
 "
         );
     }

--- a/crates/lg-buddy/src/settings/screen.rs
+++ b/crates/lg-buddy/src/settings/screen.rs
@@ -29,7 +29,7 @@ pub(super) const BACKEND: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RestartUserScreenService,
-    description: "Screen backend selection for user-session blanking and restore behavior.",
+    description: "Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration.",
 };
 
 pub(super) const IDLE_BLANK: SettingDefinition = SettingDefinition {
@@ -44,7 +44,7 @@ pub(super) const IDLE_BLANK: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RestartUserScreenService,
-    description: "Idle-driven blanking and restore behavior for the configured screen.",
+    description: "Blank the TV screen when the computer is idle or locked, and restore it when activity resumes.",
 };
 
 pub(super) const IDLE_TIMEOUT: SettingDefinition = SettingDefinition {
@@ -59,7 +59,7 @@ pub(super) const IDLE_TIMEOUT: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RestartUserScreenService,
-    description: "Idle timeout in seconds before LG Buddy blanks the configured screen.",
+    description: "Seconds of user inactivity before LG Buddy blanks the configured screen.",
 };
 
 pub(super) const RESTORE_POLICY: SettingDefinition = SettingDefinition {
@@ -74,7 +74,7 @@ pub(super) const RESTORE_POLICY: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RestartUserScreenService,
-    description: "Screen restore policy after LG Buddy blanks the configured screen.",
+    description: "Conservative restores the TV only after LG Buddy blanked or powered it off. Aggressive also attempts to restore it without a prior LG Buddy action.",
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/lg-buddy/src/settings/system.rs
+++ b/crates/lg-buddy/src/settings/system.rs
@@ -17,7 +17,7 @@ pub(super) const SLEEP_WAKE_POLICY: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RuntimePolicyOnly,
-    description: "System sleep and wake policy for lifecycle hooks.",
+    description: "Power off the TV before the computer sleeps and restore it after waking.",
 };
 
 #[cfg(test)]

--- a/crates/lg-buddy/src/settings/updates.rs
+++ b/crates/lg-buddy/src/settings/updates.rs
@@ -21,7 +21,8 @@ pub(super) const AUTO_CHECK: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::ManageUpdateCheckTimer,
-    description: "Automatic background update checks and update notifications.",
+    description:
+        "Periodically check for new LG Buddy versions and notify you when an update is available.",
 };
 
 pub(super) const CHANNEL: SettingDefinition = SettingDefinition {
@@ -36,7 +37,8 @@ pub(super) const CHANNEL: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RuntimePolicyOnly,
-    description: "Release channel used by all update operations.",
+    description:
+        "Choose stable releases or include prerelease versions in update checks and installation.",
 };
 
 pub(super) fn apply_check_timer<C: ServiceController>(

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -1,0 +1,529 @@
+//! Toolkit-independent coordination for the read-only Settings view.
+
+use std::error::Error;
+use std::fmt;
+
+use crate::presentation::brightness::UserFacingError;
+use crate::presentation::settings::{SettingsGroup, SettingsPresentation};
+use crate::settings::SettingsStore;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsIntent {
+    Retry,
+    Refresh,
+}
+
+/// Opaque identity for one asynchronous settings read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SettingsReadOperation(u64);
+
+impl SettingsReadOperation {
+    pub(crate) fn new(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsTransition {
+    presentation: SettingsPresentation,
+    read_operation: Option<SettingsReadOperation>,
+    diagnostic: Option<String>,
+}
+
+impl SettingsTransition {
+    pub fn presentation(&self) -> &SettingsPresentation {
+        &self.presentation
+    }
+
+    pub fn read_operation(&self) -> Option<SettingsReadOperation> {
+        self.read_operation
+    }
+
+    pub fn diagnostic(&self) -> Option<&str> {
+        self.diagnostic.as_deref()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsReadFailure {
+    Stopped,
+    Unreadable,
+    Internal,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsReadError {
+    failure: SettingsReadFailure,
+    diagnostic: String,
+}
+
+impl SettingsReadError {
+    pub fn new(failure: SettingsReadFailure, diagnostic: impl Into<String>) -> Self {
+        Self {
+            failure,
+            diagnostic: diagnostic.into(),
+        }
+    }
+
+    pub fn stopped() -> Self {
+        Self::new(SettingsReadFailure::Stopped, "settings read stopped")
+    }
+
+    pub fn unreadable(diagnostic: impl Into<String>) -> Self {
+        Self::new(SettingsReadFailure::Unreadable, diagnostic)
+    }
+
+    pub fn internal(diagnostic: impl Into<String>) -> Self {
+        Self::new(SettingsReadFailure::Internal, diagnostic)
+    }
+
+    pub fn failure(&self) -> SettingsReadFailure {
+        self.failure
+    }
+
+    pub fn diagnostic(&self) -> &str {
+        &self.diagnostic
+    }
+}
+
+impl fmt::Display for SettingsReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.diagnostic)
+    }
+}
+
+impl Error for SettingsReadError {}
+
+pub trait SettingsBackend: Send + Sync + 'static {
+    fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError>;
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct EnvironmentSettingsBackend;
+
+impl SettingsBackend for EnvironmentSettingsBackend {
+    fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError> {
+        let store = SettingsStore::load_from_env()
+            .map_err(|error| SettingsReadError::unreadable(error.to_string()))?;
+        Ok(SettingsPresentation::from_store(&store).groups().to_vec())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SettingsApplicationState {
+    Loading(SettingsReadOperation),
+    Ready,
+    Failed,
+    Closed,
+}
+
+#[derive(Debug)]
+pub struct SettingsApplication {
+    state: SettingsApplicationState,
+    next_operation_id: u64,
+    presentation: SettingsPresentation,
+}
+
+impl SettingsApplication {
+    pub fn open() -> (Self, SettingsTransition) {
+        let operation = SettingsReadOperation::new(0);
+        let presentation = SettingsPresentation::loading();
+        (
+            Self {
+                state: SettingsApplicationState::Loading(operation),
+                next_operation_id: 1,
+                presentation: presentation.clone(),
+            },
+            SettingsTransition {
+                presentation,
+                read_operation: Some(operation),
+                diagnostic: None,
+            },
+        )
+    }
+
+    pub fn handle_intent(&mut self, intent: SettingsIntent) -> Option<SettingsTransition> {
+        match intent {
+            SettingsIntent::Retry if matches!(self.state, SettingsApplicationState::Failed) => {
+                Some(self.begin_read())
+            }
+            SettingsIntent::Refresh
+                if matches!(
+                    self.state,
+                    SettingsApplicationState::Ready | SettingsApplicationState::Failed
+                ) =>
+            {
+                Some(self.begin_read())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn complete_read(
+        &mut self,
+        operation: SettingsReadOperation,
+        result: Result<Vec<SettingsGroup>, SettingsReadError>,
+    ) -> Option<SettingsTransition> {
+        if !matches!(self.state, SettingsApplicationState::Loading(active) if active == operation) {
+            return None;
+        }
+
+        let (presentation, diagnostic) = match result {
+            Ok(groups) => {
+                self.state = SettingsApplicationState::Ready;
+                (SettingsPresentation::ready(groups), None)
+            }
+            Err(error) => {
+                self.state = SettingsApplicationState::Failed;
+                let diagnostic = error.diagnostic().to_string();
+                (
+                    SettingsPresentation::failed(user_facing_read_error(error.failure())),
+                    Some(diagnostic),
+                )
+            }
+        };
+        self.presentation = presentation.clone();
+        Some(SettingsTransition {
+            presentation,
+            read_operation: None,
+            diagnostic,
+        })
+    }
+
+    pub fn shutdown(&mut self) {
+        self.state = SettingsApplicationState::Closed;
+    }
+
+    pub fn presentation(&self) -> &SettingsPresentation {
+        &self.presentation
+    }
+
+    fn begin_read(&mut self) -> SettingsTransition {
+        let operation = SettingsReadOperation::new(self.next_operation_id);
+        self.next_operation_id += 1;
+        self.state = SettingsApplicationState::Loading(operation);
+        self.presentation = SettingsPresentation::loading();
+        SettingsTransition {
+            presentation: self.presentation.clone(),
+            read_operation: Some(operation),
+            diagnostic: None,
+        }
+    }
+}
+
+fn user_facing_read_error(failure: SettingsReadFailure) -> UserFacingError {
+    match failure {
+        SettingsReadFailure::Stopped => UserFacingError::new(
+            "Settings loading stopped",
+            "The current settings could not be loaded. Retry to try again.",
+        ),
+        SettingsReadFailure::Unreadable => UserFacingError::new(
+            "LG Buddy could not read its settings",
+            "Check the settings configuration, then retry.",
+        ),
+        SettingsReadFailure::Internal => UserFacingError::new(
+            "LG Buddy could not load settings",
+            "Retry. If this continues, check the LG Buddy logs.",
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::*;
+    use crate::presentation::settings::{SettingsRow, SettingsStatus};
+    use crate::settings::{ConfigEnvReader, SettingValue, SettingsStore, SETTINGS_REGISTRY};
+
+    fn groups(contents: &str) -> Vec<SettingsGroup> {
+        let store = ConfigEnvReader::parse("/tmp/config.env", contents).into_store();
+        SettingsPresentation::from_store(&store).groups().to_vec()
+    }
+
+    fn row<'a>(groups: &'a [SettingsGroup], group: &str, title: &str) -> &'a SettingsRow {
+        groups
+            .iter()
+            .find(|item| item.title() == group)
+            .unwrap()
+            .rows()
+            .iter()
+            .find(|item| item.title() == title)
+            .unwrap()
+    }
+
+    fn rows(groups: &[SettingsGroup]) -> Vec<&SettingsRow> {
+        groups.iter().flat_map(|group| group.rows()).collect()
+    }
+
+    fn test_path(label: &str) -> std::path::PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "lg-buddy-settings-view-{label}-{}-{nanos}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn default_settings_are_ready_and_grouped() {
+        let groups = groups("");
+        assert_eq!(groups.len(), 3);
+        assert_eq!(groups[0].rows().len(), 4);
+        assert_eq!(groups[1].rows().len(), 1);
+        assert_eq!(groups[2].rows().len(), 2);
+
+        let backend = row(&groups, "Screen", "Desktop integration");
+        assert_eq!(backend.value_label(), "Automatic");
+        assert_eq!(backend.source_label(), "Default");
+        assert_eq!(backend.default_label(), "Automatic");
+        assert!(backend.problem().is_none());
+    }
+
+    #[test]
+    fn persisted_values_use_friendly_labels_and_sources() {
+        let groups = groups(
+            "screen_backend=wayland\nscreen_idle_blank=disabled\nscreen_idle_timeout=450\nscreen_restore_policy=aggressive\nsystem_sleep_wake_policy=disabled\nupdates_auto_check=disabled\nupdates_channel=prerelease\n",
+        );
+        assert_eq!(
+            row(&groups, "Screen", "Desktop integration").value_label(),
+            "Wayland"
+        );
+        assert_eq!(
+            row(&groups, "Screen", "Desktop integration").source_label(),
+            "Saved configuration"
+        );
+        assert_eq!(
+            row(&groups, "Screen", "Idle timeout").value_label(),
+            "450 seconds"
+        );
+        assert_eq!(
+            row(&groups, "Updates", "Update channel").value_label(),
+            "Prerelease"
+        );
+    }
+
+    #[test]
+    fn aliases_are_canonicalized_and_explained_as_accepted_values() {
+        let groups = groups("screen_restore_policy=marker_only\n");
+        let restore = row(&groups, "Screen", "Restore policy");
+        assert_eq!(restore.value_label(), "Conservative");
+        assert_eq!(restore.accepted_values_label(), "Conservative, Aggressive");
+        assert!(restore.problem().is_none());
+    }
+
+    #[test]
+    fn invalid_values_are_visible_and_never_replaced_by_defaults() {
+        let groups = groups("screen_backend=not-a-backend\n");
+        let backend = row(&groups, "Screen", "Desktop integration");
+        assert_eq!(backend.value_label(), "Invalid value");
+        assert_eq!(backend.source_label(), "Invalid configuration");
+        assert_eq!(
+            backend.problem(),
+            Some(
+                "Invalid configured value \"not-a-backend\". Accepted values: Automatic, GNOME, Wayland, swayidle (deprecated)."
+            )
+        );
+        assert_ne!(backend.value_label(), backend.default_label());
+    }
+
+    #[test]
+    fn every_scoped_row_uses_registry_metadata_and_tv_keys_are_excluded() {
+        let groups = groups(
+            "tvs_primary_ip=192.0.2.10\n\
+tvs_primary_mac=not-a-mac\n\
+tvs_primary_input=HDMI_1\n\
+tvs_primary_platform=not-a-platform\n\
+screen_backend=wayland\n",
+        );
+        let expected = [
+            (
+                "screen.backend",
+                "Desktop integration",
+                "Automatic",
+                "Automatic, GNOME, Wayland, swayidle (deprecated)",
+            ),
+            (
+                "screen.idle_blank",
+                "Idle blanking",
+                "Enabled",
+                "Enabled, Disabled",
+            ),
+            (
+                "screen.idle_timeout",
+                "Idle timeout",
+                "300 seconds",
+                "1–86400 seconds",
+            ),
+            (
+                "screen.restore_policy",
+                "Restore policy",
+                "Conservative",
+                "Conservative, Aggressive",
+            ),
+            (
+                "system.sleep_wake_policy",
+                "TV sleep & wake",
+                "Enabled",
+                "Enabled, Disabled",
+            ),
+            (
+                "updates.auto_check",
+                "Automatic update checks",
+                "Enabled",
+                "Enabled, Disabled",
+            ),
+            (
+                "updates.channel",
+                "Update channel",
+                "Stable",
+                "Stable, Prerelease",
+            ),
+        ];
+        let rendered = rows(&groups);
+        assert_eq!(rendered.len(), expected.len());
+        assert_eq!(groups[0].title(), "Screen");
+        assert_eq!(groups[1].title(), "Sleep & Wake");
+        assert_eq!(groups[2].title(), "Updates");
+
+        for ((key, title, default, accepted), rendered) in expected.iter().zip(rendered.iter()) {
+            let definition = SETTINGS_REGISTRY.get_by_name(key).unwrap();
+            assert_eq!(rendered.title(), *title);
+            assert_eq!(rendered.description(), definition.description());
+            assert_eq!(rendered.default_label(), *default);
+            assert_eq!(rendered.accepted_values_label(), *accepted);
+            assert!(definition.default_value().is_some());
+            assert!(definition.fallback_storage_keys().is_empty());
+        }
+
+        assert!(rendered.iter().all(|row| {
+            !matches!(
+                row.title(),
+                "TV address" | "TV MAC address" | "TV input" | "TV platform"
+            )
+        }));
+        assert_eq!(
+            SETTINGS_REGISTRY
+                .get_by_name("screen.backend")
+                .unwrap()
+                .default_value(),
+            Some(SettingValue::Enum("auto"))
+        );
+    }
+
+    #[test]
+    fn missing_values_use_defaults_and_legacy_aliases_remain_valid_without_legacy_keys() {
+        let default_groups = groups("");
+        assert!(rows(&default_groups)
+            .iter()
+            .all(|row| row.source_label() == "Default" && row.problem().is_none()));
+
+        let alias_groups = groups("screen_restore_policy=marker_only\n");
+        let restore = row(&alias_groups, "Screen", "Restore policy");
+        assert_eq!(restore.value_label(), "Conservative");
+        assert_eq!(restore.source_label(), "Saved configuration");
+        assert_eq!(restore.accepted_values_label(), "Conservative, Aggressive");
+    }
+
+    #[test]
+    fn application_suppresses_duplicate_reads_and_retries_failed_reads() {
+        let (mut app, opening) = SettingsApplication::open();
+        let first = opening.read_operation().unwrap();
+        assert!(matches!(
+            opening.presentation().status(),
+            SettingsStatus::Loading { .. }
+        ));
+        assert!(app.handle_intent(SettingsIntent::Retry).is_none());
+        assert!(app.handle_intent(SettingsIntent::Refresh).is_none());
+
+        let failed = app
+            .complete_read(first, Err(SettingsReadError::stopped()))
+            .unwrap();
+        assert!(matches!(
+            failed.presentation().status(),
+            SettingsStatus::Failed(_)
+        ));
+        assert_eq!(
+            failed.presentation().retry_action().unwrap().intent(),
+            SettingsIntent::Retry
+        );
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let refreshed = refresh.read_operation().unwrap();
+        assert!(app.handle_intent(SettingsIntent::Refresh).is_none());
+        assert!(app.handle_intent(SettingsIntent::Retry).is_none());
+        assert!(app.complete_read(first, Ok(groups(""))).is_none());
+        let refreshed_ready = app
+            .complete_read(refreshed, Ok(groups("updates_channel=prerelease\n")))
+            .unwrap();
+        assert_eq!(
+            row(
+                refreshed_ready.presentation().groups(),
+                "Updates",
+                "Update channel"
+            )
+            .value_label(),
+            "Prerelease"
+        );
+        assert!(matches!(
+            refreshed_ready.presentation().status(),
+            SettingsStatus::Ready
+        ));
+
+        let retry = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let second = retry.read_operation().unwrap();
+        let ready = app.complete_read(second, Ok(groups(""))).unwrap();
+        assert!(matches!(
+            ready.presentation().status(),
+            SettingsStatus::Ready
+        ));
+        assert_eq!(
+            row(ready.presentation().groups(), "Updates", "Update channel").value_label(),
+            "Stable"
+        );
+    }
+
+    #[test]
+    fn shutdown_rejects_late_read_results() {
+        let (mut app, opening) = SettingsApplication::open();
+        let operation = opening.read_operation().unwrap();
+        app.shutdown();
+        assert!(app
+            .complete_read(operation, Ok(groups("updates_channel=prerelease\n")))
+            .is_none());
+        assert!(matches!(
+            app.presentation().status(),
+            SettingsStatus::Loading { .. }
+        ));
+    }
+
+    #[test]
+    fn unreadable_settings_path_reaches_failed_presentation() {
+        let path = test_path("unreadable");
+        fs::create_dir(&path).unwrap();
+        let read_error = SettingsStore::load(&path).unwrap_err();
+        let diagnostic = read_error.to_string();
+        let (mut app, opening) = SettingsApplication::open();
+        let failed = app
+            .complete_read(
+                opening.read_operation().unwrap(),
+                Err(SettingsReadError::unreadable(diagnostic.clone())),
+            )
+            .unwrap();
+        assert_eq!(failed.diagnostic(), Some(diagnostic.as_str()));
+        assert!(matches!(
+            failed.presentation().status(),
+            SettingsStatus::Failed(_)
+        ));
+        let error = match failed.presentation().status() {
+            SettingsStatus::Failed(error) => error,
+            _ => unreachable!(),
+        };
+        assert_eq!(error.summary(), "LG Buddy could not read its settings");
+        assert!(!error.detail().contains(path.to_str().unwrap()));
+        fs::remove_dir(&path).unwrap();
+    }
+}

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -634,6 +634,33 @@ the native webOS exchange; GTK fixtures cover the form and intent mapping, and
 the installed accessibility check covers the blank-state CTA, modal form,
 validation feedback, and dismissal through Escape and the header's Cancel button.
 
+## Read-only Settings Increment
+
+[#176](https://github.com/Staphylococcus/LG_Buddy/issues/176) adds **Settings**
+as the third destination. `SettingsApplication` owns loading, failure, retry,
+and refresh on entry. Its backend reads `SettingsStore` on a worker thread;
+operation identities reject stale completions and results after close.
+Configuration reads do not depend on a configured or reachable TV.
+
+The application builds three groups—Screen, Sleep & Wake, and Updates—from
+the seven behavior settings. Descriptions, defaults, accepted values, and
+effective-value sources come from the existing registry and store. Friendly
+titles and value labels belong to the presentation layer. Invalid values stay
+invalid, and persisted configuration is not treated as proof of runtime
+application or service health.
+
+GTK maps the presentation to a native `AdwPreferencesPage`, preference groups,
+and expandable rows. Descriptions and current values are visible immediately;
+source, default, and accepted values appear in expanded details. It neither
+parses configuration nor calls the settings CLI. Shared descriptions are
+improved in the registry rather than copied into GTK. This increment introduces
+no settings writes; ordinary editing and runtime application belong to #177.
+
+Headless tests cover registry/store presentation and the loading/refresh/retry
+flow. Renderer tests cover native grouping, invalid text, expansion, and narrow
+layout. The installed AT-SPI smoke verifies the third tab, keyboard access to
+details, externally changed configuration, and preservation of the settings file.
+
 ## Evolution Rules
 
 Later GUI areas follow the same method:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -49,6 +49,19 @@ With no TV configured, choose **Pair a TV** to get started.
 
 ![The TVs tab with no TV configured and a Pair a TV button](screenshots/tvs-empty.png)
 
+### Settings
+
+The development version adds a read-only **Settings** tab with **Screen**,
+**Sleep & Wake**, and **Updates** groups. Each row shows the current configured
+value and a description shared with the settings commands. Expand a row to see
+its source, default, and accepted values. Invalid saved values are identified
+explicitly; they are not silently replaced by defaults.
+
+Settings reloads when you enter the tab. These values describe configuration,
+not whether the corresponding service is currently running. For now, use the
+[settings commands](#configuration) to make changes. TV identity, HDMI input,
+and pairing remain in **TVs**.
+
 ### Pair Your First TV
 
 Open **TVs → Pair a TV**. The dialog pairs your first TV using native webOS.

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -15,7 +15,8 @@ WINDOW_TITLE = "LG Buddy"
 CONTROL_NAME = "OLED Pixel Brightness"
 VOLUME_NAME = "TV Volume"
 DEFAULT_TIMEOUT_SECONDS = 10
-MAX_ACCESSIBLES = 256
+# Expanded Settings rows expose their detail widgets as well as the navigation.
+MAX_ACCESSIBLES = 1024
 
 
 def accessible_tree(root: object | None = None) -> list[object]:
@@ -97,7 +98,10 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_TIMEOUT_SECONDS,
         help=f"maximum observation time in seconds (default: {DEFAULT_TIMEOUT_SECONDS})",
     )
-    parser.add_argument("--select-page", choices=("Overview", "TVs"))
+    parser.add_argument("--select-page", choices=("Overview", "TVs", "Settings"))
+    parser.add_argument("--expected-settings-state", choices=("ready", "invalid"))
+    parser.add_argument("--expected-settings-timeout")
+    parser.add_argument("--require-settings-details", action="store_true")
     parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid", "unpair"))
     parser.add_argument("--expected-tv-address")
     parser.add_argument("--expected-tv-name", default="Primary TV")
@@ -216,6 +220,27 @@ def tvs_contract(expected_state: str, address: str | None, tv_name: str):
     return accessibles, None
 
 
+def settings_contract(args: argparse.Namespace):
+    accessibles = accessible_tree()
+    names = {name(item) for item in accessibles}
+    if not {"Screen", "Sleep & Wake", "Updates", "Desktop integration", "Idle blanking",
+            "Idle timeout", "Restore policy", "TV sleep & wake", "Automatic update checks",
+            "Update channel"} <= names:
+        return None
+    if args.expected_settings_timeout and args.expected_settings_timeout not in names:
+        return None
+    if args.expected_settings_state == "invalid" and not any(value.startswith("Invalid value") for value in names):
+        return None
+    if args.expected_settings_state == "ready" and any(value.startswith("Invalid value") for value in names):
+        return None
+    if args.require_settings_details:
+        visible = {name(item) for item in accessibles
+                   if item.getState().contains(pyatspi.STATE_SHOWING)}
+        if not {"Source", "Default", "Accepted values"} <= visible:
+            return None
+    return accessibles, None
+
+
 def main() -> int:
     args = parse_args()
     if args.select_page:
@@ -257,11 +282,13 @@ def main() -> int:
     deadline = time.monotonic() + args.timeout
     contract = None
     while time.monotonic() < deadline:
-        if args.expected_tvs_state:
+        if args.expected_settings_state:
+            contract = settings_contract(args)
+        elif args.expected_tvs_state:
             contract = tvs_contract(args.expected_tvs_state, args.expected_tv_address, args.expected_tv_name)
         else:
             contract = observed_contract(args.expected_state, args.expected_slider_value)
-        if contract is not None and (args.expected_tvs_state or audio_contract(contract[0], args)):
+        if contract is not None and (args.expected_settings_state or args.expected_tvs_state or audio_contract(contract[0], args)):
             break
         contract = None
         time.sleep(0.1)
@@ -283,7 +310,7 @@ def main() -> int:
                     print(f"    value: {item.queryValue().currentValue}", file=sys.stderr)
             except Exception:
                 continue
-        expected = f" {args.expected_tvs_state or args.expected_state} state"
+        expected = f" {args.expected_settings_state or args.expected_tvs_state or args.expected_state} state"
         if args.expected_slider_value is not None:
             expected += f" at slider value {args.expected_slider_value:g}"
         raise SystemExit(
@@ -296,7 +323,7 @@ def main() -> int:
         {(role_name(item), name(item)) for item in accessibles if name(item)}
     )
     print("AT-SPI accessibility contract verified:")
-    print(f"  presentation state: {args.expected_tvs_state or args.expected_state}")
+    print(f"  presentation state: {args.expected_settings_state or args.expected_tvs_state or args.expected_state}")
     if slider_value is not None:
         print(f"  slider value: {slider_value:g}")
     for observed_role, accessible_name in observed:

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -240,6 +240,23 @@ observe_gui_state --expected-slider-value 55 --expected-volume 21 --expected-mut
 observe_gui_state --select-page TVs
 TV_ADDRESS="$(sed -n 's/^tvs_primary_ip=//p' "$CONFIG_FILE" | tail -n1)"
 observe_gui_state --expected-tvs-state configured --expected-tv-address "$TV_ADDRESS" --expected-tv-name OLED42C2
+# Settings reads the shared store without changing it, including invalid values.
+cp "$CONFIG_FILE" "$WORK_DIR/before-settings.env"
+printf '%s\n' 'screen_idle_timeout=600' 'updates_channel=not-a-channel' >> "$CONFIG_FILE"
+cp "$CONFIG_FILE" "$WORK_DIR/settings-snapshot.env"
+observe_gui_state --select-page Settings
+observe_gui_state --expected-settings-state invalid --expected-settings-timeout '600 seconds'
+xdotool windowsize --sync "$WINDOW_ID" 700 780
+observe_gui_state --focus-control "Desktop integration" --window-id "$WINDOW_ID"
+xdotool key --window "$WINDOW_ID" space
+observe_gui_state --expected-settings-state invalid --require-settings-details
+cmp "$CONFIG_FILE" "$WORK_DIR/settings-snapshot.env" || fail "Inspecting Settings changed configuration."
+# Returning to Settings reloads changes made outside the GUI.
+observe_gui_state --select-page TVs
+printf '%s\n' 'screen_idle_timeout=120' 'updates_channel=stable' >> "$CONFIG_FILE"
+observe_gui_state --select-page Settings
+observe_gui_state --expected-settings-state ready --expected-settings-timeout '120 seconds'
+cp "$WORK_DIR/before-settings.env" "$CONFIG_FILE"
 observe_gui_state --select-page Overview
 observe_gui_state --expected-slider-value 55 --expected-volume 21 --expected-muted true
 xdotool windowfocus --sync "$WINDOW_ID"
@@ -424,6 +441,9 @@ if [ "${LG_BUDDY_TEST_PLATFORM_CONTRACT:-0}" = "1" ]; then
         PLATFORM_HEIGHT="$(printf '%s\n' "$geometry" | sed -n 's/^HEIGHT=//p')"
         xwd -silent -id "$WINDOW_ID" -out "$screenshot"
         PLATFORM_MEAN="$(python3 "$SCRIPT_DIR/xwd_mean.py" "$screenshot")"
+
+        observe_gui_state --select-page Settings
+        observe_gui_state --expected-settings-state ready
 
         xdotool windowfocus --sync "$WINDOW_ID"
         send_closing_mnemonic Escape


### PR DESCRIPTION
## Summary

Adds a read-only Settings destination for inspecting LG Buddy's screen, sleep/wake, and update behavior. The application builds the view from the existing settings registry and store; GTK renders native preference groups and expandable rows. Shared descriptions are improved at their source for both CLI and GUI.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

- Settings joins Overview and TVs, with Screen, Sleep & Wake, and Updates groups covering all seven behavior settings.
- Rows show descriptions and current values. Expanding a row reveals its source, default, and accepted values; invalid saved values remain explicit rather than falling back to defaults.
- Entering Settings reloads configuration. Failed reads offer Retry, and loading runs off the GTK thread.
- The view adapts to narrow windows and uses the existing bottom navigation at smaller widths. TV management stays in TVs; behavior editing and application remain in #177.

## Validation

- `cargo test -p lg-buddy`: 887 unit tests, 48 integration tests, and all 134 Cucumber scenarios passed; the optional hardware test remained ignored.
- Display-backed GTK suite passed, including Settings rendering, retry, refresh, text escaping, and narrow layout.
- Installed GUI smoke passed with isolated configuration and mocked TV access: keyboard expansion, external settings changes, file preservation, light/dark themes, and 2× scaling.
- Both binaries build; workspace Clippy with warnings denied, formatting, shell syntax, Python parsing, and diff whitespace checks pass.
- Visually inspected wide and narrow Settings screenshots.

## Related Issue

Fixes #176
