### PR TITLE
Add a native About dialog

### DIFF
--- a/crates/lg-buddy-gui/build.rs
+++ b/crates/lg-buddy-gui/build.rs
@@ -2,10 +2,15 @@ use std::{env, path::PathBuf, process::Command};
 
 fn main() {
     println!("cargo:rerun-if-changed=resources");
+    println!("cargo:rerun-if-changed=../../data/icons");
     let target = PathBuf::from(env::var_os("OUT_DIR").expect("Cargo sets OUT_DIR"))
         .join("lg-buddy-gui.gresource");
     let status = Command::new("glib-compile-resources")
-        .args(["--sourcedir=resources", "--target"])
+        .args([
+            "--sourcedir=resources",
+            "--sourcedir=../../data",
+            "--target",
+        ])
         .arg(target)
         .arg("resources/resources.gresource.xml")
         .status()

--- a/crates/lg-buddy-gui/resources/resources.gresource.xml
+++ b/crates/lg-buddy-gui/resources/resources.gresource.xml
@@ -2,5 +2,6 @@
 <gresources>
   <gresource prefix="/io/github/staphylococcus/LGBuddy">
     <file>icons/edit-delete-symbolic.svg</file>
+    <file alias="icons/scalable/apps/io.github.staphylococcus.LGBuddy.svg">icons/hicolor/scalable/apps/io.github.staphylococcus.LGBuddy.svg</file>
   </gresource>
 </gresources>

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -38,6 +38,14 @@ use lg_buddy::tvs::{
 pub const APPLICATION_ID: &str = "io.github.staphylococcus.LGBuddy";
 pub const APPLICATION_NAME: &str = "LG Buddy";
 
+fn register_resources() {
+    static RESOURCES: std::sync::Once = std::sync::Once::new();
+    RESOURCES.call_once(|| {
+        gtk::gio::resources_register_include!("lg-buddy-gui.gresource")
+            .expect("bundled GUI resources must be valid");
+    });
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GuiCommand {
     Brightness,

--- a/crates/lg-buddy-gui/src/tvs.rs
+++ b/crates/lg-buddy-gui/src/tvs.rs
@@ -515,11 +515,7 @@ struct UnpairButton {
 
 impl UnpairButton {
     fn new(on_intent: &IntentHandler) -> Self {
-        static RESOURCES: std::sync::Once = std::sync::Once::new();
-        RESOURCES.call_once(|| {
-            gtk::gio::resources_register_include!("lg-buddy-gui.gresource")
-                .expect("bundled GUI resources must be valid");
-        });
+        crate::register_resources();
         let icon = gtk::gio::FileIcon::new(&gtk::gio::File::for_uri(
             "resource:///io/github/staphylococcus/LGBuddy/icons/edit-delete-symbolic.svg",
         ));

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -40,6 +40,19 @@ impl ApplicationWindow {
             .width_request(280)
             .height_request(240)
             .build();
+        crate::register_resources();
+        gtk::IconTheme::for_display(&gtk::prelude::WidgetExt::display(&window))
+            .add_resource_path("/io/github/staphylococcus/LGBuddy/icons");
+        let about = gtk::gio::SimpleAction::new("about", None);
+        about.connect_activate({
+            let window = window.downgrade();
+            move |_, _| {
+                if let Some(window) = window.upgrade() {
+                    show_about(&window);
+                }
+            }
+        });
+        window.add_action(&about);
         let overview = crate::overview::OverviewView::new(&window, Rc::clone(&on_overview));
         let tvs = crate::tvs::TvsView::new(Rc::clone(&on_tvs));
         let pairing = crate::pairing::PairingView::new(on_tvs);
@@ -78,6 +91,16 @@ impl ApplicationWindow {
             .policy(adw::ViewSwitcherPolicy::Wide)
             .build();
         let header = adw::HeaderBar::builder().title_widget(&switcher).build();
+        let menu = gtk::gio::Menu::new();
+        menu.append(Some("About LG Buddy"), Some("win.about"));
+        let menu_button = gtk::MenuButton::builder()
+            .icon_name("open-menu-symbolic")
+            .primary(true)
+            .tooltip_text("Main Menu")
+            .menu_model(&menu)
+            .build();
+        menu_button.update_property(&[gtk::accessible::Property::Label("Main Menu")]);
+        header.pack_end(&menu_button);
         let switcher_bar = adw::ViewSwitcherBar::builder().stack(&stack).build();
         let toasts = adw::ToastOverlay::new();
         toasts.set_child(Some(&stack));
@@ -188,6 +211,40 @@ impl ApplicationWindow {
     pub(crate) fn choose_page(&self, page: ApplicationPage) {
         self.stack.set_visible_child_name(page_name(page));
     }
+}
+
+fn show_about(window: &adw::ApplicationWindow) {
+    // ponytail: let Adwaita own the About layout, subpages, links, and dismissal.
+    let dialog = adw::AboutDialog::builder()
+        .application_name(crate::APPLICATION_NAME)
+        .application_icon(crate::APPLICATION_ID)
+        .developer_name("LG Buddy Contributors")
+        .version(lg_buddy::version::VersionInfo::current().version())
+        .website("https://github.com/Staphylococcus/LG_Buddy")
+        .issue_url("https://github.com/Staphylococcus/LG_Buddy/issues/new/choose")
+        .developers([
+            "Vas Zayarskiy https://github.com/Staphylococcus",
+            "Faceless3882 https://github.com/Faceless3882",
+            "Contributors https://github.com/Staphylococcus/LG_Buddy/graphs/contributors",
+        ])
+        .license_type(gtk::License::Gpl30Only)
+        .debug_info(lg_buddy::version::version_text())
+        .debug_info_filename("lg-buddy-version.txt")
+        .build();
+    dialog.add_acknowledgement_section(
+        Some("With Thanks"),
+        &[
+            "chros73 — bscpylgtv https://github.com/chros73/bscpylgtv",
+            "JPersson77 — LGTV Companion https://github.com/JPersson77/LGTVCompanion",
+        ],
+    );
+    dialog.add_legal_section(
+        "GNOME edit-delete icon",
+        None,
+        gtk::License::Custom,
+        Some("By Jakub Steiner, dedicated to the public domain under <a href=\"https://creativecommons.org/publicdomain/zero/1.0/\">CC0 1.0 Universal</a>."),
+    );
+    dialog.present(Some(window));
 }
 
 fn page_name(page: ApplicationPage) -> &'static str {

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -50,6 +50,12 @@ With no TV configured, choose **Pair a TV** to get started.
 
 ![The TVs tab with no TV configured and a Pair a TV button](screenshots/tvs-empty.png)
 
+### About LG Buddy
+
+Development builds provide **About LG Buddy** in the main menu. It shows
+the app version, project and issue links, credits, license, and build information
+that can be saved when reporting a problem.
+
 ### Settings
 
 The released **1.6.0-beta.1** does not include GUI Settings. Development builds


### PR DESCRIPTION
## Summary

LG Buddy now provides a standard Adwaita About dialog from the main menu, making the app version, project links, credits, license, and build information available inside the app. The dialog reuses the existing version source and bundles the canonical app icon so source builds can display it too.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

Choose **Main Menu → About LG Buddy** to see the icon, version, website, issue link, credits, legal information, acknowledgements, and saveable build information. Native Adwaita presentation adapts to narrow windows and supports normal dismissal.

## Validation

- `cargo test -p lg-buddy`
- Display-backed `cargo test -p lg-buddy-gui -- --test-threads=1`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check` and `git diff --check`
- Isolated GUI checks: open About through the actual menu, verify normal and 360-pixel layouts, dismiss About, and verify Escape dismisses the menu without closing the app.
- Opened the dialog in the latest host build for visual review.

## Related Issue

Relates to #128 and v1.6.0 release preparation.
