### PR TITLE
Hide idle-only settings when idle blanking is disabled

### DIFF
--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -116,13 +116,13 @@ impl SettingsView {
 
     fn render_rows(&self, presentation: &SettingsPresentation) {
         for row in self.rows.borrow().iter() {
-            if let Some(presentation) = presentation
+            if let Some(current) = presentation
                 .groups()
                 .iter()
                 .flat_map(|group| group.rows())
                 .find(|value| value.setting() == row.presentation.borrow().setting())
             {
-                row.render(presentation);
+                row.render(current, presentation.row_visible(current.setting()));
             }
         }
     }
@@ -319,7 +319,7 @@ impl NativeSettingRow {
         };
         // Populate values without producing commit intents.
         native.render_editor(initial.editor());
-        native.render_state(initial);
+        native.render_state(initial, true);
         native
     }
 
@@ -353,9 +353,9 @@ impl NativeSettingRow {
         self.rendering.set(false);
     }
 
-    fn render(&self, current: &SettingsRow) {
+    fn render(&self, current: &SettingsRow, visible: bool) {
         let previous = self.presentation.borrow().clone();
-        if previous == *current {
+        if previous == *current && self.row.is_visible() == visible {
             return;
         }
         if current.edit_status() != SettingsEditStatus::Saving
@@ -364,11 +364,12 @@ impl NativeSettingRow {
         {
             self.render_editor(current.editor());
         }
-        self.render_state(current);
+        self.render_state(current, visible);
     }
 
-    fn render_state(&self, current: &SettingsRow) {
+    fn render_state(&self, current: &SettingsRow, visible: bool) {
         self.rendering.set(true);
+        self.row.set_visible(visible);
         self.row.set_sensitive(current.editor_enabled());
         self.row.update_property(&[
             gtk::accessible::Property::Label(current.title()),
@@ -378,7 +379,8 @@ impl NativeSettingRow {
                 current.value_label()
             )),
         ]);
-        self.problem.set_visible(current.problem().is_some());
+        self.problem
+            .set_visible(visible && current.problem().is_some());
         self.problem.set_subtitle(current.problem().unwrap_or(""));
         self.problem
             .update_property(&[gtk::accessible::Property::Label(
@@ -391,7 +393,7 @@ impl NativeSettingRow {
             severity,
             Some(SettingsFeedbackSeverity::Warning | SettingsFeedbackSeverity::Error)
         );
-        self.feedback.set_visible(feedback.is_some());
+        self.feedback.set_visible(visible && feedback.is_some());
         self.feedback.set_subtitle(message);
         self.feedback
             .update_property(&[gtk::accessible::Property::Label(message)]);
@@ -666,7 +668,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     assert!(entry.is_sensitive());
     assert!(view.rows.borrow()[2].feedback.is_visible());
     assert!(intents.borrow().is_empty(), "restoration emits no write");
-    match &view.rows.borrow()[1].editor {
+    match &view.rows.borrow()[0].editor {
         NativeEditor::Toggle(switch) => switch.set_active(false),
         _ => unreachable!(),
     }
@@ -728,6 +730,45 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     );
     assert_eq!(entry.position(), 1, "completion must not move the caret");
 
+    // An external settings refresh can hide the currently focused idle editor.
+    // Keep its native widget/draft and hide its associated errors too.
+    entry.grab_focus();
+    intents.borrow_mut().clear();
+    let disabled = SettingsPresentation::from_store(
+        &ConfigEnvReader::parse(
+            "/unused/config.env",
+            "screen_idle_blank=disabled\nscreen_backend=invalid\nscreen_idle_timeout=600\n",
+        )
+        .into_store(),
+    );
+    view.render(&disabled);
+    pump_until(|| !entry.is_mapped());
+    assert!(rows[0].is_visible(), "Idle blanking remains available");
+    assert!(!rows[1].is_visible(), "Desktop integration is hidden");
+    assert!(!rows[2].is_visible(), "Idle timeout is hidden");
+    assert!(rows[3].is_visible(), "Restore policy remains available");
+    assert!(!view.rows.borrow()[1].problem.is_visible());
+    assert!(!view.rows.borrow()[2].feedback.is_visible());
+    assert!(
+        intents.borrow().is_empty(),
+        "hiding rows must not save a draft"
+    );
+    window.child_focus(gtk::DirectionType::TabForward);
+    assert!(GtkWindowExt::focus(&window).is_some_and(|focus| focus.is_mapped()));
+
+    view.render(failed.presentation());
+    pump_until(|| entry.is_mapped());
+    assert!(rows[1].is_visible());
+    assert!(rows[2].is_visible());
+    assert!(view.rows.borrow()[2].feedback.is_visible());
+    assert_eq!(entry.text(), "721", "hiding must preserve the editor draft");
+    assert!(view
+        .rows
+        .borrow()
+        .iter()
+        .zip(&rows)
+        .all(|(native, row)| native.row == *row));
+
     window.set_default_size(360, 600);
     pump_until(|| window.width() <= 360);
     let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
@@ -779,7 +820,7 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
         .content(view.widget())
         .build();
     window.present();
-    let choice = match &view.rows.borrow()[0].editor {
+    let choice = match &view.rows.borrow()[1].editor {
         NativeEditor::Choice(choice) => choice.clone(),
         _ => unreachable!(),
     };
@@ -833,7 +874,7 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
         .unwrap()
         .success());
     pump_until(|| !intents.borrow().is_empty());
-    let expected = ready.presentation().groups()[0].rows()[0]
+    let expected = ready.presentation().groups()[0].rows()[1]
         .editor()
         .choices()
         .unwrap()

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -156,6 +156,19 @@ impl SettingsPresentation {
         self.retry_action.as_ref()
     }
 
+    /// Keep dependent settings intact while only presenting controls that apply.
+    /// Missing or invalid blanking values retain the controls for diagnosis.
+    pub fn row_visible(&self, setting: BehaviorSetting) -> bool {
+        !matches!(
+            setting,
+            BehaviorSetting::ScreenBackend | BehaviorSetting::ScreenIdleTimeout
+        ) || !matches!(
+            self.row(BehaviorSetting::ScreenIdleBlank)
+                .map(SettingsRow::editor),
+            Some(SettingsEditor::Toggle { value: Some(false) })
+        )
+    }
+
     pub(crate) fn row(&self, setting: BehaviorSetting) -> Option<&SettingsRow> {
         self.groups
             .iter()
@@ -446,8 +459,8 @@ pub(crate) fn groups_from_store(store: &SettingsStore) -> Vec<SettingsGroup> {
             "Screen",
             "Choose when LG Buddy blanks and restores your TV screen.",
             vec![
-                row_from_effective(setting("screen.backend")),
                 row_from_effective(setting("screen.idle_blank")),
+                row_from_effective(setting("screen.backend")),
                 row_from_effective(setting("screen.idle_timeout")),
                 row_from_effective(setting("screen.restore_policy")),
             ],

--- a/crates/lg-buddy/src/settings/mutation.rs
+++ b/crates/lg-buddy/src/settings/mutation.rs
@@ -107,6 +107,73 @@ mod tests {
     use crate::settings::{SettingSource, SettingsCommandRunner};
 
     #[test]
+    fn idle_control_visibility_follows_persistence_even_when_runtime_apply_fails() {
+        use crate::presentation::settings::SettingsPresentation;
+        use crate::settings_view::{BehaviorSetting, SettingsApplication, SettingsIntent};
+
+        let path = unique_test_path("idle-visibility");
+        std::fs::write(&path, "screen_backend=wayland\nscreen_idle_timeout=600\n").unwrap();
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(
+            opening.read_operation().unwrap(),
+            Ok(
+                SettingsPresentation::from_store(&SettingsStore::load(&path).unwrap())
+                    .groups()
+                    .to_vec(),
+            ),
+        )
+        .unwrap();
+
+        for enabled in [false, true] {
+            let started = app
+                .handle_intent(SettingsIntent::SetEnabled {
+                    setting: BehaviorSetting::ScreenIdleBlank,
+                    enabled,
+                })
+                .unwrap();
+            let operation = started.mutation_operation().unwrap();
+            let mutation = SettingsMutation::set(
+                &SettingsStore::load(&path).unwrap(),
+                "screen.idle_blank",
+                if enabled { "enabled" } else { "disabled" },
+            )
+            .unwrap();
+            let controller = if enabled {
+                FakeServiceController::active_or_enabled()
+            } else {
+                FakeServiceController::failing_restart()
+            };
+            let result = execute_settings_mutation(
+                &path,
+                mutation,
+                &SettingsApplier::new(controller),
+                &mut |_| {},
+            );
+            let done = app.complete_mutation(operation, result).unwrap();
+            let presentation = done.presentation();
+            assert_eq!(
+                presentation.row_visible(BehaviorSetting::ScreenBackend),
+                enabled
+            );
+            assert_eq!(
+                presentation.row_visible(BehaviorSetting::ScreenIdleTimeout),
+                enabled
+            );
+            assert!(presentation.row_visible(BehaviorSetting::ScreenRestorePolicy));
+            let toggle = presentation.groups()[0]
+                .rows()
+                .iter()
+                .find(|row| row.setting() == BehaviorSetting::ScreenIdleBlank)
+                .unwrap();
+            assert_eq!(toggle.retry_apply_action().is_some(), !enabled);
+            let saved = std::fs::read_to_string(&path).unwrap();
+            assert!(saved.contains("screen_backend=wayland\n"));
+            assert!(saved.contains("screen_idle_timeout=600\n"));
+        }
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
     fn shared_executor_and_cli_write_the_same_values_and_runtime_actions() {
         for (key, value, restarts, enables, disables) in [
             ("screen.backend", "gnome", 1, 0, 0),

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -762,6 +762,26 @@ mod tests {
     }
 
     #[test]
+    fn idle_controls_are_hidden_only_for_explicitly_disabled_blanking() {
+        for (config, visible) in [
+            ("", true),
+            ("screen_idle_blank=enabled\n", true),
+            ("screen_idle_blank=disabled\n", false),
+            ("screen_idle_blank=invalid\n", true),
+        ] {
+            let presentation = SettingsPresentation::ready(groups(config));
+            for setting in [
+                BehaviorSetting::ScreenBackend,
+                BehaviorSetting::ScreenIdleTimeout,
+            ] {
+                assert_eq!(presentation.row_visible(setting), visible, "{config}");
+            }
+            assert!(presentation.row_visible(BehaviorSetting::ScreenIdleBlank));
+            assert!(presentation.row_visible(BehaviorSetting::ScreenRestorePolicy));
+        }
+    }
+
+    #[test]
     fn persisted_values_use_friendly_labels_and_sources() {
         let groups = groups(
             "screen_backend=wayland\nscreen_idle_blank=disabled\nscreen_idle_timeout=450\nscreen_restore_policy=aggressive\nsystem_sleep_wake_policy=disabled\nupdates_auto_check=disabled\nupdates_channel=prerelease\n",
@@ -819,16 +839,16 @@ screen_backend=wayland\n",
         );
         let expected = [
             (
-                "screen.backend",
-                "Desktop integration",
-                "Automatic",
-                "Automatic, GNOME, Wayland, swayidle (deprecated)",
-            ),
-            (
                 "screen.idle_blank",
                 "Idle blanking",
                 "Enabled",
                 "Enabled, Disabled",
+            ),
+            (
+                "screen.backend",
+                "Desktop integration",
+                "Automatic",
+                "Automatic, GNOME, Wayland, swayidle (deprecated)",
             ),
             (
                 "screen.idle_timeout",
@@ -1347,6 +1367,9 @@ screen_backend=wayland\n",
             })
             .unwrap();
         let operation = transition.mutation_operation().unwrap().clone();
+        assert!(transition
+            .presentation()
+            .row_visible(BehaviorSetting::ScreenIdleTimeout));
         let transition = app
             .complete_mutation(
                 &operation,
@@ -1360,6 +1383,9 @@ screen_backend=wayland\n",
             .row(BehaviorSetting::ScreenIdleBlank)
             .unwrap();
         assert_eq!(row.edit_status(), SettingsEditStatus::PersistenceFailed);
+        assert!(transition
+            .presentation()
+            .row_visible(BehaviorSetting::ScreenIdleTimeout));
         assert!(row.retry_apply_action().is_some());
         let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
         let refreshed = app

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -176,6 +176,12 @@ changes are validated, persisted, and applied automatically; writes are
 serialized in application state, with accepted edits queued in order. There is
 no Save or Cancel button.
 
+The application presentation hides Desktop integration and Idle timeout when
+Idle blanking is explicitly disabled. GTK retains the native rows and their
+values while hiding them; Restore policy remains visible because it also
+governs restoration outside idle blanking. Invalid blanking values keep the
+dependent controls available for diagnosis.
+
 Settings displays configured values only; there is no separate GUI surface for
 a resolved screen backend, service health, runtime state, update availability,
 or update progress. Normal successful changes are silent. Feedback appears

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -123,6 +123,11 @@ Leave **Desktop integration** at **Automatic** unless you need to select a
 particular compatible desktop. See the [session backend model](session-backend-model.md)
 for compatibility details, including the deprecated `swayidle` option.
 
+Turning off **Idle blanking** hides **Desktop integration** and **Idle timeout**
+while keeping their saved values for when you turn it back on. **Restore policy**
+stays available because it also controls restoration after system sleep and
+explicit screen-on requests.
+
 <a id="gamepad-activity"></a>
 ## Keep the screen awake with a gamepad
 


### PR DESCRIPTION
## Summary

Settings now hides Desktop integration and Idle timeout when idle blanking is explicitly disabled. The application presentation owns this visibility rule; GTK retains the native rows and hides their associated feedback, preserving values and editor state.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

Idle blanking appears first, followed by its dependent controls while enabled. Restore policy stays visible because it also governs restoration after system sleep and explicit screen-on requests. Re-enabling blanking restores the previous choices. Failed saves retain the existing visibility; persisted changes with runtime-apply failures retain the existing warning/retry behavior. Invalid blanking values keep the controls available for diagnosis.

## Validation

- `cargo test -p lg-buddy`: full suite passed, including 908 library tests and 134 Cucumber scenarios.
- Display-backed `cargo test -p lg-buddy-gui -- --test-threads=1`: passed, including focused-row hiding, keyboard traversal, retained widgets/drafts, and hidden feedback.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all --check` and `git diff --check`: passed.
- `scripts/test-installed-gui.sh` under a private D-Bus/Xvfb session: passed, including installed launch, release GUI behavior, and AT-SPI accessibility checks.

No live TV behavior was changed or exercised; runtime policy, defaults, and CLI settings remain unchanged.

## Related Issue

Fixes #202.

Related to #196: the forthcoming inhibition control should follow the same application-owned visibility rule when introduced.
