### PR TITLE
Add manual update checks to Settings

### DIFF
--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -28,7 +28,8 @@ use lg_buddy::pairing::{
 };
 use lg_buddy::settings_view::{
     EnvironmentSettingsBackend, SettingsBackend, SettingsIntent, SettingsMutationOperation,
-    SettingsReadError, SettingsReadOperation, SettingsTransition,
+    SettingsReadError, SettingsReadOperation, SettingsTransition, UpdateCheckError,
+    UpdateCheckOperation,
 };
 use lg_buddy::tvs::{
     EnvironmentTvsBackend, TvsBackend, TvsIntent, TvsModelReadOperation, TvsReadError,
@@ -330,6 +331,37 @@ impl ApplicationController {
         if let Some(operation) = transition.mutation_operation() {
             Self::start_settings_mutation(controller, operation.clone());
         }
+        if let Some(operation) = transition.update_check_operation() {
+            Self::start_update_check(controller, operation);
+        }
+    }
+
+    fn start_update_check(controller: &Rc<Self>, operation: UpdateCheckOperation) {
+        let backend = Arc::clone(&controller.settings_backend);
+        let (sender, receiver) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let _ = sender.send(backend.check_for_updates());
+        });
+        // A read must not keep the application alive after its window closes.
+        let controller = Rc::downgrade(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || {
+            let Some(controller) = controller.upgrade().filter(|value| !value.closed.get()) else {
+                return glib::ControlFlow::Break;
+            };
+            let result = match receiver.try_recv() {
+                Ok(result) => result,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => Err(UpdateCheckError::stopped()),
+            };
+            let transition = controller
+                .application
+                .borrow_mut()
+                .complete_update_check(operation, result);
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
+            }
+            glib::ControlFlow::Break
+        });
     }
 
     fn start_settings_mutation(controller: &Rc<Self>, operation: SettingsMutationOperation) {
@@ -789,6 +821,15 @@ pub(crate) mod controller_test_support {
     struct DefaultSettingsBackend;
 
     impl lg_buddy::settings_view::SettingsBackend for DefaultSettingsBackend {
+        fn check_for_updates(
+            &self,
+        ) -> Result<
+            lg_buddy::presentation::update_check::UpdateCheckReport,
+            lg_buddy::settings_view::UpdateCheckError,
+        > {
+            panic!("unexpected update check")
+        }
+
         fn write_setting(
             &self,
             _operation: lg_buddy::settings_view::SettingsMutationOperation,
@@ -1060,6 +1101,7 @@ pub(crate) mod controller_test_support {
         run_pairing_scenario();
         run_settings_scenario();
         run_settings_write_scenario();
+        run_manual_update_check_scenario();
 
         let (backend, controls) = BlockingBackend::new();
         let application = test_application("Blocking");
@@ -1228,6 +1270,15 @@ pub(crate) mod controller_test_support {
             Mutex<std::collections::VecDeque<Result<Vec<SettingsGroup>, SettingsReadError>>>,
         );
         impl SettingsBackend for SettingsMock {
+            fn check_for_updates(
+                &self,
+            ) -> Result<
+                lg_buddy::presentation::update_check::UpdateCheckReport,
+                lg_buddy::settings_view::UpdateCheckError,
+            > {
+                panic!("unexpected update check")
+            }
+
             fn write_setting(
                 &self,
                 _operation: lg_buddy::settings_view::SettingsMutationOperation,
@@ -1311,6 +1362,192 @@ pub(crate) mod controller_test_support {
         controller.window.close();
     }
 
+    fn run_manual_update_check_scenario() {
+        use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+        use lg_buddy::settings_view::{SettingsBackend, UpdateCheckError};
+        use lg_buddy::updates::UpdateChannel;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct Checker {
+            path: std::path::PathBuf,
+            started: mpsc::Sender<UpdateChannel>,
+            replies: Mutex<mpsc::Receiver<Result<bool, UpdateCheckError>>>,
+            calls: AtomicUsize,
+        }
+        impl SettingsBackend for Checker {
+            fn read_settings(
+                &self,
+            ) -> Result<
+                Vec<lg_buddy::presentation::settings::SettingsGroup>,
+                lg_buddy::settings_view::SettingsReadError,
+            > {
+                Ok(
+                    lg_buddy::presentation::settings::SettingsPresentation::from_store(
+                        &lg_buddy::settings::SettingsStore::load(&self.path).unwrap(),
+                    )
+                    .groups()
+                    .to_vec(),
+                )
+            }
+
+            fn write_setting(
+                &self,
+                _: lg_buddy::settings_view::SettingsMutationOperation,
+                _: &mut dyn FnMut(lg_buddy::settings::SettingsMutationStage),
+            ) -> Result<
+                lg_buddy::settings::SettingsMutationOutcome,
+                lg_buddy::settings::SettingsMutationFailure,
+            > {
+                panic!("checking must not change preferences or services")
+            }
+
+            fn check_for_updates(&self) -> Result<UpdateCheckReport, UpdateCheckError> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                let store = lg_buddy::settings::SettingsStore::load(&self.path).unwrap();
+                let channel = match store
+                    .effective_by_name("updates.channel")
+                    .unwrap()
+                    .required_value()
+                    .unwrap()
+                    .as_enum()
+                    .unwrap()
+                {
+                    "stable" => UpdateChannel::Stable,
+                    "prerelease" => UpdateChannel::Prerelease,
+                    _ => unreachable!(),
+                };
+                self.started.send(channel).unwrap();
+                let available = self.replies.lock().unwrap().recv().unwrap()?;
+                Ok(UpdateCheckReport {
+                    installed_version: "1.6.0".into(),
+                    channel,
+                    available_release: available.then(|| AvailableUpdate {
+                        version: "1.7.0".into(),
+                        url: "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0"
+                            .into(),
+                    }),
+                    warning: None,
+                })
+            }
+        }
+
+        fn find_button(widget: &gtk::Widget, label: &str) -> Option<gtk::Button> {
+            if let Some(button) = widget.downcast_ref::<gtk::Button>() {
+                if button.label().as_deref() == Some(label) && button.is_visible() {
+                    return Some(button.clone());
+                }
+            }
+            let mut child = widget.first_child();
+            while let Some(widget) = child {
+                if let Some(button) = find_button(&widget, label) {
+                    return Some(button);
+                }
+                child = widget.next_sibling();
+            }
+            None
+        }
+
+        let path =
+            std::env::temp_dir().join(format!("lg-buddy-update-check-{}.env", std::process::id()));
+        std::fs::write(
+            &path,
+            "updates_auto_check=disabled\nupdates_channel=stable\n",
+        )
+        .unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let backend = Arc::new(Checker {
+            path: path.clone(),
+            started: started_tx,
+            replies: Mutex::new(reply_rx),
+            calls: AtomicUsize::new(0),
+        });
+        let application = test_application("ManualUpdates");
+        let (controller, opening) = ApplicationController::new(
+            &application,
+            Arc::new(PanicBackend),
+            Arc::new(EmptyTvsBackend),
+            backend.clone(),
+        );
+        ApplicationController::render_settings_transition(&controller, opening.settings().unwrap());
+        controller
+            .window
+            .choose_page(super::ApplicationPage::Settings);
+        controller.present();
+        let native = controller.window.window();
+        pump_until(|| find_button(native.upcast_ref(), "Check for updates").is_some());
+        let check = find_button(native.upcast_ref(), "Check for updates").unwrap();
+        check.emit_clicked();
+        pump_until(|| backend.calls.load(Ordering::SeqCst) == 1);
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+            UpdateChannel::Stable
+        );
+        assert!(!check.is_sensitive());
+        ApplicationController::handle_settings_intent(
+            &controller,
+            lg_buddy::settings_view::SettingsIntent::CheckForUpdates,
+        );
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+
+        // Navigation and refresh remain responsive while the worker is blocked.
+        std::fs::write(
+            &path,
+            "updates_auto_check=disabled\nupdates_channel=prerelease\n",
+        )
+        .unwrap();
+        let saved = std::fs::read(&path).unwrap();
+        controller.window.choose_page(super::ApplicationPage::Tvs);
+        controller
+            .window
+            .choose_page(super::ApplicationPage::Settings);
+        pump_until(|| widget_contains_text(native.upcast_ref(), "Prerelease"));
+        reply_tx.send(Ok(true)).unwrap();
+        pump_until(|| widget_contains_text(native.upcast_ref(), "Update available: 1.7.0"));
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Last successful check: stable channel, compared with installed version 1.6.0."
+        ));
+        assert_eq!(std::fs::read(&path).unwrap(), saved);
+
+        check.emit_clicked();
+        pump_until(|| backend.calls.load(Ordering::SeqCst) == 2);
+        assert_eq!(
+            started_rx.recv_timeout(Duration::from_secs(2)).unwrap(),
+            UpdateChannel::Prerelease
+        );
+        reply_tx
+            .send(Err(lg_buddy::updates::UpdatesError::Http {
+                url: "https://api.github.com".into(),
+                message: "test offline".into(),
+            }
+            .into()))
+            .unwrap();
+        pump_until(|| find_button(native.upcast_ref(), "Retry check").is_some());
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Could not check for updates"
+        ));
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Update available: 1.7.0"
+        ));
+        find_button(native.upcast_ref(), "Retry check")
+            .unwrap()
+            .emit_clicked();
+        pump_until(|| backend.calls.load(Ordering::SeqCst) == 3);
+        reply_tx.send(Ok(false)).unwrap();
+        pump_until(|| widget_contains_text(native.upcast_ref(), "No newer release available"));
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Last successful check: prerelease channel, compared with installed version 1.6.0."
+        ));
+        assert_eq!(std::fs::read(&path).unwrap(), saved);
+        controller.shutdown();
+        controller.window.close();
+        std::fs::remove_file(path).unwrap();
+    }
+
     fn run_settings_write_scenario() {
         use adw::prelude::{ComboRowExt, PreferencesRowExt};
         use lg_buddy::settings::{
@@ -1327,6 +1564,15 @@ pub(crate) mod controller_test_support {
             panic_after_save: bool,
         }
         impl lg_buddy::settings_view::SettingsBackend for SettingsWriter {
+            fn check_for_updates(
+                &self,
+            ) -> Result<
+                lg_buddy::presentation::update_check::UpdateCheckReport,
+                lg_buddy::settings_view::UpdateCheckError,
+            > {
+                panic!("unexpected update check")
+            }
+
             fn read_settings(
                 &self,
             ) -> Result<

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -6,6 +6,7 @@ use lg_buddy::presentation::settings::{
     SettingsCommitPolicy, SettingsEditStatus, SettingsEditor, SettingsFeedbackSeverity,
     SettingsPresentation, SettingsRow, SettingsStatus,
 };
+use lg_buddy::presentation::update_check::UpdateCheckPresentation;
 use lg_buddy::settings_view::SettingsIntent;
 
 /// Stable native controls render application-owned values and commit policies.
@@ -18,6 +19,7 @@ pub(crate) struct SettingsView {
     status: adw::StatusPage,
     retry: gtk::Button,
     retry_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    update_check: UpdateCheckView,
 }
 
 impl SettingsView {
@@ -50,6 +52,7 @@ impl SettingsView {
         root.add_named(&status, Some("status"));
         root.add_named(&page, Some("settings"));
         root.set_visible_child_name("status");
+        let update_check = UpdateCheckView::new(Rc::clone(&on_intent));
         Self {
             root,
             page,
@@ -59,6 +62,7 @@ impl SettingsView {
             status,
             retry,
             retry_intent,
+            update_check,
         }
     }
 
@@ -104,6 +108,9 @@ impl SettingsView {
                             native.add(&row.feedback);
                             self.rows.borrow_mut().push(row);
                         }
+                        if group.title() == "Updates" {
+                            self.update_check.attach(&native);
+                        }
                         self.page.add(&native);
                         self.groups.borrow_mut().push(native);
                     }
@@ -124,6 +131,128 @@ impl SettingsView {
             {
                 row.render(current, presentation.row_visible(current.setting()));
             }
+        }
+        self.update_check.render(presentation.update_check());
+    }
+}
+
+struct UpdateCheckView {
+    installed: adw::ActionRow,
+    check: gtk::Button,
+    check_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    spinner: gtk::Spinner,
+    result: adw::ActionRow,
+    release: gtk::LinkButton,
+    error: adw::ActionRow,
+    warning: adw::ActionRow,
+}
+
+impl UpdateCheckView {
+    fn new(on_intent: Rc<dyn Fn(SettingsIntent)>) -> Self {
+        let installed = detail_row("Installed version", "");
+        let check = gtk::Button::with_label("Check for updates");
+        check.add_css_class("suggested-action");
+        check.set_valign(gtk::Align::Center);
+        check.update_property(&[gtk::accessible::Property::Label("Check for updates")]);
+        let check_intent = Rc::new(RefCell::new(None));
+        check.connect_clicked({
+            let check_intent = Rc::clone(&check_intent);
+            move |_| {
+                let intent = check_intent.borrow().clone();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
+        let spinner = gtk::Spinner::new();
+        spinner.set_valign(gtk::Align::Center);
+        spinner.set_visible(false);
+        spinner.update_property(&[gtk::accessible::Property::Label("Checking for updates")]);
+        installed.add_suffix(&check);
+        installed.add_suffix(&spinner);
+
+        let result = detail_row("", "");
+        result.set_accessible_role(gtk::AccessibleRole::Status);
+        result.set_visible(false);
+        let release = gtk::LinkButton::builder()
+            .label("View release")
+            .uri("https://github.com/Staphylococcus/LG_Buddy/releases")
+            .valign(gtk::Align::Center)
+            .visible(false)
+            .build();
+        release.update_property(&[gtk::accessible::Property::Label("View available release")]);
+        result.add_suffix(&release);
+
+        let error = detail_row("", "");
+        error.add_css_class("error");
+        error.set_accessible_role(gtk::AccessibleRole::Alert);
+        error.set_visible(false);
+
+        let warning = detail_row("", "");
+        warning.add_css_class("warning");
+        warning.set_accessible_role(gtk::AccessibleRole::Alert);
+        warning.set_visible(false);
+
+        Self {
+            installed,
+            check,
+            check_intent,
+            spinner,
+            result,
+            release,
+            error,
+            warning,
+        }
+    }
+
+    fn attach(&self, group: &adw::PreferencesGroup) {
+        group.add(&self.installed);
+        group.add(&self.result);
+        group.add(&self.error);
+        group.add(&self.warning);
+    }
+
+    fn render(&self, presentation: &UpdateCheckPresentation) {
+        self.installed
+            .set_subtitle(presentation.installed_version_label());
+        let action = presentation.check_action();
+        self.check_intent.replace(Some(action.intent()));
+        self.check.set_label(action.label());
+        self.check.set_sensitive(action.enabled());
+        self.check
+            .update_property(&[gtk::accessible::Property::Label(action.label())]);
+        self.spinner.set_visible(presentation.checking());
+        self.spinner.set_spinning(presentation.checking());
+
+        if let Some(report) = presentation.result() {
+            self.result.set_visible(true);
+            self.result.set_title(&report.title());
+            self.result.set_subtitle(&report.description());
+            if let Some(release) = report.available_release.as_ref() {
+                self.release.set_uri(&release.url);
+                self.release.set_visible(true);
+            } else {
+                self.release.set_visible(false);
+            }
+            if let Some(warning) = report.warning.as_deref() {
+                self.warning.set_title("Cache warning");
+                self.warning.set_subtitle(warning);
+                self.warning.set_visible(true);
+            } else {
+                self.warning.set_visible(false);
+            }
+        } else {
+            self.result.set_visible(false);
+            self.release.set_visible(false);
+            self.warning.set_visible(false);
+        }
+
+        if let Some(error) = presentation.error() {
+            self.error.set_title(error.summary());
+            self.error.set_subtitle(error.detail());
+            self.error.set_visible(true);
+        } else {
+            self.error.set_visible(false);
         }
     }
 }
@@ -778,6 +907,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     );
     window.close();
     choice_row_click_opens_the_value_menu(application);
+    update_check_renderer_scenarios(application);
 }
 
 #[cfg(test)]
@@ -888,6 +1018,210 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
             value: expected.into(),
         }],
         "choosing a value must commit directly from the row"
+    );
+    window.close();
+}
+
+#[cfg(test)]
+fn update_check_renderer_scenarios(application: &adw::Application) {
+    use crate::controller_test_support::pump_until;
+    use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+    use lg_buddy::settings::{ConfigEnvReader, SettingsStore};
+    use lg_buddy::settings_view::{SettingsApplication, SettingsIntent, UpdateCheckError};
+    use lg_buddy::updates::UpdateChannel;
+
+    let intents = Rc::new(RefCell::new(Vec::new()));
+    let on_intent: Rc<dyn Fn(SettingsIntent)> = Rc::new({
+        let intents = Rc::clone(&intents);
+        move |intent| intents.borrow_mut().push(intent)
+    });
+    let view = SettingsView::new(on_intent);
+    let window = adw::ApplicationWindow::builder()
+        .application(application)
+        .title("LG Buddy Update Check Renderer Test")
+        .default_width(900)
+        .default_height(700)
+        .content(view.widget())
+        .build();
+    let (mut model, opening) = SettingsApplication::open();
+    let store = SettingsStore::from_reader(ConfigEnvReader::parse(
+        "/unused/config.env",
+        "updates_channel=stable\n",
+    ));
+    let ready = model
+        .complete_read(
+            opening.read_operation().unwrap(),
+            Ok(SettingsPresentation::from_store(&store).groups().to_vec()),
+        )
+        .unwrap();
+    view.render(ready.presentation());
+    window.present();
+    pump_until(|| view.page.is_mapped() && view.groups.borrow().len() == 3);
+
+    let stable_rows: Vec<_> = view
+        .rows
+        .borrow()
+        .iter()
+        .map(|row| row.row.clone())
+        .collect();
+    assert_eq!(stable_rows.len(), 7);
+    assert_eq!(
+        view.update_check.installed.title().as_str(),
+        "Installed version"
+    );
+    assert!(!view.update_check.spinner.is_visible());
+    assert!(!view.update_check.result.is_visible());
+    assert!(!view.update_check.error.is_visible());
+    assert!(!view.update_check.warning.is_visible());
+
+    let check = view.update_check.check.clone();
+    assert_eq!(check.accessible_role(), gtk::AccessibleRole::Button);
+    assert!(check.grab_focus());
+    intents.borrow_mut().clear();
+    check.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::CheckForUpdates],
+        "only activating Check should submit an update-check intent"
+    );
+    let checking = model
+        .handle_intent(intents.borrow_mut().pop().unwrap())
+        .unwrap();
+    let operation = checking.update_check_operation().unwrap();
+    view.render(checking.presentation());
+    assert!(view.update_check.spinner.is_visible());
+    assert_eq!(check.label().as_deref(), Some("Checking…"));
+    assert!(!check.is_sensitive());
+    assert!(
+        check.is_focusable(),
+        "checking must leave the Check button available to the keyboard focus ring"
+    );
+    assert!(
+        intents.borrow().is_empty(),
+        "rendering must not submit an intent"
+    );
+
+    let available = UpdateCheckReport {
+        installed_version: "1.6.0".into(),
+        channel: UpdateChannel::Stable,
+        available_release: Some(AvailableUpdate {
+            version: "1.7.0".into(),
+            url: "https://example.test/releases/v1.7.0?name=release%3C1%3E".into(),
+        }),
+        warning: Some("Cache <could not>& be refreshed.".into()),
+    };
+    let success = model
+        .complete_update_check(operation, Ok(available))
+        .unwrap();
+    view.render(success.presentation());
+    assert!(!view.update_check.spinner.is_visible());
+    assert!(check.is_sensitive());
+    assert_eq!(check.label().as_deref(), Some("Check for updates"));
+    assert!(view.update_check.result.is_visible());
+    assert_eq!(
+        view.update_check.result.title().as_str(),
+        "Update available: 1.7.0"
+    );
+    assert!(view
+        .update_check
+        .result
+        .subtitle()
+        .is_some_and(|text| text.contains("stable") && text.contains("1.6.0")));
+    assert!(view.update_check.release.is_visible());
+    assert_eq!(
+        view.update_check.release.uri().as_str(),
+        "https://example.test/releases/v1.7.0?name=release%3C1%3E"
+    );
+    assert_eq!(
+        view.update_check.release.accessible_role(),
+        gtk::AccessibleRole::Link
+    );
+    assert!(view.update_check.warning.is_visible());
+    assert_eq!(
+        view.update_check.warning.accessible_role(),
+        gtk::AccessibleRole::Alert
+    );
+    assert!(view
+        .update_check
+        .warning
+        .subtitle()
+        .is_some_and(|text| text == "Cache <could not>& be refreshed."));
+    assert!(
+        intents.borrow().is_empty(),
+        "rendering must not submit an intent"
+    );
+
+    let checking_again = model
+        .handle_intent(SettingsIntent::CheckForUpdates)
+        .unwrap();
+    let operation = checking_again.update_check_operation().unwrap();
+    view.render(checking_again.presentation());
+    assert!(view.update_check.result.is_visible());
+    assert!(view.update_check.warning.is_visible());
+    let current = UpdateCheckReport {
+        installed_version: "1.6.0".into(),
+        channel: UpdateChannel::Stable,
+        available_release: None,
+        warning: None,
+    };
+    let current = model.complete_update_check(operation, Ok(current)).unwrap();
+    view.render(current.presentation());
+    assert!(view.update_check.result.is_visible());
+    assert_eq!(
+        view.update_check.result.title().as_str(),
+        "No newer release available"
+    );
+    assert!(!view.update_check.release.is_visible());
+    assert!(!view.update_check.warning.is_visible());
+
+    let checking_again = model
+        .handle_intent(SettingsIntent::CheckForUpdates)
+        .unwrap();
+    let operation = checking_again.update_check_operation().unwrap();
+    view.render(checking_again.presentation());
+    let failed = model
+        .complete_update_check(operation, Err(UpdateCheckError::stopped()))
+        .unwrap();
+    view.render(failed.presentation());
+    assert!(view.update_check.result.is_visible());
+    assert_eq!(
+        view.update_check.result.title().as_str(),
+        "No newer release available"
+    );
+    assert!(view.update_check.error.is_visible());
+    assert_eq!(
+        view.update_check.error.accessible_role(),
+        gtk::AccessibleRole::Alert
+    );
+    assert_eq!(check.label().as_deref(), Some("Retry check"));
+    assert!(check.is_sensitive());
+
+    intents.borrow_mut().clear();
+    check.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::CheckForUpdates],
+        "Retry check must reuse the application-owned intent"
+    );
+    intents.borrow_mut().clear();
+    view.render(failed.presentation());
+    assert!(
+        intents.borrow().is_empty(),
+        "rendering must not submit an intent"
+    );
+    assert!(view
+        .rows
+        .borrow()
+        .iter()
+        .zip(&stable_rows)
+        .all(|(current, original)| current.row == *original));
+
+    window.set_default_size(360, 700);
+    pump_until(|| window.width() <= 360);
+    let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
+    assert!(
+        minimum <= 360,
+        "update-check controls must fit a narrow window: {minimum}"
     );
     window.close();
 }

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -154,6 +154,18 @@ impl Application {
         Some(self.settings_transition(transition))
     }
 
+    pub fn complete_update_check(
+        &mut self,
+        operation: crate::settings_view::UpdateCheckOperation,
+        result: Result<
+            crate::presentation::update_check::UpdateCheckReport,
+            crate::settings_view::UpdateCheckError,
+        >,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.settings.complete_update_check(operation, result)?;
+        Some(self.settings_transition(transition))
+    }
+
     fn settings_transition(&mut self, transition: SettingsTransition) -> ApplicationTransition {
         let tvs = self.tvs.set_controls_available(
             !self.overview.has_pending_write() && !self.settings.is_mutating(),

--- a/crates/lg-buddy/src/presentation/mod.rs
+++ b/crates/lg-buddy/src/presentation/mod.rs
@@ -3,3 +3,4 @@ pub mod overview;
 pub mod pairing;
 pub mod settings;
 pub mod tvs;
+pub mod update_check;

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -1,4 +1,5 @@
 use crate::presentation::brightness::UserFacingError;
+use crate::presentation::update_check::UpdateCheckPresentation;
 use crate::settings::{EffectiveSetting, SettingSource, SettingType, SettingValue, SettingsStore};
 use crate::settings_view::{BehaviorSetting, SettingsIntent};
 
@@ -8,6 +9,7 @@ pub struct SettingsPresentation {
     status: SettingsStatus,
     groups: Vec<SettingsGroup>,
     retry_action: Option<SettingsAction>,
+    update_check: UpdateCheckPresentation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,6 +110,7 @@ impl SettingsPresentation {
             },
             groups: Vec::new(),
             retry_action: None,
+            update_check: UpdateCheckPresentation::default(),
         }
     }
 
@@ -116,6 +119,7 @@ impl SettingsPresentation {
             status: SettingsStatus::Ready,
             groups,
             retry_action: None,
+            update_check: UpdateCheckPresentation::default(),
         }
     }
 
@@ -124,6 +128,7 @@ impl SettingsPresentation {
             status: SettingsStatus::Failed(error),
             groups,
             retry_action: Some(SettingsAction::new("Retry", true, SettingsIntent::Retry)),
+            update_check: UpdateCheckPresentation::default(),
         }
     }
 
@@ -154,6 +159,14 @@ impl SettingsPresentation {
 
     pub fn retry_action(&self) -> Option<&SettingsAction> {
         self.retry_action.as_ref()
+    }
+
+    pub fn update_check(&self) -> &UpdateCheckPresentation {
+        &self.update_check
+    }
+
+    pub(crate) fn update_check_mut(&mut self) -> &mut UpdateCheckPresentation {
+        &mut self.update_check
     }
 
     /// Keep dependent settings intact while only presenting controls that apply.

--- a/crates/lg-buddy/src/presentation/update_check.rs
+++ b/crates/lg-buddy/src/presentation/update_check.rs
@@ -1,0 +1,109 @@
+use crate::presentation::brightness::UserFacingError;
+use crate::presentation::settings::SettingsAction;
+use crate::settings_view::SettingsIntent;
+use crate::updates::UpdateChannel;
+use crate::version::VersionInfo;
+
+/// A completed check, including the channel actually used by discovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateCheckReport {
+    pub installed_version: String,
+    pub channel: UpdateChannel,
+    pub available_release: Option<AvailableUpdate>,
+    pub warning: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AvailableUpdate {
+    pub version: String,
+    pub url: String,
+}
+
+impl UpdateCheckReport {
+    pub fn title(&self) -> String {
+        match &self.available_release {
+            Some(release) => format!("Update available: {}", release.version),
+            None => "No newer release available".to_string(),
+        }
+    }
+
+    pub fn description(&self) -> String {
+        format!(
+            "Last successful check: {} channel, compared with installed version {}.",
+            self.channel.as_str(),
+            self.installed_version
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateCheckPresentation {
+    installed_version_label: String,
+    checking: bool,
+    result: Option<UpdateCheckReport>,
+    error: Option<UserFacingError>,
+}
+
+impl Default for UpdateCheckPresentation {
+    fn default() -> Self {
+        let version = VersionInfo::current();
+        Self {
+            installed_version_label: format!(
+                "{} ({})",
+                version.version(),
+                version.channel().as_str()
+            ),
+            checking: false,
+            result: None,
+            error: None,
+        }
+    }
+}
+
+impl UpdateCheckPresentation {
+    pub fn installed_version_label(&self) -> &str {
+        &self.installed_version_label
+    }
+
+    pub fn checking(&self) -> bool {
+        self.checking
+    }
+
+    pub fn check_action(&self) -> SettingsAction {
+        SettingsAction::new(
+            if self.checking {
+                "Checking…"
+            } else if self.error.is_some() {
+                "Retry check"
+            } else {
+                "Check for updates"
+            },
+            !self.checking,
+            SettingsIntent::CheckForUpdates,
+        )
+    }
+
+    pub fn result(&self) -> Option<&UpdateCheckReport> {
+        self.result.as_ref()
+    }
+
+    pub fn error(&self) -> Option<&UserFacingError> {
+        self.error.as_ref()
+    }
+
+    pub(crate) fn start(&mut self) {
+        self.checking = true;
+        self.error = None;
+    }
+
+    pub(crate) fn complete(&mut self, result: Result<UpdateCheckReport, UserFacingError>) {
+        self.checking = false;
+        match result {
+            Ok(report) => {
+                self.result = Some(report);
+                self.error = None;
+            }
+            Err(error) => self.error = Some(error),
+        }
+    }
+}

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -9,6 +9,7 @@ use crate::presentation::settings::{
     SettingsEditStatus, SettingsEditor, SettingsFeedback, SettingsFeedbackSeverity, SettingsGroup,
     SettingsPresentation, SettingsRow,
 };
+use crate::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
 use crate::settings::{
     execute_settings_mutation, retry_settings_apply, ConfigPathResolver, SettingsApplier,
     SettingsApplyOutcome, SettingsError, SettingsMutation, SettingsMutationFailure,
@@ -57,6 +58,7 @@ impl BehaviorSetting {
 pub enum SettingsIntent {
     Retry,
     Refresh,
+    CheckForUpdates,
     SetEnabled {
         setting: BehaviorSetting,
         enabled: bool,
@@ -113,6 +115,51 @@ impl SettingsMutationOperation {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SettingsReadOperation(u64);
 
+/// Opaque identity for a manual check, independent of settings reads and writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct UpdateCheckOperation(u64);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateCheckError {
+    presentation: UserFacingError,
+    diagnostic: String,
+}
+
+impl UpdateCheckError {
+    pub fn stopped() -> Self {
+        Self {
+            presentation: UserFacingError::new(
+                "Update check stopped",
+                "The check did not finish. Try again.",
+            ),
+            diagnostic: "the update check worker stopped before returning a result".into(),
+        }
+    }
+}
+
+impl From<crate::updates::UpdatesError> for UpdateCheckError {
+    fn from(error: crate::updates::UpdatesError) -> Self {
+        use crate::updates::UpdatesError;
+        let detail = match &error {
+            UpdatesError::Settings(_) | UpdatesError::SettingsInvariant(_) => {
+                "Check the saved Update channel in Settings, then try again."
+            }
+            UpdatesError::Http { .. } => "Check your internet connection, then try again.",
+            UpdatesError::ApiStatus { status: 403 | 429, .. } => {
+                "The release service refused the request. Try again later."
+            }
+            UpdatesError::InvalidLocalVersion { .. } => {
+                "The installed version could not be compared. Install a supported LG Buddy release."
+            }
+            _ => "Release information could not be retrieved. Try again; if this continues, check the LG Buddy logs.",
+        };
+        Self {
+            presentation: UserFacingError::new("Could not check for updates", detail),
+            diagnostic: error.to_string(),
+        }
+    }
+}
+
 impl SettingsReadOperation {
     pub(crate) fn new(id: u64) -> Self {
         Self(id)
@@ -124,6 +171,7 @@ pub struct SettingsTransition {
     presentation: SettingsPresentation,
     read_operation: Option<SettingsReadOperation>,
     mutation_operation: Option<SettingsMutationOperation>,
+    update_check_operation: Option<UpdateCheckOperation>,
     diagnostic: Option<String>,
 }
 
@@ -138,6 +186,10 @@ impl SettingsTransition {
 
     pub fn mutation_operation(&self) -> Option<&SettingsMutationOperation> {
         self.mutation_operation.as_ref()
+    }
+
+    pub fn update_check_operation(&self) -> Option<UpdateCheckOperation> {
+        self.update_check_operation
     }
 
     pub fn diagnostic(&self) -> Option<&str> {
@@ -198,6 +250,8 @@ impl Error for SettingsReadError {}
 pub trait SettingsBackend: Send + Sync + 'static {
     fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError>;
 
+    fn check_for_updates(&self) -> Result<UpdateCheckReport, UpdateCheckError>;
+
     fn write_setting(
         &self,
         operation: SettingsMutationOperation,
@@ -209,6 +263,22 @@ pub trait SettingsBackend: Send + Sync + 'static {
 pub struct EnvironmentSettingsBackend;
 
 impl SettingsBackend for EnvironmentSettingsBackend {
+    fn check_for_updates(&self) -> Result<UpdateCheckReport, UpdateCheckError> {
+        let outcome = crate::updates::check_for_updates()?;
+        let result = outcome.result();
+        Ok(UpdateCheckReport {
+            installed_version: result.current_version().to_string(),
+            channel: result.check_channel(),
+            available_release: result.update_available().then(|| AvailableUpdate {
+                version: result.latest().version().to_string(),
+                url: result.latest().url().to_owned(),
+            }),
+            warning: (!outcome.warnings().is_empty()).then(|| {
+                "The release check succeeded, but its cache could not be read or saved. A later check may need to download the release information again.".into()
+            }),
+        })
+    }
+
     fn read_settings(&self) -> Result<Vec<SettingsGroup>, SettingsReadError> {
         let store = SettingsStore::load_from_env()
             .map_err(|error| SettingsReadError::unreadable(error.to_string()))?;
@@ -267,6 +337,7 @@ pub struct SettingsApplication {
     pending_mutation: Option<PendingMutation>,
     queued_mutations: VecDeque<PendingMutation>,
     reconcile_mutation: Option<PendingMutation>,
+    pending_update_check: Option<UpdateCheckOperation>,
 }
 
 impl SettingsApplication {
@@ -283,11 +354,13 @@ impl SettingsApplication {
                 pending_mutation: None,
                 queued_mutations: VecDeque::new(),
                 reconcile_mutation: None,
+                pending_update_check: None,
             },
             SettingsTransition {
                 presentation,
                 read_operation: Some(operation),
                 mutation_operation: None,
+                update_check_operation: None,
                 diagnostic: None,
             },
         )
@@ -298,6 +371,18 @@ impl SettingsApplication {
             return None;
         }
         match intent {
+            SettingsIntent::CheckForUpdates
+                if self.pending_update_check.is_none()
+                    && !self.presentation.groups().is_empty() =>
+            {
+                let operation = UpdateCheckOperation(self.next_operation_id);
+                self.next_operation_id += 1;
+                self.pending_update_check = Some(operation);
+                self.presentation.update_check_mut().start();
+                let mut transition = self.transition(None, None, None);
+                transition.update_check_operation = Some(operation);
+                Some(transition)
+            }
             SettingsIntent::Retry if matches!(self.state, SettingsApplicationState::Failed) => {
                 Some(self.begin_read())
             }
@@ -411,7 +496,9 @@ impl SettingsApplication {
                 )
             }
         };
+        let update_check = self.presentation.update_check().clone();
         self.presentation = presentation;
+        *self.presentation.update_check_mut() = update_check;
         if matches!(self.state, SettingsApplicationState::Ready) {
             self.finish_mutation(None, diagnostic)
         } else {
@@ -491,6 +578,22 @@ impl SettingsApplication {
         }
     }
 
+    pub fn complete_update_check(
+        &mut self,
+        operation: UpdateCheckOperation,
+        result: Result<UpdateCheckReport, UpdateCheckError>,
+    ) -> Option<SettingsTransition> {
+        if self.closed || self.pending_update_check != Some(operation) {
+            return None;
+        }
+        self.pending_update_check = None;
+        let diagnostic = result.as_ref().err().map(|error| error.diagnostic.clone());
+        self.presentation
+            .update_check_mut()
+            .complete(result.map_err(|error| error.presentation));
+        Some(self.transition(None, None, diagnostic))
+    }
+
     pub fn mutation_worker_stopped(
         &mut self,
         operation: &SettingsMutationOperation,
@@ -558,6 +661,7 @@ impl SettingsApplication {
             presentation: self.presentation.clone(),
             read_operation: Some(operation),
             mutation_operation: None,
+            update_check_operation: None,
             diagnostic: None,
         }
     }
@@ -569,7 +673,9 @@ impl SettingsApplication {
     ) -> Option<SettingsTransition> {
         let previous_row = self.presentation.row(setting)?.clone();
         if matches!(self.state, SettingsApplicationState::Loading(_)) {
+            let update_check = self.presentation.update_check().clone();
             self.presentation = SettingsPresentation::ready(self.presentation.groups().to_vec());
+            *self.presentation.update_check_mut() = update_check;
         }
         let operation = SettingsMutationOperation::new(self.next_operation_id, setting, request);
         self.next_operation_id += 1;
@@ -633,6 +739,7 @@ impl SettingsApplication {
             presentation: self.presentation.clone(),
             read_operation,
             mutation_operation,
+            update_check_operation: None,
             diagnostic,
         }
     }
@@ -779,6 +886,168 @@ mod tests {
             assert!(presentation.row_visible(BehaviorSetting::ScreenIdleBlank));
             assert!(presentation.row_visible(BehaviorSetting::ScreenRestorePolicy));
         }
+    }
+
+    fn update_report(channel: crate::updates::UpdateChannel) -> UpdateCheckReport {
+        UpdateCheckReport {
+            installed_version: "1.6.0".into(),
+            channel,
+            available_release: Some(AvailableUpdate {
+                version: "1.7.0".into(),
+                url: "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0".into(),
+            }),
+            warning: None,
+        }
+    }
+
+    #[test]
+    fn manual_check_is_independent_of_auto_checks_edits_and_refreshes() {
+        use crate::updates::UpdateChannel;
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(
+            opening.read_operation().unwrap(),
+            Ok(groups(
+                "updates_auto_check=disabled\nupdates_channel=stable\n",
+            )),
+        )
+        .unwrap();
+        let checking = app.handle_intent(SettingsIntent::CheckForUpdates).unwrap();
+        let operation = checking.update_check_operation().unwrap();
+        assert!(checking.presentation().update_check().checking());
+        assert!(!checking
+            .presentation()
+            .update_check()
+            .check_action()
+            .enabled());
+        assert!(checking.mutation_operation().is_none());
+        assert!(!app.is_mutating());
+        assert!(app.handle_intent(SettingsIntent::CheckForUpdates).is_none());
+
+        // A refresh can observe a newer saved channel while discovery is in flight.
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        app.complete_read(
+            refresh.read_operation().unwrap(),
+            Ok(groups(
+                "updates_auto_check=disabled\nupdates_channel=prerelease\n",
+            )),
+        )
+        .unwrap();
+        assert!(app.presentation().update_check().checking());
+        let completed = app
+            .complete_update_check(operation, Ok(update_report(UpdateChannel::Stable)))
+            .unwrap();
+        let result = completed.presentation().update_check().result().unwrap();
+        assert_eq!(result.channel, UpdateChannel::Stable);
+        assert!(result.description().contains("stable channel"));
+        assert_eq!(
+            completed
+                .presentation()
+                .row(BehaviorSetting::UpdatesChannel)
+                .unwrap()
+                .value_label(),
+            "Prerelease"
+        );
+        assert_eq!(
+            completed
+                .presentation()
+                .row(BehaviorSetting::UpdatesAutoCheck)
+                .unwrap()
+                .value_label(),
+            "Disabled"
+        );
+
+        let previous = completed.presentation().update_check().clone();
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let edit = app
+            .handle_intent(SettingsIntent::Commit {
+                setting: BehaviorSetting::UpdatesChannel,
+                value: "stable".into(),
+            })
+            .unwrap();
+        assert_eq!(edit.presentation().update_check(), &previous);
+        assert!(app
+            .complete_read(refresh.read_operation().unwrap(), Ok(groups("")))
+            .is_none());
+        assert!(app
+            .complete_update_check(operation, Ok(update_report(UpdateChannel::Prerelease)))
+            .is_none());
+    }
+
+    #[test]
+    fn retry_retains_last_channel_result_and_ignores_stale_or_closed_checks() {
+        use crate::updates::UpdateChannel;
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        let first = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        app.complete_update_check(first, Ok(update_report(UpdateChannel::Stable)))
+            .unwrap();
+        let second = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        assert!(app.presentation().update_check().result().is_some());
+        assert!(app
+            .complete_update_check(first, Err(UpdateCheckError::stopped()))
+            .is_none());
+        let failed = app
+            .complete_update_check(second, Err(UpdateCheckError::stopped()))
+            .unwrap();
+        assert!(failed.presentation().update_check().error().is_some());
+        assert!(failed
+            .presentation()
+            .update_check()
+            .check_action()
+            .enabled());
+        assert_eq!(
+            failed
+                .presentation()
+                .update_check()
+                .result()
+                .unwrap()
+                .channel,
+            UpdateChannel::Stable
+        );
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        app.complete_read(
+            refresh.read_operation().unwrap(),
+            Err(SettingsReadError::unreadable("test")),
+        )
+        .unwrap();
+        let retry = app.handle_intent(SettingsIntent::Retry).unwrap();
+        app.complete_read(retry.read_operation().unwrap(), Ok(groups("")))
+            .unwrap();
+        assert!(app.presentation().update_check().error().is_some());
+        let third = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        let mut current = update_report(UpdateChannel::Prerelease);
+        current.available_release = None;
+        current.warning = Some("Cache could not be saved.".into());
+        let done = app
+            .complete_update_check(third, Ok(current.clone()))
+            .unwrap();
+        assert_eq!(done.presentation().update_check().result(), Some(&current));
+        assert!(done.presentation().update_check().error().is_none());
+        assert_eq!(current.title(), "No newer release available");
+        let last = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        app.shutdown();
+        assert!(app
+            .complete_update_check(last, Err(UpdateCheckError::stopped()))
+            .is_none());
+        assert!(app.handle_intent(SettingsIntent::CheckForUpdates).is_none());
     }
 
     #[test]

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -849,6 +849,22 @@ pub struct UpdateCheckResult {
 }
 
 impl UpdateCheckResult {
+    pub fn check_channel(&self) -> UpdateChannel {
+        self.check_channel
+    }
+
+    pub fn current_version(&self) -> &Version {
+        &self.current_version
+    }
+
+    pub fn current_channel(&self) -> ReleaseChannel {
+        self.current_channel
+    }
+
+    pub fn latest(&self) -> &ReleaseInfo {
+        &self.latest
+    }
+
     pub fn update_available(&self) -> bool {
         self.latest.version > self.current_version
     }
@@ -883,6 +899,22 @@ impl UpdateCheckResult {
             self.latest.channel(),
             self.latest.url().to_string(),
         )
+    }
+}
+
+#[derive(Debug)]
+pub struct UpdateCheckOutcome {
+    result: UpdateCheckResult,
+    warnings: Vec<UpdatesDeferredFailure>,
+}
+
+impl UpdateCheckOutcome {
+    pub fn result(&self) -> &UpdateCheckResult {
+        &self.result
+    }
+
+    pub fn warnings(&self) -> &[UpdatesDeferredFailure] {
+        &self.warnings
     }
 }
 
@@ -1229,6 +1261,20 @@ pub fn run_updates_command<W: io::Write>(
     run_updates_command_with_update_settings(command, writer, context)
 }
 
+pub fn check_for_updates() -> Result<UpdateCheckOutcome, UpdatesError> {
+    let client = UreqGitHubReleasesClient::default();
+    let cache_store = DefaultUpdateCacheStore::from_env();
+    let update_settings = EnvUpdateSettings::from_env()?;
+
+    run_update_check(
+        VersionInfo::current(),
+        &client,
+        &cache_store,
+        &update_settings,
+        current_unix_seconds(),
+    )
+}
+
 pub(crate) fn discover_install_candidate(
     current: VersionInfo,
 ) -> Result<ReleaseInfo, UpdatesError> {
@@ -1282,6 +1328,63 @@ struct UpdatesRunContext<'a, C, N, S, U> {
     now_unix_seconds: u64,
 }
 
+struct PreparedUpdateCheck {
+    result: UpdateCheckResult,
+    cache: UpdateCheckCache,
+    deferred_failures: Vec<UpdatesDeferredFailure>,
+}
+
+fn prepare_update_check<C: GitHubReleasesClient, S: UpdateCacheStore, U: UpdateSettings>(
+    version: VersionInfo,
+    client: &C,
+    cache_store: &S,
+    update_settings: &U,
+    now_unix_seconds: u64,
+) -> Result<PreparedUpdateCheck, UpdatesError> {
+    let channel = update_settings.channel()?;
+    let mut deferred_failures = Vec::new();
+    let mut cache = match cache_store.load() {
+        Ok(cache) => cache,
+        Err(err) => {
+            deferred_failures.push(UpdatesDeferredFailure::Cache(Box::new(err)));
+            UpdateCheckCache::default()
+        }
+    };
+    let result = check_updates_with_cache(channel, version, client, &mut cache, now_unix_seconds)?;
+
+    Ok(PreparedUpdateCheck {
+        result,
+        cache,
+        deferred_failures,
+    })
+}
+
+fn run_update_check<C: GitHubReleasesClient, S: UpdateCacheStore, U: UpdateSettings>(
+    version: VersionInfo,
+    client: &C,
+    cache_store: &S,
+    update_settings: &U,
+    now_unix_seconds: u64,
+) -> Result<UpdateCheckOutcome, UpdatesError> {
+    let mut prepared = prepare_update_check(
+        version,
+        client,
+        cache_store,
+        update_settings,
+        now_unix_seconds,
+    )?;
+    if let Err(err) = cache_store.save(&prepared.cache) {
+        prepared
+            .deferred_failures
+            .push(UpdatesDeferredFailure::Cache(Box::new(err)));
+    }
+
+    Ok(UpdateCheckOutcome {
+        result: prepared.result,
+        warnings: prepared.deferred_failures,
+    })
+}
+
 fn run_updates_command_with_update_settings<
     W: io::Write,
     C: GitHubReleasesClient,
@@ -1300,22 +1403,14 @@ fn run_updates_command_with_update_settings<
         return Ok(());
     }
     let notify = command.notify();
-    let channel = context.update_settings.channel()?;
-    let mut deferred_failures = Vec::new();
-    let mut cache = match context.cache_store.load() {
-        Ok(cache) => cache,
-        Err(err) => {
-            deferred_failures.push(UpdatesDeferredFailure::Cache(Box::new(err)));
-            UpdateCheckCache::default()
-        }
-    };
-    let result = check_updates_with_cache(
-        channel,
+    let mut prepared = prepare_update_check(
         context.version,
         context.client,
-        &mut cache,
+        context.cache_store,
+        context.update_settings,
         context.now_unix_seconds,
     )?;
+    let result = &prepared.result;
 
     writer.write_all(result.render().as_bytes())?;
     let notification_decision =
@@ -1323,7 +1418,8 @@ fn run_updates_command_with_update_settings<
             notify_requested: notify,
             update_available: result.update_available(),
             latest: &result.latest,
-            last_notification: cache
+            last_notification: prepared
+                .cache
                 .entry(result.check_channel)
                 .and_then(|entry| entry.last_notification.as_ref()),
         });
@@ -1334,7 +1430,7 @@ fn run_updates_command_with_update_settings<
                 .and_then(|request| context.notifier.show_update_notification(&request));
             match notification_result {
                 Ok(_) => {
-                    cache.record_notification(
+                    prepared.cache.record_notification(
                         result.check_channel,
                         &result.latest,
                         context.now_unix_seconds,
@@ -1343,7 +1439,9 @@ fn run_updates_command_with_update_settings<
                 }
                 Err(err) => {
                     writer.write_all(render_update_notification_failure(reason).as_bytes())?;
-                    deferred_failures.push(UpdatesDeferredFailure::Notification(err));
+                    prepared
+                        .deferred_failures
+                        .push(UpdatesDeferredFailure::Notification(err));
                 }
             }
         }
@@ -1355,12 +1453,14 @@ fn run_updates_command_with_update_settings<
             }
         }
     }
-    if let Err(err) = context.cache_store.save(&cache) {
-        deferred_failures.push(UpdatesDeferredFailure::Cache(Box::new(err)));
+    if let Err(err) = context.cache_store.save(&prepared.cache) {
+        prepared
+            .deferred_failures
+            .push(UpdatesDeferredFailure::Cache(Box::new(err)));
     }
 
-    if !deferred_failures.is_empty() {
-        return Err(UpdatesError::DeferredFailures(deferred_failures));
+    if !prepared.deferred_failures.is_empty() {
+        return Err(UpdatesError::DeferredFailures(prepared.deferred_failures));
     }
 
     Ok(())
@@ -1545,15 +1645,15 @@ mod tests {
     use super::{
         atomic_write_file, check_updates, check_updates_with_cache,
         discover_install_candidate_with, evaluate_update_notification_policy,
-        parse_release_version, resolve_update_cache_path, run_updates_command_with,
-        run_updates_command_with_update_settings, CachedReleaseInfo, CachedUpdateCheck,
-        CachedUpdateNotification, DefaultUpdateCacheStore, EnvUpdateSettings, FileUpdateCacheStore,
-        GitHubReleaseResponse, GitHubReleasesClient, ReleaseAsset, ReleaseEndpoint, ReleaseInfo,
-        StaticUpdateSettings, UpdateCachePathError, UpdateCachePathSources, UpdateCacheStore,
-        UpdateChannel, UpdateCheckCache, UpdateNotificationDecision, UpdateNotificationPolicyInput,
-        UpdateNotificationReason, UpdateNotificationSkipReason, UpdateSettings, UpdatesCommand,
-        UpdatesDeferredFailure, UpdatesError, UpdatesRunContext, UreqGitHubReleasesClient,
-        MAX_GITHUB_RESPONSE_BYTES,
+        parse_release_version, resolve_update_cache_path, run_update_check,
+        run_updates_command_with, run_updates_command_with_update_settings, CachedReleaseInfo,
+        CachedUpdateCheck, CachedUpdateNotification, DefaultUpdateCacheStore, EnvUpdateSettings,
+        FileUpdateCacheStore, GitHubReleaseResponse, GitHubReleasesClient, ReleaseAsset,
+        ReleaseEndpoint, ReleaseInfo, StaticUpdateSettings, UpdateCachePathError,
+        UpdateCachePathSources, UpdateCacheStore, UpdateChannel, UpdateCheckCache,
+        UpdateNotificationDecision, UpdateNotificationPolicyInput, UpdateNotificationReason,
+        UpdateNotificationSkipReason, UpdateSettings, UpdatesCommand, UpdatesDeferredFailure,
+        UpdatesError, UpdatesRunContext, UreqGitHubReleasesClient, MAX_GITHUB_RESPONSE_BYTES,
     };
     use crate::session_notifications::{
         UpdateNotificationError, UpdateNotificationHandoff, UpdateNotificationOutcome,
@@ -3185,6 +3285,243 @@ mod tests {
                 "lg-buddy/1.1.0".to_string()
             )]
         );
+    }
+
+    #[test]
+    fn manual_update_outcome_uses_saved_channel_when_auto_check_is_disabled() {
+        for automatic_checks in ["disabled", "bogus"] {
+            for (channel, response, endpoint, expected_version) in [
+                (
+                    UpdateChannel::Stable,
+                    stable_release("v1.1.1"),
+                    "https://api.example.test/releases/latest",
+                    "1.1.1",
+                ),
+                (
+                    UpdateChannel::Prerelease,
+                    format!("[{}]", prerelease("v1.2.0-beta.1")),
+                    "https://api.example.test/releases?per_page=1",
+                    "1.2.0-beta.1",
+                ),
+            ] {
+                let config = format!(
+                    "updates_auto_check={automatic_checks}\nupdates_channel={}\n",
+                    channel.as_str()
+                );
+                let config_dir = unique_temp_dir("manual-update-settings");
+                let config_path = config_dir.join("config.env");
+                fs::write(&config_path, &config).expect("write update settings");
+                let settings = EnvUpdateSettings {
+                    store: SettingsStore::load(&config_path).expect("load update settings"),
+                };
+                let client = MockGitHubReleasesClient::new(vec![Ok(response)]);
+                let cache_store = MemoryUpdateCacheStore::default();
+
+                let outcome = run_update_check(
+                    version_info("1.1.0", ReleaseChannel::Stable),
+                    &client,
+                    &cache_store,
+                    &settings,
+                    TEST_NOW,
+                )
+                .expect("manual update check should use saved settings");
+
+                assert_eq!(outcome.result().check_channel(), channel);
+                assert_eq!(
+                    outcome.result().current_version(),
+                    &Version::parse("1.1.0").unwrap()
+                );
+                assert_eq!(outcome.result().current_channel(), ReleaseChannel::Stable);
+                assert_eq!(
+                    outcome.result().latest().version(),
+                    &Version::parse(expected_version).unwrap()
+                );
+                assert!(outcome.result().update_available());
+                assert!(outcome.warnings().is_empty());
+                assert_eq!(
+                    client.requests(),
+                    vec![(endpoint.to_string(), "lg-buddy/1.1.0".to_string())]
+                );
+
+                let cli_client =
+                    MockGitHubReleasesClient::new(vec![Ok(if channel == UpdateChannel::Stable {
+                        stable_release("v1.1.1")
+                    } else {
+                        format!("[{}]", prerelease("v1.2.0-beta.1"))
+                    })]);
+                let cli_notifier = RecordingNotifier::default();
+                let cli_cache_store = MemoryUpdateCacheStore::default();
+                let mut cli_output = Vec::new();
+                run_updates_command_with_update_settings(
+                    check(),
+                    &mut cli_output,
+                    updates_run_context(
+                        version_info("1.1.0", ReleaseChannel::Stable),
+                        &cli_client,
+                        &cli_notifier,
+                        &cli_cache_store,
+                        &settings,
+                        TEST_NOW,
+                    ),
+                )
+                .expect("equivalent CLI update check should succeed");
+                assert_eq!(rendered(&cli_output), outcome.result().render());
+                assert!(cli_notifier.notifications().is_empty());
+                assert_eq!(
+                    fs::read(&config_path).expect("read update settings"),
+                    config.as_bytes()
+                );
+
+                fs::remove_dir_all(config_dir).expect("remove update settings temp dir");
+            }
+        }
+    }
+
+    #[test]
+    fn manual_update_outcome_reuses_cached_not_modified_release() {
+        let client =
+            MockGitHubReleasesClient::new_responses(vec![Ok(GitHubReleaseResponse::NotModified)]);
+        let mut cache = UpdateCheckCache::default();
+        cache.set_entry(
+            UpdateChannel::Prerelease,
+            cached_entry(
+                Some("\"prerelease-etag\""),
+                "1.2.0-beta.1",
+                UpdateChannel::Prerelease,
+                "https://github.test/releases/tag/v1.2.0-beta.1",
+                TEST_NOW - 10,
+            ),
+        );
+        let cache_store = MemoryUpdateCacheStore::with_cache(cache);
+        let settings = StaticUpdateSettings::disabled(UpdateChannel::Prerelease);
+
+        let outcome = run_update_check(
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &cache_store,
+            &settings,
+            TEST_NOW,
+        )
+        .expect("cached 304 update check should succeed");
+
+        assert_eq!(
+            outcome.result().latest().version(),
+            &Version::parse("1.2.0-beta.1").unwrap()
+        );
+        assert!(outcome.result().update_available());
+        assert!(outcome.warnings().is_empty());
+        assert_eq!(
+            client.requests_with_etags(),
+            vec![(
+                "https://api.example.test/releases?per_page=1".to_string(),
+                "lg-buddy/1.1.0".to_string(),
+                Some("\"prerelease-etag\"".to_string()),
+            )]
+        );
+        assert_eq!(
+            cache_store
+                .cache()
+                .entry(UpdateChannel::Prerelease)
+                .expect("prerelease cache entry")
+                .last_checked_at_unix_seconds,
+            TEST_NOW
+        );
+    }
+
+    #[test]
+    fn manual_update_outcome_preserves_result_when_cache_save_fails() {
+        let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
+        let cache_store = FailingSaveUpdateCacheStore::default();
+        let settings = StaticUpdateSettings::disabled(UpdateChannel::Stable);
+
+        let outcome = run_update_check(
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &cache_store,
+            &settings,
+            TEST_NOW,
+        )
+        .expect("cache failures should be deferred until after a valid result");
+
+        assert_eq!(
+            outcome.result().latest().version(),
+            &Version::parse("1.1.1").unwrap()
+        );
+        assert_eq!(outcome.warnings().len(), 1);
+        assert!(matches!(
+            &outcome.warnings()[0],
+            UpdatesDeferredFailure::Cache(cache_err)
+                if matches!(cache_err.as_ref(), UpdatesError::Io(_))
+        ));
+    }
+
+    #[test]
+    fn manual_update_outcome_preserves_result_when_cache_load_fails() {
+        let cache_dir = unique_temp_dir("manual-update-cache-load");
+        let cache_path = cache_dir.join("lg-buddy").join("update-check.json");
+        fs::create_dir_all(cache_path.parent().expect("cache path parent"))
+            .expect("create cache directory");
+        fs::write(&cache_path, "{").expect("write malformed cache");
+
+        let client = MockGitHubReleasesClient::new(vec![Ok(stable_release("v1.1.1"))]);
+        let cache_store = FileUpdateCacheStore::new(cache_path.clone());
+        let settings = StaticUpdateSettings::disabled(UpdateChannel::Stable);
+
+        let outcome = run_update_check(
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &cache_store,
+            &settings,
+            TEST_NOW,
+        )
+        .expect("cache load failures should be deferred until after a valid result");
+
+        assert_eq!(
+            outcome.result().latest().version(),
+            &Version::parse("1.1.1").unwrap()
+        );
+        assert_eq!(outcome.warnings().len(), 1);
+        assert!(matches!(
+            &outcome.warnings()[0],
+            UpdatesDeferredFailure::Cache(cache_err)
+                if matches!(cache_err.as_ref(), UpdatesError::CacheDecode { path, .. } if path == &cache_path)
+        ));
+        assert_eq!(
+            cache_store
+                .load()
+                .expect("successful check should replace malformed cache")
+                .entry(UpdateChannel::Stable)
+                .expect("stable cache entry")
+                .latest
+                .version,
+            "1.1.1"
+        );
+
+        fs::remove_dir_all(cache_dir).expect("remove cache temp dir");
+    }
+
+    #[test]
+    fn manual_update_outcome_returns_network_failures_without_cache_warning() {
+        let client = MockGitHubReleasesClient::new(vec![Err(UpdatesError::ApiStatus {
+            url: "https://api.example.test/releases/latest".to_string(),
+            status: 503,
+            body: "unavailable".to_string(),
+        })]);
+        let cache_store = MemoryUpdateCacheStore::default();
+        let settings = StaticUpdateSettings::disabled(UpdateChannel::Stable);
+
+        let err = run_update_check(
+            version_info("1.1.0", ReleaseChannel::Stable),
+            &client,
+            &cache_store,
+            &settings,
+            TEST_NOW,
+        )
+        .expect_err("network failures should remain check errors");
+
+        assert!(matches!(err, UpdatesError::ApiStatus { status: 503, .. }));
+        assert_eq!(cache_store.load_count(), 1);
+        assert!(cache_store.cache().entry(UpdateChannel::Stable).is_none());
     }
 
     #[test]

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -5,10 +5,9 @@ development tree. The application and GUI are a single Rust workspace, with
 the application owning state and the GTK crate rendering it.
 
 > The `v1.6.0` frontend covers Overview, TVs, Settings, first-TV pairing, and
-> About. The broader GUI
-> first-run, runtime/service, and update state surface is deferred to
-> `v1.7.0` and [issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129);
-> its runtime and service contents are still TBD.
+> About. The development tree also provides manual update checks in Settings.
+> First-run completion, update installation, and on-demand diagnostics remain
+> tracked for `v1.7.0` in [issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129).
 
 ## Boundary
 
@@ -182,12 +181,22 @@ values while hiding them; Restore policy remains visible because it also
 governs restoration outside idle blanking. Invalid blanking values keep the
 dependent controls available for diagnosis.
 
-Settings displays configured values only; there is no separate GUI surface for
-a resolved screen backend, service health, runtime state, update availability,
-or update progress. Normal successful changes are silent. Feedback appears
+Settings also offers **Check for updates** in the Updates group, including the
+installed version. An explicit check uses the saved channel independently of
+automatic checks, reusing the CLI's discovery, comparison, and cache policy.
+The application owns checking, available-release, no-newer-release, failure,
+and cache-warning presentation. It rejects duplicate checks and retains the last
+successful result with the channel and version actually checked across settings
+refreshes and edits. GTK runs the declared operation off the UI thread and renders
+its result, retry action, and native release link. A check neither installs an
+update nor changes preferences or sends a desktop notification.
+
+There is no separate GUI surface for a resolved screen backend, service health,
+runtime state, or update installation progress. Normal successful setting changes
+are silent. Feedback appears
 when a read, validation, persistence, or runtime apply result needs attention;
 an apply warning keeps the saved value and can offer **Retry apply**. The
-broader runtime/service and update state UI is deferred as described at the top
+broader diagnostics and update installation UI is deferred as described at the top
 of this document.
 
 The main menu's **About LG Buddy** action is implemented by the native

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -171,9 +171,19 @@ GUI and terminal changes use the same saved configuration. See
 format, and compatibility behavior.
 
 <a id="updates"></a>
-## Install an update
+## Check for and install an update
 
-To see whether an update is available, run:
+In **Settings → Updates**, choose **Check for updates**. This works even when
+automatic checks are off and uses your saved release channel. The app shows
+the installed version, then an available version with a release link or a
+message that no newer release is available. If a check fails, use **Retry check**.
+
+The last successful result stays labelled with the channel and installed version
+it checked, including while you change channels or retry. A cache warning can
+appear alongside a successful result; it does not mean the release check failed.
+Checking does not install anything or change your update preferences.
+
+The terminal equivalent is:
 
 ```bash
 lg-buddy updates check

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -233,7 +233,7 @@ def settings_contract(args: argparse.Namespace):
     names = {name(item) for item in accessibles}
     if not {"Screen", "Sleep & Wake", "Updates", "Desktop integration", "Idle blanking",
             "Idle timeout", "Restore policy", "TV sleep & wake", "Automatic update checks",
-            "Update channel"} <= names:
+            "Update channel", "Check for updates", "Installed version"} <= names:
         return None
     if args.expected_settings_timeout:
         timeout_entry = next(


### PR DESCRIPTION
## Summary

Settings → Updates now provides **Check for updates**, so users can check the saved release channel without opening a terminal or enabling automatic checks. The GUI and CLI share the existing release discovery, version comparison, and cache handling.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

The Updates group shows the installed version, a checking state, and either an available version with a release link, no newer release, or an actionable error with Retry check. A successful result remains labelled with the channel and installed version actually checked, including when preferences change during a request or a later request fails. Cache warnings preserve a valid release result.

Checks run off the UI thread and reject duplicate requests. Existing settings remain usable while checking. Manual checks do not install releases, change preferences, or send desktop notifications; GUI installation remains #199.

## Validation

- `cargo test -p lg-buddy`: passed, including 915 library tests, 134 Cucumber scenarios, and all integration suites; one hardware-only test remains ignored.
- Display-backed `cargo test -p lg-buddy-gui -- --test-threads=1`: passed, including blocked-check responsiveness, channel changes, retry, retained results, keyboard access, release links, and 360px layout.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: passed.
- `cargo fmt --all --check`, `git diff --check`, and Python syntax validation: passed.
- Canonical `scripts/test-installed-gui.sh` under private D-Bus/Xvfb: passed, including the installed Settings accessibility contract.

Release responses and failures are covered with deterministic updater and GUI backend fixtures. Installed smoke verifies the shipped action and version readout without making live release requests. No live TV operation or host installation was used.

## Related Issue

Fixes #197.

Part of #129. Provides the checking and result-presentation foundation for #199.
