### PR TITLE
Simplify Settings and TV management controls

### DIFF
--- a/crates/lg-buddy-gui/build.rs
+++ b/crates/lg-buddy-gui/build.rs
@@ -1,0 +1,14 @@
+use std::{env, path::PathBuf, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-changed=resources");
+    let target = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"))
+        .join("lg-buddy-gui.gresource");
+    let status = Command::new("glib-compile-resources")
+        .args(["--sourcedir=resources", "--target"])
+        .arg(target)
+        .arg("resources/resources.gresource.xml")
+        .status()
+        .expect("glib-compile-resources is required to build the GTK frontend");
+    assert!(status.success(), "could not compile GUI resources");
+}

--- a/crates/lg-buddy-gui/resources/icons/README.md
+++ b/crates/lg-buddy-gui/resources/icons/README.md
@@ -1,0 +1,5 @@
+`edit-delete-symbolic.svg` is GNOME Icon Development Kit's `edit-delete` icon
+by Jakub Steiner, distributed under CC0 1.0. Its license metadata is included
+in the SVG. The file is unchanged apart from its symbolic-icon filename.
+
+Source: [GNOME Icon Development Kit](https://gitlab.gnome.org/Teams/Design/icon-development-kit/-/raw/main/icons/edit-delete.svg).

--- a/crates/lg-buddy-gui/resources/icons/edit-delete-symbolic.svg
+++ b/crates/lg-buddy-gui/resources/icons/edit-delete-symbolic.svg
@@ -1,0 +1,23 @@
+<svg gpa:rendering="symbolic" xmlns="http://www.w3.org/2000/svg" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gpa="https://www.gtk.org/grappa" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" width="16" height="16" gpa:version="1" gpa:state="0" gpa:state-names="outline empty">
+  <path id="path0" fill="none" stroke="url(&quot;#gpa:foreground&quot;) rgb(0,0,0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M 1 8 C 1 11.8659935, 4.13400698 15, 8 15 C 11.8659935 15, 15 11.8659935, 15 8 C 15 4.13400698, 11.8659935 1, 8 1 C 4.13400698 1, 1 4.13400698, 1 8 Z" class="transparent-fill foreground-stroke" gpa:stroke="foreground" gpa:fill="none" gpa:states="outline" gpa:stroke-minwidth="25%" gpa:stroke-maxwidth="150%" >
+    </path>
+  <path id="path1" fill="none" stroke="url(&quot;#gpa:foreground&quot;) rgb(0,0,0)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" d="M 6 6 L 10 10 M 10 6 L 6 10" class="transparent-fill foreground-stroke" gpa:stroke="foreground" gpa:fill="none" gpa:states="outline" gpa:stroke-minwidth="25%" gpa:stroke-maxwidth="150%" >
+    </path>
+  <metadata>
+    <rdf:RDF>
+      <cc:Work>
+        <cc:license rdf:resource="https://creativecommons.org/publicdomain/zero/1.0/"></cc:license>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>edit delete cross x adw avatar-delete</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Jakub Steiner</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+</svg>

--- a/crates/lg-buddy-gui/resources/resources.gresource.xml
+++ b/crates/lg-buddy-gui/resources/resources.gresource.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/github/staphylococcus/LGBuddy">
+    <file>icons/edit-delete-symbolic.svg</file>
+  </gresource>
+</gresources>

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1001,6 +1001,11 @@ pub(crate) mod controller_test_support {
                 return true;
             }
         }
+        if let Some(entry) = widget.downcast_ref::<gtk::Entry>() {
+            if entry.text() == expected {
+                return true;
+            }
+        }
         let mut child = widget.first_child();
         while let Some(current) = child {
             if widget_contains_text(&current, expected) {
@@ -1279,7 +1284,7 @@ pub(crate) mod controller_test_support {
         retry_button(native.upcast_ref())
             .expect("visible Retry button")
             .emit_clicked();
-        pump_until(|| widget_contains_text(native.upcast_ref(), "600 seconds"));
+        pump_until(|| widget_contains_text(native.upcast_ref(), "600"));
         assert_eq!(
             controller.navigation.borrow().selected(),
             super::ApplicationPage::Settings
@@ -1288,7 +1293,7 @@ pub(crate) mod controller_test_support {
         controller
             .window
             .choose_page(super::ApplicationPage::Settings);
-        pump_until(|| widget_contains_text(native.upcast_ref(), "120 seconds"));
+        pump_until(|| widget_contains_text(native.upcast_ref(), "120"));
         controller.shutdown();
         controller.window.close();
     }

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1299,6 +1299,7 @@ pub(crate) mod controller_test_support {
     }
 
     fn run_settings_write_scenario() {
+        use adw::prelude::{ComboRowExt, PreferencesRowExt};
         use lg_buddy::settings::{
             execute_settings_mutation, SettingsApplier, SettingsMutation, SettingsMutationFailure,
             SettingsMutationOutcome, SettingsMutationStage, SettingsStore,
@@ -1357,6 +1358,21 @@ pub(crate) mod controller_test_support {
                 );
                 result
             }
+        }
+        fn update_channel(widget: &gtk::Widget) -> Option<adw::ComboRow> {
+            if let Some(row) = widget.downcast_ref::<adw::ComboRow>() {
+                if row.title() == "Update channel" {
+                    return Some(row.clone());
+                }
+            }
+            let mut child = widget.first_child();
+            while let Some(current) = child {
+                if let Some(row) = update_channel(&current) {
+                    return Some(row);
+                }
+                child = current.next_sibling();
+            }
+            None
         }
         for (suffix, panic_after_save, close_pending) in [
             ("SettingsWrite", false, false),
@@ -1424,10 +1440,8 @@ pub(crate) mod controller_test_support {
                     });
                 } else {
                     pump_until(|| {
-                        widget_contains_text(
-                            native.upcast_ref(),
-                            "Saved; no runtime action was required.",
-                        )
+                        update_channel(native.upcast_ref())
+                            .is_some_and(|row| row.selected() == 1 && row.is_sensitive())
                     });
                 }
                 controller.shutdown();

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -309,7 +309,9 @@ impl ApplicationController {
         if let Some(diagnostic) = transition.diagnostic() {
             eprintln!("LG Buddy GUI: {diagnostic}");
         }
-        controller.window.render_settings(transition.presentation());
+        if !controller.closed.get() {
+            controller.window.render_settings(transition.presentation());
+        }
         if let Some(operation) = transition.read_operation() {
             Self::start_settings_read(controller, operation);
         }
@@ -319,56 +321,33 @@ impl ApplicationController {
     }
 
     fn start_settings_mutation(controller: &Rc<Self>, operation: SettingsMutationOperation) {
-        use lg_buddy::settings::{
-            SettingsMutationFailure, SettingsMutationOutcome, SettingsMutationStage,
-        };
-        enum Update {
-            Progress(SettingsMutationStage),
-            Done(Box<Result<SettingsMutationOutcome, SettingsMutationFailure>>),
-            Stopped,
-        }
         let backend = Arc::clone(&controller.settings_backend);
         let worker_operation = operation.clone();
-        let (sender, receiver) = mpsc::channel();
-        // Atomic publication and runtime apply finish even when the window closes.
-        let mut application_hold = Some(controller.gtk_application.hold());
+        let (sender, receiver) = mpsc::sync_channel(1);
+        // Keep the controller and application alive until accepted writes drain.
+        let application_hold = controller.gtk_application.hold();
         thread::spawn(move || {
-            let result = backend.write_setting(worker_operation, &mut |stage| {
-                let _ = sender.send(Update::Progress(stage));
-            });
-            let _ = sender.send(Update::Done(Box::new(result)));
+            let result = backend.write_setting(worker_operation, &mut |_| {});
+            let _ = sender.send(result);
         });
-        let controller = Rc::downgrade(controller);
-        glib::timeout_add_local(Duration::from_millis(10), move || loop {
-            let update = match receiver.try_recv() {
-                Ok(update) => update,
+        let controller = Rc::clone(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || {
+            let transition = match receiver.try_recv() {
+                Ok(result) => controller
+                    .application
+                    .borrow_mut()
+                    .complete_settings_mutation(&operation, result),
                 Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
-                Err(mpsc::TryRecvError::Disconnected) => Update::Stopped,
+                Err(mpsc::TryRecvError::Disconnected) => controller
+                    .application
+                    .borrow_mut()
+                    .settings_mutation_worker_stopped(&operation),
             };
-            let done = matches!(update, Update::Done(_) | Update::Stopped);
-            if let Some(controller) = controller.upgrade() {
-                let transition = match update {
-                    Update::Progress(stage) => controller
-                        .application
-                        .borrow_mut()
-                        .settings_mutation_progress(&operation, stage),
-                    Update::Done(result) => controller
-                        .application
-                        .borrow_mut()
-                        .complete_settings_mutation(&operation, *result),
-                    Update::Stopped => controller
-                        .application
-                        .borrow_mut()
-                        .settings_mutation_worker_stopped(&operation),
-                };
-                if let Some(transition) = transition {
-                    Self::apply_transition(&controller, transition);
-                }
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
             }
-            if done {
-                drop(application_hold.take());
-                return glib::ControlFlow::Break;
-            }
+            let _ = &application_hold;
+            glib::ControlFlow::Break
         });
     }
 
@@ -378,22 +357,22 @@ impl ApplicationController {
         thread::spawn(move || {
             let _ = sender.send(backend.read_settings());
         });
-        let controller = Rc::downgrade(controller);
+        let controller = Rc::clone(controller);
+        let application_hold = controller.gtk_application.hold();
         glib::timeout_add_local(Duration::from_millis(10), move || {
             let result = match receiver.try_recv() {
                 Ok(result) => result,
                 Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
                 Err(mpsc::TryRecvError::Disconnected) => Err(SettingsReadError::stopped()),
             };
-            if let Some(controller) = controller.upgrade() {
-                let transition = controller
-                    .application
-                    .borrow_mut()
-                    .complete_settings_read(operation, result);
-                if let Some(transition) = transition {
-                    Self::apply_transition(&controller, transition);
-                }
+            let transition = controller
+                .application
+                .borrow_mut()
+                .complete_settings_read(operation, result);
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
             }
+            let _ = &application_hold;
             glib::ControlFlow::Break
         });
     }
@@ -412,9 +391,11 @@ impl ApplicationController {
         if let Some(diagnostic) = transition.diagnostic() {
             eprintln!("LG Buddy GUI: {diagnostic}");
         }
-        controller.window.render_tvs(transition.presentation());
-        if let Some(message) = transition.toast_message() {
-            controller.window.show_toast(message);
+        if !controller.closed.get() {
+            controller.window.render_tvs(transition.presentation());
+            if let Some(message) = transition.toast_message() {
+                controller.window.show_toast(message);
+            }
         }
         if let Some(operation) = transition.read_operation() {
             Self::start_tvs_read(controller, operation);
@@ -437,11 +418,11 @@ impl ApplicationController {
         let backend = Arc::clone(&controller.tvs_backend);
         let worker_operation = operation.clone();
         let (sender, receiver) = mpsc::sync_channel(1);
-        let mut application_hold = Some(controller.gtk_application.hold());
+        let application_hold = controller.gtk_application.hold();
         thread::spawn(move || {
             let _ = sender.send(backend.manage(&worker_operation));
         });
-        let controller = Rc::downgrade(controller);
+        let controller = Rc::clone(controller);
         glib::timeout_add_local(Duration::from_millis(10), move || {
             let result = match receiver.try_recv() {
                 Ok(result) => result,
@@ -450,16 +431,14 @@ impl ApplicationController {
                     Err(lg_buddy::tvs::TvsManagementError::stopped())
                 }
             };
-            if let Some(controller) = controller.upgrade() {
-                let transition = controller
-                    .application
-                    .borrow_mut()
-                    .complete_tvs_management(&operation, result);
-                if let Some(transition) = transition {
-                    Self::apply_transition(&controller, transition);
-                }
+            let transition = controller
+                .application
+                .borrow_mut()
+                .complete_tvs_management(&operation, result);
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
             }
-            drop(application_hold.take());
+            let _ = &application_hold;
             glib::ControlFlow::Break
         });
     }
@@ -1374,10 +1353,11 @@ pub(crate) mod controller_test_support {
             }
             None
         }
-        for (suffix, panic_after_save, close_pending) in [
-            ("SettingsWrite", false, false),
-            ("SettingsStopped", true, false),
-            ("SettingsClose", false, true),
+        for (suffix, panic_after_save, close_pending, queued) in [
+            ("SettingsWrite", false, false, false),
+            ("SettingsStopped", true, false, false),
+            ("SettingsClose", false, true, false),
+            ("SettingsQueuedClose", false, true, true),
         ] {
             let path =
                 std::env::temp_dir().join(format!("lg-buddy-{suffix}-{}.env", std::process::id()));
@@ -1415,6 +1395,16 @@ pub(crate) mod controller_test_support {
             );
             pump_until(|| started_rx.try_recv().is_ok());
             assert!(std::fs::read_to_string(&path).unwrap().contains("stable"));
+            assert!(update_channel(native.upcast_ref()).unwrap().is_sensitive());
+            if queued {
+                ApplicationController::handle_settings_intent(
+                    &controller,
+                    lg_buddy::settings_view::SettingsIntent::Commit {
+                        setting: BehaviorSetting::UpdatesChannel,
+                        value: "stable".into(),
+                    },
+                );
+            }
             pump_for(Duration::from_millis(20));
             if close_pending {
                 ApplicationController::handle_intent(&controller, OverviewIntent::Cancel);
@@ -1426,6 +1416,11 @@ pub(crate) mod controller_test_support {
                     .unwrap()
                     .contains("prerelease")
             });
+            if queued {
+                pump_until(|| started_rx.try_recv().is_ok());
+                release_tx.send(()).unwrap();
+                pump_until(|| std::fs::read_to_string(&path).unwrap().contains("stable"));
+            }
             if close_pending {
                 pump_for(Duration::from_millis(30));
                 assert!(

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -96,6 +96,8 @@ impl SettingsView {
                         for row in group.rows() {
                             let row = NativeSettingRow::new(row, Rc::clone(&self.on_intent));
                             native.add(&row.row);
+                            native.add(&row.problem);
+                            native.add(&row.feedback);
                             self.rows.borrow_mut().push(row);
                         }
                         self.page.add(&native);
@@ -119,8 +121,8 @@ impl SettingsView {
 }
 
 enum NativeEditor {
-    Toggle(gtk::Switch),
-    Choice(gtk::DropDown),
+    Toggle(adw::SwitchRow),
+    Choice(adw::ComboRow),
     Number {
         entry: gtk::Entry,
         finalized: Rc<RefCell<String>>,
@@ -128,13 +130,10 @@ enum NativeEditor {
 }
 
 struct NativeSettingRow {
-    row: adw::ExpanderRow,
-    value: gtk::Label,
-    source: adw::ActionRow,
+    row: adw::ActionRow,
     problem: adw::ActionRow,
     feedback: adw::ActionRow,
     warning: gtk::Image,
-    reset: gtk::Button,
     retry: gtk::Button,
     editor: NativeEditor,
     presentation: Rc<RefCell<SettingsRow>>,
@@ -144,31 +143,11 @@ struct NativeSettingRow {
 
 impl NativeSettingRow {
     fn new(initial: &SettingsRow, on_intent: Rc<dyn Fn(SettingsIntent)>) -> Self {
-        let row = adw::ExpanderRow::builder()
-            .use_markup(false)
-            .title_lines(0)
-            .subtitle_lines(0)
-            .build();
-        row.set_title(initial.title());
-        row.set_subtitle(initial.description());
-        let value = gtk::Label::builder()
-            .wrap(true)
-            .wrap_mode(gtk::pango::WrapMode::Word)
-            .width_chars(12)
-            .max_width_chars(12)
-            .xalign(1.0)
-            .valign(gtk::Align::Center)
-            .build();
-        value.add_css_class("dim-label");
-        row.add_suffix(&value);
-        let warning = gtk::Image::from_icon_name("dialog-warning-symbolic");
-        row.add_prefix(&warning);
         let presentation = Rc::new(RefCell::new(initial.clone()));
         let rendering = Rc::new(Cell::new(false));
-        let editor_row = detail_row("Value", "");
-        let editor = match initial.editor() {
+        let (row, editor): (adw::ActionRow, NativeEditor) = match initial.editor() {
             SettingsEditor::Toggle { .. } => {
-                let switch = gtk::Switch::builder().valign(gtk::Align::Center).build();
+                let switch = adw::SwitchRow::new();
                 switch.update_property(&[gtk::accessible::Property::Label(initial.title())]);
                 switch.connect_active_notify({
                     let presentation = Rc::clone(&presentation);
@@ -187,14 +166,33 @@ impl NativeSettingRow {
                         }
                     }
                 });
-                editor_row.add_suffix(&switch);
-                editor_row.set_activatable_widget(Some(&switch));
-                NativeEditor::Toggle(switch)
+                (switch.clone().upcast(), NativeEditor::Toggle(switch))
             }
             SettingsEditor::Choice { options, .. } => {
                 let labels: Vec<_> = options.iter().map(|choice| choice.label()).collect();
-                let dropdown = gtk::DropDown::from_strings(&labels);
-                dropdown.set_valign(gtk::Align::Center);
+                let dropdown = adw::ComboRow::builder()
+                    .model(&gtk::StringList::new(&labels))
+                    .build();
+                // Preserve the native popup while keeping the selected value readable.
+                dropdown.set_list_factory(dropdown.factory().as_ref());
+                let factory = gtk::SignalListItemFactory::new();
+                factory.connect_setup(|_, item| {
+                    let item = item.downcast_ref::<gtk::ListItem>().unwrap();
+                    let label = gtk::Label::builder()
+                        .wrap(true)
+                        .wrap_mode(gtk::pango::WrapMode::Word)
+                        .xalign(1.0)
+                        .build();
+                    label.add_css_class("dim-label");
+                    item.set_child(Some(&label));
+                });
+                factory.connect_bind(|_, item| {
+                    let item = item.downcast_ref::<gtk::ListItem>().unwrap();
+                    let value = item.item().and_downcast::<gtk::StringObject>().unwrap();
+                    let label = item.child().and_downcast::<gtk::Label>().unwrap();
+                    label.set_label(&value.string());
+                });
+                dropdown.set_factory(Some(&factory));
                 dropdown.update_property(&[gtk::accessible::Property::Label(initial.title())]);
                 dropdown.connect_selected_notify({
                     let presentation = Rc::clone(&presentation);
@@ -219,8 +217,7 @@ impl NativeSettingRow {
                         }
                     }
                 });
-                editor_row.add_suffix(&dropdown);
-                NativeEditor::Choice(dropdown)
+                (dropdown.clone().upcast(), NativeEditor::Choice(dropdown))
             }
             SettingsEditor::Number { text } => {
                 let entry = gtk::Entry::builder()
@@ -271,66 +268,42 @@ impl NativeSettingRow {
                     }
                 });
                 entry.add_controller(focus);
-                editor_row.add_suffix(&entry);
-                NativeEditor::Number { entry, finalized }
+                let row = adw::ActionRow::new();
+                row.add_suffix(&entry);
+                row.set_activatable_widget(Some(&entry));
+                (row, NativeEditor::Number { entry, finalized })
             }
         };
-        row.add_row(&editor_row);
+        row.set_use_markup(false);
+        row.set_title(initial.title());
+        row.set_subtitle(initial.description());
+        row.set_title_lines(0);
+        row.set_subtitle_lines(0);
+        let warning = gtk::Image::from_icon_name("dialog-warning-symbolic");
+        row.add_prefix(&warning);
         let problem = detail_row("", "");
         problem.add_css_class("error");
         problem.set_accessible_role(gtk::AccessibleRole::Alert);
-        row.add_row(&problem);
         let feedback = detail_row("", "");
         let retry = gtk::Button::builder()
             .label("Retry apply")
             .valign(gtk::Align::Center)
             .build();
         feedback.add_suffix(&retry);
-        row.add_row(&feedback);
-        let source = detail_row("Source", initial.source_label());
-        row.add_row(&source);
-        let default = detail_row("Default", initial.default_label());
-        let reset = gtk::Button::builder()
-            .label("Reset")
-            // Let Reset replace a focused draft without a preceding focus-loss commit.
-            .focus_on_click(false)
-            .valign(gtk::Align::Center)
-            .build();
-        reset.update_property(&[gtk::accessible::Property::Label(&format!(
-            "Reset {}",
-            initial.title()
-        ))]);
-        default.add_suffix(&reset);
-        row.add_row(&default);
-        row.add_row(&detail_row(
-            "Accepted values",
-            initial.accepted_values_label(),
-        ));
-        for (button, is_retry) in [(&reset, false), (&retry, true)] {
-            button.connect_clicked({
-                let presentation = Rc::clone(&presentation);
-                let on_intent = Rc::clone(&on_intent);
-                move |_| {
-                    let row = presentation.borrow().clone();
-                    let action = if is_retry {
-                        row.retry_apply_action()
-                    } else {
-                        row.reset_action()
-                    };
-                    if let Some(action) = action.filter(|action| action.enabled()) {
-                        on_intent(action.intent());
-                    }
+        retry.connect_clicked({
+            let presentation = Rc::clone(&presentation);
+            move |_| {
+                let row = presentation.borrow().clone();
+                if let Some(action) = row.retry_apply_action().filter(|action| action.enabled()) {
+                    on_intent(action.intent());
                 }
-            });
-        }
+            }
+        });
         let native = Self {
             row,
-            value,
-            source,
             problem,
             feedback,
             warning,
-            reset,
             retry,
             editor,
             presentation,
@@ -391,8 +364,7 @@ impl NativeSettingRow {
             );
         }
         widget.set_sensitive(current.editor_enabled());
-        self.value.set_label(current.value_label());
-        self.source.set_subtitle(current.source_label());
+        self.row.set_sensitive(current.editor_enabled());
         self.row.update_property(&[
             gtk::accessible::Property::Label(current.title()),
             gtk::accessible::Property::Description(&format!(
@@ -440,25 +412,21 @@ impl NativeSettingRow {
             .set_visible(current.problem().is_some() || is_warning);
         self.warning
             .set_tooltip_text(current.problem().or(is_warning.then_some(message)));
-        if is_warning && current.edit_status() != previous.edit_status() {
-            self.row.set_expanded(true);
-        }
-        for (button, action) in [
-            (&self.reset, current.reset_action()),
-            (&self.retry, current.retry_apply_action()),
-        ] {
-            button.set_visible(action.is_some());
-            button.set_sensitive(action.is_some_and(|action| action.enabled()));
-            if let Some(action) = action {
-                button.set_label(action.label());
-                // GtkButton labels itself from its child; use the setting-specific name instead.
-                button.reset_relation(gtk::AccessibleRelation::LabelledBy);
-                button.update_property(&[gtk::accessible::Property::Label(&format!(
+        let action = current.retry_apply_action();
+        self.retry.set_visible(action.is_some());
+        self.retry
+            .set_sensitive(action.is_some_and(|action| action.enabled()));
+        if let Some(action) = action {
+            self.retry.set_label(action.label());
+            // GtkButton labels itself from its child; use the setting-specific name instead.
+            self.retry
+                .reset_relation(gtk::AccessibleRelation::LabelledBy);
+            self.retry
+                .update_property(&[gtk::accessible::Property::Label(&format!(
                     "{} {}",
                     action.label(),
                     current.title()
                 ))]);
-            }
         }
         self.presentation.replace(current.clone());
         if !in_flight(current.edit_status())
@@ -546,10 +514,13 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     view.render(&presentation);
     pump_until(|| view.page.is_mapped() && view.groups.borrow()[0].width() > 0);
     let widgets = descendants(view.widget().upcast_ref());
-    let rows: Vec<adw::ExpanderRow> = widgets
+    let rows: Vec<_> = view
+        .rows
+        .borrow()
         .iter()
-        .filter_map(|widget| widget.clone().downcast().ok())
+        .map(|row| row.row.clone())
         .collect();
+    assert!(!widgets.iter().any(|widget| widget.is::<adw::ExpanderRow>()));
     assert_eq!(view.groups.borrow().len(), 3);
     assert_eq!(rows.len(), 7);
     assert!(widgets
@@ -581,9 +552,8 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .zip(presentation.groups().iter().flat_map(|group| group.rows()))
     {
         assert_eq!(row.title(), declared.title());
-        assert_eq!(row.subtitle(), declared.description());
+        assert_eq!(row.subtitle().as_deref(), Some(declared.description()));
         assert!(!row.uses_markup());
-        assert!(!row.shows_enable_switch());
     }
     assert_eq!(
         view.rows
@@ -601,13 +571,13 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             .count(),
         3
     );
-    rows[0].set_expanded(true);
-    pump_until(|| rows[0].is_expanded());
-    let first_details = descendants(rows[0].upcast_ref());
-    assert!(first_details
+    assert!(!widgets
         .iter()
-        .filter_map(|widget| widget.clone().downcast::<adw::ActionRow>().ok())
-        .any(|row| row.title() == "Accepted values"));
+        .filter_map(|widget| widget.clone().downcast::<gtk::Label>().ok())
+        .any(|label| matches!(
+            label.text().as_str(),
+            "Source" | "Default" | "Accepted values" | "Reset"
+        )));
     assert!(widgets
         .iter()
         .any(|widget| widget.accessible_role() == gtk::AccessibleRole::Alert));
@@ -631,7 +601,6 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         NativeEditor::Number { entry, .. } => entry.clone(),
         _ => unreachable!(),
     };
-    rows[2].set_expanded(true);
     pump_until(|| entry.is_mapped());
     entry.grab_focus();
     entry.set_text("900");
@@ -653,7 +622,6 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         "progress must preserve the submitted draft"
     );
     assert!(!entry.is_sensitive());
-    assert!(rows[2].is_expanded(), "progress preserves expansion");
     assert!(
         intents.borrow().is_empty(),
         "programmatic blur does not resubmit"
@@ -699,14 +667,9 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             value: "prerelease".into(),
         })
     );
-    view.rows.borrow()[2].reset.emit_clicked();
-    assert_eq!(
-        intents.borrow_mut().pop(),
-        Some(SettingsIntent::Reset(BehaviorSetting::ScreenIdleTimeout))
-    );
     entry.grab_focus();
     entry.set_text("720");
-    view.rows.borrow()[2].reset.grab_focus();
+    rows[0].grab_focus();
     pump_until(|| !intents.borrow().is_empty());
     assert_eq!(
         intents.borrow_mut().pop(),
@@ -724,19 +687,18 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         "settings rows must fit a narrow window: {minimum}"
     );
     window.close();
-    reset_pointer_click_discards_the_unfinalized_timeout(application);
+    choice_row_click_opens_the_value_menu(application);
 }
 
 #[cfg(test)]
-fn reset_pointer_click_discards_the_unfinalized_timeout(application: &adw::Application) {
+fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
     use crate::controller_test_support::pump_until;
     use lg_buddy::settings::ConfigEnvReader;
     use lg_buddy::settings_view::{BehaviorSetting, SettingsApplication};
     use std::process::Command;
 
     let (mut model, opening) = SettingsApplication::open();
-    let store =
-        ConfigEnvReader::parse("/unused/config.env", "screen_idle_timeout=600\n").into_store();
+    let store = ConfigEnvReader::parse("/unused/config.env", "").into_store();
     let ready = model
         .complete_read(
             opening.read_operation().unwrap(),
@@ -762,31 +724,23 @@ fn reset_pointer_click_discards_the_unfinalized_timeout(application: &adw::Appli
     view.render(ready.presentation());
     let window = adw::ApplicationWindow::builder()
         .application(application)
-        .title("LG Buddy Reset Pointer Test")
+        .title("LG Buddy Choice Pointer Test")
         .default_width(800)
         .default_height(900)
         .content(view.widget())
         .build();
-    // Target the final row geometry, not a frame of the expansion animation.
-    let settings = window.settings();
-    let animations = settings.is_gtk_enable_animations();
-    settings.set_gtk_enable_animations(false);
     window.present();
-    let (entry, reset) = {
-        let rows = view.rows.borrow();
-        rows[2].row.set_expanded(true);
-        let NativeEditor::Number { entry, .. } = &rows[2].editor else {
-            unreachable!()
-        };
-        (entry.clone(), rows[2].reset.clone())
+    let choice = match &view.rows.borrow()[0].editor {
+        NativeEditor::Choice(choice) => choice.clone(),
+        _ => unreachable!(),
     };
-    pump_until(|| reset.is_mapped() && reset.width() > 0);
+    pump_until(|| choice.is_mapped() && choice.width() > 0);
     let search = Command::new("xdotool")
         .args([
             "search",
             "--onlyvisible",
             "--name",
-            "^LG Buddy Reset Pointer Test$",
+            "^LG Buddy Choice Pointer Test$",
         ])
         .output()
         .expect("xdotool is required for native pointer tests");
@@ -798,27 +752,52 @@ fn reset_pointer_click_discards_the_unfinalized_timeout(application: &adw::Appli
         .status()
         .unwrap()
         .success());
-    entry.grab_focus();
-    entry.set_text("900");
-    assert!(intents.borrow().is_empty());
-    let bounds = reset
+    let bounds = choice
         .compute_bounds(&window)
-        .expect("Reset belongs to the test window");
+        .expect("the choice row belongs to the test window");
     let x = (bounds.x() + bounds.width() / 2.0).round().to_string();
     let y = (bounds.y() + bounds.height() / 2.0).round().to_string();
-    // XTest sends press/release events, exercising focus transfer before clicked.
-    // emit_clicked() bypasses that ordering and cannot reproduce the lost Reset.
+    // Click the row body, not an inner dropdown control.
     assert!(Command::new("xdotool")
         .args(["mousemove", "--sync", "--window", id, &x, &y, "click", "1"])
         .status()
         .unwrap()
         .success());
+    fn visible_popover(widget: &gtk::Widget) -> bool {
+        if widget.is::<gtk::Popover>() && widget.is_mapped() {
+            return true;
+        }
+        let mut child = widget.first_child();
+        while let Some(current) = child {
+            if visible_popover(&current) {
+                return true;
+            }
+            child = current.next_sibling();
+        }
+        false
+    }
+    pump_until(|| visible_popover(choice.upcast_ref()));
+    assert!(intents.borrow().is_empty(), "opening choices must not save");
+    assert!(Command::new("xdotool")
+        .args(["key", "End", "Return"])
+        .status()
+        .unwrap()
+        .success());
     pump_until(|| !intents.borrow().is_empty());
+    let expected = ready.presentation().groups()[0].rows()[0]
+        .editor()
+        .choices()
+        .unwrap()
+        .last()
+        .unwrap()
+        .value();
     assert_eq!(
         *intents.borrow(),
-        vec![SettingsIntent::Reset(BehaviorSetting::ScreenIdleTimeout)],
-        "Reset must replace the draft without committing it first"
+        vec![SettingsIntent::Commit {
+            setting: BehaviorSetting::ScreenBackend,
+            value: expected.into(),
+        }],
+        "choosing a value must commit directly from the row"
     );
     window.close();
-    settings.set_gtk_enable_animations(animations);
 }

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -76,6 +76,10 @@ impl SettingsView {
         self.retry_intent
             .replace(action.map(|action| action.intent()));
         match presentation.status() {
+            SettingsStatus::Loading { .. } if !presentation.groups().is_empty() => {
+                self.render_rows(presentation);
+                self.root.set_visible_child_name("settings");
+            }
             SettingsStatus::Loading { message } => {
                 self.status.set_title(message);
                 self.status.set_description(None);
@@ -104,17 +108,21 @@ impl SettingsView {
                         self.groups.borrow_mut().push(native);
                     }
                 }
-                for row in self.rows.borrow().iter() {
-                    if let Some(presentation) = presentation
-                        .groups()
-                        .iter()
-                        .flat_map(|group| group.rows())
-                        .find(|value| value.setting() == row.presentation.borrow().setting())
-                    {
-                        row.render(presentation);
-                    }
-                }
+                self.render_rows(presentation);
                 self.root.set_visible_child_name("settings");
+            }
+        }
+    }
+
+    fn render_rows(&self, presentation: &SettingsPresentation) {
+        for row in self.rows.borrow().iter() {
+            if let Some(presentation) = presentation
+                .groups()
+                .iter()
+                .flat_map(|group| group.rows())
+                .find(|value| value.setting() == row.presentation.borrow().setting())
+            {
+                row.render(presentation);
             }
         }
     }
@@ -138,7 +146,6 @@ struct NativeSettingRow {
     editor: NativeEditor,
     presentation: Rc<RefCell<SettingsRow>>,
     rendering: Rc<Cell<bool>>,
-    restore_focus: Cell<bool>,
 }
 
 impl NativeSettingRow {
@@ -221,6 +228,7 @@ impl NativeSettingRow {
             }
             SettingsEditor::Number { text } => {
                 let entry = gtk::Entry::builder()
+                    .text(text)
                     .width_chars(8)
                     .max_width_chars(8)
                     .input_purpose(gtk::InputPurpose::Digits)
@@ -308,11 +316,10 @@ impl NativeSettingRow {
             editor,
             presentation,
             rendering,
-            restore_focus: Cell::new(false),
         };
         // Populate values without producing commit intents.
         native.render_editor(initial.editor());
-        native.render(initial);
+        native.render_state(initial);
         native
     }
 
@@ -333,8 +340,13 @@ impl NativeSettingRow {
                 );
             }
             (NativeEditor::Number { entry, finalized }, SettingsEditor::Number { text }) => {
-                entry.set_text(text);
-                finalized.replace(text.clone());
+                // Preserve a newer, unsubmitted draft and leave the caret alone on success.
+                if entry.text().as_str() == finalized.borrow().as_str() {
+                    if entry.text().as_str() != text {
+                        entry.set_text(text);
+                    }
+                    finalized.replace(text.clone());
+                }
             }
             _ => unreachable!("a behavior setting keeps its declared editor type"),
         }
@@ -343,27 +355,20 @@ impl NativeSettingRow {
 
     fn render(&self, current: &SettingsRow) {
         let previous = self.presentation.borrow().clone();
-        if !in_flight(current.edit_status())
-            && (previous.editor() != current.editor() || in_flight(previous.edit_status()))
+        if previous == *current {
+            return;
+        }
+        if current.edit_status() != SettingsEditStatus::Saving
+            && (previous.editor() != current.editor()
+                || previous.edit_status() == SettingsEditStatus::Saving)
         {
             self.render_editor(current.editor());
         }
+        self.render_state(current);
+    }
+
+    fn render_state(&self, current: &SettingsRow) {
         self.rendering.set(true);
-        let widget: &gtk::Widget = match &self.editor {
-            NativeEditor::Toggle(widget) => widget.upcast_ref(),
-            NativeEditor::Choice(widget) => widget.upcast_ref(),
-            NativeEditor::Number { entry, .. } => entry.upcast_ref(),
-        };
-        if in_flight(current.edit_status()) && !in_flight(previous.edit_status()) {
-            self.restore_focus.set(
-                widget
-                    .root()
-                    .and_then(|root| root.downcast::<gtk::Window>().ok())
-                    .and_then(|window| GtkWindowExt::focus(&window))
-                    .is_some_and(|focus| focus == *widget || focus.is_ancestor(widget)),
-            );
-        }
-        widget.set_sensitive(current.editor_enabled());
         self.row.set_sensitive(current.editor_enabled());
         self.row.update_property(&[
             gtk::accessible::Property::Label(current.title()),
@@ -429,25 +434,8 @@ impl NativeSettingRow {
                 ))]);
         }
         self.presentation.replace(current.clone());
-        if !in_flight(current.edit_status())
-            && in_flight(previous.edit_status())
-            && self.restore_focus.replace(false)
-            && widget.is_mapped()
-        {
-            widget.grab_focus();
-        }
         self.rendering.set(false);
     }
-}
-
-fn in_flight(status: SettingsEditStatus) -> bool {
-    matches!(
-        status,
-        SettingsEditStatus::Validating
-            | SettingsEditStatus::Persisting
-            | SettingsEditStatus::Persisted
-            | SettingsEditStatus::Applying
-    )
 }
 
 fn detail_row(title: &str, value: &str) -> adw::ActionRow {
@@ -596,6 +584,15 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         )
         .unwrap();
     view.render(ready.presentation());
+    let refresh = editing.handle_intent(SettingsIntent::Refresh).unwrap();
+    view.render(refresh.presentation());
+    assert_eq!(view.root.visible_child_name().as_deref(), Some("settings"));
+    assert!(
+        view.page.is_mapped(),
+        "refresh must not unmap populated settings"
+    );
+    assert!(view.rows.borrow().iter().all(|row| row.row.is_sensitive()));
+    // A new edit supersedes this refresh; its stale read must not replace the value.
     intents.borrow_mut().clear();
     let entry = match &view.rows.borrow()[2].editor {
         NativeEditor::Number { entry, .. } => entry.clone(),
@@ -618,35 +615,37 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .measure(gtk::Orientation::Vertical, 600)
         .1;
     let writing = editing.handle_intent(intent).unwrap();
+    assert!(editing
+        .complete_read(
+            refresh.read_operation().unwrap(),
+            Ok(presentation.groups().to_vec())
+        )
+        .is_none());
     view.render(writing.presentation());
-    for stage in [
-        lg_buddy::settings::SettingsMutationStage::Validating,
-        lg_buddy::settings::SettingsMutationStage::Persisting,
-        lg_buddy::settings::SettingsMutationStage::Persisted,
-        lg_buddy::settings::SettingsMutationStage::Applying,
-    ] {
-        let progress = editing
-            .mutation_progress(writing.mutation_operation().unwrap(), stage)
-            .unwrap();
-        view.render(progress.presentation());
-        assert!(!view.rows.borrow()[2].feedback.is_visible());
-        assert_eq!(
-            view.groups.borrow()[0]
-                .measure(gtk::Orientation::Vertical, 600)
-                .1,
-            initial_height,
-            "an ordinary setting change must not shift the layout"
-        );
-    }
+    assert!(view.rows.borrow().iter().all(|row| row.row.is_sensitive()));
+    assert!(!view.rows.borrow()[2].feedback.is_visible());
+    assert_eq!(
+        view.groups.borrow()[0]
+            .measure(gtk::Orientation::Vertical, 600)
+            .1,
+        initial_height,
+        "an ordinary setting change must not shift the layout"
+    );
+    assert!(
+        GtkWindowExt::focus(&window).is_some_and(|focus| focus
+            == entry.clone().upcast::<gtk::Widget>()
+            || focus.is_ancestor(&entry)),
+        "saving must keep keyboard focus"
+    );
     assert_eq!(
         entry.text(),
         "900",
-        "progress must preserve the submitted draft"
+        "saving must preserve the submitted draft"
     );
-    assert!(!entry.is_sensitive());
+    assert!(entry.is_sensitive());
     assert!(
         intents.borrow().is_empty(),
-        "programmatic blur does not resubmit"
+        "rendering must not resubmit the value"
     );
     let failed = editing
         .complete_mutation(
@@ -700,6 +699,34 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             value: "720".into(),
         })
     );
+
+    let writing = editing
+        .handle_intent(SettingsIntent::Commit {
+            setting: BehaviorSetting::ScreenIdleTimeout,
+            value: "720".into(),
+        })
+        .unwrap();
+    view.render(writing.presentation());
+    entry.grab_focus();
+    entry.set_text("721");
+    entry.set_position(1);
+    let failed = editing
+        .complete_mutation(
+            writing.mutation_operation().unwrap(),
+            Err(lg_buddy::settings::SettingsMutationFailure::Persistence(
+                lg_buddy::settings::SettingsError::Apply {
+                    message: "write failed".into(),
+                },
+            )),
+        )
+        .unwrap();
+    view.render(failed.presentation());
+    assert_eq!(
+        entry.text(),
+        "721",
+        "completion must preserve a newer unsubmitted draft"
+    );
+    assert_eq!(entry.position(), 1, "completion must not move the caret");
 
     window.set_default_size(360, 600);
     pump_until(|| window.width() <= 360);

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -614,8 +614,30 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         }]
     );
     let intent = intents.borrow_mut().pop().unwrap();
+    let initial_height = view.groups.borrow()[0]
+        .measure(gtk::Orientation::Vertical, 600)
+        .1;
     let writing = editing.handle_intent(intent).unwrap();
     view.render(writing.presentation());
+    for stage in [
+        lg_buddy::settings::SettingsMutationStage::Validating,
+        lg_buddy::settings::SettingsMutationStage::Persisting,
+        lg_buddy::settings::SettingsMutationStage::Persisted,
+        lg_buddy::settings::SettingsMutationStage::Applying,
+    ] {
+        let progress = editing
+            .mutation_progress(writing.mutation_operation().unwrap(), stage)
+            .unwrap();
+        view.render(progress.presentation());
+        assert!(!view.rows.borrow()[2].feedback.is_visible());
+        assert_eq!(
+            view.groups.borrow()[0]
+                .measure(gtk::Orientation::Vertical, 600)
+                .1,
+            initial_height,
+            "an ordinary setting change must not shift the layout"
+        );
+    }
     assert_eq!(
         entry.text(),
         "900",

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -443,8 +443,10 @@ impl TvsView {
             TvsStatus::Ready => match presentation.selected_profile() {
                 Some(profile) => {
                     mode.input.set_sensitive(presentation.input_enabled());
-                    mode.input.set_selected(hdmi_index(profile.input()));
-                    mode.unpair.render(presentation.unpair_action());
+                    let selected = hdmi_index(profile.input());
+                    if mode.input.selected() != selected {
+                        mode.input.set_selected(selected);
+                    }
                     mode.show_details(profile)
                 }
                 None => {
@@ -585,6 +587,7 @@ impl PairButton {
     }
 
     fn render(&self, action: Option<&TvsAction>) {
+        let was_visible = self.button.is_visible();
         self.intent.replace(
             action
                 .filter(|action| action.enabled())
@@ -600,7 +603,7 @@ impl PairButton {
             .update_property(&[gtk::accessible::Property::Label(
                 action.map_or("Pair a TV", TvsAction::label),
             )]);
-        if action.is_some() && !self.button.has_focus() {
+        if action.is_some() && !was_visible && !self.button.has_focus() {
             let button = self.button.clone();
             gtk::glib::idle_add_local_once(move || {
                 if button.is_mapped() && button.is_visible() && button.is_sensitive() {
@@ -866,8 +869,13 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
         .expect("input transition");
     view.render(&window, pending.presentation());
-    assert!(!view.single.input.is_sensitive());
+    assert!(view.single.input.is_sensitive());
     assert!(!view.single.unpair.button.is_sensitive());
+    view.single.input.set_selected(3);
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(TvsIntent::SetInput(HdmiInput::Hdmi4))
+    );
 
     let (mut app, opening) = TvsApplication::open();
     let ready_multiple = app

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -48,7 +48,7 @@ struct TvsMode {
     platform: adw::ActionRow,
     credentials: adw::ActionRow,
     credential_description: gtk::Label,
-    unpair: ActionButton,
+    unpair: UnpairButton,
     management_error: gtk::Label,
     management_actions: gtk::Box,
     management_retry: RetryButton,
@@ -111,13 +111,8 @@ impl TvsMode {
             .margin_end(12)
             .build();
         credential_description.add_css_class("dim-label");
-        let unpair = ActionButton::new(on_intent);
-        unpair.button.add_css_class("destructive-action");
-        let unpair_row = adw::ActionRow::builder()
-            .activatable(false)
-            .selectable(false)
-            .build();
-        unpair_row.add_suffix(&unpair.button);
+        let unpair = UnpairButton::new(on_intent);
+        details.set_header_suffix(Some(&unpair.button));
         let management_error = gtk::Label::builder()
             .xalign(0.0)
             .wrap(true)
@@ -139,7 +134,6 @@ impl TvsMode {
         details_box.append(&management_actions);
         details_box.append(&details);
         details_box.append(&credential_description);
-        details.add(&unpair_row);
         let clamp = adw::Clamp::builder()
             .maximum_size(600)
             .tightening_threshold(400)
@@ -512,17 +506,23 @@ struct PairButton {
     intent: Rc<RefCell<Option<TvsIntent>>>,
 }
 
-struct ActionButton {
+struct UnpairButton {
     button: gtk::Button,
     intent: Rc<RefCell<Option<TvsIntent>>>,
 }
 
-impl ActionButton {
+impl UnpairButton {
     fn new(on_intent: &IntentHandler) -> Self {
         let button = gtk::Button::builder()
+            .icon_name("list-remove-symbolic")
+            .width_request(36)
+            .height_request(36)
+            .valign(gtk::Align::Center)
             .visible(false)
             .sensitive(false)
             .build();
+        button.add_css_class("flat");
+        button.add_css_class("circular");
         let intent = Rc::new(RefCell::new(None));
         button.connect_clicked({
             let on_intent = Rc::clone(on_intent);
@@ -546,7 +546,6 @@ impl ActionButton {
         self.button.set_visible(action.is_some());
         self.button
             .set_sensitive(action.is_some_and(TvsAction::enabled));
-        self.button.set_label(action.map_or("", TvsAction::label));
         self.button.set_tooltip_text(action.map(TvsAction::label));
         self.button
             .update_property(&[gtk::accessible::Property::Label(

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -513,8 +513,16 @@ struct UnpairButton {
 
 impl UnpairButton {
     fn new(on_intent: &IntentHandler) -> Self {
+        static RESOURCES: std::sync::Once = std::sync::Once::new();
+        RESOURCES.call_once(|| {
+            gtk::gio::resources_register_include!("lg-buddy-gui.gresource")
+                .expect("bundled GUI resources must be valid");
+        });
+        let icon = gtk::gio::FileIcon::new(&gtk::gio::File::for_uri(
+            "resource:///io/github/staphylococcus/LGBuddy/icons/edit-delete-symbolic.svg",
+        ));
         let button = gtk::Button::builder()
-            .icon_name("list-remove-symbolic")
+            .child(&gtk::Image::from_gicon(&icon))
             .width_request(36)
             .height_request(36)
             .valign(gtk::Align::Center)
@@ -523,6 +531,7 @@ impl UnpairButton {
             .build();
         button.add_css_class("flat");
         button.add_css_class("circular");
+        button.add_css_class("destructive-action");
         let intent = Rc::new(RefCell::new(None));
         button.connect_clicked({
             let on_intent = Rc::clone(on_intent);

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -12,7 +12,7 @@ use crate::overview::{
 };
 use crate::pairing::{PairingError, PairingFailure, PairingOperation, PairingStage};
 use crate::presentation::settings::SettingsGroup;
-use crate::settings::{SettingsMutationFailure, SettingsMutationOutcome, SettingsMutationStage};
+use crate::settings::{SettingsMutationFailure, SettingsMutationOutcome};
 use crate::settings_view::{
     SettingsApplication, SettingsIntent, SettingsMutationOperation, SettingsReadError,
     SettingsReadOperation, SettingsTransition,
@@ -134,15 +134,6 @@ impl Application {
         result: Result<Vec<SettingsGroup>, SettingsReadError>,
     ) -> Option<ApplicationTransition> {
         let transition = self.settings.complete_read(operation, result)?;
-        Some(self.settings_transition(transition))
-    }
-
-    pub fn settings_mutation_progress(
-        &mut self,
-        operation: &SettingsMutationOperation,
-        stage: SettingsMutationStage,
-    ) -> Option<ApplicationTransition> {
-        let transition = self.settings.mutation_progress(operation, stage)?;
         Some(self.settings_transition(transition))
     }
 
@@ -596,7 +587,7 @@ mod settings_tests {
             .unwrap()
             .enabled());
         assert!(app.handle_tvs_intent(TvsIntent::PairTv).is_none());
-        assert!(!editable(&write));
+        assert!(editable(&write));
         let operation = write.settings().unwrap().mutation_operation().unwrap();
         let done = app
             .complete_settings_mutation(
@@ -626,9 +617,6 @@ mod settings_tests {
             close.overview().unwrap().update(),
             OverviewFrontendUpdate::Close
         ));
-        assert!(app
-            .settings_mutation_progress(operation, SettingsMutationStage::Persisted)
-            .is_none());
         assert!(app.settings_mutation_worker_stopped(operation).is_none());
         assert!(app
             .handle_settings_intent(SettingsIntent::Reset(BehaviorSetting::UpdatesChannel))

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -21,10 +21,7 @@ pub enum SettingsStatus {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SettingsEditStatus {
     Unchanged,
-    Validating,
-    Persisting,
-    Persisted,
-    Applying,
+    Saving,
     Applied,
     ValidationFailed,
     PersistenceFailed,

--- a/crates/lg-buddy/src/presentation/tvs.rs
+++ b/crates/lg-buddy/src/presentation/tvs.rs
@@ -156,26 +156,27 @@ impl TvsPresentation {
 
     pub(crate) fn set_management(
         &mut self,
-        enabled: bool,
+        input_enabled: bool,
+        actions_enabled: bool,
         confirming: bool,
         confirmation_enabled: bool,
         error: Option<super::brightness::UserFacingError>,
         retry_apply: bool,
     ) {
-        self.input_enabled = enabled;
+        self.input_enabled = input_enabled;
         if let Some(action) = &mut self.pair_action {
             action.enabled = confirmation_enabled;
         }
         self.unpair_action = self
             .selected_profile()
-            .map(|_| TvsAction::new("Unpair TV…", enabled, TvsIntent::UnpairTv));
+            .map(|_| TvsAction::new("Unpair TV…", actions_enabled, TvsIntent::UnpairTv));
         self.unpair_confirmation = confirming.then(|| UnpairConfirmation {
             confirm: TvsAction::new("Unpair", confirmation_enabled, TvsIntent::ConfirmUnpair),
             cancel: TvsAction::new("Cancel", true, TvsIntent::CancelUnpair),
         });
         self.management_error = error;
-        self.retry_apply_action =
-            retry_apply.then(|| TvsAction::new("Retry", enabled, TvsIntent::RetryInputApply));
+        self.retry_apply_action = retry_apply
+            .then(|| TvsAction::new("Retry", actions_enabled, TvsIntent::RetryInputApply));
     }
 
     pub fn title(&self) -> &str {

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -1,5 +1,6 @@
-//! Toolkit-independent coordination for the read-only Settings view.
+//! Toolkit-independent coordination for the Settings view.
 
+use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt;
 
@@ -248,8 +249,6 @@ enum SettingsApplicationState {
     Loading(SettingsReadOperation),
     Ready,
     Failed,
-    Mutating(SettingsMutationOperation),
-    Closed,
 }
 
 #[derive(Debug, Clone)]
@@ -264,7 +263,9 @@ pub struct SettingsApplication {
     next_operation_id: u64,
     presentation: SettingsPresentation,
     controls_available: bool,
+    closed: bool,
     pending_mutation: Option<PendingMutation>,
+    queued_mutations: VecDeque<PendingMutation>,
     reconcile_mutation: Option<PendingMutation>,
 }
 
@@ -278,7 +279,9 @@ impl SettingsApplication {
                 next_operation_id: 1,
                 presentation: presentation.clone(),
                 controls_available: true,
+                closed: false,
                 pending_mutation: None,
+                queued_mutations: VecDeque::new(),
                 reconcile_mutation: None,
             },
             SettingsTransition {
@@ -291,22 +294,23 @@ impl SettingsApplication {
     }
 
     pub fn handle_intent(&mut self, intent: SettingsIntent) -> Option<SettingsTransition> {
+        if self.closed {
+            return None;
+        }
         match intent {
             SettingsIntent::Retry if matches!(self.state, SettingsApplicationState::Failed) => {
                 Some(self.begin_read())
             }
             SettingsIntent::Refresh
-                if matches!(
-                    self.state,
-                    SettingsApplicationState::Ready | SettingsApplicationState::Failed
-                ) =>
+                if self.pending_mutation.is_none()
+                    && matches!(
+                        self.state,
+                        SettingsApplicationState::Ready | SettingsApplicationState::Failed
+                    ) =>
             {
                 Some(self.begin_read())
             }
-            SettingsIntent::SetEnabled { setting, enabled }
-                if self.controls_available
-                    && matches!(self.state, SettingsApplicationState::Ready) =>
-            {
+            SettingsIntent::SetEnabled { setting, enabled } if self.can_edit() => {
                 let is_toggle = self
                     .presentation
                     .row(setting)
@@ -324,22 +328,13 @@ impl SettingsApplication {
                     })
                     .flatten()
             }
-            SettingsIntent::Commit { setting, value }
-                if self.controls_available
-                    && matches!(self.state, SettingsApplicationState::Ready) =>
-            {
+            SettingsIntent::Commit { setting, value } if self.can_edit() => {
                 self.begin_mutation(setting, SettingsMutationRequest::Set(value))
             }
-            SettingsIntent::Reset(setting)
-                if self.controls_available
-                    && matches!(self.state, SettingsApplicationState::Ready) =>
-            {
+            SettingsIntent::Reset(setting) if self.can_edit() => {
                 self.begin_mutation(setting, SettingsMutationRequest::Reset)
             }
-            SettingsIntent::RetryApply(setting)
-                if self.controls_available
-                    && matches!(self.state, SettingsApplicationState::Ready) =>
-            {
+            SettingsIntent::RetryApply(setting) if self.can_edit() => {
                 let retryable = self
                     .presentation
                     .row(setting)
@@ -360,6 +355,12 @@ impl SettingsApplication {
     ) -> Option<SettingsTransition> {
         if !matches!(self.state, SettingsApplicationState::Loading(active) if active == operation) {
             return None;
+        }
+
+        if self.closed {
+            return self
+                .start_queued_mutation()
+                .map(|next| self.transition(None, Some(next), None));
         }
 
         let (presentation, diagnostic) = match result {
@@ -410,36 +411,12 @@ impl SettingsApplication {
                 )
             }
         };
-        self.presentation = presentation.clone();
-        Some(SettingsTransition {
-            presentation,
-            read_operation: None,
-            mutation_operation: None,
-            diagnostic,
-        })
-    }
-
-    pub fn mutation_progress(
-        &mut self,
-        operation: &SettingsMutationOperation,
-        stage: SettingsMutationStage,
-    ) -> Option<SettingsTransition> {
-        if !matches!(
-            &self.state,
-            SettingsApplicationState::Mutating(active) if active == operation
-        ) {
-            return None;
+        self.presentation = presentation;
+        if matches!(self.state, SettingsApplicationState::Ready) {
+            self.finish_mutation(None, diagnostic)
+        } else {
+            Some(self.transition(None, None, diagnostic))
         }
-
-        let status = match stage {
-            SettingsMutationStage::Validating => SettingsEditStatus::Validating,
-            SettingsMutationStage::Persisting => SettingsEditStatus::Persisting,
-            SettingsMutationStage::Persisted => SettingsEditStatus::Persisted,
-            SettingsMutationStage::Applying => SettingsEditStatus::Applying,
-        };
-        self.presentation
-            .set_row_state(operation.setting(), status, None, false);
-        Some(self.transition(None, None, None))
     }
 
     pub fn complete_mutation(
@@ -451,11 +428,11 @@ impl SettingsApplication {
             Some(pending) if pending.operation == *operation => pending.clone(),
             _ => return None,
         };
-        if !matches!(
-            &self.state,
-            SettingsApplicationState::Mutating(active) if active == operation
-        ) {
-            return None;
+        if self.closed {
+            self.pending_mutation = None;
+            return self
+                .start_queued_mutation()
+                .map(|next| self.transition(None, Some(next), None));
         }
         self.pending_mutation = None;
 
@@ -486,7 +463,7 @@ impl SettingsApplication {
                     ),
                 }
                 let diagnostic = outcome.apply().as_ref().err().map(ToString::to_string);
-                Some(self.transition(None, None, diagnostic))
+                self.finish_mutation(Some(operation.setting()), diagnostic)
             }
             Err(failure) => {
                 let status = match &failure {
@@ -509,7 +486,7 @@ impl SettingsApplication {
                     preserve_retry_apply,
                 );
                 self.state = SettingsApplicationState::Ready;
-                Some(self.transition(None, None, Some(failure.error().to_string())))
+                self.finish_mutation(Some(operation.setting()), Some(failure.error().to_string()))
             }
         }
     }
@@ -522,11 +499,11 @@ impl SettingsApplication {
             Some(pending) if pending.operation == *operation => pending.clone(),
             _ => return None,
         };
-        if !matches!(
-            &self.state,
-            SettingsApplicationState::Mutating(active) if active == operation
-        ) {
-            return None;
+        if self.closed {
+            self.pending_mutation = None;
+            return self
+                .start_queued_mutation()
+                .map(|next| self.transition(None, Some(next), None));
         }
 
         self.pending_mutation = None;
@@ -540,11 +517,12 @@ impl SettingsApplication {
             false,
         );
         self.reconcile_mutation = Some(pending);
+        self.presentation.set_controls_available(false);
         Some(self.begin_read())
     }
 
     pub fn is_mutating(&self) -> bool {
-        self.pending_mutation.is_some()
+        self.pending_mutation.is_some() || !self.queued_mutations.is_empty()
     }
 
     pub fn set_controls_available(&mut self, available: bool) -> Option<SettingsTransition> {
@@ -552,17 +530,23 @@ impl SettingsApplication {
             return None;
         }
         self.controls_available = available;
-        self.presentation
-            .set_controls_available(available && !self.is_mutating());
+        self.presentation.set_controls_available(available);
         Some(self.transition(None, None, None))
     }
 
     pub fn shutdown(&mut self) {
-        self.state = SettingsApplicationState::Closed;
+        self.closed = true;
     }
 
     pub fn presentation(&self) -> &SettingsPresentation {
         &self.presentation
+    }
+
+    fn can_edit(&self) -> bool {
+        self.controls_available
+            && self.reconcile_mutation.is_none()
+            && !self.presentation.groups().is_empty()
+            && !matches!(self.state, SettingsApplicationState::Failed)
     }
 
     fn begin_read(&mut self) -> SettingsTransition {
@@ -584,17 +568,59 @@ impl SettingsApplication {
         request: SettingsMutationRequest,
     ) -> Option<SettingsTransition> {
         let previous_row = self.presentation.row(setting)?.clone();
+        if matches!(self.state, SettingsApplicationState::Loading(_)) {
+            self.presentation = SettingsPresentation::ready(self.presentation.groups().to_vec());
+        }
         let operation = SettingsMutationOperation::new(self.next_operation_id, setting, request);
         self.next_operation_id += 1;
-        self.pending_mutation = Some(PendingMutation {
-            operation: operation.clone(),
+        self.queued_mutations.push_back(PendingMutation {
+            operation,
             previous_row,
         });
-        self.state = SettingsApplicationState::Mutating(operation.clone());
+        // ponytail: one FIFO keeps writes ordered without disabling the form.
+        let operation = if self.pending_mutation.is_none() {
+            self.start_queued_mutation()
+        } else {
+            None
+        };
         self.presentation
-            .set_row_state(setting, SettingsEditStatus::Validating, None, false);
-        self.presentation.set_controls_available(false);
-        Some(self.transition(None, Some(operation), None))
+            .set_row_state(setting, SettingsEditStatus::Saving, None, false);
+        Some(self.transition(None, operation, None))
+    }
+
+    fn start_queued_mutation(&mut self) -> Option<SettingsMutationOperation> {
+        let pending = self.queued_mutations.pop_front()?;
+        let operation = pending.operation.clone();
+        self.pending_mutation = Some(pending);
+        self.state = SettingsApplicationState::Ready;
+        Some(operation)
+    }
+
+    fn finish_mutation(
+        &mut self,
+        completed: Option<BehaviorSetting>,
+        diagnostic: Option<String>,
+    ) -> Option<SettingsTransition> {
+        for queued in &mut self.queued_mutations {
+            if completed.is_none_or(|setting| setting == queued.operation.setting()) {
+                queued.previous_row = self.presentation.row(queued.operation.setting())?.clone();
+            }
+        }
+        let operation = self.start_queued_mutation();
+        // A completion must not replace a newer submitted value in the editor.
+        for queued in operation.iter().chain(
+            self.queued_mutations
+                .iter()
+                .map(|pending| &pending.operation),
+        ) {
+            self.presentation.set_row_state(
+                queued.setting(),
+                SettingsEditStatus::Saving,
+                None,
+                false,
+            );
+        }
+        Some(self.transition(None, operation, diagnostic))
     }
 
     fn transition(
@@ -993,7 +1019,7 @@ screen_backend=wayland\n",
     }
 
     #[test]
-    fn mutation_suppresses_duplicates_and_worker_stop_is_recoverable() {
+    fn mutation_keeps_controls_available_and_worker_stop_is_recoverable() {
         let (mut app, opening) = SettingsApplication::open();
         app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
             .unwrap();
@@ -1007,20 +1033,17 @@ screen_backend=wayland\n",
         let operation = transition.mutation_operation().unwrap().clone();
         assert!(app.is_mutating());
         assert!(app
-            .handle_intent(SettingsIntent::Commit {
-                setting: BehaviorSetting::ScreenIdleBlank,
-                value: "enabled".to_string(),
-            })
-            .is_none());
-
-        app.mutation_progress(&operation, SettingsMutationStage::Persisting)
-            .unwrap();
+            .presentation()
+            .groups()
+            .iter()
+            .flat_map(|group| group.rows())
+            .all(|row| row.editor_enabled()));
         assert_eq!(
             app.presentation()
                 .row(BehaviorSetting::ScreenIdleBlank)
                 .unwrap()
                 .edit_status(),
-            SettingsEditStatus::Persisting
+            SettingsEditStatus::Saving
         );
 
         let stopped = app.mutation_worker_stopped(&operation).unwrap();
@@ -1045,6 +1068,156 @@ screen_backend=wayland\n",
         assert!(app
             .handle_intent(SettingsIntent::RetryApply(BehaviorSetting::ScreenIdleBlank))
             .is_some());
+    }
+
+    #[test]
+    fn rapid_edits_save_in_order_and_failures_restore_the_latest_saved_value() {
+        let path = test_path("queued-edits");
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let first = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::UpdatesChannel,
+                value: "prerelease".into(),
+            })
+            .unwrap();
+        for (setting, value) in [
+            (BehaviorSetting::SystemSleepWakePolicy, "disabled"),
+            (BehaviorSetting::UpdatesChannel, "bad"),
+        ] {
+            let queued = app
+                .handle_intent(SettingsIntent::Commit {
+                    setting,
+                    value: value.into(),
+                })
+                .unwrap();
+            assert!(
+                queued.mutation_operation().is_none(),
+                "only one write runs at a time"
+            );
+            assert!(rows(queued.presentation().groups())
+                .iter()
+                .all(|row| row.editor_enabled()));
+        }
+        let mut operation = first.mutation_operation().unwrap().clone();
+        // Neither of these settings invokes a system service.
+        let applier = SettingsApplier::from_env();
+        for (index, expected) in [
+            BehaviorSetting::UpdatesChannel,
+            BehaviorSetting::SystemSleepWakePolicy,
+            BehaviorSetting::UpdatesChannel,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            assert_eq!(operation.setting(), expected);
+            let SettingsMutationRequest::Set(value) = operation.request() else {
+                unreachable!()
+            };
+            let result = SettingsMutation::set(
+                &SettingsStore::load(&path).unwrap(),
+                operation.key_name(),
+                value,
+            )
+            .map_err(SettingsMutationFailure::Validation)
+            .and_then(|mutation| execute_settings_mutation(&path, mutation, &applier, &mut |_| {}));
+            let done = app.complete_mutation(&operation, result).unwrap();
+            assert!(app
+                .complete_mutation(
+                    &operation,
+                    Err(SettingsMutationFailure::Persistence(SettingsError::Apply {
+                        message: "stale".into()
+                    }))
+                )
+                .is_none());
+            let channel = done
+                .presentation()
+                .row(BehaviorSetting::UpdatesChannel)
+                .unwrap();
+            assert_eq!(channel.value_label(), "Prerelease");
+            if index < 2 {
+                assert_eq!(
+                    channel.edit_status(),
+                    SettingsEditStatus::Saving,
+                    "an older result must not replace the queued draft"
+                );
+                operation = done.mutation_operation().unwrap().clone();
+            } else {
+                assert!(done.mutation_operation().is_none());
+                assert_eq!(channel.edit_status(), SettingsEditStatus::ValidationFailed);
+                assert!(channel.feedback().is_some());
+            }
+        }
+        assert!(!app.is_mutating());
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert!(saved.contains("system_sleep_wake_policy=disabled"));
+        assert!(saved.contains("updates_channel=prerelease"));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn queued_edits_resume_after_a_stopped_worker_is_reconciled() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let first = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::ScreenIdleTimeout,
+                value: "600".into(),
+            })
+            .unwrap();
+        app.handle_intent(SettingsIntent::Commit {
+            setting: BehaviorSetting::UpdatesChannel,
+            value: "prerelease".into(),
+        })
+        .unwrap();
+        let stopped = app
+            .mutation_worker_stopped(first.mutation_operation().unwrap())
+            .unwrap();
+        assert!(
+            app.is_mutating(),
+            "queued writes still exclude TV configuration changes"
+        );
+        let ready = app
+            .complete_read(
+                stopped.read_operation().unwrap(),
+                Ok(groups("screen_idle_timeout=600\n")),
+            )
+            .unwrap();
+        assert_eq!(
+            ready.mutation_operation().unwrap().setting(),
+            BehaviorSetting::UpdatesChannel
+        );
+        assert!(ready
+            .presentation()
+            .row(BehaviorSetting::ScreenIdleTimeout)
+            .unwrap()
+            .retry_apply_action()
+            .is_some());
+    }
+
+    #[test]
+    fn closing_drains_already_accepted_edits_without_accepting_new_ones() {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let intent = SettingsIntent::Commit {
+            setting: BehaviorSetting::UpdatesChannel,
+            value: "prerelease".into(),
+        };
+        let first = app.handle_intent(intent.clone()).unwrap();
+        app.handle_intent(intent.clone()).unwrap();
+        app.shutdown();
+        assert!(app.handle_intent(intent).is_none());
+        let second = app
+            .mutation_worker_stopped(first.mutation_operation().unwrap())
+            .unwrap();
+        assert!(second.read_operation().is_none());
+        assert!(app
+            .mutation_worker_stopped(second.mutation_operation().unwrap())
+            .is_none());
+        assert!(!app.is_mutating());
     }
 
     #[test]

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -431,29 +431,14 @@ impl SettingsApplication {
             return None;
         }
 
-        let (status, message) = match stage {
-            SettingsMutationStage::Validating => {
-                (SettingsEditStatus::Validating, "Checking this value…")
-            }
-            SettingsMutationStage::Persisting => {
-                (SettingsEditStatus::Persisting, "Saving this setting…")
-            }
-            SettingsMutationStage::Persisted => {
-                (SettingsEditStatus::Persisted, "Setting saved; applying it…")
-            }
-            SettingsMutationStage::Applying => {
-                (SettingsEditStatus::Applying, "Applying this setting…")
-            }
+        let status = match stage {
+            SettingsMutationStage::Validating => SettingsEditStatus::Validating,
+            SettingsMutationStage::Persisting => SettingsEditStatus::Persisting,
+            SettingsMutationStage::Persisted => SettingsEditStatus::Persisted,
+            SettingsMutationStage::Applying => SettingsEditStatus::Applying,
         };
-        self.presentation.set_row_state(
-            operation.setting(),
-            status,
-            Some(SettingsFeedback::new(
-                SettingsFeedbackSeverity::Info,
-                message,
-            )),
-            false,
-        );
+        self.presentation
+            .set_row_state(operation.setting(), status, None, false);
         Some(self.transition(None, None, None))
     }
 
@@ -484,15 +469,12 @@ impl SettingsApplication {
                     .set_controls_available(self.controls_available);
                 self.state = SettingsApplicationState::Ready;
                 match outcome.apply() {
-                    Ok(apply_outcome) => {
-                        let (severity, message) = apply_feedback(apply_outcome);
-                        self.presentation.set_row_state(
-                            operation.setting(),
-                            SettingsEditStatus::Applied,
-                            Some(SettingsFeedback::new(severity, message)),
-                            false,
-                        )
-                    }
+                    Ok(apply_outcome) => self.presentation.set_row_state(
+                        operation.setting(),
+                        SettingsEditStatus::Applied,
+                        apply_feedback(apply_outcome),
+                        false,
+                    ),
                     Err(_error) => self.presentation.set_row_state(
                         operation.setting(),
                         SettingsEditStatus::ApplyFailed,
@@ -609,15 +591,8 @@ impl SettingsApplication {
             previous_row,
         });
         self.state = SettingsApplicationState::Mutating(operation.clone());
-        self.presentation.set_row_state(
-            setting,
-            SettingsEditStatus::Validating,
-            Some(SettingsFeedback::new(
-                SettingsFeedbackSeverity::Info,
-                "Checking this value…",
-            )),
-            false,
-        );
+        self.presentation
+            .set_row_state(setting, SettingsEditStatus::Validating, None, false);
         self.presentation.set_controls_available(false);
         Some(self.transition(None, Some(operation), None))
     }
@@ -651,41 +626,29 @@ fn mutation_failure_message(failure: &SettingsMutationFailure) -> String {
     }
 }
 
-fn apply_feedback(outcome: &SettingsApplyOutcome) -> (SettingsFeedbackSeverity, String) {
-    match outcome {
-        SettingsApplyOutcome::NotInstalled { service } => (
-            SettingsFeedbackSeverity::Warning,
-            format!(
-                "Saved; {} is not installed yet.",
-                apply_target_label(service)
-            ),
+fn apply_feedback(outcome: &SettingsApplyOutcome) -> Option<SettingsFeedback> {
+    let message = match outcome {
+        SettingsApplyOutcome::NotInstalled { service } => format!(
+            "Saved; {} is not installed yet.",
+            apply_target_label(service)
         ),
-        SettingsApplyOutcome::InactiveDisabled { service } => (
-            SettingsFeedbackSeverity::Warning,
-            format!(
-                "Saved; {} is inactive and disabled. It will apply when started.",
-                apply_target_label(service)
-            ),
+        SettingsApplyOutcome::InactiveDisabled { service } => format!(
+            "Saved; {} is inactive and disabled. It will apply when started.",
+            apply_target_label(service)
         ),
-        SettingsApplyOutcome::Skipped { .. } => (
-            SettingsFeedbackSeverity::Warning,
-            "Saved; runtime apply was skipped by configuration.".to_string(),
-        ),
-        SettingsApplyOutcome::NoActionRequired => (
-            SettingsFeedbackSeverity::Info,
-            "Saved; no runtime action was required.".to_string(),
-        ),
-        SettingsApplyOutcome::Enabled { .. } => (
-            SettingsFeedbackSeverity::Info,
-            "Saved; scheduled for the next graphical session.".to_string(),
-        ),
-        SettingsApplyOutcome::Restarted { .. }
+        SettingsApplyOutcome::Skipped { .. } => {
+            "Saved; runtime apply was skipped by configuration.".to_string()
+        }
+        SettingsApplyOutcome::NoActionRequired
+        | SettingsApplyOutcome::Enabled { .. }
+        | SettingsApplyOutcome::Restarted { .. }
         | SettingsApplyOutcome::EnabledStarted { .. }
-        | SettingsApplyOutcome::DisabledStopped { .. } => (
-            SettingsFeedbackSeverity::Info,
-            "Saved and applied".to_string(),
-        ),
-    }
+        | SettingsApplyOutcome::DisabledStopped { .. } => return None,
+    };
+    Some(SettingsFeedback::new(
+        SettingsFeedbackSeverity::Warning,
+        message,
+    ))
 }
 
 fn apply_target_label(service: &str) -> &'static str {
@@ -1242,26 +1205,54 @@ screen_backend=wayland\n",
 
     #[test]
     fn apply_outcomes_do_not_claim_runtime_application_when_deferred() {
-        let (severity, message) = apply_feedback(&SettingsApplyOutcome::NotInstalled {
-            service: "lg-buddy-screen.service",
-        });
-        assert_eq!(severity, SettingsFeedbackSeverity::Warning);
-        assert!(message.contains("Saved;"));
-        assert!(message.contains("not installed"));
-        assert!(message.contains("screen integration"));
-        assert!(!message.contains("LG_Buddy"));
-        assert!(!message.contains("Saved and applied"));
+        for (outcome, detail) in [
+            (
+                SettingsApplyOutcome::NotInstalled {
+                    service: "lg-buddy-screen.service",
+                },
+                "not installed",
+            ),
+            (
+                SettingsApplyOutcome::InactiveDisabled {
+                    service: "lg-buddy-screen.service",
+                },
+                "inactive and disabled",
+            ),
+            (
+                SettingsApplyOutcome::Skipped {
+                    reason: "test".into(),
+                },
+                "skipped",
+            ),
+        ] {
+            let feedback = apply_feedback(&outcome).expect("incomplete apply needs feedback");
+            assert_eq!(feedback.severity(), SettingsFeedbackSeverity::Warning);
+            assert!(feedback.message().contains(detail));
+        }
+    }
 
-        let (severity, message) = apply_feedback(&SettingsApplyOutcome::NoActionRequired);
-        assert_eq!(severity, SettingsFeedbackSeverity::Info);
-        assert!(message.contains("no runtime action"));
-        assert!(!message.contains("Saved and applied"));
-
-        let (_, message) = apply_feedback(&SettingsApplyOutcome::Enabled {
-            unit: "LG_Buddy_update_check.timer",
-        });
-        assert!(message.contains("next graphical session"));
-        assert!(!message.contains("Saved and applied"));
+    #[test]
+    fn successful_apply_outcomes_are_silent() {
+        for outcome in [
+            SettingsApplyOutcome::NoActionRequired,
+            SettingsApplyOutcome::Enabled {
+                unit: "LG_Buddy_update_check.timer",
+            },
+            SettingsApplyOutcome::Restarted {
+                service: "LG_Buddy_screen.service",
+            },
+            SettingsApplyOutcome::EnabledStarted {
+                unit: "LG_Buddy_update_check.timer",
+            },
+            SettingsApplyOutcome::DisabledStopped {
+                unit: "LG_Buddy_update_check.timer",
+            },
+        ] {
+            assert!(
+                apply_feedback(&outcome).is_none(),
+                "unexpected feedback for {outcome:?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/lg-buddy/src/tvs.rs
+++ b/crates/lg-buddy/src/tvs.rs
@@ -451,12 +451,14 @@ pub struct TvsApplication {
     state: TvsState,
     next_operation_id: u64,
     pending_model: Option<TvsModelReadOperation>,
+    pending_input: Option<HdmiInput>,
     pairing: Option<PairingApplication>,
     management: Option<TvsManagementOperation>,
     confirming_unpair: bool,
     controls_available: bool,
     management_error: Option<UserFacingError>,
     input_apply_failed: bool,
+    closed: bool,
 }
 
 impl TvsApplication {
@@ -466,26 +468,47 @@ impl TvsApplication {
             state: TvsState::Loading(operation),
             next_operation_id: 1,
             pending_model: None,
+            pending_input: None,
             pairing: None,
             management: None,
             confirming_unpair: false,
             controls_available: true,
             management_error: None,
             input_apply_failed: false,
+            closed: false,
         };
         let transition = application.transition(Some(operation), None);
         (application, transition)
     }
 
     pub fn handle_intent(&mut self, intent: TvsIntent) -> Option<TvsTransition> {
+        if self.closed {
+            return None;
+        }
         match intent {
             TvsIntent::SetInput(input) => {
-                if !self.can_manage() || self.confirming_unpair {
+                if !self.can_set_input() || self.confirming_unpair {
                     return None;
                 }
                 let profile = self.selected_profile()?;
-                if profile.input() == input {
+                let current_input = self
+                    .pending_input
+                    .or_else(|| {
+                        self.management
+                            .as_ref()
+                            .and_then(|operation| match operation.action {
+                                TvsManagementAction::SetInput(input) => Some(input),
+                                _ => None,
+                            })
+                    })
+                    .unwrap_or(profile.input());
+                if current_input == input {
                     return None;
+                }
+                if self.management.is_some() {
+                    self.pending_input = Some(input);
+                    self.management_error = None;
+                    return Some(self.transition(None, None));
                 }
                 self.start_management(TvsManagementAction::SetInput(input))
             }
@@ -579,6 +602,9 @@ impl TvsApplication {
         operation: TvsReadOperation,
         result: Result<Vec<TvProfile>, TvsReadError>,
     ) -> Option<TvsTransition> {
+        if self.closed {
+            return None;
+        }
         if !matches!(self.state, TvsState::Loading(active) if active == operation) {
             return None;
         }
@@ -610,6 +636,9 @@ impl TvsApplication {
         operation: TvsModelReadOperation,
         result: Result<String, TvsReadError>,
     ) -> Option<TvsTransition> {
+        if self.closed {
+            return None;
+        }
         if self.pending_model.as_ref() != Some(&operation) {
             return None;
         }
@@ -636,10 +665,12 @@ impl TvsApplication {
             pairing.shutdown();
         }
         self.pairing = None;
-        self.management = None;
         self.confirming_unpair = false;
-        self.state = TvsState::Closed;
         self.pending_model = None;
+        self.closed = true;
+        if self.management.is_none() {
+            self.state = TvsState::Closed;
+        }
     }
 
     pub fn pairing_progress(
@@ -647,6 +678,9 @@ impl TvsApplication {
         operation: &PairingOperation,
         stage: PairingStage,
     ) -> Option<TvsTransition> {
+        if self.closed {
+            return None;
+        }
         self.pairing
             .as_mut()?
             .progress(operation, stage)
@@ -658,6 +692,9 @@ impl TvsApplication {
         operation: &PairingOperation,
         result: Result<TvProfile, PairingError>,
     ) -> Option<TvsTransition> {
+        if self.closed {
+            return None;
+        }
         if !self.pairing.as_mut()?.complete(operation, &result) {
             return None;
         }
@@ -703,10 +740,21 @@ impl TvsApplication {
     }
 
     fn can_manage(&self) -> bool {
-        self.controls_available
+        !self.closed
+            && self.controls_available
             && self.management.is_none()
             && self.pairing.is_none()
             && self.selected_profile().is_some()
+    }
+
+    fn can_set_input(&self) -> bool {
+        !self.closed
+            && self.controls_available
+            && self.pairing.is_none()
+            && self.selected_profile().is_some()
+            && self.management.as_ref().is_none_or(|operation| {
+                matches!(operation.action, TvsManagementAction::SetInput(_))
+            })
     }
 
     pub fn is_managing(&self) -> bool {
@@ -745,6 +793,7 @@ impl TvsApplication {
             return None;
         }
         self.management = None;
+        let pending_input = self.pending_input.take();
         let toast = match result {
             Ok(TvsManagementOutcome::Unpaired) => {
                 self.state = TvsState::Empty;
@@ -776,8 +825,13 @@ impl TvsApplication {
                 None
             }
         };
+        if let Some(input) = pending_input {
+            let mut transition = self.start_management(TvsManagementAction::SetInput(input))?;
+            transition.profile_changed = !self.closed;
+            return Some(transition);
+        }
         let mut transition = self.transition(None, None);
-        transition.profile_changed = true;
+        transition.profile_changed = !self.closed;
         transition.toast_message = toast;
         Some(transition)
     }
@@ -835,13 +889,22 @@ impl TvsApplication {
             TvsState::Failed(error) => TvsPresentation::failed(error.clone()),
             TvsState::Closed => TvsPresentation::loading(),
         };
-        if let Some(operation) = &self.management {
-            if let TvsManagementAction::SetInput(input) = operation.action {
-                presentation.set_input(input);
-            }
+        let pending_input = self.pending_input.or_else(|| {
+            self.management
+                .as_ref()
+                .and_then(|operation| match operation.action {
+                    TvsManagementAction::SetInput(input) => Some(input),
+                    _ => None,
+                })
+        });
+        if let Some(input) = pending_input {
+            presentation.set_input(input);
         }
+        let input_enabled = self.can_set_input() && !self.confirming_unpair;
+        let actions_enabled = self.can_manage() && !self.confirming_unpair;
         presentation.set_management(
-            self.can_manage() && !self.confirming_unpair,
+            input_enabled,
+            actions_enabled,
             self.confirming_unpair,
             self.controls_available,
             self.management_error.clone(),
@@ -1405,16 +1468,44 @@ mod management_tests {
             started.presentation().selected_profile().unwrap().input(),
             HdmiInput::Hdmi3
         );
-        assert!(!started.presentation().input_enabled());
-        assert!(app
+        assert!(started.presentation().input_enabled());
+        let queued = app
             .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi4))
-            .is_none());
+            .expect("a later input choice is queued");
+        assert_eq!(
+            queued.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi4
+        );
+        assert!(queued.presentation().input_enabled());
+        let queued = app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi2))
+            .expect("the latest input choice replaces the queued one");
+        assert_eq!(
+            queued.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi2
+        );
         assert!(app.handle_intent(TvsIntent::UnpairTv).is_none());
         let failed = app
             .complete_management(
                 started.management_operation().unwrap(),
                 Err(TvsManagementError::stopped()),
             )
+            .unwrap();
+        assert_eq!(
+            failed.presentation().selected_profile().unwrap().input(),
+            HdmiInput::Hdmi2
+        );
+        assert!(failed.presentation().input_enabled());
+        let queued_operation = failed
+            .management_operation()
+            .expect("the queued input must start after the first result");
+        assert_eq!(
+            queued_operation.action(),
+            TvsManagementAction::SetInput(HdmiInput::Hdmi2)
+        );
+        assert_eq!(queued_operation.profile().input(), HdmiInput::Hdmi1);
+        let failed = app
+            .complete_management(queued_operation, Err(TvsManagementError::stopped()))
             .unwrap();
         assert_eq!(
             failed.presentation().selected_profile().unwrap().input(),
@@ -1452,6 +1543,48 @@ mod management_tests {
                 retry.management_operation().unwrap(),
                 Err(TvsManagementError::stopped())
             )
+            .is_some());
+        assert!(app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi4))
+            .is_none());
+    }
+
+    #[test]
+    fn shutdown_drains_a_queued_input_change() {
+        let (mut app, ready) = configured();
+        let started = app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi3))
+            .unwrap();
+        app.handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi4))
+            .expect("queued input");
+        app.handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi2))
+            .expect("latest queued input");
+        app.shutdown();
+
+        let queued = app
+            .complete_management(
+                started.management_operation().unwrap(),
+                Err(TvsManagementError::stopped()),
+            )
+            .expect("the active write completes after close");
+        let queued_operation = queued
+            .management_operation()
+            .expect("the queued write starts after close");
+        assert!(!queued.profile_changed());
+        assert_eq!(
+            queued_operation.action(),
+            TvsManagementAction::SetInput(HdmiInput::Hdmi2)
+        );
+        let completed = app
+            .complete_management(queued_operation, Err(TvsManagementError::stopped()))
+            .expect("the queued write completes after close");
+        assert_eq!(
+            completed.presentation().profiles(),
+            ready.presentation().profiles()
+        );
+        assert!(!completed.profile_changed());
+        assert!(app
+            .handle_intent(TvsIntent::SetInput(HdmiInput::Hdmi2))
             .is_none());
     }
 }

--- a/crates/lg-buddy/tests/settings_operations.rs
+++ b/crates/lg-buddy/tests/settings_operations.rs
@@ -57,12 +57,8 @@ fn run_mutation(
         .mutation_operation()
         .expect("mutation operation")
         .clone();
-    let mut progress = |stage| {
-        app.mutation_progress(&operation, stage)
-            .expect("mutation progress belongs to active operation");
-    };
     let outcome = backend
-        .write_setting(operation.clone(), &mut progress)
+        .write_setting(operation.clone(), &mut |_| {})
         .expect("settings mutation succeeds");
     app.complete_mutation(
         &operation,
@@ -240,12 +236,8 @@ fn invalid_edit_preserves_config_bytes_and_effective_value() {
         .mutation_operation()
         .expect("mutation operation")
         .clone();
-    let mut progress = |stage| {
-        app.mutation_progress(&operation, stage)
-            .expect("validation progress belongs to active operation");
-    };
     let failure = backend
-        .write_setting(operation.clone(), &mut progress)
+        .write_setting(operation.clone(), &mut |_| {})
         .expect_err("invalid value is rejected before persistence");
     let transition = app
         .complete_mutation(&operation, Err::<SettingsMutationOutcome, _>(failure))
@@ -340,12 +332,8 @@ exit 23
         .mutation_operation()
         .expect("retry mutation operation")
         .clone();
-    let mut progress = |stage| {
-        app.mutation_progress(&retry_operation, stage)
-            .expect("retry progress belongs to active operation");
-    };
     let retry_outcome = backend
-        .write_setting(retry_operation.clone(), &mut progress)
+        .write_setting(retry_operation.clone(), &mut |_| {})
         .expect("retry application returns an outcome");
     assert!(!retry_outcome.change().file_changed());
     app.complete_mutation(

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,6 +14,7 @@ Compiling and testing the GTK frontend additionally requires:
 - GTK 4.10 or newer development files
 - libadwaita 1.5 or newer development files
 - `pkg-config`
+- `glib-compile-resources` (provided by the GLib development tools)
 - a graphical session or virtual display for renderer tests
 - `xdotool` for native pointer tests and the executable launch smoke test
 - AT-SPI 2 and its Python bindings (`python3-pyatspi` on Debian/Fedora,

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -662,9 +662,11 @@ workflow.
 
 GTK maps the presentation to a native `AdwPreferencesPage`, preference groups,
 direct `AdwSwitchRow`, `AdwComboRow`, and `AdwActionRow` editors. It renders
-values through those native controls, plus progress, feedback, and retry
-actions only when needed; it does not parse configuration, call the settings
-CLI, or implement validation or service policy. A shared typed settings
+values through those native controls, plus error/warning feedback and retry
+actions when needed. Mutation stages still drive control availability, but
+the application emits no routine progress or success messages, keeping the
+layout stable during ordinary edits. GTK does not parse configuration, call
+the settings CLI, or implement validation or service policy. A shared typed settings
 executor is used by both CLI and GUI to validate, persist, and apply mutations.
 A validation or persistence failure restores the previous row value. A
 successful save followed by an apply failure keeps the saved value, shows a

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -651,29 +651,32 @@ cannot overwrite each other's configuration snapshots.
 
 The application builds three groups—Screen, Sleep & Wake, and Updates—from
 seven behavior settings. Descriptions, defaults, accepted values, and
-effective-value sources come from the existing registry and store. Invalid
-values remain invalid rather than silently defaulting. The rows
-declare native editors and commit policy: toggles and bounded choices use
+effective-value sources come from the existing registry and store. GTK shows
+the registry descriptions and typed feedback; application code owns metadata
+validation and feedback decisions. Invalid values remain invalid rather than
+silently defaulting. The rows declare native editors and commit policy:
+toggles and bounded choices use
 `OnChange`, while the numeric idle timeout uses `OnFinalize` (Enter or focus
-loss). **Reset** is an immediate semantic intent; the view has no Save or
-Cancel workflow.
+loss). The view has no detail accordion, reset action, Save button, or Cancel
+workflow.
 
 GTK maps the presentation to a native `AdwPreferencesPage`, preference groups,
-expandable rows, and the declared editors. It renders values, progress,
-feedback, and retry actions; it does not parse configuration, call the settings
-CLI, or implement validation or service policy. A shared typed settings executor
-is used by both CLI and GUI to validate, persist, and apply mutations. A
-validation or persistence failure restores the previous row value. A successful
-save followed by an apply failure keeps the saved value, shows a warning, and
-offers **Retry apply**. Missing or inactive user units are reported precisely;
-the workflow does not attempt privileged repair.
+direct `AdwSwitchRow`, `AdwComboRow`, and `AdwActionRow` editors. It renders
+values through those native controls, plus progress, feedback, and retry
+actions only when needed; it does not parse configuration, call the settings
+CLI, or implement validation or service policy. A shared typed settings
+executor is used by both CLI and GUI to validate, persist, and apply mutations.
+A validation or persistence failure restores the previous row value. A
+successful save followed by an apply failure keeps the saved value, shows a
+warning, and offers **Retry apply**. Missing or inactive user units are
+reported precisely; the workflow does not attempt privileged repair.
 
 Headless tests cover registry/store presentation and the shared mutation
 executor, including validation, persistence, apply failure, and retry. Renderer
-tests cover native editors, commit timing, reset, feedback, and narrow layout.
-The installed AT-SPI smoke verifies the third tab, keyboard access to details
-and editors, externally changed configuration, and preservation of the settings
-file.
+tests cover native editors, commit timing, choice-menu interaction, feedback,
+and narrow layout. The installed AT-SPI smoke verifies the third tab, direct
+keyboard access to editors, numeric draft and Enter validation, externally
+changed configuration, and preservation of the settings file.
 
 ## Evolution Rules
 

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -663,9 +663,10 @@ workflow.
 GTK maps the presentation to a native `AdwPreferencesPage`, preference groups,
 direct `AdwSwitchRow`, `AdwComboRow`, and `AdwActionRow` editors. It renders
 values through those native controls, plus error/warning feedback and retry
-actions when needed. Mutation stages still drive control availability, but
-the application emits no routine progress or success messages, keeping the
-layout stable during ordinary edits. GTK does not parse configuration, call
+actions when needed. Controls remain enabled during ordinary edits; the
+application queues accepted changes and saves them in order, including when
+the window closes. GTK receives completion and error results, without rendering
+intermediate mutation stages or moving focus. Unchanged rows are left alone. GTK does not parse configuration, call
 the settings CLI, or implement validation or service policy. A shared typed settings
 executor is used by both CLI and GUI to validate, persist, and apply mutations.
 A validation or persistence failure restores the previous row value. A

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -38,9 +38,10 @@ selection saves immediately and changes which input LG Buddy manages; it does
 not switch the TV’s current source. If saving fails, the previous selection is
 restored.
 
-To remove the connection or recover from pairing problems, choose **Unpair
-TV…** and confirm. This removes the saved TV profile and its local native
-credential, while keeping other settings. It does not revoke authorization on
+To remove the connection or recover from pairing problems, click the **Unpair
+TV…** icon beside the TV model name and confirm. This removes the saved TV
+profile and its local native credential, while keeping other settings. It does
+not revoke authorization on
 the TV or remove compatibility credential storage. Cancelling the confirmation
 keeps the connection. Once unpaired, use **Pair a TV** to reconnect through
 native webOS. Cancelling or failing this new pairing leaves no TV configured.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -69,8 +69,9 @@ Each setting shows a description and its current value:
   attention, with **Retry apply** offered when runtime application fails.
 
 Each change is validated, saved, and applied automatically, without a separate
-**Save** or **Cancel** button. The row reports progress while this runs. Settings
-and TV changes wait for one another to finish. A validation or persistence failure
+**Save** or **Cancel** button. Successful changes need no notification and keep
+the layout stable. Controls are briefly disabled while Settings and TV changes
+wait for one another to finish. A validation or persistence failure
 restores the previous value and explains the error. If saving succeeds but
 runtime application fails, the saved value remains, a warning is shown, and
 **Retry apply** repeats only the runtime step.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -58,13 +58,14 @@ availability; it can load and edit configuration even when no TV is paired.
 Settings reloads when you enter the tab. Invalid saved values remain visible as
 invalid and are not silently replaced with defaults.
 
-Expand a row to reveal its native editor, source, default, and accepted values:
+Each setting shows a description and its current value:
 
 - toggles for idle blanking, TV sleep & wake, and automatic update checks, plus
   bounded choices for the desktop backend, restore policy, and update channel,
-  commit on change;
+  apply on change. Click a choice row to open its available values;
 - the numeric idle timeout commits when you press Enter or leave the field;
-- **Reset** removes the explicit value and applies the default immediately.
+- errors and runtime-application warnings appear only when an operation needs
+  attention, with **Retry apply** offered when runtime application fails.
 
 Each change is validated, saved, and applied automatically, without a separate
 **Save** or **Cancel** button. The row reports progress while this runs. Settings

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -70,8 +70,8 @@ Each setting shows a description and its current value:
 
 Each change is validated, saved, and applied automatically, without a separate
 **Save** or **Cancel** button. Successful changes need no notification and keep
-the layout stable. Controls are briefly disabled while Settings and TV changes
-wait for one another to finish. A validation or persistence failure
+the layout stable. Settings stay responsive while changes are saved in order.
+TV management waits until those changes finish. A validation or persistence failure
 restores the previous value and explains the error. If saving succeeds but
 runtime application fails, the saved value remains, a warning is shown, and
 **Retry apply** repeats only the runtime step.

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -15,7 +15,7 @@ WINDOW_TITLE = "LG Buddy"
 CONTROL_NAME = "OLED Pixel Brightness"
 VOLUME_NAME = "TV Volume"
 DEFAULT_TIMEOUT_SECONDS = 10
-# Expanded Settings rows expose their detail widgets as well as the navigation.
+# Settings uses direct native rows; keep traversal bounded while the UI updates.
 MAX_ACCESSIBLES = 1024
 
 
@@ -101,7 +101,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--select-page", choices=("Overview", "TVs", "Settings"))
     parser.add_argument("--expected-settings-state", choices=("ready", "invalid"))
     parser.add_argument("--expected-settings-timeout")
-    parser.add_argument("--require-settings-details", action="store_true")
     parser.add_argument("--edit-settings-timeout", help="type a timeout draft through native keyboard input")
     parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid", "unpair"))
     parser.add_argument("--expected-tv-address")
@@ -221,6 +220,14 @@ def tvs_contract(expected_state: str, address: str | None, tv_name: str):
     return accessibles, None
 
 
+def text_value(accessible: object) -> str:
+    try:
+        text = accessible.queryText()
+        return str(text.getText(0, text.characterCount))
+    except Exception:
+        return ""
+
+
 def settings_contract(args: argparse.Namespace):
     accessibles = accessible_tree()
     names = {name(item) for item in accessibles}
@@ -228,17 +235,32 @@ def settings_contract(args: argparse.Namespace):
             "Idle timeout", "Restore policy", "TV sleep & wake", "Automatic update checks",
             "Update channel"} <= names:
         return None
-    if args.expected_settings_timeout and args.expected_settings_timeout not in names:
-        return None
-    if args.expected_settings_state == "invalid" and not any(value.startswith("Invalid value") for value in names):
-        return None
-    if args.expected_settings_state == "ready" and any(value.startswith("Invalid value") for value in names):
-        return None
-    if args.require_settings_details:
-        visible = {name(item) for item in accessibles
-                   if item.getState().contains(pyatspi.STATE_SHOWING)}
-        if not {"Source", "Default", "Accepted values"} <= visible:
+    if args.expected_settings_timeout:
+        timeout_entry = next(
+            (
+                item
+                for item in accessibles
+                if name(item) == "Idle timeout" and role(item) == pyatspi.ROLE_TEXT
+            ),
+            None,
+        )
+        if timeout_entry is None or text_value(timeout_entry) != args.expected_settings_timeout:
             return None
+    visible_names = set()
+    for item in accessibles:
+        try:
+            if item.getState().contains(pyatspi.STATE_SHOWING):
+                visible_names.add(name(item))
+        except Exception:
+            continue
+    invalid_values = any(
+        value.startswith("Invalid value") or value.startswith("Invalid configured value")
+        for value in visible_names
+    )
+    if args.expected_settings_state == "invalid" and not invalid_values:
+        return None
+    if args.expected_settings_state == "ready" and invalid_values:
+        return None
     return accessibles, None
 
 
@@ -266,18 +288,9 @@ def main() -> int:
                       and role(item) == pyatspi.ROLE_TEXT
                       and item.getState().contains(pyatspi.STATE_SHOWING)), None)
         if entry is None:
-            for _ in range(40):
-                if any(name(item) == "Idle timeout" and role(item) != pyatspi.ROLE_TEXT
-                       and item.getState().contains(pyatspi.STATE_FOCUSED)
-                       for item in accessible_tree()):
-                    subprocess.run(["xdotool", "key", "--window", args.window_id, "space"], check=True)
-                    break
-                subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
-                time.sleep(0.05)
-            else:
-                raise SystemExit("could not focus Idle timeout through Tab navigation")
             deadline = time.monotonic() + args.timeout
             while entry is None and time.monotonic() < deadline:
+                subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
                 entry = next((item for item in accessible_tree() if name(item) == "Idle timeout"
                               and role(item) == pyatspi.ROLE_TEXT
                               and item.getState().contains(pyatspi.STATE_SHOWING)), None)

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -245,32 +245,27 @@ cp "$CONFIG_FILE" "$WORK_DIR/before-settings.env"
 printf '%s\n' 'screen_idle_timeout=600' 'updates_channel=not-a-channel' >> "$CONFIG_FILE"
 cp "$CONFIG_FILE" "$WORK_DIR/settings-snapshot.env"
 observe_gui_state --select-page Settings
-observe_gui_state --expected-settings-state invalid --expected-settings-timeout '600 seconds'
+observe_gui_state --expected-settings-state invalid --expected-settings-timeout 600
 xdotool windowsize --sync "$WINDOW_ID" 700 780
 observe_gui_state --focus-control "Desktop integration" --window-id "$WINDOW_ID"
-xdotool key --window "$WINDOW_ID" space
-observe_gui_state --expected-settings-state invalid --require-settings-details
+observe_gui_state --expected-settings-state invalid --expected-settings-timeout 600
 cmp "$CONFIG_FILE" "$WORK_DIR/settings-snapshot.env" || fail "Inspecting Settings changed configuration."
 # Returning to Settings reloads changes made outside the GUI.
 observe_gui_state --select-page TVs
 printf '%s\n' 'screen_idle_timeout=120' 'updates_channel=stable' >> "$CONFIG_FILE"
 observe_gui_state --select-page Settings
-observe_gui_state --expected-settings-state ready --expected-settings-timeout '120 seconds'
-# A timeout draft is not saved until Enter; Reset removes the override immediately.
+observe_gui_state --expected-settings-state ready --expected-settings-timeout 120
+# The timeout draft remains local until Enter.
 cp "$CONFIG_FILE" "$WORK_DIR/before-settings-edit.env"
 observe_gui_state --edit-settings-timeout 720 --window-id "$WINDOW_ID"
 cmp "$CONFIG_FILE" "$WORK_DIR/before-settings-edit.env" || fail "Typing a timeout saved before finalization."
 xdotool key --window "$WINDOW_ID" Return
-observe_gui_state --expected-settings-state ready --expected-settings-timeout '720 seconds'
+observe_gui_state --expected-settings-state ready --expected-settings-timeout 720
 [ "$("$RUNTIME_BINARY" settings get screen.idle_timeout)" = "720" ] || fail "Finalized timeout was not saved."
 observe_gui_state --edit-settings-timeout invalid --window-id "$WINDOW_ID"
 xdotool key --window "$WINDOW_ID" Return
-observe_gui_state --expected-settings-state ready --expected-settings-timeout '720 seconds'
+observe_gui_state --expected-settings-state ready --expected-settings-timeout 720
 [ "$("$RUNTIME_BINARY" settings get screen.idle_timeout)" = "720" ] || fail "Invalid timeout changed configuration."
-observe_gui_state --focus-control "Reset Idle timeout" --window-id "$WINDOW_ID"
-observe_gui_state --activate-control "Reset Idle timeout"
-observe_gui_state --expected-settings-state ready --expected-settings-timeout '300 seconds'
-[ "$("$RUNTIME_BINARY" settings get screen.idle_timeout)" = "300" ] || fail "Reset did not restore the default timeout."
 cp "$WORK_DIR/before-settings.env" "$CONFIG_FILE"
 observe_gui_state --select-page Overview
 observe_gui_state --expected-slider-value 55 --expected-volume 21 --expected-muted true


### PR DESCRIPTION
## Summary

Make Settings values and the TV unpair action available directly. Clicking a setting such as Desktop integration opens its available values, and Unpair appears beside the TV model name instead of occupying a separate row.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

- Replace accordion editors with native choice rows, switches, and an inline timeout field. Remove the metadata sections and Reset buttons.
- Keep setting descriptions and automatic apply. Routine setting edits do not add progress or success rows; failures and incomplete runtime application still show feedback and Retry apply where appropriate. Selected choice values remain readable in narrow windows.
- Move Unpair to a flat circular button at the right of the TV model name, using the selected GNOME edit-delete circled-X icon in the native destructive-action color. Preserve its tooltip, accessible name, and confirmation dialog.
- Embed the CC0 icon as a GResource so it is available in installed builds regardless of the desktop icon theme. Building the GUI uses glib-compile-resources from the GLib development tools.
- Update the guide and installed GUI checks for direct editing.

## Validation

- Settings application tests passed, covering silent success and warnings for incomplete runtime application.

- Full display-backed GTK suite passed, including a real pointer click on Desktop integration followed by keyboard selection, timeout commit timing, stable Settings group height throughout every apply phase, failure recovery, unpair confirmation and focus restoration after cancellation, and narrow layout.
- Isolated installed GUI smoke passed with platform contracts enabled, including no-write viewing, timeout draft/Enter/invalid-input checks, and cancelling and confirming Unpair.
- Workspace Clippy with all targets/features and warnings denied, Rust formatting, Python/shell syntax, and diff checks passed.
- Visually checked wide and narrow layouts, including the red Unpair icon in light and dark themes.

## Related Issue

Follow-up to #175, #177, and #189.
