### PR TITLE
Add editable behavior settings with automatic apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ controls close at hand.
 
 **1.6.0-beta.1** introduces Overview, the TVs view, and native first-TV pairing.
 This is an early preview of 1.6; further GUI work is still being developed.
-The development branch also includes TV input changes, local unpairing, and a
-read-only Settings tab. The latest stable 1.5 release does not include this expanded
-interface. See the [beta release notes](docs/releases/1.6.0-beta.1.md) for scope
-and installation details. Screenshots use sample TV data.
+The released beta does not include GUI Settings. Development builds also include
+TV input changes, local unpairing, and editable Settings controls. The latest
+stable 1.5 release does not include this expanded interface. See the
+[beta release notes](docs/releases/1.6.0-beta.1.md) for scope and installation
+details. Screenshots use sample TV data.
 
 ![LG Buddy Overview with a connected TV, brightness and volume sliders, and connection status](docs/screenshots/overview.png)
 
@@ -37,8 +38,8 @@ Move a slider to apply its value, or click the sound icon to toggle mute.
   and saved connection details in the TVs tab.
 
 GNOME is not required. Official release bundles include prebuilt binaries, so
-normal installation does not require a Rust toolchain. Settings and updates
-remain available through the command line.
+normal installation does not require a Rust toolchain. The stable CLI remains
+available for headless controls, settings, and updates.
 
 ## Desktop Compatibility
 

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -27,8 +27,8 @@ use lg_buddy::pairing::{
     EnvironmentPairingBackend, PairingBackend, PairingError, PairingOperation, PairingStage,
 };
 use lg_buddy::settings_view::{
-    EnvironmentSettingsBackend, SettingsBackend, SettingsIntent, SettingsReadError,
-    SettingsReadOperation, SettingsTransition,
+    EnvironmentSettingsBackend, SettingsBackend, SettingsIntent, SettingsMutationOperation,
+    SettingsReadError, SettingsReadOperation, SettingsTransition,
 };
 use lg_buddy::tvs::{
     EnvironmentTvsBackend, TvsBackend, TvsIntent, TvsModelReadOperation, TvsReadError,
@@ -313,6 +313,63 @@ impl ApplicationController {
         if let Some(operation) = transition.read_operation() {
             Self::start_settings_read(controller, operation);
         }
+        if let Some(operation) = transition.mutation_operation() {
+            Self::start_settings_mutation(controller, operation.clone());
+        }
+    }
+
+    fn start_settings_mutation(controller: &Rc<Self>, operation: SettingsMutationOperation) {
+        use lg_buddy::settings::{
+            SettingsMutationFailure, SettingsMutationOutcome, SettingsMutationStage,
+        };
+        enum Update {
+            Progress(SettingsMutationStage),
+            Done(Box<Result<SettingsMutationOutcome, SettingsMutationFailure>>),
+            Stopped,
+        }
+        let backend = Arc::clone(&controller.settings_backend);
+        let worker_operation = operation.clone();
+        let (sender, receiver) = mpsc::channel();
+        // Atomic publication and runtime apply finish even when the window closes.
+        let mut application_hold = Some(controller.gtk_application.hold());
+        thread::spawn(move || {
+            let result = backend.write_setting(worker_operation, &mut |stage| {
+                let _ = sender.send(Update::Progress(stage));
+            });
+            let _ = sender.send(Update::Done(Box::new(result)));
+        });
+        let controller = Rc::downgrade(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || loop {
+            let update = match receiver.try_recv() {
+                Ok(update) => update,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => Update::Stopped,
+            };
+            let done = matches!(update, Update::Done(_) | Update::Stopped);
+            if let Some(controller) = controller.upgrade() {
+                let transition = match update {
+                    Update::Progress(stage) => controller
+                        .application
+                        .borrow_mut()
+                        .settings_mutation_progress(&operation, stage),
+                    Update::Done(result) => controller
+                        .application
+                        .borrow_mut()
+                        .complete_settings_mutation(&operation, *result),
+                    Update::Stopped => controller
+                        .application
+                        .borrow_mut()
+                        .settings_mutation_worker_stopped(&operation),
+                };
+                if let Some(transition) = transition {
+                    Self::apply_transition(&controller, transition);
+                }
+            }
+            if done {
+                drop(application_hold.take());
+                return glib::ControlFlow::Break;
+            }
+        });
     }
 
     fn start_settings_read(controller: &Rc<Self>, operation: SettingsReadOperation) {
@@ -719,6 +776,17 @@ pub(crate) mod controller_test_support {
     struct DefaultSettingsBackend;
 
     impl lg_buddy::settings_view::SettingsBackend for DefaultSettingsBackend {
+        fn write_setting(
+            &self,
+            _operation: lg_buddy::settings_view::SettingsMutationOperation,
+            _progress: &mut dyn FnMut(lg_buddy::settings::SettingsMutationStage),
+        ) -> Result<
+            lg_buddy::settings::SettingsMutationOutcome,
+            lg_buddy::settings::SettingsMutationFailure,
+        > {
+            panic!("unexpected write in a read-only test backend")
+        }
+
         fn read_settings(
             &self,
         ) -> Result<
@@ -973,6 +1041,7 @@ pub(crate) mod controller_test_support {
         );
         run_pairing_scenario();
         run_settings_scenario();
+        run_settings_write_scenario();
 
         let (backend, controls) = BlockingBackend::new();
         let application = test_application("Blocking");
@@ -1141,6 +1210,17 @@ pub(crate) mod controller_test_support {
             Mutex<std::collections::VecDeque<Result<Vec<SettingsGroup>, SettingsReadError>>>,
         );
         impl SettingsBackend for SettingsMock {
+            fn write_setting(
+                &self,
+                _operation: lg_buddy::settings_view::SettingsMutationOperation,
+                _progress: &mut dyn FnMut(lg_buddy::settings::SettingsMutationStage),
+            ) -> Result<
+                lg_buddy::settings::SettingsMutationOutcome,
+                lg_buddy::settings::SettingsMutationFailure,
+            > {
+                panic!("unexpected write in a read-only test backend")
+            }
+
             fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError> {
                 self.0
                     .lock()
@@ -1211,6 +1291,145 @@ pub(crate) mod controller_test_support {
         pump_until(|| widget_contains_text(native.upcast_ref(), "120 seconds"));
         controller.shutdown();
         controller.window.close();
+    }
+
+    fn run_settings_write_scenario() {
+        use lg_buddy::settings::{
+            execute_settings_mutation, SettingsApplier, SettingsMutation, SettingsMutationFailure,
+            SettingsMutationOutcome, SettingsMutationStage, SettingsStore,
+        };
+        use lg_buddy::settings_view::{
+            BehaviorSetting, SettingsMutationOperation, SettingsMutationRequest,
+        };
+        struct SettingsWriter {
+            path: std::path::PathBuf,
+            started: mpsc::Sender<()>,
+            release: Mutex<mpsc::Receiver<()>>,
+            panic_after_save: bool,
+        }
+        impl lg_buddy::settings_view::SettingsBackend for SettingsWriter {
+            fn read_settings(
+                &self,
+            ) -> Result<
+                Vec<lg_buddy::presentation::settings::SettingsGroup>,
+                lg_buddy::settings_view::SettingsReadError,
+            > {
+                Ok(
+                    lg_buddy::presentation::settings::SettingsPresentation::from_store(
+                        &SettingsStore::load(&self.path).unwrap(),
+                    )
+                    .groups()
+                    .to_vec(),
+                )
+            }
+            fn write_setting(
+                &self,
+                operation: SettingsMutationOperation,
+                progress: &mut dyn FnMut(SettingsMutationStage),
+            ) -> Result<SettingsMutationOutcome, SettingsMutationFailure> {
+                progress(SettingsMutationStage::Validating);
+                self.started.send(()).unwrap();
+                self.release.lock().unwrap().recv().unwrap();
+                let SettingsMutationRequest::Set(value) = operation.request() else {
+                    unreachable!()
+                };
+                let mutation = SettingsMutation::set(
+                    &SettingsStore::load(&self.path).unwrap(),
+                    operation.key_name(),
+                    value,
+                )
+                .unwrap();
+                // updates.channel has no systemd action, so this fake never touches host services.
+                let result = execute_settings_mutation(
+                    &self.path,
+                    mutation,
+                    &SettingsApplier::from_env(),
+                    progress,
+                );
+                assert!(
+                    !self.panic_after_save,
+                    "test worker stopped after publication"
+                );
+                result
+            }
+        }
+        for (suffix, panic_after_save, close_pending) in [
+            ("SettingsWrite", false, false),
+            ("SettingsStopped", true, false),
+            ("SettingsClose", false, true),
+        ] {
+            let path =
+                std::env::temp_dir().join(format!("lg-buddy-{suffix}-{}.env", std::process::id()));
+            std::fs::write(&path, "updates_channel=stable\n").unwrap();
+            let application = test_application(suffix);
+            let (started_tx, started_rx) = mpsc::channel();
+            let (release_tx, release_rx) = mpsc::channel();
+            let (controller, opening) = ApplicationController::new(
+                &application,
+                Arc::new(PanicBackend),
+                Arc::new(EmptyTvsBackend),
+                Arc::new(SettingsWriter {
+                    path: path.clone(),
+                    started: started_tx,
+                    release: Mutex::new(release_rx),
+                    panic_after_save,
+                }),
+            );
+            ApplicationController::render_settings_transition(
+                &controller,
+                opening.settings().unwrap(),
+            );
+            controller
+                .window
+                .choose_page(super::ApplicationPage::Settings);
+            controller.present();
+            let native = controller.window.window();
+            pump_until(|| widget_contains_text(native.upcast_ref(), "Stable"));
+            ApplicationController::handle_settings_intent(
+                &controller,
+                lg_buddy::settings_view::SettingsIntent::Commit {
+                    setting: BehaviorSetting::UpdatesChannel,
+                    value: "prerelease".into(),
+                },
+            );
+            pump_until(|| started_rx.try_recv().is_ok());
+            assert!(std::fs::read_to_string(&path).unwrap().contains("stable"));
+            pump_for(Duration::from_millis(20));
+            if close_pending {
+                ApplicationController::handle_intent(&controller, OverviewIntent::Cancel);
+                assert!(controller.closed.get());
+            }
+            release_tx.send(()).unwrap();
+            pump_until(|| {
+                std::fs::read_to_string(&path)
+                    .unwrap()
+                    .contains("prerelease")
+            });
+            if close_pending {
+                pump_for(Duration::from_millis(30));
+                assert!(
+                    controller.closed.get(),
+                    "late completion must not reopen Settings"
+                );
+            } else {
+                pump_until(|| widget_contains_text(native.upcast_ref(), "Prerelease"));
+                if panic_after_save {
+                    pump_until(|| {
+                        widget_contains_text(native.upcast_ref(), "The setting was saved, but runtime apply could not be confirmed. Retry apply.")
+                    });
+                } else {
+                    pump_until(|| {
+                        widget_contains_text(
+                            native.upcast_ref(),
+                            "Saved; no runtime action was required.",
+                        )
+                    });
+                }
+                controller.shutdown();
+            }
+            controller.window.close();
+            std::fs::remove_file(path).unwrap();
+        }
     }
 
     fn run_pairing_scenario() {

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -1,15 +1,20 @@
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use adw::prelude::*;
-use lg_buddy::presentation::settings::{SettingsPresentation, SettingsRow, SettingsStatus};
+use lg_buddy::presentation::settings::{
+    SettingsCommitPolicy, SettingsEditStatus, SettingsEditor, SettingsFeedbackSeverity,
+    SettingsPresentation, SettingsRow, SettingsStatus,
+};
 use lg_buddy::settings_view::SettingsIntent;
 
-/// Native preference rows for the application-owned, read-only Settings view.
+/// Stable native controls render application-owned values and commit policies.
 pub(crate) struct SettingsView {
     root: gtk::Stack,
     page: adw::PreferencesPage,
     groups: RefCell<Vec<adw::PreferencesGroup>>,
+    rows: RefCell<Vec<NativeSettingRow>>,
+    on_intent: Rc<dyn Fn(SettingsIntent)>,
     status: adw::StatusPage,
     retry: gtk::Button,
     retry_intent: Rc<RefCell<Option<SettingsIntent>>>,
@@ -24,11 +29,12 @@ impl SettingsView {
             .build();
         let retry = gtk::Button::builder().halign(gtk::Align::Center).build();
         retry.add_css_class("pill");
-        let retry_intent = Rc::new(RefCell::new(None));
+        let retry_intent = Rc::new(RefCell::new(None::<SettingsIntent>));
         retry.connect_clicked({
             let intent = Rc::clone(&retry_intent);
+            let on_intent = Rc::clone(&on_intent);
             move |_| {
-                let intent = *intent.borrow();
+                let intent = intent.borrow().clone();
                 if let Some(intent) = intent {
                     on_intent(intent);
                 }
@@ -48,6 +54,8 @@ impl SettingsView {
             root,
             page,
             groups: RefCell::new(Vec::new()),
+            rows: RefCell::new(Vec::new()),
+            on_intent,
             status,
             retry,
             retry_intent,
@@ -79,19 +87,30 @@ impl SettingsView {
                 self.root.set_visible_child_name("status");
             }
             SettingsStatus::Ready => {
-                for group in self.groups.borrow_mut().drain(..) {
-                    self.page.remove(&group);
-                }
-                for group in presentation.groups() {
-                    let native = adw::PreferencesGroup::builder()
-                        .title(gtk::glib::markup_escape_text(group.title()))
-                        .description(gtk::glib::markup_escape_text(group.description()))
-                        .build();
-                    for row in group.rows() {
-                        native.add(&setting_row(row));
+                if self.rows.borrow().is_empty() {
+                    for group in presentation.groups() {
+                        let native = adw::PreferencesGroup::builder()
+                            .title(gtk::glib::markup_escape_text(group.title()))
+                            .description(gtk::glib::markup_escape_text(group.description()))
+                            .build();
+                        for row in group.rows() {
+                            let row = NativeSettingRow::new(row, Rc::clone(&self.on_intent));
+                            native.add(&row.row);
+                            self.rows.borrow_mut().push(row);
+                        }
+                        self.page.add(&native);
+                        self.groups.borrow_mut().push(native);
                     }
-                    self.page.add(&native);
-                    self.groups.borrow_mut().push(native);
+                }
+                for row in self.rows.borrow().iter() {
+                    if let Some(presentation) = presentation
+                        .groups()
+                        .iter()
+                        .flat_map(|group| group.rows())
+                        .find(|value| value.setting() == row.presentation.borrow().setting())
+                    {
+                        row.render(presentation);
+                    }
                 }
                 self.root.set_visible_child_name("settings");
             }
@@ -99,53 +118,368 @@ impl SettingsView {
     }
 }
 
-fn setting_row(presentation: &SettingsRow) -> adw::ExpanderRow {
-    let row = adw::ExpanderRow::builder()
-        .use_markup(false)
-        .title_lines(0)
-        .subtitle_lines(0)
-        .build();
-    // Set text after construction so native child labels already use plain text.
-    row.set_title(presentation.title());
-    row.set_subtitle(presentation.description());
-    let value = gtk::Label::builder()
-        .label(presentation.value_label())
-        .wrap(true)
-        .wrap_mode(gtk::pango::WrapMode::Word)
-        .width_chars(12)
-        .max_width_chars(12)
-        .xalign(1.0)
-        .valign(gtk::Align::Center)
-        .build();
-    value.add_css_class("dim-label");
-    row.add_suffix(&value);
-    row.update_property(&[
-        gtk::accessible::Property::Label(presentation.title()),
-        gtk::accessible::Property::Description(&format!(
-            "{} {}",
-            presentation.description(),
-            presentation.value_label()
-        )),
-    ]);
-    if let Some(problem) = presentation.problem() {
-        let icon = gtk::Image::from_icon_name("dialog-warning-symbolic");
-        icon.add_css_class("error");
-        icon.set_tooltip_text(Some(problem));
-        row.add_prefix(&icon);
-        let error = detail_row("", problem);
-        error.add_css_class("error");
-        error.set_accessible_role(gtk::AccessibleRole::Alert);
-        error.update_property(&[gtk::accessible::Property::Label(problem)]);
-        row.add_row(&error);
+enum NativeEditor {
+    Toggle(gtk::Switch),
+    Choice(gtk::DropDown),
+    Number {
+        entry: gtk::Entry,
+        finalized: Rc<RefCell<String>>,
+    },
+}
+
+struct NativeSettingRow {
+    row: adw::ExpanderRow,
+    value: gtk::Label,
+    source: adw::ActionRow,
+    problem: adw::ActionRow,
+    feedback: adw::ActionRow,
+    warning: gtk::Image,
+    reset: gtk::Button,
+    retry: gtk::Button,
+    editor: NativeEditor,
+    presentation: Rc<RefCell<SettingsRow>>,
+    rendering: Rc<Cell<bool>>,
+    restore_focus: Cell<bool>,
+}
+
+impl NativeSettingRow {
+    fn new(initial: &SettingsRow, on_intent: Rc<dyn Fn(SettingsIntent)>) -> Self {
+        let row = adw::ExpanderRow::builder()
+            .use_markup(false)
+            .title_lines(0)
+            .subtitle_lines(0)
+            .build();
+        row.set_title(initial.title());
+        row.set_subtitle(initial.description());
+        let value = gtk::Label::builder()
+            .wrap(true)
+            .wrap_mode(gtk::pango::WrapMode::Word)
+            .width_chars(12)
+            .max_width_chars(12)
+            .xalign(1.0)
+            .valign(gtk::Align::Center)
+            .build();
+        value.add_css_class("dim-label");
+        row.add_suffix(&value);
+        let warning = gtk::Image::from_icon_name("dialog-warning-symbolic");
+        row.add_prefix(&warning);
+        let presentation = Rc::new(RefCell::new(initial.clone()));
+        let rendering = Rc::new(Cell::new(false));
+        let editor_row = detail_row("Value", "");
+        let editor = match initial.editor() {
+            SettingsEditor::Toggle { .. } => {
+                let switch = gtk::Switch::builder().valign(gtk::Align::Center).build();
+                switch.update_property(&[gtk::accessible::Property::Label(initial.title())]);
+                switch.connect_active_notify({
+                    let presentation = Rc::clone(&presentation);
+                    let rendering = Rc::clone(&rendering);
+                    let on_intent = Rc::clone(&on_intent);
+                    move |switch| {
+                        let row = presentation.borrow().clone();
+                        if !rendering.get()
+                            && row.editor_enabled()
+                            && row.commit_policy() == SettingsCommitPolicy::OnChange
+                        {
+                            on_intent(SettingsIntent::SetEnabled {
+                                setting: row.setting(),
+                                enabled: switch.is_active(),
+                            });
+                        }
+                    }
+                });
+                editor_row.add_suffix(&switch);
+                editor_row.set_activatable_widget(Some(&switch));
+                NativeEditor::Toggle(switch)
+            }
+            SettingsEditor::Choice { options, .. } => {
+                let labels: Vec<_> = options.iter().map(|choice| choice.label()).collect();
+                let dropdown = gtk::DropDown::from_strings(&labels);
+                dropdown.set_valign(gtk::Align::Center);
+                dropdown.update_property(&[gtk::accessible::Property::Label(initial.title())]);
+                dropdown.connect_selected_notify({
+                    let presentation = Rc::clone(&presentation);
+                    let rendering = Rc::clone(&rendering);
+                    let on_intent = Rc::clone(&on_intent);
+                    move |dropdown| {
+                        let row = presentation.borrow().clone();
+                        if !rendering.get()
+                            && row.editor_enabled()
+                            && row.commit_policy() == SettingsCommitPolicy::OnChange
+                        {
+                            if let Some(choice) = row
+                                .editor()
+                                .choices()
+                                .and_then(|choices| choices.get(dropdown.selected() as usize))
+                            {
+                                on_intent(SettingsIntent::Commit {
+                                    setting: row.setting(),
+                                    value: choice.value().to_owned(),
+                                });
+                            }
+                        }
+                    }
+                });
+                editor_row.add_suffix(&dropdown);
+                NativeEditor::Choice(dropdown)
+            }
+            SettingsEditor::Number { text } => {
+                let entry = gtk::Entry::builder()
+                    .width_chars(8)
+                    .max_width_chars(8)
+                    .input_purpose(gtk::InputPurpose::Digits)
+                    .valign(gtk::Align::Center)
+                    .build();
+                entry.update_property(&[
+                    gtk::accessible::Property::Label(initial.title()),
+                    gtk::accessible::Property::Description(
+                        "Press Enter or leave this field to apply",
+                    ),
+                ]);
+                let finalized = Rc::new(RefCell::new(text.clone()));
+                let finalize: Rc<dyn Fn(&gtk::Entry)> = Rc::new({
+                    let presentation = Rc::clone(&presentation);
+                    let rendering = Rc::clone(&rendering);
+                    let finalized = Rc::clone(&finalized);
+                    let on_intent = Rc::clone(&on_intent);
+                    move |entry| {
+                        let row = presentation.borrow().clone();
+                        let text = entry.text().to_string();
+                        if !rendering.get()
+                            && row.editor_enabled()
+                            && row.commit_policy() == SettingsCommitPolicy::OnFinalize
+                            && *finalized.borrow() != text
+                        {
+                            finalized.replace(text.clone());
+                            on_intent(SettingsIntent::Commit {
+                                setting: row.setting(),
+                                value: text,
+                            });
+                        }
+                    }
+                });
+                entry.connect_activate({
+                    let finalize = Rc::clone(&finalize);
+                    move |entry| finalize(entry)
+                });
+                let focus = gtk::EventControllerFocus::new();
+                focus.connect_leave({
+                    let entry = entry.downgrade();
+                    move |_| {
+                        if let Some(entry) = entry.upgrade() {
+                            finalize(&entry);
+                        }
+                    }
+                });
+                entry.add_controller(focus);
+                editor_row.add_suffix(&entry);
+                NativeEditor::Number { entry, finalized }
+            }
+        };
+        row.add_row(&editor_row);
+        let problem = detail_row("", "");
+        problem.add_css_class("error");
+        problem.set_accessible_role(gtk::AccessibleRole::Alert);
+        row.add_row(&problem);
+        let feedback = detail_row("", "");
+        let retry = gtk::Button::builder()
+            .label("Retry apply")
+            .valign(gtk::Align::Center)
+            .build();
+        feedback.add_suffix(&retry);
+        row.add_row(&feedback);
+        let source = detail_row("Source", initial.source_label());
+        row.add_row(&source);
+        let default = detail_row("Default", initial.default_label());
+        let reset = gtk::Button::builder()
+            .label("Reset")
+            // Let Reset replace a focused draft without a preceding focus-loss commit.
+            .focus_on_click(false)
+            .valign(gtk::Align::Center)
+            .build();
+        reset.update_property(&[gtk::accessible::Property::Label(&format!(
+            "Reset {}",
+            initial.title()
+        ))]);
+        default.add_suffix(&reset);
+        row.add_row(&default);
+        row.add_row(&detail_row(
+            "Accepted values",
+            initial.accepted_values_label(),
+        ));
+        for (button, is_retry) in [(&reset, false), (&retry, true)] {
+            button.connect_clicked({
+                let presentation = Rc::clone(&presentation);
+                let on_intent = Rc::clone(&on_intent);
+                move |_| {
+                    let row = presentation.borrow().clone();
+                    let action = if is_retry {
+                        row.retry_apply_action()
+                    } else {
+                        row.reset_action()
+                    };
+                    if let Some(action) = action.filter(|action| action.enabled()) {
+                        on_intent(action.intent());
+                    }
+                }
+            });
+        }
+        let native = Self {
+            row,
+            value,
+            source,
+            problem,
+            feedback,
+            warning,
+            reset,
+            retry,
+            editor,
+            presentation,
+            rendering,
+            restore_focus: Cell::new(false),
+        };
+        // Populate values without producing commit intents.
+        native.render_editor(initial.editor());
+        native.render(initial);
+        native
     }
-    for (title, value) in [
-        ("Source", presentation.source_label()),
-        ("Default", presentation.default_label()),
-        ("Accepted values", presentation.accepted_values_label()),
-    ] {
-        row.add_row(&detail_row(title, value));
+
+    fn render_editor(&self, editor: &SettingsEditor) {
+        self.rendering.set(true);
+        match (&self.editor, editor) {
+            (NativeEditor::Toggle(switch), SettingsEditor::Toggle { value }) => {
+                switch.set_active(value.unwrap_or(false));
+                switch.update_state(&[gtk::accessible::State::Invalid(if value.is_none() {
+                    gtk::AccessibleInvalidState::True
+                } else {
+                    gtk::AccessibleInvalidState::False
+                })]);
+            }
+            (NativeEditor::Choice(dropdown), SettingsEditor::Choice { selected, .. }) => {
+                dropdown.set_selected(
+                    selected.map_or(gtk::INVALID_LIST_POSITION, |value| value as u32),
+                );
+            }
+            (NativeEditor::Number { entry, finalized }, SettingsEditor::Number { text }) => {
+                entry.set_text(text);
+                finalized.replace(text.clone());
+            }
+            _ => unreachable!("a behavior setting keeps its declared editor type"),
+        }
+        self.rendering.set(false);
     }
-    row
+
+    fn render(&self, current: &SettingsRow) {
+        let previous = self.presentation.borrow().clone();
+        if !in_flight(current.edit_status())
+            && (previous.editor() != current.editor() || in_flight(previous.edit_status()))
+        {
+            self.render_editor(current.editor());
+        }
+        self.rendering.set(true);
+        let widget: &gtk::Widget = match &self.editor {
+            NativeEditor::Toggle(widget) => widget.upcast_ref(),
+            NativeEditor::Choice(widget) => widget.upcast_ref(),
+            NativeEditor::Number { entry, .. } => entry.upcast_ref(),
+        };
+        if in_flight(current.edit_status()) && !in_flight(previous.edit_status()) {
+            self.restore_focus.set(
+                widget
+                    .root()
+                    .and_then(|root| root.downcast::<gtk::Window>().ok())
+                    .and_then(|window| GtkWindowExt::focus(&window))
+                    .is_some_and(|focus| focus == *widget || focus.is_ancestor(widget)),
+            );
+        }
+        widget.set_sensitive(current.editor_enabled());
+        self.value.set_label(current.value_label());
+        self.source.set_subtitle(current.source_label());
+        self.row.update_property(&[
+            gtk::accessible::Property::Label(current.title()),
+            gtk::accessible::Property::Description(&format!(
+                "{} {}",
+                current.description(),
+                current.value_label()
+            )),
+        ]);
+        self.problem.set_visible(current.problem().is_some());
+        self.problem.set_subtitle(current.problem().unwrap_or(""));
+        self.problem
+            .update_property(&[gtk::accessible::Property::Label(
+                current.problem().unwrap_or(""),
+            )]);
+        let feedback = current.feedback();
+        let message = feedback.map_or("", |feedback| feedback.message());
+        let severity = feedback.map(|feedback| feedback.severity());
+        let is_warning = matches!(
+            severity,
+            Some(SettingsFeedbackSeverity::Warning | SettingsFeedbackSeverity::Error)
+        );
+        self.feedback.set_visible(feedback.is_some());
+        self.feedback.set_subtitle(message);
+        self.feedback
+            .update_property(&[gtk::accessible::Property::Label(message)]);
+        self.feedback.set_accessible_role(if is_warning {
+            gtk::AccessibleRole::Alert
+        } else {
+            gtk::AccessibleRole::Status
+        });
+        for (class, active) in [
+            ("error", severity == Some(SettingsFeedbackSeverity::Error)),
+            (
+                "warning",
+                severity == Some(SettingsFeedbackSeverity::Warning),
+            ),
+        ] {
+            if active {
+                self.feedback.add_css_class(class);
+            } else {
+                self.feedback.remove_css_class(class);
+            }
+        }
+        self.warning
+            .set_visible(current.problem().is_some() || is_warning);
+        self.warning
+            .set_tooltip_text(current.problem().or(is_warning.then_some(message)));
+        if is_warning && current.edit_status() != previous.edit_status() {
+            self.row.set_expanded(true);
+        }
+        for (button, action) in [
+            (&self.reset, current.reset_action()),
+            (&self.retry, current.retry_apply_action()),
+        ] {
+            button.set_visible(action.is_some());
+            button.set_sensitive(action.is_some_and(|action| action.enabled()));
+            if let Some(action) = action {
+                button.set_label(action.label());
+                // GtkButton labels itself from its child; use the setting-specific name instead.
+                button.reset_relation(gtk::AccessibleRelation::LabelledBy);
+                button.update_property(&[gtk::accessible::Property::Label(&format!(
+                    "{} {}",
+                    action.label(),
+                    current.title()
+                ))]);
+            }
+        }
+        self.presentation.replace(current.clone());
+        if !in_flight(current.edit_status())
+            && in_flight(previous.edit_status())
+            && self.restore_focus.replace(false)
+            && widget.is_mapped()
+        {
+            widget.grab_focus();
+        }
+        self.rendering.set(false);
+    }
+}
+
+fn in_flight(status: SettingsEditStatus) -> bool {
+    matches!(
+        status,
+        SettingsEditStatus::Validating
+            | SettingsEditStatus::Persisting
+            | SettingsEditStatus::Persisted
+            | SettingsEditStatus::Applying
+    )
 }
 
 fn detail_row(title: &str, value: &str) -> adw::ActionRow {
@@ -251,12 +585,22 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         assert!(!row.uses_markup());
         assert!(!row.shows_enable_switch());
     }
-    assert!(!widgets
-        .iter()
-        .any(|widget| widget.is::<gtk::Switch>() && widget.is_visible()));
-    assert!(!widgets
-        .iter()
-        .any(|widget| widget.is::<adw::ComboRow>() || widget.is::<gtk::Entry>()));
+    assert_eq!(
+        view.rows
+            .borrow()
+            .iter()
+            .filter(|row| matches!(row.editor, NativeEditor::Toggle(_)))
+            .count(),
+        3
+    );
+    assert_eq!(
+        view.rows
+            .borrow()
+            .iter()
+            .filter(|row| matches!(row.editor, NativeEditor::Choice(_)))
+            .count(),
+        3
+    );
     rows[0].set_expanded(true);
     pump_until(|| rows[0].is_expanded());
     let first_details = descendants(rows[0].upcast_ref());
@@ -272,6 +616,106 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .filter_map(|widget| widget.clone().downcast::<gtk::Label>().ok())
         .any(|label| label.text().contains("<invalid>&")));
 
+    // Typing stays local until finalized; Enter followed by focus loss is one intent.
+    use lg_buddy::settings_view::BehaviorSetting;
+    let (mut editing, opening) = SettingsApplication::open();
+    let ready = editing
+        .complete_read(
+            opening.read_operation().unwrap(),
+            Ok(presentation.groups().to_vec()),
+        )
+        .unwrap();
+    view.render(ready.presentation());
+    intents.borrow_mut().clear();
+    let entry = match &view.rows.borrow()[2].editor {
+        NativeEditor::Number { entry, .. } => entry.clone(),
+        _ => unreachable!(),
+    };
+    rows[2].set_expanded(true);
+    pump_until(|| entry.is_mapped());
+    entry.grab_focus();
+    entry.set_text("900");
+    assert!(intents.borrow().is_empty());
+    entry.emit_activate();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::Commit {
+            setting: BehaviorSetting::ScreenIdleTimeout,
+            value: "900".into(),
+        }]
+    );
+    let intent = intents.borrow_mut().pop().unwrap();
+    let writing = editing.handle_intent(intent).unwrap();
+    view.render(writing.presentation());
+    assert_eq!(
+        entry.text(),
+        "900",
+        "progress must preserve the submitted draft"
+    );
+    assert!(!entry.is_sensitive());
+    assert!(rows[2].is_expanded(), "progress preserves expansion");
+    assert!(
+        intents.borrow().is_empty(),
+        "programmatic blur does not resubmit"
+    );
+    let failed = editing
+        .complete_mutation(
+            writing.mutation_operation().unwrap(),
+            Err(lg_buddy::settings::SettingsMutationFailure::Persistence(
+                lg_buddy::settings::SettingsError::Apply {
+                    message: "write failed".into(),
+                },
+            )),
+        )
+        .unwrap();
+    view.render(failed.presentation());
+    assert_eq!(
+        entry.text(),
+        "600",
+        "failure restores the previous effective value"
+    );
+    assert!(entry.is_sensitive());
+    assert!(view.rows.borrow()[2].feedback.is_visible());
+    assert!(intents.borrow().is_empty(), "restoration emits no write");
+    match &view.rows.borrow()[1].editor {
+        NativeEditor::Toggle(switch) => switch.set_active(false),
+        _ => unreachable!(),
+    }
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::SetEnabled {
+            setting: BehaviorSetting::ScreenIdleBlank,
+            enabled: false,
+        })
+    );
+    match &view.rows.borrow()[6].editor {
+        NativeEditor::Choice(choice) => choice.set_selected(1),
+        _ => unreachable!(),
+    }
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::Commit {
+            setting: BehaviorSetting::UpdatesChannel,
+            value: "prerelease".into(),
+        })
+    );
+    view.rows.borrow()[2].reset.emit_clicked();
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::Reset(BehaviorSetting::ScreenIdleTimeout))
+    );
+    entry.grab_focus();
+    entry.set_text("720");
+    view.rows.borrow()[2].reset.grab_focus();
+    pump_until(|| !intents.borrow().is_empty());
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::Commit {
+            setting: BehaviorSetting::ScreenIdleTimeout,
+            value: "720".into(),
+        })
+    );
+
     window.set_default_size(360, 600);
     pump_until(|| window.width() <= 360);
     let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
@@ -280,4 +724,101 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         "settings rows must fit a narrow window: {minimum}"
     );
     window.close();
+    reset_pointer_click_discards_the_unfinalized_timeout(application);
+}
+
+#[cfg(test)]
+fn reset_pointer_click_discards_the_unfinalized_timeout(application: &adw::Application) {
+    use crate::controller_test_support::pump_until;
+    use lg_buddy::settings::ConfigEnvReader;
+    use lg_buddy::settings_view::{BehaviorSetting, SettingsApplication};
+    use std::process::Command;
+
+    let (mut model, opening) = SettingsApplication::open();
+    let store =
+        ConfigEnvReader::parse("/unused/config.env", "screen_idle_timeout=600\n").into_store();
+    let ready = model
+        .complete_read(
+            opening.read_operation().unwrap(),
+            Ok(SettingsPresentation::from_store(&store).groups().to_vec()),
+        )
+        .unwrap();
+    let model = RefCell::new(model);
+    let intents = Rc::new(RefCell::new(Vec::new()));
+    let view = Rc::new_cyclic(|renderer: &std::rc::Weak<SettingsView>| {
+        let intents = Rc::clone(&intents);
+        let renderer = renderer.clone();
+        SettingsView::new(Rc::new(move |intent| {
+            intents.borrow_mut().push(intent.clone());
+            let transition = model.borrow_mut().handle_intent(intent);
+            if let Some(transition) = transition {
+                renderer
+                    .upgrade()
+                    .unwrap()
+                    .render(transition.presentation());
+            }
+        }))
+    });
+    view.render(ready.presentation());
+    let window = adw::ApplicationWindow::builder()
+        .application(application)
+        .title("LG Buddy Reset Pointer Test")
+        .default_width(800)
+        .default_height(900)
+        .content(view.widget())
+        .build();
+    // Target the final row geometry, not a frame of the expansion animation.
+    let settings = window.settings();
+    let animations = settings.is_gtk_enable_animations();
+    settings.set_gtk_enable_animations(false);
+    window.present();
+    let (entry, reset) = {
+        let rows = view.rows.borrow();
+        rows[2].row.set_expanded(true);
+        let NativeEditor::Number { entry, .. } = &rows[2].editor else {
+            unreachable!()
+        };
+        (entry.clone(), rows[2].reset.clone())
+    };
+    pump_until(|| reset.is_mapped() && reset.width() > 0);
+    let search = Command::new("xdotool")
+        .args([
+            "search",
+            "--onlyvisible",
+            "--name",
+            "^LG Buddy Reset Pointer Test$",
+        ])
+        .output()
+        .expect("xdotool is required for native pointer tests");
+    assert!(search.status.success());
+    let id = String::from_utf8(search.stdout).unwrap();
+    let id = id.trim();
+    assert!(Command::new("xdotool")
+        .args(["windowfocus", "--sync", id])
+        .status()
+        .unwrap()
+        .success());
+    entry.grab_focus();
+    entry.set_text("900");
+    assert!(intents.borrow().is_empty());
+    let bounds = reset
+        .compute_bounds(&window)
+        .expect("Reset belongs to the test window");
+    let x = (bounds.x() + bounds.width() / 2.0).round().to_string();
+    let y = (bounds.y() + bounds.height() / 2.0).round().to_string();
+    // XTest sends press/release events, exercising focus transfer before clicked.
+    // emit_clicked() bypasses that ordering and cannot reproduce the lost Reset.
+    assert!(Command::new("xdotool")
+        .args(["mousemove", "--sync", "--window", id, &x, &y, "click", "1"])
+        .status()
+        .unwrap()
+        .success());
+    pump_until(|| !intents.borrow().is_empty());
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::Reset(BehaviorSetting::ScreenIdleTimeout)],
+        "Reset must replace the draft without committing it first"
+    );
+    window.close();
+    settings.set_gtk_enable_animations(animations);
 }

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -12,9 +12,10 @@ use crate::overview::{
 };
 use crate::pairing::{PairingError, PairingFailure, PairingOperation, PairingStage};
 use crate::presentation::settings::SettingsGroup;
+use crate::settings::{SettingsMutationFailure, SettingsMutationOutcome, SettingsMutationStage};
 use crate::settings_view::{
-    SettingsApplication, SettingsIntent, SettingsReadError, SettingsReadOperation,
-    SettingsTransition,
+    SettingsApplication, SettingsIntent, SettingsMutationOperation, SettingsReadError,
+    SettingsReadOperation, SettingsTransition,
 };
 use crate::tv::{AudioStatus, OledBrightness};
 use crate::tvs::{
@@ -111,9 +112,8 @@ impl Application {
         &mut self,
         intent: SettingsIntent,
     ) -> Option<ApplicationTransition> {
-        self.settings
-            .handle_intent(intent)
-            .map(Self::settings_transition)
+        let transition = self.settings.handle_intent(intent)?;
+        Some(self.settings_transition(transition))
     }
 
     pub fn select_page(
@@ -133,15 +133,43 @@ impl Application {
         operation: SettingsReadOperation,
         result: Result<Vec<SettingsGroup>, SettingsReadError>,
     ) -> Option<ApplicationTransition> {
-        self.settings
-            .complete_read(operation, result)
-            .map(Self::settings_transition)
+        let transition = self.settings.complete_read(operation, result)?;
+        Some(self.settings_transition(transition))
     }
 
-    fn settings_transition(transition: SettingsTransition) -> ApplicationTransition {
+    pub fn settings_mutation_progress(
+        &mut self,
+        operation: &SettingsMutationOperation,
+        stage: SettingsMutationStage,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.settings.mutation_progress(operation, stage)?;
+        Some(self.settings_transition(transition))
+    }
+
+    pub fn complete_settings_mutation(
+        &mut self,
+        operation: &SettingsMutationOperation,
+        result: Result<SettingsMutationOutcome, SettingsMutationFailure>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.settings.complete_mutation(operation, result)?;
+        Some(self.settings_transition(transition))
+    }
+
+    pub fn settings_mutation_worker_stopped(
+        &mut self,
+        operation: &SettingsMutationOperation,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.settings.mutation_worker_stopped(operation)?;
+        Some(self.settings_transition(transition))
+    }
+
+    fn settings_transition(&mut self, transition: SettingsTransition) -> ApplicationTransition {
+        let tvs = self.tvs.set_controls_available(
+            !self.overview.has_pending_write() && !self.settings.is_mutating(),
+        );
         ApplicationTransition {
             overview: None,
-            tvs: None,
+            tvs,
             settings: Some(transition),
         }
     }
@@ -237,9 +265,9 @@ impl Application {
             self.tvs.shutdown();
             self.settings.shutdown();
         }
-        let tvs = self
-            .tvs
-            .set_controls_available(!self.overview.has_pending_write());
+        let tvs = self.tvs.set_controls_available(
+            !self.overview.has_pending_write() && !self.settings.is_mutating(),
+        );
         ApplicationTransition {
             overview: Some(transition),
             tvs,
@@ -255,10 +283,13 @@ impl Application {
         } else {
             None
         };
+        let settings = self
+            .settings
+            .set_controls_available(!self.tvs.is_managing() && !self.tvs.is_pairing());
         ApplicationTransition {
             overview,
             tvs: Some(transition),
-            settings: None,
+            settings,
         }
     }
 }
@@ -512,5 +543,120 @@ mod management_tests {
             .unwrap();
         assert!(done.tvs().unwrap().presentation().input_enabled());
         assert!(app.handle_tvs_intent(TvsIntent::UnpairTv).is_some());
+    }
+}
+
+#[cfg(test)]
+mod settings_tests {
+    use super::*;
+    use crate::pairing::PairingIntent;
+    use crate::settings::{ConfigEnvReader, SettingsError};
+    use crate::settings_view::BehaviorSetting;
+
+    fn settings() -> Vec<SettingsGroup> {
+        crate::presentation::settings::SettingsPresentation::from_store(
+            &ConfigEnvReader::parse("/unused/config.env", "").into_store(),
+        )
+        .groups()
+        .to_vec()
+    }
+
+    fn editable(transition: &ApplicationTransition) -> bool {
+        transition
+            .settings()
+            .unwrap()
+            .presentation()
+            .groups()
+            .iter()
+            .flat_map(|group| group.rows())
+            .all(|row| row.editor_enabled())
+    }
+
+    #[test]
+    fn settings_write_blocks_pairing_and_close_rejects_late_completions() {
+        let (mut app, opening) = Application::open();
+        app.complete_tvs_read(opening.tvs().unwrap().read_operation().unwrap(), Ok(vec![]))
+            .unwrap();
+        app.complete_settings_read(
+            opening.settings().unwrap().read_operation().unwrap(),
+            Ok(settings()),
+        )
+        .unwrap();
+        let write = app
+            .handle_settings_intent(SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                enabled: false,
+            })
+            .unwrap();
+        assert!(!write
+            .tvs()
+            .unwrap()
+            .presentation()
+            .pair_action()
+            .unwrap()
+            .enabled());
+        assert!(app.handle_tvs_intent(TvsIntent::PairTv).is_none());
+        assert!(!editable(&write));
+        let operation = write.settings().unwrap().mutation_operation().unwrap();
+        let done = app
+            .complete_settings_mutation(
+                operation,
+                Err(SettingsMutationFailure::Persistence(SettingsError::Apply {
+                    message: "test persistence failure".into(),
+                })),
+            )
+            .unwrap();
+        assert!(done
+            .tvs()
+            .unwrap()
+            .presentation()
+            .pair_action()
+            .unwrap()
+            .enabled());
+        assert!(editable(&done));
+        let write = app
+            .handle_settings_intent(SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                enabled: false,
+            })
+            .unwrap();
+        let operation = write.settings().unwrap().mutation_operation().unwrap();
+        let close = app.handle_overview_intent(OverviewIntent::Cancel).unwrap();
+        assert!(matches!(
+            close.overview().unwrap().update(),
+            OverviewFrontendUpdate::Close
+        ));
+        assert!(app
+            .settings_mutation_progress(operation, SettingsMutationStage::Persisted)
+            .is_none());
+        assert!(app.settings_mutation_worker_stopped(operation).is_none());
+        assert!(app
+            .handle_settings_intent(SettingsIntent::Reset(BehaviorSetting::UpdatesChannel))
+            .is_none());
+    }
+
+    #[test]
+    fn pairing_blocks_settings_even_if_the_settings_read_finishes_later() {
+        let (mut app, opening) = Application::open();
+        app.complete_tvs_read(opening.tvs().unwrap().read_operation().unwrap(), Ok(vec![]))
+            .unwrap();
+        app.handle_tvs_intent(TvsIntent::PairTv).unwrap();
+        let loaded = app
+            .complete_settings_read(
+                opening.settings().unwrap().read_operation().unwrap(),
+                Ok(settings()),
+            )
+            .unwrap();
+        assert!(!editable(&loaded));
+        assert!(app
+            .handle_settings_intent(SettingsIntent::Reset(BehaviorSetting::UpdatesChannel))
+            .is_none());
+        let cancelled = app
+            .handle_tvs_intent(TvsIntent::Pairing(PairingIntent::Cancel))
+            .unwrap();
+        assert!(editable(&cancelled));
+        assert!(app
+            .handle_settings_intent(SettingsIntent::Reset(BehaviorSetting::UpdatesChannel))
+            .is_some());
     }
 }

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -1,6 +1,6 @@
 use crate::presentation::brightness::UserFacingError;
 use crate::settings::{EffectiveSetting, SettingSource, SettingType, SettingValue, SettingsStore};
-use crate::settings_view::SettingsIntent;
+use crate::settings_view::{BehaviorSetting, SettingsIntent};
 
 /// The toolkit-neutral model rendered by the Settings view.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -17,6 +17,59 @@ pub enum SettingsStatus {
     Failed(UserFacingError),
 }
 
+/// The only settings exposed by the read/write Settings view.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SettingsEditStatus {
+    Unchanged,
+    Validating,
+    Persisting,
+    Persisted,
+    Applying,
+    Applied,
+    ValidationFailed,
+    PersistenceFailed,
+    ApplyFailed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsFeedbackSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsFeedback {
+    severity: SettingsFeedbackSeverity,
+    message: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsCommitPolicy {
+    OnChange,
+    OnFinalize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsChoice {
+    value: String,
+    label: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsEditor {
+    Toggle {
+        value: Option<bool>,
+    },
+    Choice {
+        options: Vec<SettingsChoice>,
+        selected: Option<usize>,
+    },
+    Number {
+        text: String,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SettingsGroup {
     title: String,
@@ -26,6 +79,7 @@ pub struct SettingsGroup {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SettingsRow {
+    setting: BehaviorSetting,
     title: String,
     description: String,
     value_label: String,
@@ -33,6 +87,13 @@ pub struct SettingsRow {
     default_label: String,
     accepted_values_label: String,
     problem: Option<String>,
+    editor: SettingsEditor,
+    commit_policy: SettingsCommitPolicy,
+    editor_enabled: bool,
+    edit_status: SettingsEditStatus,
+    feedback: Option<SettingsFeedback>,
+    reset_action: Option<SettingsAction>,
+    retry_apply_action: Option<SettingsAction>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -61,12 +122,22 @@ impl SettingsPresentation {
         }
     }
 
-    pub(crate) fn failed(error: UserFacingError) -> Self {
+    pub(crate) fn failed_with_groups(error: UserFacingError, groups: Vec<SettingsGroup>) -> Self {
         Self {
             status: SettingsStatus::Failed(error),
-            groups: Vec::new(),
+            groups,
             retry_action: Some(SettingsAction::new("Retry", true, SettingsIntent::Retry)),
         }
+    }
+
+    /// Keep the current rows visible while an explicit refresh is in flight.
+    /// This lets the renderer retain focus and any editor state until the new
+    /// snapshot arrives.
+    pub(crate) fn mark_loading(&mut self) {
+        self.status = SettingsStatus::Loading {
+            message: "Refreshing settings…".to_string(),
+        };
+        self.retry_action = None;
     }
 
     /// Build the Settings view from the same registry-backed store used by the
@@ -86,6 +157,93 @@ impl SettingsPresentation {
 
     pub fn retry_action(&self) -> Option<&SettingsAction> {
         self.retry_action.as_ref()
+    }
+
+    pub(crate) fn row(&self, setting: BehaviorSetting) -> Option<&SettingsRow> {
+        self.groups
+            .iter()
+            .flat_map(|group| group.rows())
+            .find(|row| row.setting() == setting)
+    }
+
+    pub(crate) fn replace_row(&mut self, replacement: SettingsRow) -> Option<SettingsRow> {
+        for group in &mut self.groups {
+            if let Some(row) = group
+                .rows
+                .iter_mut()
+                .find(|row| row.setting() == replacement.setting())
+            {
+                let mut replacement = replacement;
+                replacement.editor_enabled = row.editor_enabled;
+                replacement.reset_action = replacement.reset_action.map(|mut action| {
+                    action.enabled = row.editor_enabled;
+                    action
+                });
+                replacement.retry_apply_action = None;
+                return Some(std::mem::replace(row, replacement));
+            }
+        }
+        None
+    }
+
+    pub(crate) fn set_controls_available(&mut self, available: bool) {
+        for group in &mut self.groups {
+            for row in &mut group.rows {
+                row.set_editor_enabled(available);
+            }
+        }
+    }
+
+    pub(crate) fn set_row_state(
+        &mut self,
+        setting: BehaviorSetting,
+        status: SettingsEditStatus,
+        feedback: Option<SettingsFeedback>,
+        retry_apply: bool,
+    ) {
+        if let Some(row) = self
+            .groups
+            .iter_mut()
+            .flat_map(|group| group.rows.iter_mut())
+            .find(|row| row.setting == setting)
+        {
+            row.edit_status = status;
+            row.feedback = feedback;
+            row.retry_apply_action = retry_apply.then(|| {
+                SettingsAction::new(
+                    "Retry apply",
+                    row.editor_enabled,
+                    SettingsIntent::RetryApply(setting),
+                )
+            });
+        }
+    }
+
+    /// Carry a warning about a saved value through a refresh when the saved
+    /// value is still the same. A changed value means the warning has been
+    /// reconciled and must not be resurrected.
+    pub(crate) fn preserve_apply_failures_from(&mut self, previous: &Self) {
+        for group in &mut self.groups {
+            for row in &mut group.rows {
+                let Some(old) = previous.row(row.setting) else {
+                    continue;
+                };
+                if old.retry_apply_action.is_none()
+                    || old.editor != row.editor
+                    || old.problem != row.problem
+                    || old.source_label != row.source_label
+                {
+                    continue;
+                }
+                row.edit_status = old.edit_status;
+                row.feedback = old.feedback.clone();
+                row.retry_apply_action = Some(SettingsAction::new(
+                    "Retry apply",
+                    row.editor_enabled,
+                    SettingsIntent::RetryApply(row.setting),
+                ));
+            }
+        }
     }
 }
 
@@ -115,27 +273,71 @@ impl SettingsGroup {
     }
 }
 
-impl SettingsRow {
-    pub(crate) fn new(
-        title: impl Into<String>,
-        description: impl Into<String>,
-        value_label: impl Into<String>,
-        source_label: impl Into<String>,
-        default_label: impl Into<String>,
-        accepted_values_label: impl Into<String>,
-        problem: Option<impl Into<String>>,
-    ) -> Self {
+impl SettingsFeedback {
+    pub(crate) fn new(severity: SettingsFeedbackSeverity, message: impl Into<String>) -> Self {
         Self {
-            title: title.into(),
-            description: description.into(),
-            value_label: value_label.into(),
-            source_label: source_label.into(),
-            default_label: default_label.into(),
-            accepted_values_label: accepted_values_label.into(),
-            problem: problem.map(Into::into),
+            severity,
+            message: message.into(),
         }
     }
 
+    pub fn severity(&self) -> SettingsFeedbackSeverity {
+        self.severity
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl SettingsChoice {
+    pub(crate) fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+        }
+    }
+
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+}
+
+impl SettingsEditor {
+    pub fn as_toggle(&self) -> Option<Option<bool>> {
+        match self {
+            Self::Toggle { value } => Some(*value),
+            Self::Choice { .. } | Self::Number { .. } => None,
+        }
+    }
+
+    pub fn choices(&self) -> Option<&[SettingsChoice]> {
+        match self {
+            Self::Choice { options, .. } => Some(options),
+            Self::Toggle { .. } | Self::Number { .. } => None,
+        }
+    }
+
+    pub fn selected_choice(&self) -> Option<usize> {
+        match self {
+            Self::Choice { selected, .. } => *selected,
+            Self::Toggle { .. } | Self::Number { .. } => None,
+        }
+    }
+
+    pub fn number_text(&self) -> Option<&str> {
+        match self {
+            Self::Number { text } => Some(text),
+            Self::Toggle { .. } | Self::Choice { .. } => None,
+        }
+    }
+}
+
+impl SettingsRow {
     pub fn title(&self) -> &str {
         &self.title
     }
@@ -163,6 +365,48 @@ impl SettingsRow {
     pub fn problem(&self) -> Option<&str> {
         self.problem.as_deref()
     }
+
+    pub fn setting(&self) -> BehaviorSetting {
+        self.setting
+    }
+
+    pub fn editor(&self) -> &SettingsEditor {
+        &self.editor
+    }
+
+    pub fn commit_policy(&self) -> SettingsCommitPolicy {
+        self.commit_policy
+    }
+
+    pub fn editor_enabled(&self) -> bool {
+        self.editor_enabled
+    }
+
+    pub fn edit_status(&self) -> SettingsEditStatus {
+        self.edit_status
+    }
+
+    pub fn feedback(&self) -> Option<&SettingsFeedback> {
+        self.feedback.as_ref()
+    }
+
+    pub fn reset_action(&self) -> Option<&SettingsAction> {
+        self.reset_action.as_ref()
+    }
+
+    pub fn retry_apply_action(&self) -> Option<&SettingsAction> {
+        self.retry_apply_action.as_ref()
+    }
+
+    pub(crate) fn set_editor_enabled(&mut self, enabled: bool) {
+        self.editor_enabled = enabled;
+        if let Some(action) = &mut self.reset_action {
+            action.set_enabled(enabled);
+        }
+        if let Some(action) = &mut self.retry_apply_action {
+            action.set_enabled(enabled);
+        }
+    }
 }
 
 impl SettingsAction {
@@ -183,7 +427,11 @@ impl SettingsAction {
     }
 
     pub fn intent(&self) -> SettingsIntent {
-        self.intent
+        self.intent.clone()
+    }
+
+    pub(crate) fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
     }
 }
 
@@ -201,30 +449,32 @@ pub(crate) fn groups_from_store(store: &SettingsStore) -> Vec<SettingsGroup> {
             "Screen",
             "Choose when LG Buddy blanks and restores your TV screen.",
             vec![
-                row(setting("screen.backend")),
-                row(setting("screen.idle_blank")),
-                row(setting("screen.idle_timeout")),
-                row(setting("screen.restore_policy")),
+                row_from_effective(setting("screen.backend")),
+                row_from_effective(setting("screen.idle_blank")),
+                row_from_effective(setting("screen.idle_timeout")),
+                row_from_effective(setting("screen.restore_policy")),
             ],
         ),
         SettingsGroup::new(
             "Sleep & Wake",
             "Coordinate your TV with the computer’s sleep and wake behavior.",
-            vec![row(setting("system.sleep_wake_policy"))],
+            vec![row_from_effective(setting("system.sleep_wake_policy"))],
         ),
         SettingsGroup::new(
             "Updates",
             "Choose how LG Buddy checks for new versions.",
             vec![
-                row(setting("updates.auto_check")),
-                row(setting("updates.channel")),
+                row_from_effective(setting("updates.auto_check")),
+                row_from_effective(setting("updates.channel")),
             ],
         ),
     ]
 }
 
-fn row(setting: &EffectiveSetting) -> SettingsRow {
+pub(crate) fn row_from_effective(setting: &EffectiveSetting) -> SettingsRow {
     let definition = setting.definition();
+    let behavior_setting = BehaviorSetting::from_key(setting.key_name())
+        .expect("settings registry contains every Settings view key");
     let accepted_values = accepted_values_label(setting.key_name(), definition.value_type());
     let problem = setting.invalid_value().map(|invalid| {
         format!("Invalid configured value \"{invalid}\". Accepted values: {accepted_values}.")
@@ -240,18 +490,89 @@ fn row(setting: &EffectiveSetting) -> SettingsRow {
                 .unwrap_or_else(|| "Not configured".to_string())
         });
 
-    SettingsRow::new(
-        setting_title(setting.key_name()),
-        definition.description(),
-        current_value_label,
-        source_label(setting.source()),
-        definition
+    let editor = editor_for(behavior_setting, setting, definition.value_type());
+    let commit_policy = match editor {
+        SettingsEditor::Number { .. } => SettingsCommitPolicy::OnFinalize,
+        SettingsEditor::Toggle { .. } | SettingsEditor::Choice { .. } => {
+            SettingsCommitPolicy::OnChange
+        }
+    };
+
+    SettingsRow {
+        setting: behavior_setting,
+        title: setting_title(setting.key_name()).to_string(),
+        description: definition.description().to_string(),
+        value_label: current_value_label,
+        source_label: source_label(setting.source()).to_string(),
+        default_label: definition
             .default_value()
             .map(|value| value_label(setting.key_name(), value))
             .unwrap_or_else(|| "Not configured".to_string()),
-        accepted_values,
+        accepted_values_label: accepted_values,
         problem,
-    )
+        editor,
+        commit_policy,
+        editor_enabled: true,
+        edit_status: SettingsEditStatus::Unchanged,
+        feedback: None,
+        reset_action: Some(SettingsAction::new(
+            "Reset",
+            true,
+            SettingsIntent::Reset(behavior_setting),
+        )),
+        retry_apply_action: None,
+    }
+}
+
+fn editor_for(
+    setting: BehaviorSetting,
+    effective: &EffectiveSetting,
+    value_type: SettingType,
+) -> SettingsEditor {
+    match setting {
+        BehaviorSetting::ScreenIdleBlank
+        | BehaviorSetting::SystemSleepWakePolicy
+        | BehaviorSetting::UpdatesAutoCheck => SettingsEditor::Toggle {
+            value: effective.value().and_then(|value| match value {
+                SettingValue::Enum("enabled") => Some(true),
+                SettingValue::Enum("disabled") => Some(false),
+                _ => None,
+            }),
+        },
+        BehaviorSetting::ScreenBackend
+        | BehaviorSetting::ScreenRestorePolicy
+        | BehaviorSetting::UpdatesChannel => {
+            let SettingType::Enum(enum_type) = value_type else {
+                unreachable!("choice setting must be an enum")
+            };
+            let selected = effective.value().and_then(|value| {
+                enum_type
+                    .values()
+                    .iter()
+                    .position(|allowed| Some(*allowed) == value.as_enum())
+            });
+            SettingsEditor::Choice {
+                options: enum_type
+                    .values()
+                    .iter()
+                    .map(|value| {
+                        SettingsChoice::new(
+                            *value,
+                            value_label(effective.key_name(), SettingValue::Enum(value)),
+                        )
+                    })
+                    .collect(),
+                selected,
+            }
+        }
+        BehaviorSetting::ScreenIdleTimeout => SettingsEditor::Number {
+            text: effective
+                .value()
+                .map(|value| value.to_string())
+                .or_else(|| effective.invalid_value().map(str::to_string))
+                .unwrap_or_default(),
+        },
+    }
 }
 
 fn setting_title(key: &str) -> &'static str {

--- a/crates/lg-buddy/src/presentation/tvs.rs
+++ b/crates/lg-buddy/src/presentation/tvs.rs
@@ -163,6 +163,9 @@ impl TvsPresentation {
         retry_apply: bool,
     ) {
         self.input_enabled = enabled;
+        if let Some(action) = &mut self.pair_action {
+            action.enabled = confirmation_enabled;
+        }
         self.unpair_action = self
             .selected_profile()
             .map(|_| TvsAction::new("Unpair TV…", enabled, TvsIntent::UnpairTv));

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -3,6 +3,7 @@ use std::io;
 mod command;
 mod formatter;
 mod model;
+mod mutation;
 mod screen;
 mod service;
 mod store;
@@ -16,6 +17,10 @@ pub use model::{
     ApplyStrategy, EnumSettingType, IntegerSettingType, SettingAlias, SettingDefinition,
     SettingKey, SettingMutability, SettingOperation, SettingType, SettingValue, SettingsError,
     SettingsRegistry,
+};
+pub use mutation::{
+    execute_settings_mutation, retry_settings_apply, SettingsMutationFailure,
+    SettingsMutationOutcome, SettingsMutationStage,
 };
 pub use service::{
     ServiceController, SettingsApplyOutcome, SystemdUserServiceController, UserServiceState,
@@ -175,30 +180,27 @@ impl<C: ServiceController, P: PlatformPreflight> SettingsCommandRunner<C, P> {
             SettingsCommand::Set { key, value } => {
                 let mutation = SettingsMutation::set(&self.store, &key, &value)?;
                 tv::preflight_if_required(&self.store, &self.preflight, &mutation, writer)?;
-                let change = persist_settings_mutation(self.store.path(), mutation)?;
-                let apply = self.apply_after_persist(&change)?;
-                self.formatter.write_change(writer, &change, &apply)
+                let outcome = execute_settings_mutation(
+                    self.store.path(),
+                    mutation,
+                    &self.applier,
+                    &mut |_| {},
+                )
+                .map_err(SettingsMutationFailure::into_error)?;
+                self.formatter.write_mutation_outcome(writer, &outcome)
             }
             SettingsCommand::Unset(key) => {
                 let mutation = SettingsMutation::unset(&self.store, &key)?;
-                let change = persist_settings_mutation(self.store.path(), mutation)?;
-                let apply = self.apply_after_persist(&change)?;
-                self.formatter.write_change(writer, &change, &apply)
+                let outcome = execute_settings_mutation(
+                    self.store.path(),
+                    mutation,
+                    &self.applier,
+                    &mut |_| {},
+                )
+                .map_err(SettingsMutationFailure::into_error)?;
+                self.formatter.write_mutation_outcome(writer, &outcome)
             }
         }
-    }
-
-    fn apply_after_persist(
-        &self,
-        change: &SettingsChange,
-    ) -> Result<SettingsApplyOutcome, SettingsError> {
-        self.applier
-            .apply(change)
-            .map_err(|err| SettingsError::ApplyAfterPersist {
-                key: change.mutation().key_name().to_string(),
-                path: change.path().to_path_buf(),
-                message: err.to_string(),
-            })
     }
 }
 

--- a/crates/lg-buddy/src/settings/formatter.rs
+++ b/crates/lg-buddy/src/settings/formatter.rs
@@ -9,6 +9,15 @@ use super::{
 pub struct SettingsFormatter;
 
 impl SettingsFormatter {
+    pub fn write_mutation_outcome<W: io::Write>(
+        &self,
+        writer: &mut W,
+        outcome: &super::SettingsMutationOutcome,
+    ) -> Result<(), SettingsError> {
+        let apply = outcome.apply().as_ref().map_err(Clone::clone)?;
+        self.write_change(writer, outcome.change(), apply)
+    }
+
     pub fn write_get<W: io::Write>(
         &self,
         writer: &mut W,

--- a/crates/lg-buddy/src/settings/mutation.rs
+++ b/crates/lg-buddy/src/settings/mutation.rs
@@ -1,0 +1,280 @@
+//! Shared persistence and runtime application outcomes for CLI and GUI clients.
+
+use std::path::Path;
+
+use super::{
+    persist_settings_mutation, ServiceController, SettingsApplier, SettingsApplyOutcome,
+    SettingsChange, SettingsError, SettingsMutation, SettingsStore,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingsMutationStage {
+    Validating,
+    Persisting,
+    Persisted,
+    Applying,
+}
+
+/// Failures before publication. A runtime failure belongs to the successful
+/// persistence outcome so clients cannot mistake a saved value for an unsaved one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsMutationFailure {
+    Validation(SettingsError),
+    Persistence(SettingsError),
+}
+
+impl SettingsMutationFailure {
+    pub fn error(&self) -> &SettingsError {
+        match self {
+            Self::Validation(error) | Self::Persistence(error) => error,
+        }
+    }
+
+    pub fn into_error(self) -> SettingsError {
+        match self {
+            Self::Validation(error) | Self::Persistence(error) => error,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SettingsMutationOutcome {
+    change: SettingsChange,
+    apply: Result<SettingsApplyOutcome, SettingsError>,
+}
+
+impl SettingsMutationOutcome {
+    pub fn change(&self) -> &SettingsChange {
+        &self.change
+    }
+
+    pub fn apply(&self) -> &Result<SettingsApplyOutcome, SettingsError> {
+        &self.apply
+    }
+}
+
+/// Execute an already validated mutation using the same writer and service
+/// operations for all frontends. Explicit unchanged commands still reapply,
+/// preserving the CLI's existing recovery behavior.
+pub fn execute_settings_mutation<C: ServiceController>(
+    path: &Path,
+    mutation: SettingsMutation,
+    applier: &SettingsApplier<C>,
+    progress: &mut dyn FnMut(SettingsMutationStage),
+) -> Result<SettingsMutationOutcome, SettingsMutationFailure> {
+    progress(SettingsMutationStage::Persisting);
+    let change =
+        persist_settings_mutation(path, mutation).map_err(SettingsMutationFailure::Persistence)?;
+    progress(SettingsMutationStage::Persisted);
+    Ok(apply_change(change, applier, progress))
+}
+
+/// Retry the current configuration without rewriting it or replaying an old
+/// draft. This also preserves a default or legacy source when no write occurred.
+pub fn retry_settings_apply<C: ServiceController>(
+    store: &SettingsStore,
+    key: &str,
+    applier: &SettingsApplier<C>,
+    progress: &mut dyn FnMut(SettingsMutationStage),
+) -> Result<SettingsMutationOutcome, SettingsMutationFailure> {
+    progress(SettingsMutationStage::Validating);
+    let change =
+        SettingsChange::for_apply(store, key).map_err(SettingsMutationFailure::Validation)?;
+    Ok(apply_change(change, applier, progress))
+}
+
+fn apply_change<C: ServiceController>(
+    change: SettingsChange,
+    applier: &SettingsApplier<C>,
+    progress: &mut dyn FnMut(SettingsMutationStage),
+) -> SettingsMutationOutcome {
+    progress(SettingsMutationStage::Applying);
+    let apply = applier
+        .apply(&change)
+        .map_err(|error| SettingsError::ApplyAfterPersist {
+            key: change.mutation().key_name().to_string(),
+            path: change.path().to_path_buf(),
+            message: error.to_string(),
+        });
+    SettingsMutationOutcome { change, apply }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::tests::{unique_test_path, FakeServiceController};
+    use crate::settings::SettingsCommand;
+    use crate::settings::{SettingSource, SettingsCommandRunner};
+
+    #[test]
+    fn shared_executor_and_cli_write_the_same_values_and_runtime_actions() {
+        for (key, value, restarts, enables, disables) in [
+            ("screen.backend", "gnome", 1, 0, 0),
+            ("screen.idle_blank", "disabled", 1, 0, 0),
+            ("screen.idle_timeout", "600", 1, 0, 0),
+            ("screen.restore_policy", "aggressive", 1, 0, 0),
+            ("system.sleep_wake_policy", "disabled", 0, 0, 0),
+            ("updates.auto_check", "disabled", 0, 0, 1),
+            ("updates.channel", "prerelease", 0, 0, 0),
+        ] {
+            let path = unique_test_path("mutation-shared");
+            let cli_path = unique_test_path("mutation-cli");
+            let controller = FakeServiceController::active_or_enabled();
+            let cli_controller = FakeServiceController::active_or_enabled();
+            let store = SettingsStore::load(&path).unwrap();
+            let mutation = SettingsMutation::set(&store, key, value).unwrap();
+            let mut stages = Vec::new();
+            let outcome = execute_settings_mutation(
+                &path,
+                mutation,
+                &SettingsApplier::new(controller.clone()),
+                &mut |stage| stages.push(stage),
+            )
+            .unwrap();
+            assert!(outcome.apply().is_ok(), "{key}");
+            assert_eq!(
+                stages,
+                [
+                    SettingsMutationStage::Persisting,
+                    SettingsMutationStage::Persisted,
+                    SettingsMutationStage::Applying
+                ]
+            );
+            SettingsCommandRunner::with_applier(
+                SettingsStore::load(&cli_path).unwrap(),
+                SettingsApplier::new(cli_controller.clone()),
+            )
+            .run(
+                SettingsCommand::Set {
+                    key: key.into(),
+                    value: value.into(),
+                },
+                &mut Vec::new(),
+            )
+            .unwrap();
+            assert_eq!(
+                std::fs::read(&path).unwrap(),
+                std::fs::read(&cli_path).unwrap()
+            );
+            for service in [&controller, &cli_controller] {
+                assert_eq!(service.restarts.get(), restarts, "{key}");
+                assert_eq!(service.enables.get(), enables, "{key}");
+                assert_eq!(service.disables.get(), disables, "{key}");
+            }
+            std::fs::remove_file(path).unwrap();
+            std::fs::remove_file(cli_path).unwrap();
+        }
+    }
+
+    #[test]
+    fn runtime_failure_keeps_saved_value_and_retry_does_not_rewrite_config() {
+        let path = unique_test_path("mutation-retry");
+        std::fs::write(&path, "# preserve me\nscreen_idle_timeout=broken\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let mutation = SettingsMutation::set(&store, "screen.idle_timeout", "600").unwrap();
+        let outcome = execute_settings_mutation(
+            &path,
+            mutation,
+            &SettingsApplier::new(FakeServiceController::failing_restart()),
+            &mut |_| {},
+        )
+        .unwrap();
+        assert!(matches!(
+            outcome.apply(),
+            Err(SettingsError::ApplyAfterPersist { .. })
+        ));
+        assert_eq!(
+            outcome
+                .change()
+                .effective_setting()
+                .value()
+                .unwrap()
+                .to_string(),
+            "600"
+        );
+        let contents = std::fs::read(&path).unwrap();
+        let modified = std::fs::metadata(&path).unwrap().modified().unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let mut stages = Vec::new();
+        let retry = retry_settings_apply(
+            &store,
+            "screen.idle_timeout",
+            &SettingsApplier::new(FakeServiceController::active_or_enabled()),
+            &mut |stage| stages.push(stage),
+        )
+        .unwrap();
+        assert!(matches!(
+            retry.apply(),
+            Ok(SettingsApplyOutcome::Restarted { .. })
+        ));
+        assert!(!retry.change().file_changed());
+        assert_eq!(
+            stages,
+            [
+                SettingsMutationStage::Validating,
+                SettingsMutationStage::Applying
+            ]
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), contents);
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().modified().unwrap(),
+            modified
+        );
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn persistence_failure_does_not_run_apply() {
+        let path = unique_test_path("mutation-no-write");
+        let store = SettingsStore::load(&path).unwrap();
+        let mutation = SettingsMutation::set(&store, "screen.idle_timeout", "600").unwrap();
+        std::fs::create_dir(&path).unwrap();
+        let controller = FakeServiceController::active_or_enabled();
+        let mut stages = Vec::new();
+        assert!(matches!(
+            execute_settings_mutation(
+                &path,
+                mutation,
+                &SettingsApplier::new(controller.clone()),
+                &mut |stage| stages.push(stage)
+            ),
+            Err(SettingsMutationFailure::Persistence(_))
+        ));
+        assert_eq!(controller.restarts.get(), 0);
+        assert_eq!(stages, [SettingsMutationStage::Persisting]);
+        std::fs::remove_dir(path).unwrap();
+    }
+
+    #[test]
+    fn reset_removes_invalid_override_and_retry_preserves_default_source() {
+        let path = unique_test_path("mutation-reset");
+        std::fs::write(&path, "screen_idle_timeout=broken\n").unwrap();
+        let store = SettingsStore::load(&path).unwrap();
+        let mutation = SettingsMutation::unset(&store, "screen.idle_timeout").unwrap();
+        let applier = SettingsApplier::new(FakeServiceController::missing());
+        let reset = execute_settings_mutation(&path, mutation, &applier, &mut |_| {}).unwrap();
+        assert_eq!(
+            reset.change().effective_setting().source(),
+            SettingSource::Default
+        );
+        assert!(matches!(
+            reset.apply(),
+            Ok(SettingsApplyOutcome::NotInstalled { .. })
+        ));
+        let retry = retry_settings_apply(
+            &SettingsStore::load(&path).unwrap(),
+            "screen.idle_timeout",
+            &applier,
+            &mut |_| {},
+        )
+        .unwrap();
+        assert_eq!(
+            retry.change().effective_setting().source(),
+            SettingSource::Default
+        );
+        assert!(!std::fs::read_to_string(&path)
+            .unwrap()
+            .contains("screen_idle_timeout"));
+        std::fs::remove_file(path).unwrap();
+    }
+}

--- a/crates/lg-buddy/src/settings/store.rs
+++ b/crates/lg-buddy/src/settings/store.rs
@@ -256,9 +256,26 @@ pub struct SettingsChange {
     mutation: SettingsMutation,
     path: PathBuf,
     file_changed: bool,
+    effective: EffectiveSetting,
 }
 
 impl SettingsChange {
+    pub fn effective_setting(&self) -> &EffectiveSetting {
+        &self.effective
+    }
+
+    pub(crate) fn for_apply(store: &SettingsStore, key: &str) -> Result<Self, SettingsError> {
+        let effective = store.effective_by_name(key)?;
+        let value = effective.required_value()?;
+        let mutation = SettingsMutation::set(store, key, &value.to_string())?;
+        Ok(Self {
+            mutation,
+            path: store.path().to_path_buf(),
+            file_changed: false,
+            effective,
+        })
+    }
+
     pub fn mutation(&self) -> SettingsMutation {
         self.mutation
     }
@@ -302,6 +319,18 @@ pub(crate) fn persist_settings_mutation(
         mutation,
         path: editor.path().to_path_buf(),
         file_changed,
+        effective: EffectiveSetting {
+            definition: mutation.definition(),
+            value: mutation.new_value,
+            source: match mutation.action() {
+                SettingsMutationAction::Set => SettingSource::ConfigEnv,
+                SettingsMutationAction::Unset if mutation.new_value.is_some() => {
+                    SettingSource::Default
+                }
+                SettingsMutationAction::Unset => SettingSource::Missing,
+            },
+            invalid_value: None,
+        },
     })
 }
 

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -4,13 +4,108 @@ use std::error::Error;
 use std::fmt;
 
 use crate::presentation::brightness::UserFacingError;
-use crate::presentation::settings::{SettingsGroup, SettingsPresentation};
-use crate::settings::SettingsStore;
+use crate::presentation::settings::{
+    SettingsEditStatus, SettingsEditor, SettingsFeedback, SettingsFeedbackSeverity, SettingsGroup,
+    SettingsPresentation, SettingsRow,
+};
+use crate::settings::{
+    execute_settings_mutation, retry_settings_apply, ConfigPathResolver, SettingsApplier,
+    SettingsApplyOutcome, SettingsError, SettingsMutation, SettingsMutationFailure,
+    SettingsMutationOutcome, SettingsMutationStage, SettingsStore,
+};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BehaviorSetting {
+    ScreenBackend,
+    ScreenIdleBlank,
+    ScreenIdleTimeout,
+    ScreenRestorePolicy,
+    SystemSleepWakePolicy,
+    UpdatesAutoCheck,
+    UpdatesChannel,
+}
+
+impl BehaviorSetting {
+    pub fn key_name(self) -> &'static str {
+        match self {
+            Self::ScreenBackend => "screen.backend",
+            Self::ScreenIdleBlank => "screen.idle_blank",
+            Self::ScreenIdleTimeout => "screen.idle_timeout",
+            Self::ScreenRestorePolicy => "screen.restore_policy",
+            Self::SystemSleepWakePolicy => "system.sleep_wake_policy",
+            Self::UpdatesAutoCheck => "updates.auto_check",
+            Self::UpdatesChannel => "updates.channel",
+        }
+    }
+
+    pub(crate) fn from_key(key: &str) -> Option<Self> {
+        Some(match key {
+            "screen.backend" => Self::ScreenBackend,
+            "screen.idle_blank" => Self::ScreenIdleBlank,
+            "screen.idle_timeout" => Self::ScreenIdleTimeout,
+            "screen.restore_policy" => Self::ScreenRestorePolicy,
+            "system.sleep_wake_policy" => Self::SystemSleepWakePolicy,
+            "updates.auto_check" => Self::UpdatesAutoCheck,
+            "updates.channel" => Self::UpdatesChannel,
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SettingsIntent {
     Retry,
     Refresh,
+    SetEnabled {
+        setting: BehaviorSetting,
+        enabled: bool,
+    },
+    Commit {
+        setting: BehaviorSetting,
+        value: String,
+    },
+    Reset(BehaviorSetting),
+    RetryApply(BehaviorSetting),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SettingsMutationRequest {
+    Set(String),
+    Reset,
+    RetryApply,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsMutationOperation {
+    id: u64,
+    setting: BehaviorSetting,
+    request: SettingsMutationRequest,
+}
+
+impl SettingsMutationOperation {
+    fn new(id: u64, setting: BehaviorSetting, request: SettingsMutationRequest) -> Self {
+        Self {
+            id,
+            setting,
+            request,
+        }
+    }
+
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub fn setting(&self) -> BehaviorSetting {
+        self.setting
+    }
+
+    pub fn key_name(&self) -> &'static str {
+        self.setting.key_name()
+    }
+
+    pub fn request(&self) -> &SettingsMutationRequest {
+        &self.request
+    }
 }
 
 /// Opaque identity for one asynchronous settings read.
@@ -27,6 +122,7 @@ impl SettingsReadOperation {
 pub struct SettingsTransition {
     presentation: SettingsPresentation,
     read_operation: Option<SettingsReadOperation>,
+    mutation_operation: Option<SettingsMutationOperation>,
     diagnostic: Option<String>,
 }
 
@@ -37,6 +133,10 @@ impl SettingsTransition {
 
     pub fn read_operation(&self) -> Option<SettingsReadOperation> {
         self.read_operation
+    }
+
+    pub fn mutation_operation(&self) -> Option<&SettingsMutationOperation> {
+        self.mutation_operation.as_ref()
     }
 
     pub fn diagnostic(&self) -> Option<&str> {
@@ -96,6 +196,12 @@ impl Error for SettingsReadError {}
 
 pub trait SettingsBackend: Send + Sync + 'static {
     fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError>;
+
+    fn write_setting(
+        &self,
+        operation: SettingsMutationOperation,
+        progress: &mut dyn FnMut(SettingsMutationStage),
+    ) -> Result<SettingsMutationOutcome, SettingsMutationFailure>;
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -107,6 +213,34 @@ impl SettingsBackend for EnvironmentSettingsBackend {
             .map_err(|error| SettingsReadError::unreadable(error.to_string()))?;
         Ok(SettingsPresentation::from_store(&store).groups().to_vec())
     }
+
+    fn write_setting(
+        &self,
+        operation: SettingsMutationOperation,
+        progress: &mut dyn FnMut(SettingsMutationStage),
+    ) -> Result<SettingsMutationOutcome, SettingsMutationFailure> {
+        let path =
+            ConfigPathResolver::resolve_from_env().map_err(SettingsMutationFailure::Persistence)?;
+        let store = SettingsStore::load(&path).map_err(SettingsMutationFailure::Persistence)?;
+        let applier = SettingsApplier::from_env();
+        match operation.request() {
+            SettingsMutationRequest::Set(value) => {
+                progress(SettingsMutationStage::Validating);
+                let mutation = SettingsMutation::set(&store, operation.key_name(), value)
+                    .map_err(SettingsMutationFailure::Validation)?;
+                execute_settings_mutation(&path, mutation, &applier, progress)
+            }
+            SettingsMutationRequest::Reset => {
+                progress(SettingsMutationStage::Validating);
+                let mutation = SettingsMutation::unset(&store, operation.key_name())
+                    .map_err(SettingsMutationFailure::Validation)?;
+                execute_settings_mutation(&path, mutation, &applier, progress)
+            }
+            SettingsMutationRequest::RetryApply => {
+                retry_settings_apply(&store, operation.key_name(), &applier, progress)
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -114,7 +248,14 @@ enum SettingsApplicationState {
     Loading(SettingsReadOperation),
     Ready,
     Failed,
+    Mutating(SettingsMutationOperation),
     Closed,
+}
+
+#[derive(Debug, Clone)]
+struct PendingMutation {
+    operation: SettingsMutationOperation,
+    previous_row: SettingsRow,
 }
 
 #[derive(Debug)]
@@ -122,6 +263,9 @@ pub struct SettingsApplication {
     state: SettingsApplicationState,
     next_operation_id: u64,
     presentation: SettingsPresentation,
+    controls_available: bool,
+    pending_mutation: Option<PendingMutation>,
+    reconcile_mutation: Option<PendingMutation>,
 }
 
 impl SettingsApplication {
@@ -133,10 +277,14 @@ impl SettingsApplication {
                 state: SettingsApplicationState::Loading(operation),
                 next_operation_id: 1,
                 presentation: presentation.clone(),
+                controls_available: true,
+                pending_mutation: None,
+                reconcile_mutation: None,
             },
             SettingsTransition {
                 presentation,
                 read_operation: Some(operation),
+                mutation_operation: None,
                 diagnostic: None,
             },
         )
@@ -155,6 +303,52 @@ impl SettingsApplication {
             {
                 Some(self.begin_read())
             }
+            SettingsIntent::SetEnabled { setting, enabled }
+                if self.controls_available
+                    && matches!(self.state, SettingsApplicationState::Ready) =>
+            {
+                let is_toggle = self
+                    .presentation
+                    .row(setting)
+                    .is_some_and(|row| matches!(row.editor(), SettingsEditor::Toggle { .. }));
+                is_toggle
+                    .then(|| {
+                        self.begin_mutation(
+                            setting,
+                            SettingsMutationRequest::Set(if enabled {
+                                "enabled".to_string()
+                            } else {
+                                "disabled".to_string()
+                            }),
+                        )
+                    })
+                    .flatten()
+            }
+            SettingsIntent::Commit { setting, value }
+                if self.controls_available
+                    && matches!(self.state, SettingsApplicationState::Ready) =>
+            {
+                self.begin_mutation(setting, SettingsMutationRequest::Set(value))
+            }
+            SettingsIntent::Reset(setting)
+                if self.controls_available
+                    && matches!(self.state, SettingsApplicationState::Ready) =>
+            {
+                self.begin_mutation(setting, SettingsMutationRequest::Reset)
+            }
+            SettingsIntent::RetryApply(setting)
+                if self.controls_available
+                    && matches!(self.state, SettingsApplicationState::Ready) =>
+            {
+                let retryable = self
+                    .presentation
+                    .row(setting)
+                    .and_then(SettingsRow::retry_apply_action)
+                    .is_some_and(|action| action.enabled());
+                retryable
+                    .then(|| self.begin_mutation(setting, SettingsMutationRequest::RetryApply))
+                    .flatten()
+            }
             _ => None,
         }
     }
@@ -170,14 +364,48 @@ impl SettingsApplication {
 
         let (presentation, diagnostic) = match result {
             Ok(groups) => {
+                let previous = self.presentation.clone();
+                let mut presentation = SettingsPresentation::ready(groups);
+                presentation.preserve_apply_failures_from(&previous);
+                if let Some(pending) = self.reconcile_mutation.take() {
+                    let changed =
+                        presentation
+                            .row(pending.operation.setting())
+                            .is_some_and(|row| {
+                                row.value_label() != pending.previous_row.value_label()
+                                    || row.source_label() != pending.previous_row.source_label()
+                            });
+                    presentation.set_row_state(
+                        pending.operation.setting(),
+                        if changed {
+                            SettingsEditStatus::ApplyFailed
+                        } else {
+                            SettingsEditStatus::PersistenceFailed
+                        },
+                        Some(SettingsFeedback::new(
+                            SettingsFeedbackSeverity::Warning,
+                            if changed {
+                                "The setting was saved, but runtime apply could not be confirmed. Retry apply."
+                            } else {
+                                "The saved value is unchanged; runtime apply could not be confirmed. Retry apply."
+                            },
+                        )),
+                        true,
+                    );
+                }
+                presentation.set_controls_available(self.controls_available);
                 self.state = SettingsApplicationState::Ready;
-                (SettingsPresentation::ready(groups), None)
+                (presentation, None)
             }
             Err(error) => {
                 self.state = SettingsApplicationState::Failed;
                 let diagnostic = error.diagnostic().to_string();
+                let previous_groups = self.presentation.groups().to_vec();
                 (
-                    SettingsPresentation::failed(user_facing_read_error(error.failure())),
+                    SettingsPresentation::failed_with_groups(
+                        user_facing_read_error(error.failure()),
+                        previous_groups,
+                    ),
                     Some(diagnostic),
                 )
             }
@@ -186,8 +414,165 @@ impl SettingsApplication {
         Some(SettingsTransition {
             presentation,
             read_operation: None,
+            mutation_operation: None,
             diagnostic,
         })
+    }
+
+    pub fn mutation_progress(
+        &mut self,
+        operation: &SettingsMutationOperation,
+        stage: SettingsMutationStage,
+    ) -> Option<SettingsTransition> {
+        if !matches!(
+            &self.state,
+            SettingsApplicationState::Mutating(active) if active == operation
+        ) {
+            return None;
+        }
+
+        let (status, message) = match stage {
+            SettingsMutationStage::Validating => {
+                (SettingsEditStatus::Validating, "Checking this value…")
+            }
+            SettingsMutationStage::Persisting => {
+                (SettingsEditStatus::Persisting, "Saving this setting…")
+            }
+            SettingsMutationStage::Persisted => {
+                (SettingsEditStatus::Persisted, "Setting saved; applying it…")
+            }
+            SettingsMutationStage::Applying => {
+                (SettingsEditStatus::Applying, "Applying this setting…")
+            }
+        };
+        self.presentation.set_row_state(
+            operation.setting(),
+            status,
+            Some(SettingsFeedback::new(
+                SettingsFeedbackSeverity::Info,
+                message,
+            )),
+            false,
+        );
+        Some(self.transition(None, None, None))
+    }
+
+    pub fn complete_mutation(
+        &mut self,
+        operation: &SettingsMutationOperation,
+        result: Result<SettingsMutationOutcome, SettingsMutationFailure>,
+    ) -> Option<SettingsTransition> {
+        let pending = match &self.pending_mutation {
+            Some(pending) if pending.operation == *operation => pending.clone(),
+            _ => return None,
+        };
+        if !matches!(
+            &self.state,
+            SettingsApplicationState::Mutating(active) if active == operation
+        ) {
+            return None;
+        }
+        self.pending_mutation = None;
+
+        match result {
+            Ok(outcome) => {
+                let effective = outcome.change().effective_setting();
+                let mut replacement = crate::presentation::settings::row_from_effective(effective);
+                replacement.set_editor_enabled(self.controls_available);
+                self.presentation.replace_row(replacement);
+                self.presentation
+                    .set_controls_available(self.controls_available);
+                self.state = SettingsApplicationState::Ready;
+                match outcome.apply() {
+                    Ok(apply_outcome) => {
+                        let (severity, message) = apply_feedback(apply_outcome);
+                        self.presentation.set_row_state(
+                            operation.setting(),
+                            SettingsEditStatus::Applied,
+                            Some(SettingsFeedback::new(severity, message)),
+                            false,
+                        )
+                    }
+                    Err(_error) => self.presentation.set_row_state(
+                        operation.setting(),
+                        SettingsEditStatus::ApplyFailed,
+                        Some(SettingsFeedback::new(
+                            SettingsFeedbackSeverity::Warning,
+                            "Saved, but could not apply yet. Retry apply.",
+                        )),
+                        true,
+                    ),
+                }
+                let diagnostic = outcome.apply().as_ref().err().map(ToString::to_string);
+                Some(self.transition(None, None, diagnostic))
+            }
+            Err(failure) => {
+                let status = match &failure {
+                    SettingsMutationFailure::Validation(_) => SettingsEditStatus::ValidationFailed,
+                    SettingsMutationFailure::Persistence(_) => {
+                        SettingsEditStatus::PersistenceFailed
+                    }
+                };
+                let preserve_retry_apply = pending.previous_row.retry_apply_action().is_some();
+                self.presentation.replace_row(pending.previous_row);
+                self.presentation
+                    .set_controls_available(self.controls_available);
+                self.presentation.set_row_state(
+                    operation.setting(),
+                    status,
+                    Some(SettingsFeedback::new(
+                        SettingsFeedbackSeverity::Error,
+                        mutation_failure_message(&failure),
+                    )),
+                    preserve_retry_apply,
+                );
+                self.state = SettingsApplicationState::Ready;
+                Some(self.transition(None, None, Some(failure.error().to_string())))
+            }
+        }
+    }
+
+    pub fn mutation_worker_stopped(
+        &mut self,
+        operation: &SettingsMutationOperation,
+    ) -> Option<SettingsTransition> {
+        let pending = match &self.pending_mutation {
+            Some(pending) if pending.operation == *operation => pending.clone(),
+            _ => return None,
+        };
+        if !matches!(
+            &self.state,
+            SettingsApplicationState::Mutating(active) if active == operation
+        ) {
+            return None;
+        }
+
+        self.pending_mutation = None;
+        self.presentation.set_row_state(
+            operation.setting(),
+            SettingsEditStatus::PersistenceFailed,
+            Some(SettingsFeedback::new(
+                SettingsFeedbackSeverity::Warning,
+                "Refreshing settings to reconcile the stopped write…",
+            )),
+            false,
+        );
+        self.reconcile_mutation = Some(pending);
+        Some(self.begin_read())
+    }
+
+    pub fn is_mutating(&self) -> bool {
+        self.pending_mutation.is_some()
+    }
+
+    pub fn set_controls_available(&mut self, available: bool) -> Option<SettingsTransition> {
+        if self.controls_available == available {
+            return None;
+        }
+        self.controls_available = available;
+        self.presentation
+            .set_controls_available(available && !self.is_mutating());
+        Some(self.transition(None, None, None))
     }
 
     pub fn shutdown(&mut self) {
@@ -202,12 +587,114 @@ impl SettingsApplication {
         let operation = SettingsReadOperation::new(self.next_operation_id);
         self.next_operation_id += 1;
         self.state = SettingsApplicationState::Loading(operation);
-        self.presentation = SettingsPresentation::loading();
+        self.presentation.mark_loading();
         SettingsTransition {
             presentation: self.presentation.clone(),
             read_operation: Some(operation),
+            mutation_operation: None,
             diagnostic: None,
         }
+    }
+
+    fn begin_mutation(
+        &mut self,
+        setting: BehaviorSetting,
+        request: SettingsMutationRequest,
+    ) -> Option<SettingsTransition> {
+        let previous_row = self.presentation.row(setting)?.clone();
+        let operation = SettingsMutationOperation::new(self.next_operation_id, setting, request);
+        self.next_operation_id += 1;
+        self.pending_mutation = Some(PendingMutation {
+            operation: operation.clone(),
+            previous_row,
+        });
+        self.state = SettingsApplicationState::Mutating(operation.clone());
+        self.presentation.set_row_state(
+            setting,
+            SettingsEditStatus::Validating,
+            Some(SettingsFeedback::new(
+                SettingsFeedbackSeverity::Info,
+                "Checking this value…",
+            )),
+            false,
+        );
+        self.presentation.set_controls_available(false);
+        Some(self.transition(None, Some(operation), None))
+    }
+
+    fn transition(
+        &self,
+        read_operation: Option<SettingsReadOperation>,
+        mutation_operation: Option<SettingsMutationOperation>,
+        diagnostic: Option<String>,
+    ) -> SettingsTransition {
+        SettingsTransition {
+            presentation: self.presentation.clone(),
+            read_operation,
+            mutation_operation,
+            diagnostic,
+        }
+    }
+}
+
+fn mutation_failure_message(failure: &SettingsMutationFailure) -> String {
+    match failure {
+        SettingsMutationFailure::Validation(error) => match error {
+            SettingsError::InvalidValue { .. } => {
+                "That value is not valid. Choose one of the accepted values.".to_string()
+            }
+            _ => "That change is not valid for this setting.".to_string(),
+        },
+        SettingsMutationFailure::Persistence(_) => {
+            "LG Buddy could not save this setting. Your previous value was kept.".to_string()
+        }
+    }
+}
+
+fn apply_feedback(outcome: &SettingsApplyOutcome) -> (SettingsFeedbackSeverity, String) {
+    match outcome {
+        SettingsApplyOutcome::NotInstalled { service } => (
+            SettingsFeedbackSeverity::Warning,
+            format!(
+                "Saved; {} is not installed yet.",
+                apply_target_label(service)
+            ),
+        ),
+        SettingsApplyOutcome::InactiveDisabled { service } => (
+            SettingsFeedbackSeverity::Warning,
+            format!(
+                "Saved; {} is inactive and disabled. It will apply when started.",
+                apply_target_label(service)
+            ),
+        ),
+        SettingsApplyOutcome::Skipped { .. } => (
+            SettingsFeedbackSeverity::Warning,
+            "Saved; runtime apply was skipped by configuration.".to_string(),
+        ),
+        SettingsApplyOutcome::NoActionRequired => (
+            SettingsFeedbackSeverity::Info,
+            "Saved; no runtime action was required.".to_string(),
+        ),
+        SettingsApplyOutcome::Enabled { .. } => (
+            SettingsFeedbackSeverity::Info,
+            "Saved; scheduled for the next graphical session.".to_string(),
+        ),
+        SettingsApplyOutcome::Restarted { .. }
+        | SettingsApplyOutcome::EnabledStarted { .. }
+        | SettingsApplyOutcome::DisabledStopped { .. } => (
+            SettingsFeedbackSeverity::Info,
+            "Saved and applied".to_string(),
+        ),
+    }
+}
+
+fn apply_target_label(service: &str) -> &'static str {
+    if service.contains("screen") {
+        "the screen integration"
+    } else if service.contains("update_check") {
+        "automatic update checks"
+    } else {
+        "the related service"
     }
 }
 
@@ -234,7 +721,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::*;
-    use crate::presentation::settings::{SettingsRow, SettingsStatus};
+    use crate::presentation::settings::{
+        SettingsEditStatus, SettingsFeedback, SettingsFeedbackSeverity, SettingsRow, SettingsStatus,
+    };
     use crate::settings::{ConfigEnvReader, SettingValue, SettingsStore, SETTINGS_REGISTRY};
 
     fn groups(contents: &str) -> Vec<SettingsGroup> {
@@ -484,6 +973,311 @@ screen_backend=wayland\n",
             row(ready.presentation().groups(), "Updates", "Update channel").value_label(),
             "Stable"
         );
+    }
+
+    #[test]
+    fn failed_refresh_keeps_hidden_apply_warning_for_retry() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        app.presentation.set_row_state(
+            BehaviorSetting::ScreenIdleBlank,
+            SettingsEditStatus::ApplyFailed,
+            Some(SettingsFeedback::new(
+                SettingsFeedbackSeverity::Warning,
+                "Saved, but could not apply yet. Retry apply.",
+            )),
+            true,
+        );
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let failed = app
+            .complete_read(
+                refresh.read_operation().unwrap(),
+                Err(SettingsReadError::unreadable("temporary read failure")),
+            )
+            .unwrap();
+        assert!(matches!(
+            failed.presentation().status(),
+            SettingsStatus::Failed(_)
+        ));
+        assert_eq!(failed.presentation().groups().len(), 3);
+        assert_eq!(
+            failed
+                .presentation()
+                .row(BehaviorSetting::ScreenIdleBlank)
+                .unwrap()
+                .edit_status(),
+            SettingsEditStatus::ApplyFailed
+        );
+        assert!(failed
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleBlank)
+            .unwrap()
+            .retry_apply_action()
+            .is_some());
+
+        let retry = app.handle_intent(SettingsIntent::Retry).unwrap();
+        let ready = app
+            .complete_read(retry.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let row = ready
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleBlank)
+            .unwrap();
+        assert_eq!(row.edit_status(), SettingsEditStatus::ApplyFailed);
+        assert!(row.retry_apply_action().is_some());
+    }
+
+    #[test]
+    fn mutation_suppresses_duplicates_and_worker_stop_is_recoverable() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+
+        let transition = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                value: "disabled".to_string(),
+            })
+            .unwrap();
+        let operation = transition.mutation_operation().unwrap().clone();
+        assert!(app.is_mutating());
+        assert!(app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                value: "enabled".to_string(),
+            })
+            .is_none());
+
+        app.mutation_progress(&operation, SettingsMutationStage::Persisting)
+            .unwrap();
+        assert_eq!(
+            app.presentation()
+                .row(BehaviorSetting::ScreenIdleBlank)
+                .unwrap()
+                .edit_status(),
+            SettingsEditStatus::Persisting
+        );
+
+        let stopped = app.mutation_worker_stopped(&operation).unwrap();
+        assert!(stopped.read_operation().is_some());
+        let reconciled = app
+            .complete_read(stopped.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let row = reconciled
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleBlank)
+            .unwrap();
+        assert_eq!(row.edit_status(), SettingsEditStatus::PersistenceFailed);
+        assert_eq!(
+            row.feedback().unwrap().severity(),
+            SettingsFeedbackSeverity::Warning
+        );
+        assert!(row.feedback().unwrap().message().contains("unchanged"));
+        assert!(row
+            .retry_apply_action()
+            .is_some_and(|action| action.enabled()));
+        assert!(!app.is_mutating());
+        assert!(app
+            .handle_intent(SettingsIntent::RetryApply(BehaviorSetting::ScreenIdleBlank))
+            .is_some());
+    }
+
+    #[test]
+    fn set_enabled_intent_uses_canonical_toggle_values() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let transition = app
+            .handle_intent(SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::UpdatesAutoCheck,
+                enabled: false,
+            })
+            .unwrap();
+        assert_eq!(
+            transition.mutation_operation().unwrap().request(),
+            &SettingsMutationRequest::Set("disabled".to_string())
+        );
+        assert!(app
+            .handle_intent(SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::ScreenIdleTimeout,
+                enabled: true,
+            })
+            .is_none());
+    }
+
+    #[test]
+    fn failed_apply_warning_survives_unchanged_refresh_but_not_changed_value() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        app.presentation.set_row_state(
+            BehaviorSetting::ScreenIdleBlank,
+            SettingsEditStatus::ApplyFailed,
+            Some(SettingsFeedback::new(
+                SettingsFeedbackSeverity::Warning,
+                "Saved, but could not apply yet. Retry apply.",
+            )),
+            true,
+        );
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        assert_eq!(refresh.presentation().groups().len(), 3);
+        assert_eq!(
+            refresh
+                .presentation()
+                .row(BehaviorSetting::ScreenIdleBlank)
+                .unwrap()
+                .edit_status(),
+            SettingsEditStatus::ApplyFailed
+        );
+        let operation = refresh.read_operation().unwrap();
+        let ready = app.complete_read(operation, Ok(groups(""))).unwrap();
+        let row = ready
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleBlank)
+            .unwrap();
+        assert_eq!(row.edit_status(), SettingsEditStatus::ApplyFailed);
+        assert!(row.retry_apply_action().is_some());
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let changed = app
+            .complete_read(
+                refresh.read_operation().unwrap(),
+                Ok(groups("screen_idle_blank=disabled\n")),
+            )
+            .unwrap();
+        let row = changed
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleBlank)
+            .unwrap();
+        assert_eq!(row.value_label(), "Disabled");
+        assert_eq!(row.edit_status(), SettingsEditStatus::Unchanged);
+        assert!(row.retry_apply_action().is_none());
+    }
+
+    #[test]
+    fn validation_failure_restores_previous_row_without_claiming_a_save() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let transition = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleTimeout,
+                value: "bad".to_string(),
+            })
+            .unwrap();
+        let operation = transition.mutation_operation().unwrap().clone();
+        let transition = app
+            .complete_mutation(
+                &operation,
+                Err(SettingsMutationFailure::Validation(
+                    SettingsError::InvalidValue {
+                        key: "screen.idle_timeout".to_string(),
+                        value: "bad".to_string(),
+                        expected: "1–86400 seconds".to_string(),
+                    },
+                )),
+            )
+            .unwrap();
+        let row = transition
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleTimeout)
+            .unwrap();
+        assert_eq!(row.value_label(), "300 seconds");
+        assert_eq!(row.edit_status(), SettingsEditStatus::ValidationFailed);
+        assert!(row.feedback().unwrap().message().contains("not valid"));
+    }
+
+    #[test]
+    fn failed_new_edit_keeps_retry_apply_for_prior_saved_warning() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        app.presentation.set_row_state(
+            BehaviorSetting::ScreenIdleBlank,
+            SettingsEditStatus::ApplyFailed,
+            Some(SettingsFeedback::new(
+                SettingsFeedbackSeverity::Warning,
+                "Saved, but could not apply yet. Retry apply.",
+            )),
+            true,
+        );
+        let transition = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                value: "disabled".to_string(),
+            })
+            .unwrap();
+        let operation = transition.mutation_operation().unwrap().clone();
+        let transition = app
+            .complete_mutation(
+                &operation,
+                Err(SettingsMutationFailure::Persistence(SettingsError::Apply {
+                    message: "write failed".to_string(),
+                })),
+            )
+            .unwrap();
+        let row = transition
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleBlank)
+            .unwrap();
+        assert_eq!(row.edit_status(), SettingsEditStatus::PersistenceFailed);
+        assert!(row.retry_apply_action().is_some());
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let refreshed = app
+            .complete_read(refresh.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        assert!(
+            refreshed
+                .presentation()
+                .row(BehaviorSetting::ScreenIdleBlank)
+                .unwrap()
+                .retry_apply_action()
+                .is_some(),
+            "navigation must retain the pending runtime retry after a failed later edit"
+        );
+    }
+
+    #[test]
+    fn apply_outcomes_do_not_claim_runtime_application_when_deferred() {
+        let (severity, message) = apply_feedback(&SettingsApplyOutcome::NotInstalled {
+            service: "lg-buddy-screen.service",
+        });
+        assert_eq!(severity, SettingsFeedbackSeverity::Warning);
+        assert!(message.contains("Saved;"));
+        assert!(message.contains("not installed"));
+        assert!(message.contains("screen integration"));
+        assert!(!message.contains("LG_Buddy"));
+        assert!(!message.contains("Saved and applied"));
+
+        let (severity, message) = apply_feedback(&SettingsApplyOutcome::NoActionRequired);
+        assert_eq!(severity, SettingsFeedbackSeverity::Info);
+        assert!(message.contains("no runtime action"));
+        assert!(!message.contains("Saved and applied"));
+
+        let (_, message) = apply_feedback(&SettingsApplyOutcome::Enabled {
+            unit: "LG_Buddy_update_check.timer",
+        });
+        assert!(message.contains("next graphical session"));
+        assert!(!message.contains("Saved and applied"));
+    }
+
+    #[test]
+    fn shutdown_rejects_late_mutation_result() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let transition = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                value: "disabled".to_string(),
+            })
+            .unwrap();
+        let operation = transition.mutation_operation().unwrap().clone();
+        app.shutdown();
+        assert!(app.mutation_worker_stopped(&operation).is_none());
     }
 
     #[test]

--- a/crates/lg-buddy/src/tvs.rs
+++ b/crates/lg-buddy/src/tvs.rs
@@ -518,7 +518,10 @@ impl TvsApplication {
                 Some(self.transition(None, None))
             }
             TvsIntent::PairTv => {
-                if !matches!(self.state, TvsState::Empty) || self.pairing.is_some() {
+                if !self.controls_available
+                    || !matches!(self.state, TvsState::Empty)
+                    || self.pairing.is_some()
+                {
                     return None;
                 }
                 self.pairing = Some(PairingApplication::new());

--- a/crates/lg-buddy/tests/settings_operations.rs
+++ b/crates/lg-buddy/tests/settings_operations.rs
@@ -1,0 +1,357 @@
+mod support;
+
+use std::fs;
+
+use lg_buddy::presentation::settings::{
+    SettingsEditStatus, SettingsFeedbackSeverity, SettingsPresentation, SettingsStatus,
+};
+use lg_buddy::settings::{
+    SettingsCommand, SettingsCommandRunner, SettingsMutationFailure, SettingsMutationOutcome,
+    SettingsStore,
+};
+use lg_buddy::settings_view::{
+    BehaviorSetting, EnvironmentSettingsBackend, SettingsApplication, SettingsBackend,
+    SettingsIntent, SettingsTransition,
+};
+use support::{ExecutableScript, TestConfigFile, TestEnv};
+
+const BEHAVIOR_CONFIG: &str = "screen_backend=auto
+screen_idle_blank=enabled
+screen_idle_timeout=300
+screen_restore_policy=conservative
+system_sleep_wake_policy=enabled
+updates_auto_check=enabled
+updates_channel=stable
+";
+
+fn row(
+    presentation: &SettingsPresentation,
+    setting: BehaviorSetting,
+) -> &lg_buddy::presentation::settings::SettingsRow {
+    presentation
+        .groups()
+        .iter()
+        .flat_map(|group| group.rows())
+        .find(|row| row.setting() == setting)
+        .expect("settings presentation contains requested row")
+}
+
+fn open_ready(
+    app: &mut SettingsApplication,
+    opening: SettingsTransition,
+    backend: &EnvironmentSettingsBackend,
+) -> SettingsTransition {
+    let read = opening.read_operation().expect("opening read operation");
+    let groups = backend.read_settings().expect("read settings without a TV");
+    app.complete_read(read, Ok(groups))
+        .expect("complete settings read")
+}
+
+fn run_mutation(
+    app: &mut SettingsApplication,
+    backend: &EnvironmentSettingsBackend,
+    intent: SettingsIntent,
+) -> SettingsTransition {
+    let started = app.handle_intent(intent).expect("start settings mutation");
+    let operation = started
+        .mutation_operation()
+        .expect("mutation operation")
+        .clone();
+    let mut progress = |stage| {
+        app.mutation_progress(&operation, stage)
+            .expect("mutation progress belongs to active operation");
+    };
+    let outcome = backend
+        .write_setting(operation.clone(), &mut progress)
+        .expect("settings mutation succeeds");
+    app.complete_mutation(
+        &operation,
+        Ok::<SettingsMutationOutcome, SettingsMutationFailure>(outcome),
+    )
+    .expect("complete settings mutation")
+}
+
+#[test]
+fn environment_backend_edits_all_behavior_settings_without_a_tv_and_matches_cli() {
+    let gui_config = TestConfigFile::new("settings-operations-gui");
+    let cli_config = TestConfigFile::new("settings-operations-cli");
+    gui_config.write_contents(BEHAVIOR_CONFIG);
+    cli_config.write_contents(BEHAVIOR_CONFIG);
+
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", gui_config.path());
+    env.set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+
+    let backend = EnvironmentSettingsBackend;
+    let (mut app, opening) = SettingsApplication::open();
+    let ready = open_ready(&mut app, opening, &backend);
+    assert!(matches!(
+        ready.presentation().status(),
+        SettingsStatus::Ready
+    ));
+    assert_eq!(
+        ready
+            .presentation()
+            .groups()
+            .iter()
+            .map(|group| group.rows().len())
+            .sum::<usize>(),
+        7,
+        "the Settings view is independent of TV availability"
+    );
+
+    let edits = [
+        (
+            SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenBackend,
+                value: "wayland".to_string(),
+            },
+            "screen.backend",
+            "wayland",
+        ),
+        (
+            SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::ScreenIdleBlank,
+                enabled: false,
+            },
+            "screen.idle_blank",
+            "disabled",
+        ),
+        (
+            SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleTimeout,
+                value: "600".to_string(),
+            },
+            "screen.idle_timeout",
+            "600",
+        ),
+        (
+            SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenRestorePolicy,
+                value: "aggressive".to_string(),
+            },
+            "screen.restore_policy",
+            "aggressive",
+        ),
+        (
+            SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::SystemSleepWakePolicy,
+                enabled: false,
+            },
+            "system.sleep_wake_policy",
+            "disabled",
+        ),
+        (
+            SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::UpdatesAutoCheck,
+                enabled: false,
+            },
+            "updates.auto_check",
+            "disabled",
+        ),
+        (
+            SettingsIntent::Commit {
+                setting: BehaviorSetting::UpdatesChannel,
+                value: "prerelease".to_string(),
+            },
+            "updates.channel",
+            "prerelease",
+        ),
+    ];
+
+    for (intent, key, value) in edits {
+        let setting = match &intent {
+            SettingsIntent::SetEnabled { setting, .. } | SettingsIntent::Commit { setting, .. } => {
+                *setting
+            }
+            _ => unreachable!("the edit table contains only setting writes"),
+        };
+        let transition = run_mutation(&mut app, &backend, intent);
+        assert_eq!(
+            row(transition.presentation(), setting).edit_status(),
+            SettingsEditStatus::Applied
+        );
+
+        env.set("LG_BUDDY_CONFIG", cli_config.path());
+        let runner = SettingsCommandRunner::new(SettingsStore::load(cli_config.path()).unwrap());
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: key.to_string(),
+                    value: value.to_string(),
+                },
+                &mut Vec::new(),
+            )
+            .expect("CLI settings write");
+        env.set("LG_BUDDY_CONFIG", gui_config.path());
+
+        assert_eq!(
+            fs::read(gui_config.path()).unwrap(),
+            fs::read(cli_config.path()).unwrap(),
+            "GUI and CLI persist the same bytes for {key}"
+        );
+    }
+}
+
+#[test]
+fn reset_removes_a_setting_override_without_a_tv() {
+    let config = TestConfigFile::new("settings-reset");
+    config.write_contents("screen_backend=wayland\n");
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+
+    let backend = EnvironmentSettingsBackend;
+    let (mut app, opening) = SettingsApplication::open();
+    open_ready(&mut app, opening, &backend);
+    let transition = run_mutation(
+        &mut app,
+        &backend,
+        SettingsIntent::Reset(BehaviorSetting::ScreenBackend),
+    );
+
+    assert!(!fs::read_to_string(config.path())
+        .unwrap()
+        .contains("screen_backend="));
+    let setting = row(transition.presentation(), BehaviorSetting::ScreenBackend);
+    assert_eq!(setting.value_label(), "Automatic");
+    assert_eq!(setting.source_label(), "Default");
+}
+
+#[test]
+fn invalid_edit_preserves_config_bytes_and_effective_value() {
+    let config = TestConfigFile::new("settings-invalid-edit");
+    config.write_contents("screen_idle_timeout=300\n");
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "1");
+
+    let backend = EnvironmentSettingsBackend;
+    let (mut app, opening) = SettingsApplication::open();
+    open_ready(&mut app, opening, &backend);
+    let before = fs::read(config.path()).unwrap();
+    let started = app
+        .handle_intent(SettingsIntent::Commit {
+            setting: BehaviorSetting::ScreenIdleTimeout,
+            value: "not-a-number".to_string(),
+        })
+        .expect("start invalid edit");
+    let operation = started
+        .mutation_operation()
+        .expect("mutation operation")
+        .clone();
+    let mut progress = |stage| {
+        app.mutation_progress(&operation, stage)
+            .expect("validation progress belongs to active operation");
+    };
+    let failure = backend
+        .write_setting(operation.clone(), &mut progress)
+        .expect_err("invalid value is rejected before persistence");
+    let transition = app
+        .complete_mutation(&operation, Err::<SettingsMutationOutcome, _>(failure))
+        .expect("complete rejected mutation");
+
+    assert_eq!(fs::read(config.path()).unwrap(), before);
+    let setting = row(
+        transition.presentation(),
+        BehaviorSetting::ScreenIdleTimeout,
+    );
+    assert_eq!(setting.value_label(), "300 seconds");
+    assert_eq!(setting.edit_status(), SettingsEditStatus::ValidationFailed);
+    assert_eq!(
+        setting.feedback().map(|feedback| feedback.severity()),
+        Some(SettingsFeedbackSeverity::Error)
+    );
+}
+
+#[test]
+fn apply_failure_keeps_saved_value_and_retry_does_not_rewrite() {
+    let config = TestConfigFile::new("settings-apply-failure-gui");
+    let cli_config = TestConfigFile::new("settings-apply-failure-cli");
+    config.write_contents("screen_idle_timeout=300\n");
+    cli_config.write_contents("screen_idle_timeout=300\n");
+    let systemctl = ExecutableScript::new(
+        "settings-systemctl-failure",
+        "systemctl",
+        r##"#!/bin/sh
+case "$2" in
+  cat|is-active|is-enabled) exit 0 ;;
+  restart) exit 23 ;;
+esac
+exit 23
+"##,
+    );
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SYSTEMCTL", systemctl.path());
+    env.remove("LG_BUDDY_SKIP_SYSTEMD_ACTIONS");
+
+    let backend = EnvironmentSettingsBackend;
+    let (mut app, opening) = SettingsApplication::open();
+    open_ready(&mut app, opening, &backend);
+    let transition = run_mutation(
+        &mut app,
+        &backend,
+        SettingsIntent::Commit {
+            setting: BehaviorSetting::ScreenIdleTimeout,
+            value: "600".to_string(),
+        },
+    );
+    let setting = row(
+        transition.presentation(),
+        BehaviorSetting::ScreenIdleTimeout,
+    );
+    assert_eq!(setting.edit_status(), SettingsEditStatus::ApplyFailed);
+    assert_eq!(
+        setting.feedback().map(|feedback| feedback.severity()),
+        Some(SettingsFeedbackSeverity::Warning)
+    );
+    assert!(setting
+        .retry_apply_action()
+        .is_some_and(|action| action.enabled()));
+    assert!(fs::read_to_string(config.path())
+        .unwrap()
+        .contains("screen_idle_timeout=600"));
+
+    env.set("LG_BUDDY_CONFIG", cli_config.path());
+    let runner = SettingsCommandRunner::new(SettingsStore::load(cli_config.path()).unwrap());
+    assert!(runner
+        .run(
+            SettingsCommand::Set {
+                key: "screen.idle_timeout".to_string(),
+                value: "600".to_string(),
+            },
+            &mut Vec::new(),
+        )
+        .is_err());
+    env.set("LG_BUDDY_CONFIG", config.path());
+    assert_eq!(
+        fs::read(config.path()).unwrap(),
+        fs::read(cli_config.path()).unwrap()
+    );
+
+    let saved = fs::read(config.path()).unwrap();
+    let retry_started = app
+        .handle_intent(SettingsIntent::RetryApply(
+            BehaviorSetting::ScreenIdleTimeout,
+        ))
+        .expect("start retry apply");
+    let retry_operation = retry_started
+        .mutation_operation()
+        .expect("retry mutation operation")
+        .clone();
+    let mut progress = |stage| {
+        app.mutation_progress(&retry_operation, stage)
+            .expect("retry progress belongs to active operation");
+    };
+    let retry_outcome = backend
+        .write_setting(retry_operation.clone(), &mut progress)
+        .expect("retry application returns an outcome");
+    assert!(!retry_outcome.change().file_changed());
+    app.complete_mutation(
+        &retry_operation,
+        Ok::<SettingsMutationOutcome, SettingsMutationFailure>(retry_outcome),
+    )
+    .expect("complete retry apply");
+    assert_eq!(fs::read(config.path()).unwrap(), saved);
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ Compiling and testing the GTK frontend additionally requires:
 - libadwaita 1.5 or newer development files
 - `pkg-config`
 - a graphical session or virtual display for renderer tests
-- `xdotool` for the executable launch smoke test
+- `xdotool` for native pointer tests and the executable launch smoke test
 - AT-SPI 2 and its Python bindings (`python3-pyatspi` on Debian/Fedora,
   `python-atspi` on Arch) for observable GUI behavior tests
 

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -634,32 +634,46 @@ the native webOS exchange; GTK fixtures cover the form and intent mapping, and
 the installed accessibility check covers the blank-state CTA, modal form,
 validation feedback, and dismissal through Escape and the header's Cancel button.
 
-## Read-only Settings Increment
+## Settings Editing Increment
 
 [#176](https://github.com/Staphylococcus/LG_Buddy/issues/176) adds **Settings**
-as the third destination. `SettingsApplication` owns loading, failure, retry,
-and refresh on entry. Its backend reads `SettingsStore` on a worker thread;
+as the third destination in development. It was outside the released
+`1.6.0-beta.1` scope, which remains Overview, TVs, and first-TV pairing.
+[#177](https://github.com/Staphylococcus/LG_Buddy/issues/177) extends that view
+with editing while preserving the same application-owned boundary.
+
+`SettingsApplication` owns loading, failure, retry, refresh on entry, and
+mutation state. Its backend reads and writes `SettingsStore` on worker threads;
 operation identities reject stale completions and results after close.
-Configuration reads do not depend on a configured or reachable TV.
+Configuration reads and writes do not depend on a configured or reachable TV.
+Settings writes are serialized with TV management so concurrent operations
+cannot overwrite each other's configuration snapshots.
 
 The application builds three groups—Screen, Sleep & Wake, and Updates—from
-the seven behavior settings. Descriptions, defaults, accepted values, and
-effective-value sources come from the existing registry and store. Friendly
-titles and value labels belong to the presentation layer. Invalid values stay
-invalid, and persisted configuration is not treated as proof of runtime
-application or service health.
+seven behavior settings. Descriptions, defaults, accepted values, and
+effective-value sources come from the existing registry and store. Invalid
+values remain invalid rather than silently defaulting. The rows
+declare native editors and commit policy: toggles and bounded choices use
+`OnChange`, while the numeric idle timeout uses `OnFinalize` (Enter or focus
+loss). **Reset** is an immediate semantic intent; the view has no Save or
+Cancel workflow.
 
 GTK maps the presentation to a native `AdwPreferencesPage`, preference groups,
-and expandable rows. Descriptions and current values are visible immediately;
-source, default, and accepted values appear in expanded details. It neither
-parses configuration nor calls the settings CLI. Shared descriptions are
-improved in the registry rather than copied into GTK. This increment introduces
-no settings writes; ordinary editing and runtime application belong to #177.
+expandable rows, and the declared editors. It renders values, progress,
+feedback, and retry actions; it does not parse configuration, call the settings
+CLI, or implement validation or service policy. A shared typed settings executor
+is used by both CLI and GUI to validate, persist, and apply mutations. A
+validation or persistence failure restores the previous row value. A successful
+save followed by an apply failure keeps the saved value, shows a warning, and
+offers **Retry apply**. Missing or inactive user units are reported precisely;
+the workflow does not attempt privileged repair.
 
-Headless tests cover registry/store presentation and the loading/refresh/retry
-flow. Renderer tests cover native grouping, invalid text, expansion, and narrow
-layout. The installed AT-SPI smoke verifies the third tab, keyboard access to
-details, externally changed configuration, and preservation of the settings file.
+Headless tests cover registry/store presentation and the shared mutation
+executor, including validation, persistence, apply failure, and retry. Renderer
+tests cover native editors, commit timing, reset, feedback, and narrow layout.
+The installed AT-SPI smoke verifies the third tab, keyboard access to details
+and editors, externally changed configuration, and preservation of the settings
+file.
 
 ## Evolution Rules
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -51,16 +51,31 @@ With no TV configured, choose **Pair a TV** to get started.
 
 ### Settings
 
-The development version adds a read-only **Settings** tab with **Screen**,
-**Sleep & Wake**, and **Updates** groups. Each row shows the current configured
-value and a description shared with the settings commands. Expand a row to see
-its source, default, and accepted values. Invalid saved values are identified
-explicitly; they are not silently replaced by defaults.
+The released **1.6.0-beta.1** does not include GUI Settings. Development builds
+add a **Settings** tab with **Screen**, **Sleep & Wake**, and **Updates** groups.
+It exposes seven behavior settings shared with the [settings commands](#configuration). Settings remains independent of TV
+availability; it can load and edit configuration even when no TV is paired.
+Settings reloads when you enter the tab. Invalid saved values remain visible as
+invalid and are not silently replaced with defaults.
 
-Settings reloads when you enter the tab. These values describe configuration,
-not whether the corresponding service is currently running. For now, use the
-[settings commands](#configuration) to make changes. TV identity, HDMI input,
-and pairing remain in **TVs**.
+Expand a row to reveal its native editor, source, default, and accepted values:
+
+- toggles for idle blanking, TV sleep & wake, and automatic update checks, plus
+  bounded choices for the desktop backend, restore policy, and update channel,
+  commit on change;
+- the numeric idle timeout commits when you press Enter or leave the field;
+- **Reset** removes the explicit value and applies the default immediately.
+
+Each change is validated, saved, and applied automatically, without a separate
+**Save** or **Cancel** button. The row reports progress while this runs. Settings
+and TV changes wait for one another to finish. A validation or persistence failure
+restores the previous value and explains the error. If saving succeeds but
+runtime application fails, the saved value remains, a warning is shown, and
+**Retry apply** repeats only the runtime step.
+
+If the screen integration or automatic update checks are not installed or
+running, the row explains that condition. Changing a setting does not install
+or repair these services. TV identity, HDMI input, and pairing remain in **TVs**.
 
 ### Pair Your First TV
 

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -102,6 +102,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--expected-settings-state", choices=("ready", "invalid"))
     parser.add_argument("--expected-settings-timeout")
     parser.add_argument("--require-settings-details", action="store_true")
+    parser.add_argument("--edit-settings-timeout", help="type a timeout draft through native keyboard input")
     parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid", "unpair"))
     parser.add_argument("--expected-tv-address")
     parser.add_argument("--expected-tv-name", default="Primary TV")
@@ -257,6 +258,44 @@ def main() -> int:
                     continue
             time.sleep(0.1)
         raise SystemExit(f"could not select the {args.select_page} tab")
+    if args.edit_settings_timeout is not None:
+        if not args.window_id:
+            raise SystemExit("--edit-settings-timeout needs --window-id")
+        accessibles = accessible_tree()
+        entry = next((item for item in accessibles if name(item) == "Idle timeout"
+                      and role(item) == pyatspi.ROLE_TEXT
+                      and item.getState().contains(pyatspi.STATE_SHOWING)), None)
+        if entry is None:
+            for _ in range(40):
+                if any(name(item) == "Idle timeout" and role(item) != pyatspi.ROLE_TEXT
+                       and item.getState().contains(pyatspi.STATE_FOCUSED)
+                       for item in accessible_tree()):
+                    subprocess.run(["xdotool", "key", "--window", args.window_id, "space"], check=True)
+                    break
+                subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
+                time.sleep(0.05)
+            else:
+                raise SystemExit("could not focus Idle timeout through Tab navigation")
+            deadline = time.monotonic() + args.timeout
+            while entry is None and time.monotonic() < deadline:
+                entry = next((item for item in accessible_tree() if name(item) == "Idle timeout"
+                              and role(item) == pyatspi.ROLE_TEXT
+                              and item.getState().contains(pyatspi.STATE_SHOWING)), None)
+                time.sleep(0.05)
+        if entry is None:
+            raise SystemExit("could not find the Idle timeout editor")
+        for _ in range(40):
+            if any(name(item) == "Idle timeout" and role(item) == pyatspi.ROLE_TEXT
+                   and item.getState().contains(pyatspi.STATE_FOCUSED)
+                   for item in accessible_tree()):
+                break
+            subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
+            time.sleep(0.05)
+        else:
+            raise SystemExit("could not focus the Idle timeout editor through Tab navigation")
+        subprocess.run(["xdotool", "key", "--window", args.window_id, "ctrl+a"], check=True)
+        subprocess.run(["xdotool", "type", "--window", args.window_id, "--clearmodifiers", "--", args.edit_settings_timeout], check=True)
+        return 0
     if args.focus_control:
         if not args.window_id:
             raise SystemExit("--focus-control needs --window-id")

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -256,6 +256,21 @@ observe_gui_state --select-page TVs
 printf '%s\n' 'screen_idle_timeout=120' 'updates_channel=stable' >> "$CONFIG_FILE"
 observe_gui_state --select-page Settings
 observe_gui_state --expected-settings-state ready --expected-settings-timeout '120 seconds'
+# A timeout draft is not saved until Enter; Reset removes the override immediately.
+cp "$CONFIG_FILE" "$WORK_DIR/before-settings-edit.env"
+observe_gui_state --edit-settings-timeout 720 --window-id "$WINDOW_ID"
+cmp "$CONFIG_FILE" "$WORK_DIR/before-settings-edit.env" || fail "Typing a timeout saved before finalization."
+xdotool key --window "$WINDOW_ID" Return
+observe_gui_state --expected-settings-state ready --expected-settings-timeout '720 seconds'
+[ "$("$RUNTIME_BINARY" settings get screen.idle_timeout)" = "720" ] || fail "Finalized timeout was not saved."
+observe_gui_state --edit-settings-timeout invalid --window-id "$WINDOW_ID"
+xdotool key --window "$WINDOW_ID" Return
+observe_gui_state --expected-settings-state ready --expected-settings-timeout '720 seconds'
+[ "$("$RUNTIME_BINARY" settings get screen.idle_timeout)" = "720" ] || fail "Invalid timeout changed configuration."
+observe_gui_state --focus-control "Reset Idle timeout" --window-id "$WINDOW_ID"
+observe_gui_state --activate-control "Reset Idle timeout"
+observe_gui_state --expected-settings-state ready --expected-settings-timeout '300 seconds'
+[ "$("$RUNTIME_BINARY" settings get screen.idle_timeout)" = "300" ] || fail "Reset did not restore the default timeout."
 cp "$WORK_DIR/before-settings.env" "$CONFIG_FILE"
 observe_gui_state --select-page Overview
 observe_gui_state --expected-slider-value 55 --expected-volume 21 --expected-muted true


### PR DESCRIPTION
## Summary

Make the seven behavior settings editable in the GUI using the same validation, persistence, and runtime application paths as the CLI. The application owns edit policies and operation outcomes; GTK renders them and forwards semantic intents.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

- Switches and choices apply on change. The numeric timeout applies on Enter or focus loss; Reset discards any unfinished draft and immediately restores the default.
- Validation or save failures restore the previous effective value. If saving succeeds but runtime application fails, keep the saved value visible with a warning and Retry apply action. Retrying rereads the saved configuration without rewriting it.
- Show progress and precise feedback for unavailable or deferred runtime integrations. Settings work without a paired TV, and configuration writes are serialized with TV operations.
- Update the user guide and architecture documentation for the editable Settings workflow.

## Validation

- Core tests: 901 unit tests passed, one ignored; 52 integration tests and 134 Cucumber scenarios passed.
- Display-backed GTK tests passed, including an actual pointer-click regression for Reset while the timeout has an unfinished draft.
- Isolated installed GUI behavior smoke passed, covering keyboard editing, validation, reset, accessibility, and platform contracts.
- Manually verified that Reset removes the timeout override and later focus loss does not save the discarded draft.
- Workspace Clippy with all targets/features and warnings denied, Rust formatting, shell syntax, Python syntax, and diff whitespace checks passed.

## Related Issue

Closes #177
