### PR TITLE
Install release-bundle updates from Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Validate shell scripts
         run: |
-          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-installer-gui-dependencies.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-installer-gui-dependencies.sh scripts/test-installer-graphical-auth.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
           python3 -m py_compile scripts/test-release-gui-accessibility.py scripts/xwd_mean.py
 
       - name: Validate release promotion contract
@@ -108,6 +108,17 @@ jobs:
         run: |
           umask 0002
           ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --gui-target x86_64-unknown-linux-gnu --version "$SMOKE_VERSION" --output-dir dist
+
+      - name: Enable graphical authorization smoke namespaces
+        # Ubuntu 24.04 may restrict unprivileged user namespaces through
+        # AppArmor. Relax only that disposable runner setting for the
+        # isolated graphical-authorization fixture; the final probe keeps
+        # this lane mandatory if the namespace contract is still unavailable.
+        run: |
+          if ! unshare -Ur true >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          unshare -Ur true
 
       - name: Smoke test release bundle
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install GTK test prerequisites
         run: |
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y at-spi2-core dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev python3-pyatspi xdotool xvfb zenity
 
@@ -98,7 +98,7 @@ jobs:
       - name: Install smoke-test prerequisites
         run: |
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,11 @@ jobs:
           sudo env "PATH=$PATH" "CARGO_HOME=$CARGO_HOME" "RUSTUP_HOME=$RUSTUP_HOME" "RUSTUP_TOOLCHAIN=${RUSTUP_TOOLCHAIN:-stable}" "CARGO_TARGET_DIR=$sudo_target_dir" cargo test -p lg-buddy --lib platform_access_token::tests::persist_assigns_requested_owner_when_running_as_root -- --exact
 
       - name: Install GTK test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y at-spi2-core dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev python3-pyatspi xdotool xvfb zenity
+        run: |
+          # Chrome is unused; its third-party index must not block Ubuntu dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y at-spi2-core dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev python3-pyatspi xdotool xvfb zenity
 
       - name: Run display-backed GTK test suite
         run: |
@@ -92,7 +96,11 @@ jobs:
           python-version: "3.x"
 
       - name: Install smoke-test prerequisites
-        run: sudo apt-get update && sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
+        run: |
+          # Chrome is unused; its third-party index must not block Ubuntu dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
 
       - name: Build headless runtime and GTK GUI
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,11 @@ jobs:
           python-version: "3.x"
 
       - name: Install release prerequisites
-        run: sudo apt-get update && sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
+        run: |
+          # Chrome is unused; its third-party index must not block Ubuntu dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
 
       - name: Build headless runtime and GTK GUI
         env:
@@ -399,7 +403,11 @@ jobs:
           python-version: "3.x"
 
       - name: Install canary prerequisites
-        run: sudo apt-get update && sudo apt-get install -y libadwaita-1-0 libgtk-4-1 python3-venv util-linux zenity
+        run: |
+          # Chrome is unused; its third-party index must not block Ubuntu dependencies.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo apt-get update
+          sudo apt-get install -y libadwaita-1-0 libgtk-4-1 python3-venv util-linux zenity
 
       - name: Download pinned updater-capable baseline
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,17 @@ jobs:
       - name: Create release bundle
         run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --gui-target x86_64-unknown-linux-gnu --version "${{ needs.validate.outputs.version }}" --output-dir dist
 
+      - name: Enable graphical authorization smoke namespaces
+        # Ubuntu 24.04 may restrict unprivileged user namespaces through
+        # AppArmor. Relax only that disposable runner setting for the
+        # isolated graphical-authorization fixture; the final probe keeps
+        # this lane mandatory if the namespace contract is still unavailable.
+        run: |
+          if ! unshare -Ur true >/dev/null 2>&1; then
+            sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+          fi
+          unshare -Ur true
+
       - name: Smoke test release bundle
         run: |
           dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 ./scripts/test-release-bundle.sh \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install release prerequisites
         run: |
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
 
@@ -405,7 +405,7 @@ jobs:
       - name: Install canary prerequisites
         run: |
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
-          sudo rm -f /etc/apt/sources.list.d/google-chrome.list
+          sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
           sudo apt-get install -y libadwaita-1-0 libgtk-4-1 python3-venv util-linux zenity
 

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -35,6 +35,10 @@ use lg_buddy::tvs::{
     EnvironmentTvsBackend, TvsBackend, TvsIntent, TvsModelReadOperation, TvsReadError,
     TvsReadOperation, TvsTransition,
 };
+use lg_buddy::update_flow::{
+    EnvironmentUpdateInstallBackend, UpdateInstallBackend, UpdateInstallFailure,
+    UpdateInstallOperation, UpdateInstallOutcome, UpdateInstallTask,
+};
 
 pub const APPLICATION_ID: &str = "io.github.staphylococcus.LGBuddy";
 pub const APPLICATION_NAME: &str = "LG Buddy";
@@ -52,6 +56,8 @@ pub enum GuiCommand {
     Overview,
     Brightness,
     Version,
+    /// Internal entry point used only by the post-install process handoff.
+    Relaunch,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,6 +84,7 @@ where
 {
     let mut args = args.into_iter();
     let command = match args.next() {
+        Some(command) if command.as_ref() == "--gapplication-replace" => GuiCommand::Relaunch,
         Some(command) if command.as_ref() == "brightness" => GuiCommand::Brightness,
         Some(command) if matches!(command.as_ref(), "--version" | "-V") => GuiCommand::Version,
         Some(command) => return Err(GuiParseError::UnknownCommand(command.as_ref().to_string())),
@@ -96,7 +103,8 @@ pub fn help(program: &str) -> String {
 
 pub fn run(command: GuiCommand) -> glib::ExitCode {
     match command {
-        GuiCommand::Overview | GuiCommand::Brightness => run_application(command),
+        GuiCommand::Overview | GuiCommand::Brightness => run_application(command, false),
+        GuiCommand::Relaunch => run_application(GuiCommand::Overview, true),
         GuiCommand::Version => {
             print!("{}", lg_buddy::version::version_text());
             glib::ExitCode::SUCCESS
@@ -104,11 +112,16 @@ pub fn run(command: GuiCommand) -> glib::ExitCode {
     }
 }
 
-fn run_application(command: GuiCommand) -> glib::ExitCode {
+fn run_application(command: GuiCommand, replacing: bool) -> glib::ExitCode {
     glib::set_application_name(APPLICATION_NAME);
+    let mut flags = gtk::gio::ApplicationFlags::HANDLES_COMMAND_LINE
+        | gtk::gio::ApplicationFlags::ALLOW_REPLACEMENT;
+    if replacing {
+        flags |= gtk::gio::ApplicationFlags::REPLACE;
+    }
     let application = adw::Application::builder()
         .application_id(APPLICATION_ID)
-        .flags(gtk::gio::ApplicationFlags::HANDLES_COMMAND_LINE)
+        .flags(flags)
         .build();
     let controller = Rc::new(RefCell::new(None::<Rc<ApplicationController>>));
     install_application_actions(&application, Rc::clone(&controller));
@@ -119,8 +132,9 @@ fn run_application(command: GuiCommand) -> glib::ExitCode {
         Arc::new(EnvironmentTvsBackend),
         Arc::new(EnvironmentSettingsBackend),
     );
-    let arguments: &[&str] = match command {
-        GuiCommand::Brightness => &["lg-buddy-gui", "brightness"],
+    let arguments: &[&str] = match (command, replacing) {
+        (_, true) => &["lg-buddy-gui", "--gapplication-replace"],
+        (GuiCommand::Brightness, false) => &["lg-buddy-gui", "brightness"],
         _ => &["lg-buddy-gui"],
     };
     application.run_with_args(arguments)
@@ -166,6 +180,7 @@ struct ApplicationController {
     tvs_backend: Arc<dyn TvsBackend>,
     pairing_backend: Arc<dyn PairingBackend>,
     settings_backend: Arc<dyn SettingsBackend>,
+    update_install_backend: Arc<dyn UpdateInstallBackend>,
     navigation: RefCell<Navigation>,
     backend: Arc<dyn OverviewBackend>,
     closed: Cell<bool>,
@@ -193,6 +208,24 @@ impl ApplicationController {
         tvs_backend: Arc<dyn TvsBackend>,
         pairing_backend: Arc<dyn PairingBackend>,
         settings_backend: Arc<dyn SettingsBackend>,
+    ) -> (Rc<Self>, ApplicationTransition) {
+        Self::with_update_backend(
+            gtk_application,
+            backend,
+            tvs_backend,
+            pairing_backend,
+            settings_backend,
+            Arc::new(EnvironmentUpdateInstallBackend),
+        )
+    }
+
+    fn with_update_backend(
+        gtk_application: &adw::Application,
+        backend: Arc<dyn OverviewBackend>,
+        tvs_backend: Arc<dyn TvsBackend>,
+        pairing_backend: Arc<dyn PairingBackend>,
+        settings_backend: Arc<dyn SettingsBackend>,
+        update_install_backend: Arc<dyn UpdateInstallBackend>,
     ) -> (Rc<Self>, ApplicationTransition) {
         let (application, opening) = Application::open();
         let controller = Rc::new_cyclic(|controller| {
@@ -232,6 +265,7 @@ impl ApplicationController {
                 tvs_backend,
                 pairing_backend,
                 settings_backend,
+                update_install_backend,
                 navigation: RefCell::new(Navigation::default()),
                 application: RefCell::new(application),
                 gtk_application: gtk_application.clone(),
@@ -334,6 +368,71 @@ impl ApplicationController {
         if let Some(operation) = transition.update_check_operation() {
             Self::start_update_check(controller, operation);
         }
+        if let Some(operation) = transition.update_install_operation() {
+            Self::start_update_install(controller, operation.clone());
+        }
+    }
+
+    fn start_update_install(controller: &Rc<Self>, operation: UpdateInstallOperation) {
+        if let UpdateInstallTask::Relaunch(installed) = operation.task() {
+            let result = controller.update_install_backend.relaunch(installed);
+            let relaunched = result.is_ok();
+            let transition = controller.application.borrow_mut().complete_update_install(
+                &operation,
+                result.map(|_| UpdateInstallOutcome::Relaunched),
+            );
+            if let Some(transition) = transition {
+                Self::apply_transition(controller, transition);
+            }
+            if relaunched {
+                controller.gtk_application.quit();
+            }
+            return;
+        }
+        enum Update {
+            Progress(lg_buddy::update_install::UpdateInstallStage),
+            Done(Box<Result<UpdateInstallOutcome, UpdateInstallFailure>>),
+        }
+        let backend = Arc::clone(&controller.update_install_backend);
+        let worker_operation = operation.clone();
+        let (sender, receiver) = mpsc::channel();
+        // A cancelled download must settle and release its bundle lock; once
+        // installation starts the application remains open until completion.
+        let application_hold = controller.gtk_application.hold();
+        thread::spawn(move || {
+            let result = backend.run(&worker_operation, &mut |stage| {
+                let _ = sender.send(Update::Progress(stage));
+            });
+            let _ = sender.send(Update::Done(Box::new(result)));
+        });
+        let controller = Rc::clone(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || loop {
+            let update = match receiver.try_recv() {
+                Ok(update) => update,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => Update::Done(Box::new(Err(
+                    UpdateInstallFailure::worker_stopped(&operation),
+                ))),
+            };
+            let done = matches!(update, Update::Done(_));
+            let transition = match update {
+                Update::Progress(stage) => controller
+                    .application
+                    .borrow_mut()
+                    .update_install_progress(&operation, stage),
+                Update::Done(result) => controller
+                    .application
+                    .borrow_mut()
+                    .complete_update_install(&operation, *result),
+            };
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
+            }
+            if done {
+                let _ = &application_hold;
+                return glib::ControlFlow::Break;
+            }
+        });
     }
 
     fn start_update_check(controller: &Rc<Self>, operation: UpdateCheckOperation) {
@@ -776,6 +875,16 @@ mod tests {
         assert_eq!(parse_args(["--version"]), Ok(GuiCommand::Version));
         assert_eq!(parse_args(["-V"]), Ok(GuiCommand::Version));
         assert_eq!(
+            parse_args(["--gapplication-replace"]),
+            Ok(GuiCommand::Relaunch)
+        );
+        assert_eq!(
+            parse_args(["--gapplication-replace", "brightness"]),
+            Err(GuiParseError::UnexpectedArguments(vec![
+                "brightness".to_string()
+            ]))
+        );
+        assert_eq!(
             parse_args(std::iter::empty::<&str>()),
             Ok(GuiCommand::Overview)
         );
@@ -1102,6 +1211,7 @@ pub(crate) mod controller_test_support {
         run_settings_scenario();
         run_settings_write_scenario();
         run_manual_update_check_scenario();
+        run_update_install_scenario();
 
         let (backend, controls) = BlockingBackend::new();
         let application = test_application("Blocking");
@@ -1546,6 +1656,244 @@ pub(crate) mod controller_test_support {
         controller.shutdown();
         controller.window.close();
         std::fs::remove_file(path).unwrap();
+    }
+
+    fn run_update_install_scenario() {
+        use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+        use lg_buddy::update_flow::{
+            UpdateInstallBackend, UpdateInstallFailure, UpdateInstallOperation,
+            UpdateInstallOutcome, UpdateInstallTask,
+        };
+        use lg_buddy::update_install::{
+            InstalledUpdate, PreparedUpdateInstall, UpdateInstallError, UpdateInstallStage,
+        };
+        use lg_buddy::updates::UpdateChannel;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        fn prepared() -> PreparedUpdateInstall {
+            PreparedUpdateInstall::from_parts(
+                lg_buddy::version::VersionInfo::current(),
+                "1.7.0".parse().unwrap(),
+                UpdateChannel::Stable,
+                "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0",
+                "v1.7.0",
+                "x86_64-unknown-linux-musl",
+                "a".repeat(40),
+            )
+        }
+        struct Settings;
+        impl lg_buddy::settings_view::SettingsBackend for Settings {
+            fn read_settings(
+                &self,
+            ) -> Result<
+                Vec<lg_buddy::presentation::settings::SettingsGroup>,
+                lg_buddy::settings_view::SettingsReadError,
+            > {
+                let store = lg_buddy::settings::ConfigEnvReader::parse(
+                    "/tmp/unused-gui-update.env",
+                    "updates_auto_check=disabled\nupdates_channel=stable\n",
+                )
+                .into_store();
+                Ok(
+                    lg_buddy::presentation::settings::SettingsPresentation::from_store(&store)
+                        .groups()
+                        .to_vec(),
+                )
+            }
+            fn check_for_updates(
+                &self,
+            ) -> Result<UpdateCheckReport, lg_buddy::settings_view::UpdateCheckError> {
+                Ok(UpdateCheckReport {
+                    installed_version: "1.6.0".into(),
+                    channel: UpdateChannel::Stable,
+                    available_release: Some(AvailableUpdate {
+                        version: "1.7.0".into(),
+                        url: prepared().release().url().into(),
+                    }),
+                    warning: None,
+                })
+            }
+            fn write_setting(
+                &self,
+                _: lg_buddy::settings_view::SettingsMutationOperation,
+                _: &mut dyn FnMut(lg_buddy::settings::SettingsMutationStage),
+            ) -> Result<
+                lg_buddy::settings::SettingsMutationOutcome,
+                lg_buddy::settings::SettingsMutationFailure,
+            > {
+                panic!("update workflow must not change saved settings")
+            }
+        }
+        enum WorkerReply {
+            BeginInstall,
+            Done(bool),
+        }
+        struct Updater {
+            replies: Mutex<mpsc::Receiver<WorkerReply>>,
+            installs: AtomicUsize,
+            handoffs: AtomicUsize,
+        }
+        impl UpdateInstallBackend for Updater {
+            fn run(
+                &self,
+                operation: &UpdateInstallOperation,
+                progress: &mut dyn FnMut(UpdateInstallStage),
+            ) -> Result<UpdateInstallOutcome, UpdateInstallFailure> {
+                match operation.task() {
+                    UpdateInstallTask::Prepare {
+                        version, channel, ..
+                    } => {
+                        assert_eq!(version, "1.7.0");
+                        assert_eq!(*channel, UpdateChannel::Stable);
+                        Ok(UpdateInstallOutcome::Prepared(prepared()))
+                    }
+                    UpdateInstallTask::Install { cancellation, .. } => {
+                        self.installs.fetch_add(1, Ordering::SeqCst);
+                        progress(UpdateInstallStage::Acquiring);
+                        loop {
+                            match self.replies.lock().unwrap().recv().unwrap() {
+                                WorkerReply::BeginInstall => {
+                                    cancellation.claim_installer_boundary()?;
+                                    progress(UpdateInstallStage::Installing);
+                                }
+                                WorkerReply::Done(false) => {
+                                    return Err(UpdateInstallError::AuthorizationDeclined.into())
+                                }
+                                WorkerReply::Done(true) => {
+                                    progress(UpdateInstallStage::VerifyingInstalled);
+                                    return Ok(UpdateInstallOutcome::Installed(
+                                        InstalledUpdate::from_parts(
+                                            "1.7.0".parse().unwrap(),
+                                            UpdateChannel::Stable,
+                                            "v1.7.0",
+                                            "x86_64-unknown-linux-musl",
+                                            "a".repeat(40),
+                                            "/usr/bin/lg-buddy",
+                                            "/usr/bin/lg-buddy-gui",
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                    UpdateInstallTask::Relaunch(_) => panic!("handoff is a main-thread effect"),
+                }
+            }
+            fn relaunch(&self, installed: &InstalledUpdate) -> Result<(), UpdateInstallFailure> {
+                assert_eq!(
+                    installed.gui_path(),
+                    std::path::Path::new("/usr/bin/lg-buddy-gui")
+                );
+                assert_eq!(installed.identity().version().to_string(), "1.7.0");
+                self.handoffs.fetch_add(1, Ordering::SeqCst);
+                Err(UpdateInstallFailure::stopped())
+            }
+        }
+        fn button(widget: &gtk::Widget, label: &str) -> Option<gtk::Button> {
+            if let Some(button) = widget.downcast_ref::<gtk::Button>() {
+                if button.is_visible() && button.label().as_deref() == Some(label) {
+                    return Some(button.clone());
+                }
+            }
+            let mut child = widget.first_child();
+            while let Some(widget) = child {
+                if let Some(button) = button(&widget, label) {
+                    return Some(button);
+                }
+                child = widget.next_sibling();
+            }
+            None
+        }
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let updater = Arc::new(Updater {
+            replies: Mutex::new(reply_rx),
+            installs: AtomicUsize::new(0),
+            handoffs: AtomicUsize::new(0),
+        });
+        let application = test_application("UpdateInstall");
+        let (controller, opening) = ApplicationController::with_update_backend(
+            &application,
+            Arc::new(PanicBackend),
+            Arc::new(EmptyTvsBackend),
+            Arc::new(lg_buddy::pairing::EnvironmentPairingBackend),
+            Arc::new(Settings),
+            updater.clone(),
+        );
+        ApplicationController::render_settings_transition(&controller, opening.settings().unwrap());
+        controller
+            .window
+            .choose_page(super::ApplicationPage::Settings);
+        controller.present();
+        let native = controller.window.window();
+        pump_until(|| button(native.upcast_ref(), "Check for updates").is_some());
+        button(native.upcast_ref(), "Check for updates")
+            .unwrap()
+            .emit_clicked();
+        pump_until(|| button(native.upcast_ref(), "Install update…").is_some());
+        button(native.upcast_ref(), "Install update…")
+            .unwrap()
+            .emit_clicked();
+        pump_until(|| button(native.upcast_ref(), "Install and restart").is_some());
+        assert_eq!(updater.installs.load(Ordering::SeqCst), 0);
+        button(native.upcast_ref(), "Cancel")
+            .unwrap()
+            .emit_clicked();
+        assert_eq!(updater.installs.load(Ordering::SeqCst), 0);
+        for success in [false, true] {
+            let label = if success {
+                "Retry update"
+            } else {
+                "Install update…"
+            };
+            button(native.upcast_ref(), label).unwrap().emit_clicked();
+            pump_until(|| button(native.upcast_ref(), "Install and restart").is_some());
+            button(native.upcast_ref(), "Install and restart")
+                .unwrap()
+                .emit_clicked();
+            pump_until(|| updater.installs.load(Ordering::SeqCst) == if success { 2 } else { 1 });
+            ApplicationController::handle_settings_intent(
+                &controller,
+                lg_buddy::settings_view::SettingsIntent::ConfirmUpdateInstall,
+            );
+            controller.window.choose_page(super::ApplicationPage::Tvs);
+            controller
+                .window
+                .choose_page(super::ApplicationPage::Settings);
+            reply_tx.send(WorkerReply::BeginInstall).unwrap();
+            pump_until(|| widget_contains_text(native.upcast_ref(), "Installing update…"));
+            ApplicationController::handle_intent(&controller, super::OverviewIntent::Cancel);
+            assert!(
+                !controller.closed.get(),
+                "claimed installation keeps progress and errors visible"
+            );
+            assert!(button(native.upcast_ref(), "Cancel").is_none());
+            reply_tx.send(WorkerReply::Done(success)).unwrap();
+            pump_until(|| {
+                button(
+                    native.upcast_ref(),
+                    if success {
+                        "Retry restart"
+                    } else {
+                        "Retry update"
+                    },
+                )
+                .is_some()
+            });
+        }
+        assert_eq!(updater.installs.load(Ordering::SeqCst), 2);
+        assert_eq!(updater.handoffs.load(Ordering::SeqCst), 1);
+        button(native.upcast_ref(), "Retry restart")
+            .unwrap()
+            .emit_clicked();
+        assert_eq!(updater.handoffs.load(Ordering::SeqCst), 2);
+        assert_eq!(
+            updater.installs.load(Ordering::SeqCst),
+            2,
+            "restart retry cannot reinstall"
+        );
+        assert_eq!(application.windows().len(), 1);
+        controller.shutdown();
+        controller.window.close();
     }
 
     fn run_settings_write_scenario() {

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -358,6 +358,9 @@ impl ApplicationController {
         }
         if !controller.closed.get() {
             controller.window.render_settings(transition.presentation());
+            if let Some(notice) = transition.update_notice() {
+                controller.window.show_update_notice(notice);
+            }
         }
         if let Some(operation) = transition.read_operation() {
             Self::start_settings_read(controller, operation);
@@ -1613,11 +1616,12 @@ pub(crate) mod controller_test_support {
             .choose_page(super::ApplicationPage::Settings);
         pump_until(|| widget_contains_text(native.upcast_ref(), "Prerelease"));
         reply_tx.send(Ok(true)).unwrap();
-        pump_until(|| widget_contains_text(native.upcast_ref(), "Update available: 1.7.0"));
-        assert!(widget_contains_text(
-            native.upcast_ref(),
-            "Last successful check: stable channel, compared with installed version 1.6.0."
-        ));
+        pump_until(|| check.is_sensitive());
+        assert_eq!(check.label().as_deref(), Some("Check for updates"));
+        assert!(
+            !widget_contains_text(native.upcast_ref(), "Update available: 1.7.0"),
+            "an old-channel result must not replace the current row"
+        );
         assert_eq!(std::fs::read(&path).unwrap(), saved);
 
         check.emit_clicked();
@@ -1633,7 +1637,7 @@ pub(crate) mod controller_test_support {
             }
             .into()))
             .unwrap();
-        pump_until(|| find_button(native.upcast_ref(), "Retry check").is_some());
+        pump_until(|| find_button(native.upcast_ref(), "Copy details").is_some());
         assert!(widget_contains_text(
             native.upcast_ref(),
             "Could not check for updates"
@@ -1642,15 +1646,16 @@ pub(crate) mod controller_test_support {
             native.upcast_ref(),
             "Update available: 1.7.0"
         ));
-        find_button(native.upcast_ref(), "Retry check")
+        find_button(native.upcast_ref(), "Check for updates")
             .unwrap()
             .emit_clicked();
         pump_until(|| backend.calls.load(Ordering::SeqCst) == 3);
         reply_tx.send(Ok(false)).unwrap();
-        pump_until(|| widget_contains_text(native.upcast_ref(), "No newer release available"));
-        assert!(widget_contains_text(
+        pump_until(|| widget_contains_text(native.upcast_ref(), "Already up to date"));
+        assert_eq!(check.label().as_deref(), Some("Check for updates"));
+        assert!(!widget_contains_text(
             native.upcast_ref(),
-            "Last successful check: prerelease channel, compared with installed version 1.6.0."
+            "No newer release available"
         ));
         assert_eq!(std::fs::read(&path).unwrap(), saved);
         controller.shutdown();
@@ -1659,6 +1664,7 @@ pub(crate) mod controller_test_support {
     }
 
     fn run_update_install_scenario() {
+        use adw::prelude::AdwApplicationWindowExt;
         use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
         use lg_buddy::update_flow::{
             UpdateInstallBackend, UpdateInstallFailure, UpdateInstallOperation,
@@ -1840,12 +1846,16 @@ pub(crate) mod controller_test_support {
             .emit_clicked();
         assert_eq!(updater.installs.load(Ordering::SeqCst), 0);
         for success in [false, true] {
-            let label = if success {
-                "Retry update"
-            } else {
-                "Install update…"
-            };
-            button(native.upcast_ref(), label).unwrap().emit_clicked();
+            pump_until(|| {
+                native
+                    .downcast_ref::<adw::ApplicationWindow>()
+                    .unwrap()
+                    .visible_dialog()
+                    .is_none()
+            });
+            button(native.upcast_ref(), "Install update…")
+                .unwrap()
+                .emit_clicked();
             pump_until(|| button(native.upcast_ref(), "Install and restart").is_some());
             button(native.upcast_ref(), "Install and restart")
                 .unwrap()
@@ -1869,20 +1879,18 @@ pub(crate) mod controller_test_support {
             assert!(button(native.upcast_ref(), "Cancel").is_none());
             reply_tx.send(WorkerReply::Done(success)).unwrap();
             pump_until(|| {
-                button(
-                    native.upcast_ref(),
-                    if success {
-                        "Retry restart"
-                    } else {
-                        "Retry update"
-                    },
-                )
-                .is_some()
+                native
+                    .downcast_ref::<adw::ApplicationWindow>()
+                    .unwrap()
+                    .visible_dialog()
+                    .is_none()
             });
+            pump_until(|| button(native.upcast_ref(), "Copy details").is_some());
+            assert!(button(native.upcast_ref(), "Install update…").is_some());
         }
         assert_eq!(updater.installs.load(Ordering::SeqCst), 2);
         assert_eq!(updater.handoffs.load(Ordering::SeqCst), 1);
-        button(native.upcast_ref(), "Retry restart")
+        button(native.upcast_ref(), "Install update…")
             .unwrap()
             .emit_clicked();
         assert_eq!(updater.handoffs.load(Ordering::SeqCst), 2);

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1476,7 +1476,7 @@ pub(crate) mod controller_test_support {
     }
 
     fn run_manual_update_check_scenario() {
-        use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+        use lg_buddy::presentation::update_check::UpdateCheckReport;
         use lg_buddy::settings_view::{SettingsBackend, UpdateCheckError};
         use lg_buddy::updates::UpdateChannel;
         use std::sync::atomic::{AtomicUsize, Ordering};
@@ -1534,11 +1534,7 @@ pub(crate) mod controller_test_support {
                 Ok(UpdateCheckReport {
                     installed_version: "1.6.0".into(),
                     channel,
-                    available_release: available.then(|| AvailableUpdate {
-                        version: "1.7.0".into(),
-                        url: "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0"
-                            .into(),
-                    }),
+                    update_available: available,
                     warning: None,
                 })
             }
@@ -1619,7 +1615,7 @@ pub(crate) mod controller_test_support {
         pump_until(|| check.is_sensitive());
         assert_eq!(check.label().as_deref(), Some("Check for updates"));
         assert!(
-            !widget_contains_text(native.upcast_ref(), "Update available: 1.7.0"),
+            !widget_contains_text(native.upcast_ref(), "Update available"),
             "an old-channel result must not replace the current row"
         );
         assert_eq!(std::fs::read(&path).unwrap(), saved);
@@ -1644,7 +1640,7 @@ pub(crate) mod controller_test_support {
         ));
         assert!(!widget_contains_text(
             native.upcast_ref(),
-            "Update available: 1.7.0"
+            "Update available"
         ));
         find_button(native.upcast_ref(), "Check for updates")
             .unwrap()
@@ -1665,7 +1661,7 @@ pub(crate) mod controller_test_support {
 
     fn run_update_install_scenario() {
         use adw::prelude::AdwApplicationWindowExt;
-        use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+        use lg_buddy::presentation::update_check::UpdateCheckReport;
         use lg_buddy::update_flow::{
             UpdateInstallBackend, UpdateInstallFailure, UpdateInstallOperation,
             UpdateInstallOutcome, UpdateInstallTask,
@@ -1679,10 +1675,10 @@ pub(crate) mod controller_test_support {
         fn prepared() -> PreparedUpdateInstall {
             PreparedUpdateInstall::from_parts(
                 lg_buddy::version::VersionInfo::current(),
-                "1.7.0".parse().unwrap(),
+                "1.7.1".parse().unwrap(),
                 UpdateChannel::Stable,
-                "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0",
-                "v1.7.0",
+                "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.1",
+                "v1.7.1",
                 "x86_64-unknown-linux-musl",
                 "a".repeat(40),
             )
@@ -1712,10 +1708,7 @@ pub(crate) mod controller_test_support {
                 Ok(UpdateCheckReport {
                     installed_version: "1.6.0".into(),
                     channel: UpdateChannel::Stable,
-                    available_release: Some(AvailableUpdate {
-                        version: "1.7.0".into(),
-                        url: prepared().release().url().into(),
-                    }),
+                    update_available: true,
                     warning: None,
                 })
             }
@@ -1736,6 +1729,7 @@ pub(crate) mod controller_test_support {
         }
         struct Updater {
             replies: Mutex<mpsc::Receiver<WorkerReply>>,
+            preparations: AtomicUsize,
             installs: AtomicUsize,
             handoffs: AtomicUsize,
         }
@@ -1746,12 +1740,12 @@ pub(crate) mod controller_test_support {
                 progress: &mut dyn FnMut(UpdateInstallStage),
             ) -> Result<UpdateInstallOutcome, UpdateInstallFailure> {
                 match operation.task() {
-                    UpdateInstallTask::Prepare {
-                        version, channel, ..
-                    } => {
-                        assert_eq!(version, "1.7.0");
-                        assert_eq!(*channel, UpdateChannel::Stable);
-                        Ok(UpdateInstallOutcome::Prepared(prepared()))
+                    UpdateInstallTask::Prepare => {
+                        if self.preparations.fetch_add(1, Ordering::SeqCst) == 0 {
+                            Ok(UpdateInstallOutcome::UpToDate)
+                        } else {
+                            Ok(UpdateInstallOutcome::Prepared(prepared()))
+                        }
                     }
                     UpdateInstallTask::Install { cancellation, .. } => {
                         self.installs.fetch_add(1, Ordering::SeqCst);
@@ -1769,9 +1763,9 @@ pub(crate) mod controller_test_support {
                                     progress(UpdateInstallStage::VerifyingInstalled);
                                     return Ok(UpdateInstallOutcome::Installed(
                                         InstalledUpdate::from_parts(
-                                            "1.7.0".parse().unwrap(),
+                                            "1.7.1".parse().unwrap(),
                                             UpdateChannel::Stable,
-                                            "v1.7.0",
+                                            "v1.7.1",
                                             "x86_64-unknown-linux-musl",
                                             "a".repeat(40),
                                             "/usr/bin/lg-buddy",
@@ -1790,7 +1784,7 @@ pub(crate) mod controller_test_support {
                     installed.gui_path(),
                     std::path::Path::new("/usr/bin/lg-buddy-gui")
                 );
-                assert_eq!(installed.identity().version().to_string(), "1.7.0");
+                assert_eq!(installed.identity().version().to_string(), "1.7.1");
                 self.handoffs.fetch_add(1, Ordering::SeqCst);
                 Err(UpdateInstallFailure::stopped())
             }
@@ -1813,6 +1807,7 @@ pub(crate) mod controller_test_support {
         let (reply_tx, reply_rx) = mpsc::channel();
         let updater = Arc::new(Updater {
             replies: Mutex::new(reply_rx),
+            preparations: AtomicUsize::new(0),
             installs: AtomicUsize::new(0),
             handoffs: AtomicUsize::new(0),
         });
@@ -1839,7 +1834,31 @@ pub(crate) mod controller_test_support {
         button(native.upcast_ref(), "Install update…")
             .unwrap()
             .emit_clicked();
+        pump_until(|| button(native.upcast_ref(), "Check for updates").is_some());
+        pump_until(|| {
+            native
+                .downcast_ref::<adw::ApplicationWindow>()
+                .unwrap()
+                .visible_dialog()
+                .is_none()
+        });
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Already up to date"
+        ));
+        assert_eq!(updater.installs.load(Ordering::SeqCst), 0);
+        button(native.upcast_ref(), "Check for updates")
+            .unwrap()
+            .emit_clicked();
+        pump_until(|| button(native.upcast_ref(), "Install update…").is_some());
+        button(native.upcast_ref(), "Install update…")
+            .unwrap()
+            .emit_clicked();
         pump_until(|| button(native.upcast_ref(), "Install and restart").is_some());
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Install LG Buddy 1.7.1?"
+        ));
         assert_eq!(updater.installs.load(Ordering::SeqCst), 0);
         button(native.upcast_ref(), "Cancel")
             .unwrap()

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1638,7 +1638,7 @@ pub(crate) mod controller_test_support {
             native.upcast_ref(),
             "Could not check for updates"
         ));
-        assert!(widget_contains_text(
+        assert!(!widget_contains_text(
             native.upcast_ref(),
             "Update available: 1.7.0"
         ));

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1135,6 +1135,7 @@ pub(crate) mod controller_test_support {
         application
     }
 
+    #[track_caller]
     pub(crate) fn pump_until(mut ready: impl FnMut() -> bool) {
         let context = glib::MainContext::default();
         let deadline = Instant::now() + Duration::from_secs(3);
@@ -1826,7 +1827,10 @@ pub(crate) mod controller_test_support {
             .choose_page(super::ApplicationPage::Settings);
         controller.present();
         let native = controller.window.window();
-        pump_until(|| button(native.upcast_ref(), "Check for updates").is_some());
+        pump_until(|| {
+            button(native.upcast_ref(), "Check for updates")
+                .is_some_and(|button| button.is_mapped())
+        });
         button(native.upcast_ref(), "Check for updates")
             .unwrap()
             .emit_clicked();

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -156,6 +156,7 @@ struct UpdaterView {
     cancel_intent: Rc<RefCell<Option<SettingsIntent>>>,
     release: gtk::LinkButton,
     presented: Cell<bool>,
+    close_pending: Rc<Cell<bool>>,
     pulse: RefCell<Option<gtk::glib::SourceId>>,
     notice: RefCell<Option<adw::Toast>>,
 }
@@ -249,6 +250,33 @@ impl UpdaterView {
                 }
             }
         });
+        let close_pending = Rc::new(Cell::new(false));
+        toolbar.connect_map({
+            let close_pending = Rc::clone(&close_pending);
+            let dialog = dialog.downgrade();
+            let action = action.downgrade();
+            move |_| {
+                if !close_pending.get() {
+                    return;
+                }
+                // libadwaita 1.5 ignores force_close before its first opening
+                // frame. Finish that close after the content has mapped and
+                // the opening callback has returned.
+                let close_pending = Rc::clone(&close_pending);
+                let dialog = dialog.clone();
+                let action = action.clone();
+                gtk::glib::idle_add_local_once(move || {
+                    if close_pending.replace(false) {
+                        if let Some(dialog) = dialog.upgrade() {
+                            dialog.force_close();
+                        }
+                        if let Some(action) = action.upgrade() {
+                            action.grab_focus();
+                        }
+                    }
+                });
+            }
+        });
         Self {
             row,
             action,
@@ -264,6 +292,7 @@ impl UpdaterView {
             cancel_intent,
             release,
             presented: Cell::new(false),
+            close_pending,
             pulse: RefCell::new(None),
             notice: RefCell::new(None),
         }
@@ -305,11 +334,16 @@ impl UpdaterView {
         }
         if !active {
             if self.presented.replace(false) {
-                self.dialog.force_close();
-                self.action.grab_focus();
+                if self.dialog.child().is_some_and(|child| child.is_mapped()) {
+                    self.dialog.force_close();
+                    self.action.grab_focus();
+                } else {
+                    self.close_pending.set(true);
+                }
             }
             return;
         }
+        self.close_pending.set(false);
         let title = install.title().unwrap_or("Updating LG Buddy…");
         self.title.set_text(title);
         self.description.set_text(install.description());
@@ -1311,6 +1345,38 @@ fn updater_renderer_scenarios(application: &adw::Application) {
         intents.borrow_mut().pop(),
         Some(SettingsIntent::PrepareUpdateInstall)
     );
+    let preparation = model
+        .handle_intent(SettingsIntent::PrepareUpdateInstall)
+        .unwrap();
+    view.render(preparation.presentation());
+    // Complete before pumping GTK: on libadwaita 1.5 the dialog's opening
+    // frame has not run yet, but the finished workflow must still dismiss it.
+    let current = model
+        .complete_update_install(
+            preparation.update_install_operation().unwrap(),
+            Ok(UpdateInstallOutcome::UpToDate),
+        )
+        .unwrap();
+    view.render(current.presentation());
+    view.show_update_notice(current.update_notice().unwrap(), &overlay);
+    pump_until(|| window.visible_dialog().is_none() && view.updater.dialog.parent().is_none());
+    assert!(action.has_focus());
+    assert_eq!(action.label().as_deref(), Some("Check for updates"));
+
+    let checking = model
+        .handle_intent(SettingsIntent::CheckForUpdates)
+        .unwrap();
+    model
+        .complete_update_check(
+            checking.update_check_operation().unwrap(),
+            Ok(UpdateCheckReport {
+                installed_version: "1.6.0".into(),
+                channel: UpdateChannel::Stable,
+                update_available: true,
+                warning: None,
+            }),
+        )
+        .unwrap();
     let preparation = model
         .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -6,8 +6,8 @@ use lg_buddy::presentation::settings::{
     SettingsCommitPolicy, SettingsEditStatus, SettingsEditor, SettingsFeedbackSeverity,
     SettingsPresentation, SettingsRow, SettingsStatus,
 };
-use lg_buddy::presentation::updater::UpdaterPresentation;
 use lg_buddy::settings_view::SettingsIntent;
+use lg_buddy::settings_view::UpdateNotice;
 
 /// Stable native controls render application-owned values and commit policies.
 pub(crate) struct SettingsView {
@@ -108,17 +108,21 @@ impl SettingsView {
                             native.add(&row.feedback);
                             self.rows.borrow_mut().push(row);
                         }
+                        if group.title() == "Updates" {
+                            native.add(&self.updater.row);
+                        }
                         self.page.add(&native);
                         self.groups.borrow_mut().push(native);
-                        if group.title() == "Updates" {
-                            self.page.add(&self.updater.group);
-                        }
                     }
                 }
                 self.render_rows(presentation);
                 self.root.set_visible_child_name("settings");
             }
         }
+    }
+
+    pub(crate) fn show_update_notice(&self, notice: &UpdateNotice, overlay: &adw::ToastOverlay) {
+        self.updater.show_notice(notice, overlay);
     }
 
     fn render_rows(&self, presentation: &SettingsPresentation) {
@@ -132,211 +136,262 @@ impl SettingsView {
                 row.render(current, presentation.row_visible(current.setting()));
             }
         }
-        self.updater.render(&presentation.updater());
+        self.updater.render(presentation);
     }
 }
 
-/// One stable card renders the current step of the application-owned workflow.
+/// One native settings row launches the temporary installation dialog.
 struct UpdaterView {
-    group: adw::PreferencesGroup,
     row: adw::ActionRow,
     action: gtk::Button,
     action_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    dialog: adw::Dialog,
+    title: gtk::Label,
+    description: gtk::Label,
+    progress: gtk::ProgressBar,
+    install: gtk::Button,
+    actions: gtk::Box,
+    install_intent: Rc<RefCell<Option<SettingsIntent>>>,
     cancel: gtk::Button,
     cancel_intent: Rc<RefCell<Option<SettingsIntent>>>,
-    actions: gtk::Box,
-    footer: gtk::ListBoxRow,
     release: gtk::LinkButton,
-    spinner: gtk::Spinner,
-    warning: gtk::Label,
-    details: adw::ExpanderRow,
-    details_text: gtk::Label,
+    presented: Cell<bool>,
+    pulse: RefCell<Option<gtk::glib::SourceId>>,
+    notice: RefCell<Option<adw::Toast>>,
 }
 
 impl UpdaterView {
     fn new(on_intent: Rc<dyn Fn(SettingsIntent)>) -> Self {
-        let group = adw::PreferencesGroup::new();
-        let card = gtk::ListBox::new();
-        card.set_selection_mode(gtk::SelectionMode::None);
-        card.add_css_class("boxed-list");
         let row = detail_row("", "");
         row.set_title_lines(0);
-        row.set_accessible_role(gtk::AccessibleRole::Status);
-        let spinner = gtk::Spinner::new();
-        spinner.set_valign(gtk::Align::Center);
-        row.add_suffix(&spinner);
-        card.append(&row);
+        let (action, action_intent) = updater_button(Rc::clone(&on_intent));
+        action.set_valign(gtk::Align::Center);
+        row.add_suffix(&action);
+        row.set_activatable_widget(Some(&action));
 
-        let warning = gtk::Label::builder()
+        let title = gtk::Label::builder()
+            .xalign(0.0)
             .wrap(true)
             .wrap_mode(gtk::pango::WrapMode::WordChar)
-            .selectable(true)
-            .xalign(0.0)
-            .margin_start(12)
-            .margin_end(12)
-            .margin_bottom(12)
             .build();
-        warning.add_css_class("warning");
-        warning.set_accessible_role(gtk::AccessibleRole::Alert);
-        let footer_content = gtk::Box::new(gtk::Orientation::Vertical, 0);
-        footer_content.append(&warning);
-
+        title.add_css_class("title-2");
+        title.set_accessible_role(gtk::AccessibleRole::Status);
+        let description = gtk::Label::builder()
+            .xalign(0.0)
+            .wrap(true)
+            .wrap_mode(gtk::pango::WrapMode::WordChar)
+            .build();
+        description.add_css_class("dim-label");
+        let progress = gtk::ProgressBar::new();
+        progress.set_pulse_step(0.08);
+        let release = gtk::LinkButton::with_label(
+            "https://github.com/Staphylococcus/LG_Buddy/releases",
+            "View release",
+        );
+        release.set_halign(gtk::Align::Start);
+        let (install, install_intent) = updater_button(Rc::clone(&on_intent));
+        install.add_css_class("suggested-action");
+        let (cancel, cancel_intent) = updater_button(Rc::clone(&on_intent));
         let actions = gtk::Box::builder()
             .orientation(gtk::Orientation::Horizontal)
             .spacing(6)
             .halign(gtk::Align::End)
-            .margin_start(12)
-            .margin_end(12)
-            .margin_bottom(12)
-            .build();
-        let release = gtk::LinkButton::builder()
-            .label("View release")
-            .uri("https://github.com/Staphylococcus/LG_Buddy/releases")
-            .build();
-        release.update_property(&[gtk::accessible::Property::Label("View available release")]);
-        actions.append(&release);
-        let cancel = gtk::Button::new();
-        cancel.add_css_class("flat");
-        let cancel_intent = Rc::new(RefCell::new(None));
-        cancel.connect_clicked({
-            let intent = Rc::clone(&cancel_intent);
-            let on_intent = Rc::clone(&on_intent);
-            move |_| {
-                let intent = intent.borrow().clone();
-                if let Some(intent) = intent {
-                    on_intent(intent);
-                }
-            }
-        });
-        actions.append(&cancel);
-        let action = gtk::Button::new();
-        action.add_css_class("suggested-action");
-        let action_intent = Rc::new(RefCell::new(None));
-        action.connect_clicked({
-            let intent = Rc::clone(&action_intent);
-            move |_| {
-                let intent = intent.borrow().clone();
-                if let Some(intent) = intent {
-                    on_intent(intent);
-                }
-            }
-        });
-        actions.append(&action);
-        footer_content.append(&actions);
-        let footer = gtk::ListBoxRow::builder()
-            .activatable(false)
-            .selectable(false)
-            .child(&footer_content)
-            .build();
-        card.append(&footer);
-
-        let details = adw::ExpanderRow::builder()
-            .use_markup(false)
-            .visible(false)
-            .build();
-        let details_text = gtk::Label::builder()
-            .selectable(true)
-            .wrap(true)
-            .wrap_mode(gtk::pango::WrapMode::WordChar)
-            .xalign(0.0)
-            .margin_start(12)
-            .margin_end(12)
+            .margin_start(24)
+            .margin_end(24)
             .margin_top(12)
-            .margin_bottom(12)
+            .margin_bottom(24)
             .build();
-        details.add_row(&details_text);
-        card.append(&details);
-        group.add(&card);
+        actions.append(&cancel);
+        actions.append(&install);
+        let content = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(16)
+            .margin_start(24)
+            .margin_end(24)
+            .margin_top(12)
+            .margin_bottom(24)
+            .build();
+        for widget in [
+            title.upcast_ref::<gtk::Widget>(),
+            description.upcast_ref(),
+            progress.upcast_ref(),
+            release.upcast_ref(),
+        ] {
+            content.append(widget);
+        }
+        let scroller = gtk::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .propagate_natural_height(true)
+            .child(&content)
+            .build();
+        let header = adw::HeaderBar::builder()
+            .show_start_title_buttons(false)
+            .show_end_title_buttons(false)
+            .build();
+        let toolbar = adw::ToolbarView::builder().content(&scroller).build();
+        toolbar.add_top_bar(&header);
+        toolbar.add_bottom_bar(&actions);
+        let dialog = adw::Dialog::builder()
+            .title("Software update")
+            .content_width(440)
+            .content_height(360)
+            .child(&toolbar)
+            // Ask the application to cancel; the installer can cross its
+            // non-cancellable boundary before the next progress event arrives.
+            .can_close(false)
+            .build();
+        dialog.connect_close_attempt({
+            let cancel_intent = Rc::clone(&cancel_intent);
+            move |_| {
+                let intent = cancel_intent.borrow().clone();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
         Self {
-            group,
             row,
             action,
             action_intent,
+            dialog,
+            title,
+            description,
+            progress,
+            install,
+            actions,
+            install_intent,
             cancel,
             cancel_intent,
-            actions,
-            footer,
             release,
-            spinner,
-            warning,
-            details,
-            details_text,
+            presented: Cell::new(false),
+            pulse: RefCell::new(None),
+            notice: RefCell::new(None),
         }
     }
 
-    fn render(&self, presentation: &UpdaterPresentation) {
-        let action_had_focus = self.action.has_focus();
-        let cancel_had_focus = self.cancel.has_focus();
-        let release_had_focus = self.release.has_focus();
-        self.row.set_title(presentation.title());
-        self.row.set_subtitle(presentation.description());
-        self.row.update_property(&[
-            gtk::accessible::Property::Label(presentation.title()),
-            gtk::accessible::Property::Description(presentation.description()),
-        ]);
-        if presentation.is_error() {
-            self.row.add_css_class("error");
-        } else {
-            self.row.remove_css_class("error");
+    fn render(&self, settings: &SettingsPresentation) {
+        let row = settings.updater();
+        self.row.set_title(row.title());
+        self.row.set_subtitle(row.description());
+        render_updater_button(&self.action, &self.action_intent, Some(row.action()));
+
+        let install = settings.update_install();
+        let active = install.busy() || install.cancel_action().is_some();
+        if active || settings.update_check().checking() {
+            if let Some(previous) = self.notice.take() {
+                previous.dismiss();
+            }
         }
-        for (button, intent, action) in [
-            (&self.action, &self.action_intent, presentation.action()),
-            (
-                &self.cancel,
-                &self.cancel_intent,
-                presentation.cancel_action(),
-            ),
-        ] {
-            button.set_visible(action.is_some());
-            button.set_sensitive(action.is_some_and(|action| action.enabled()));
-            button.set_label(action.map_or("", |action| action.label()));
-            button.update_property(&[gtk::accessible::Property::Label(
-                action.map_or("", |action| action.label()),
-            )]);
-            intent.replace(action.map(|action| action.intent()));
+        self.progress.set_visible(install.busy());
+        // ponytail: the installer reports stages, so progress stays indeterminate.
+        if install.busy() && self.pulse.borrow().is_none() {
+            self.progress.pulse();
+            let progress = self.progress.downgrade();
+            self.pulse.replace(Some(gtk::glib::timeout_add_local(
+                std::time::Duration::from_millis(100),
+                move || {
+                    let Some(progress) = progress.upgrade() else {
+                        return gtk::glib::ControlFlow::Break;
+                    };
+                    progress.pulse();
+                    gtk::glib::ControlFlow::Continue
+                },
+            )));
+        } else if !install.busy() {
+            if let Some(pulse) = self.pulse.take() {
+                pulse.remove();
+            }
+            self.progress.set_fraction(0.0);
         }
-        self.spinner.set_visible(presentation.busy());
-        self.spinner.set_spinning(presentation.busy());
-        self.spinner
-            .update_property(&[gtk::accessible::Property::Label(presentation.title())]);
-        self.release.set_visible(presentation.release().is_some());
-        if let Some(release) = presentation.release() {
+        if !active {
+            if self.presented.replace(false) {
+                self.dialog.force_close();
+                self.action.grab_focus();
+            }
+            return;
+        }
+        let title = install.title().unwrap_or("Updating LG Buddy…");
+        self.title.set_text(title);
+        self.description.set_text(install.description());
+        self.progress
+            .update_property(&[gtk::accessible::Property::Label(title)]);
+        render_updater_button(&self.install, &self.install_intent, install.action());
+        render_updater_button(&self.cancel, &self.cancel_intent, install.cancel_action());
+        self.actions
+            .set_visible(install.action().is_some() || install.cancel_action().is_some());
+        let release = settings
+            .update_check()
+            .result()
+            .and_then(|report| report.available_release.as_ref());
+        self.release
+            .set_visible(!install.busy() && release.is_some());
+        if let Some(release) = release {
             self.release.set_uri(&release.url);
         }
-        let has_actions = presentation.action().is_some()
-            || presentation.cancel_action().is_some()
-            || presentation.release().is_some();
-        self.actions.set_visible(has_actions);
-        self.warning.set_visible(presentation.warning().is_some());
-        self.warning.set_text(presentation.warning().unwrap_or(""));
-        self.footer
-            .set_visible(has_actions || presentation.warning().is_some());
-
-        if let Some(details) = presentation.details() {
-            if self.details_text.text().as_str() != details {
-                self.details.set_expanded(false);
-                self.details_text.set_text(details);
-            }
-            self.details.set_title(presentation.details_title());
-            self.details.set_visible(true);
-        } else {
-            self.details.set_expanded(false);
-            self.details.set_visible(false);
-            self.details_text.set_text("");
-        }
-        // Follow a disappearing action within this card, without taking focus
-        // from another setting when an asynchronous completion arrives.
-        if (action_had_focus && !self.action.is_visible())
-            || (cancel_had_focus && !self.cancel.is_visible())
-            || (release_had_focus && !self.release.is_visible())
-        {
-            if self.action.is_visible() && self.action.is_sensitive() {
-                self.action.grab_focus();
-            } else if self.cancel.is_visible() && self.cancel.is_sensitive() {
+        if !self.presented.get() {
+            if let Some(parent) = self.row.root().and_downcast::<gtk::Window>() {
+                self.presented.set(true);
+                self.dialog.present(Some(&parent));
                 self.cancel.grab_focus();
             }
         }
     }
+
+    fn show_notice(&self, notice: &UpdateNotice, overlay: &adw::ToastOverlay) {
+        if let Some(previous) = self.notice.take() {
+            previous.dismiss();
+        }
+        let toast = adw::Toast::builder()
+            .title(notice.title())
+            .use_markup(false)
+            .build();
+        if let Some(details) = notice.details() {
+            toast.set_button_label(Some("Copy details"));
+            toast.set_timeout(0);
+            toast.set_priority(adw::ToastPriority::High);
+            let details = details.to_owned();
+            let clipboard = self.row.clipboard();
+            toast.connect_button_clicked(move |_| clipboard.set_text(&details));
+        }
+        self.notice.replace(Some(toast.clone()));
+        overlay.add_toast(toast);
+    }
+}
+
+impl Drop for UpdaterView {
+    fn drop(&mut self) {
+        if let Some(pulse) = self.pulse.take() {
+            pulse.remove();
+        }
+    }
+}
+
+fn updater_button(
+    on_intent: Rc<dyn Fn(SettingsIntent)>,
+) -> (gtk::Button, Rc<RefCell<Option<SettingsIntent>>>) {
+    let button = gtk::Button::new();
+    let intent = Rc::new(RefCell::new(None));
+    button.connect_clicked({
+        let intent = Rc::clone(&intent);
+        move |_| {
+            let intent = intent.borrow().clone();
+            if let Some(intent) = intent {
+                on_intent(intent);
+            }
+        }
+    });
+    (button, intent)
+}
+
+fn render_updater_button(
+    button: &gtk::Button,
+    intent: &RefCell<Option<SettingsIntent>>,
+    action: Option<&lg_buddy::presentation::settings::SettingsAction>,
+) {
+    button.set_visible(action.is_some());
+    button.set_sensitive(action.is_some_and(|action| action.enabled()));
+    button.set_label(action.map_or("", |action| action.label()));
+    intent.replace(action.map(|action| action.intent()));
 }
 
 enum NativeEditor {
@@ -728,7 +783,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .map(|row| row.row.clone())
         .collect();
     assert!(!rows.iter().any(|row| row.is::<adw::ExpanderRow>()));
-    assert!(!view.updater.details.is_visible());
+    assert!(!view.updater.presented.get());
     assert_eq!(view.groups.borrow().len(), 3);
     assert_eq!(rows.len(), 7);
     assert!(widgets
@@ -1115,12 +1170,10 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
 fn updater_renderer_scenarios(application: &adw::Application) {
     use crate::controller_test_support::pump_until;
     use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
-    use lg_buddy::settings::{ConfigEnvReader, SettingsStore};
-    use lg_buddy::settings_view::{BehaviorSetting, SettingsApplication, UpdateCheckError};
-    use lg_buddy::update_flow::UpdateInstallOutcome;
-    use lg_buddy::update_install::{
-        InstalledUpdate, PreparedUpdateInstall, UpdateInstallError, UpdateInstallStage,
-    };
+    use lg_buddy::settings::ConfigEnvReader;
+    use lg_buddy::settings_view::{BehaviorSetting, SettingsApplication};
+    use lg_buddy::update_flow::{UpdateInstallOutcome, UpdateInstallTask};
+    use lg_buddy::update_install::{PreparedUpdateInstall, UpdateInstallError, UpdateInstallStage};
     use lg_buddy::updates::UpdateChannel;
     use lg_buddy::version::VersionInfo;
 
@@ -1157,31 +1210,23 @@ fn updater_renderer_scenarios(application: &adw::Application) {
             "newer-commit",
         )
     }
-    fn assert_narrow(view: &SettingsView) {
-        let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
-        assert!(
-            minimum <= 360,
-            "updater card must fit a narrow window: {minimum}"
-        );
-    }
-
     let intents = Rc::new(RefCell::new(Vec::new()));
     let view = SettingsView::new(Rc::new({
         let intents = Rc::clone(&intents);
         move |intent| intents.borrow_mut().push(intent)
     }));
+    let overlay = adw::ToastOverlay::new();
+    overlay.set_child(Some(view.widget()));
     let window = adw::ApplicationWindow::builder()
         .application(application)
         .title("LG Buddy Updater Renderer Test")
         .default_width(900)
         .default_height(700)
-        .content(view.widget())
+        .content(&overlay)
         .build();
     let (mut model, opening) = SettingsApplication::open();
-    let store = SettingsStore::from_reader(ConfigEnvReader::parse(
-        "/unused/config.env",
-        "updates_channel=stable\n",
-    ));
+    let store =
+        ConfigEnvReader::parse("/unused/config.env", "updates_channel=stable\n").into_store();
     model
         .complete_read(
             opening.read_operation().unwrap(),
@@ -1191,156 +1236,188 @@ fn updater_renderer_scenarios(application: &adw::Application) {
     view.render(model.presentation());
     window.present();
     pump_until(|| view.updater.row.is_mapped() && view.updater.row.width() > 0);
-    let stable_rows: Vec<_> = view
-        .rows
-        .borrow()
-        .iter()
-        .map(|row| row.row.clone())
-        .collect();
-    let card_row = view.updater.row.clone();
+    let row = view.updater.row.clone();
     let action = view.updater.action.clone();
-    assert_eq!(stable_rows.len(), 7);
-    assert_eq!(card_row.title().as_str(), "Installed version");
+    assert_eq!(row.title(), "Installed version");
     assert_eq!(action.label().as_deref(), Some("Check for updates"));
-    assert!(!view.updater.spinner.is_visible());
-    assert!(!view.updater.details.is_visible());
-    assert!(!view.updater.release.is_visible());
-    assert!(!view.updater.warning.is_visible());
-    assert_eq!(card_row.accessible_role(), gtk::AccessibleRole::Status);
-
-    // Compare native label allocations, not hard-coded padding or widget types.
-    let rows = view.rows.borrow();
-    for row in rows.iter().filter(|row| {
+    assert!(!view.updater.presented.get());
+    assert!(view.updater.pulse.borrow().is_none());
+    assert_eq!(action.accessible_role(), gtk::AccessibleRole::Button);
+    for setting in view.rows.borrow().iter().filter(|row| {
         matches!(
             row.presentation.borrow().setting(),
             BehaviorSetting::UpdatesAutoCheck | BehaviorSetting::UpdatesChannel
         )
     }) {
-        assert!(row.warning.parent().is_none());
-        assert!(
-            (title_x(&row.row, &window) - title_x(&card_row, &window)).abs() < 1.0,
-            "updater and normal settings text must share their left edge: setting={}, updater={}",
-            title_x(&row.row, &window),
-            title_x(&card_row, &window)
-        );
+        assert!(setting.warning.parent().is_none());
+        assert!((title_x(&setting.row, &window) - title_x(&row, &window)).abs() < 1.0);
     }
-    drop(rows);
+    let bounds = action.compute_bounds(&row).unwrap();
+    assert!(
+        bounds.y() >= 0.0 && bounds.y() + bounds.height() <= row.height() as f32,
+        "the action must fit inside the same native row"
+    );
 
-    assert!(action.grab_focus());
     action.emit_clicked();
-    assert_eq!(*intents.borrow(), vec![SettingsIntent::CheckForUpdates]);
-    intents.borrow_mut().clear();
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::CheckForUpdates)
+    );
     let checking = model
         .handle_intent(SettingsIntent::CheckForUpdates)
         .unwrap();
     view.render(checking.presentation());
-    assert!(view.updater.spinner.is_visible());
     assert!(!action.is_sensitive());
     assert_eq!(action.label().as_deref(), Some("Checking…"));
-    assert!(action.is_focusable());
-    assert!(intents.borrow().is_empty());
+    assert!(!view.updater.presented.get());
+    let current = model
+        .complete_update_check(
+            checking.update_check_operation().unwrap(),
+            Ok(UpdateCheckReport {
+                installed_version: "1.6.0".into(),
+                channel: UpdateChannel::Stable,
+                available_release: None,
+                warning: None,
+            }),
+        )
+        .unwrap();
+    view.render(current.presentation());
+    view.show_update_notice(current.update_notice().unwrap(), &overlay);
+    assert_eq!(action.label().as_deref(), Some("Check for updates"));
+    assert_eq!(row.title(), "Installed version");
+    let current_toast = view.updater.notice.borrow().as_ref().unwrap().clone();
+    assert_eq!(current_toast.title().as_deref(), Some("Already up to date"));
+    view.render(model.presentation());
+    assert_eq!(view.updater.notice.borrow().as_ref(), Some(&current_toast));
 
-    let report = UpdateCheckReport {
-        installed_version: "1.6.0".into(),
-        channel: UpdateChannel::Stable,
-        available_release: Some(AvailableUpdate {
-            version: "1.7.0".into(),
-            url: "https://example.test/releases/v1.7.0?name=release%3C1%3E".into(),
-        }),
-        warning: Some("Cache <could not>& be refreshed.".into()),
-    };
+    let checking = model
+        .handle_intent(SettingsIntent::CheckForUpdates)
+        .unwrap();
+    view.render(checking.presentation());
+    assert!(view.updater.notice.borrow().is_none());
     model
-        .complete_update_check(checking.update_check_operation().unwrap(), Ok(report))
+        .complete_update_check(
+            checking.update_check_operation().unwrap(),
+            Ok(UpdateCheckReport {
+                installed_version: "1.6.0".into(),
+                channel: UpdateChannel::Stable,
+                available_release: Some(AvailableUpdate {
+                    version: "1.7.0".into(),
+                    url: "https://example.test/releases/v1.7.0".into(),
+                }),
+                warning: None,
+            }),
+        )
         .unwrap();
     view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Update available: 1.7.0");
+    assert_eq!(row.title(), "Update available: 1.7.0");
     assert_eq!(action.label().as_deref(), Some("Install update…"));
-    assert!(view.updater.release.is_visible());
-    assert_eq!(
-        view.updater.release.uri().as_str(),
-        "https://example.test/releases/v1.7.0?name=release%3C1%3E"
-    );
-    assert_eq!(
-        view.updater.warning.text().as_str(),
-        "Cache <could not>& be refreshed."
-    );
-    assert!(view.updater.warning.is_visible());
-    assert!(!view.updater.spinner.is_visible());
-    assert_narrow(&view);
-
-    assert!(action.grab_focus());
     action.emit_clicked();
     assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::PrepareUpdateInstall]
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::PrepareUpdateInstall)
     );
-    intents.borrow_mut().clear();
-    model
+    let preparation = model
         .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();
-    view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Preparing update…");
-    assert!(!action.is_visible());
-    assert!(view.updater.cancel.is_visible());
-    assert!(view.updater.cancel.has_focus());
-    assert!(!view.updater.release.is_visible());
-    assert!(!view.updater.warning.is_visible());
-    view.updater.cancel.emit_clicked();
-    assert_eq!(*intents.borrow(), vec![SettingsIntent::CancelUpdateInstall]);
-    intents.borrow_mut().clear();
+    view.render(preparation.presentation());
+    pump_until(|| {
+        window.visible_dialog().as_ref() == Some(&view.updater.dialog)
+            && view.updater.cancel.is_mapped()
+            && view.updater.cancel.height() > 0
+    });
+    assert!(view.updater.progress.is_visible());
+    assert!(view.updater.pulse.borrow().is_some());
+    assert!(!action.is_sensitive());
+    assert_eq!(action.label().as_deref(), Some("Install update…"));
+    // Closing requests cancellation through the application; it cannot bypass
+    // a worker that already claimed the installer boundary.
+    view.updater.dialog.close();
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::CancelUpdateInstall)
+    );
     model
         .handle_intent(SettingsIntent::CancelUpdateInstall)
         .unwrap();
     view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Update available: 1.7.0");
+    pump_until(|| window.visible_dialog().is_none() && view.updater.dialog.parent().is_none());
+    assert!(view.updater.pulse.borrow().is_none());
     assert!(action.has_focus());
 
-    let preparing = model
+    let preparation = model
         .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();
+    view.render(preparation.presentation());
+    pump_until(|| view.updater.dialog.child().unwrap().is_mapped());
     model
         .complete_update_install(
-            preparing.update_install_operation().unwrap(),
+            preparation.update_install_operation().unwrap(),
             Ok(UpdateInstallOutcome::Prepared(prepared())),
         )
         .unwrap();
     view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Install LG Buddy 1.7.0?");
-    assert_eq!(action.label().as_deref(), Some("Install and restart"));
-    assert!(view.updater.cancel.is_visible());
-    assert!(!view.updater.release.is_visible());
-    assert!(!view.updater.spinner.is_visible());
-    assert_narrow(&view);
-    action.emit_clicked();
+    pump_until(|| view.updater.dialog.child().unwrap().is_mapped());
+    assert_eq!(view.updater.title.text(), "Install LG Buddy 1.7.0?");
+    assert!(!view.updater.progress.is_visible());
+    assert!(view.updater.release.is_visible());
     assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::ConfirmUpdateInstall]
+        view.updater.install.label().as_deref(),
+        Some("Install and restart")
     );
-    intents.borrow_mut().clear();
+    assert!(view.updater.cancel.is_visible());
+    pump_until(|| {
+        if !view.updater.install.is_mapped() || view.updater.install.height() == 0 {
+            return false;
+        }
+        let bounds = view
+            .updater
+            .install
+            .compute_bounds(&view.updater.dialog)
+            .unwrap();
+        bounds.y() >= 0.0 && bounds.y() + bounds.height() <= view.updater.dialog.height() as f32
+    });
+    assert!(
+        view.updater.install.is_mapped(),
+        "confirmation must remain reachable without scrolling"
+    );
+    view.updater.install.emit_clicked();
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::ConfirmUpdateInstall)
+    );
     let installing = model
         .handle_intent(SettingsIntent::ConfirmUpdateInstall)
         .unwrap();
     let operation = installing.update_install_operation().unwrap();
-    model
-        .update_install_progress(operation, UpdateInstallStage::Acquiring)
-        .unwrap();
-    view.render(model.presentation());
+    view.render(installing.presentation());
+    assert!(view.updater.progress.is_visible());
+    assert!(!view.updater.install.is_visible());
+    assert!(!view.updater.release.is_visible());
+    if let UpdateInstallTask::Install { cancellation, .. } = operation.task() {
+        cancellation.claim_installer_boundary().unwrap();
+    } else {
+        panic!("expected install task");
+    }
+    view.updater.dialog.close();
     assert_eq!(
-        card_row.title().as_str(),
-        "Downloading and verifying update…"
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::CancelUpdateInstall)
     );
-    assert!(view.updater.spinner.is_visible());
-    assert!(view.updater.cancel.is_visible());
-    assert!(!action.is_visible());
+    assert!(model
+        .handle_intent(SettingsIntent::CancelUpdateInstall)
+        .is_none());
+    assert!(view.updater.dialog.is_mapped());
     model
         .update_install_progress(operation, UpdateInstallStage::Installing)
         .unwrap();
     view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Installing update…");
-    assert!(!view.updater.actions.is_visible());
     assert!(!view.updater.cancel.is_visible());
+    assert_eq!(view.updater.title.text(), "Installing update…");
+    view.updater.dialog.close();
+    assert!(intents.borrow().is_empty());
 
-    model
+    let failed = model
         .complete_update_install(
             operation,
             Err(UpdateInstallError::InstallerFailedWithOutput {
@@ -1351,121 +1428,39 @@ fn updater_renderer_scenarios(application: &adw::Application) {
             .into()),
         )
         .unwrap();
-    view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Could not install update");
-    assert!(card_row.has_css_class("error"));
-    assert_eq!(action.label().as_deref(), Some("Retry update"));
-    assert!(!view.updater.release.is_visible());
-    assert!(view.updater.details.is_visible());
-    assert!(!view.updater.details.is_expanded());
-    assert!(view.updater.details_text.is_selectable());
-    assert!(view
-        .updater
-        .details_text
-        .text()
-        .contains("No space left on device"));
-    assert!(!view.updater.details_text.text().contains("private-value"));
-    view.updater.details.set_expanded(true);
-    view.render(model.presentation());
-    assert!(view.updater.details.is_expanded());
-    assert!(view.updater.details_text.grab_focus());
-    assert_narrow(&view);
-    action.emit_clicked();
-    assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::PrepareUpdateInstall]
-    );
-    intents.borrow_mut().clear();
-    let preparing = model
-        .handle_intent(SettingsIntent::PrepareUpdateInstall)
-        .unwrap();
-    view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Preparing update…");
-    assert!(!card_row.has_css_class("error"));
-    assert_eq!(view.updater.details.title().as_str(), "Last update failure");
-    assert!(
-        view.updater.details_text.has_focus(),
-        "progress must not steal diagnostic selection focus"
-    );
-    model
-        .complete_update_install(
-            preparing.update_install_operation().unwrap(),
-            Ok(UpdateInstallOutcome::Prepared(prepared())),
-        )
-        .unwrap();
-    let installing = model
-        .handle_intent(SettingsIntent::ConfirmUpdateInstall)
-        .unwrap();
-    let installed = InstalledUpdate::from_parts(
-        "1.7.0".parse().unwrap(),
-        UpdateChannel::Stable,
-        "v1.7.0",
-        "x86_64-unknown-linux-gnu",
-        "newer-commit",
-        "/unused/lg-buddy",
-        "/unused/lg-buddy-gui",
-    );
-    let restarting = model
-        .complete_update_install(
-            installing.update_install_operation().unwrap(),
-            Ok(UpdateInstallOutcome::Installed(installed)),
-        )
-        .unwrap();
-    view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Restarting LG Buddy…");
-    assert!(!view.updater.actions.is_visible());
-    assert!(view.updater.spinner.is_visible());
-    model
-        .complete_update_install(
-            restarting.update_install_operation().unwrap(),
-            Err(lg_buddy::update_flow::UpdateInstallFailure::stopped()),
-        )
-        .unwrap();
-    view.render(model.presentation());
-    assert_eq!(action.label().as_deref(), Some("Retry restart"));
-    action.emit_clicked();
-    assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::RelaunchUpdatedApplication]
-    );
-    intents.borrow_mut().clear();
-
-    // A check replaces the prior result or failure in the same card.
-    let checking = model
-        .handle_intent(SettingsIntent::CheckForUpdates)
-        .unwrap();
-    view.render(checking.presentation());
-    assert!(view.updater.spinner.is_visible());
-    assert!(!card_row.has_css_class("error"));
-    assert!(!view.updater.release.is_visible());
-    model
-        .complete_update_check(
-            checking.update_check_operation().unwrap(),
-            Err(UpdateCheckError::stopped()),
-        )
-        .unwrap();
-    view.render(model.presentation());
-    assert_eq!(card_row.title().as_str(), "Update check stopped");
-    assert_eq!(action.label().as_deref(), Some("Retry check"));
-    assert!(card_row.has_css_class("error"));
-    action.emit_clicked();
-    assert_eq!(*intents.borrow(), vec![SettingsIntent::CheckForUpdates]);
-    intents.borrow_mut().clear();
-    view.render(model.presentation());
+    view.render(failed.presentation());
+    view.show_update_notice(failed.update_notice().unwrap(), &overlay);
+    pump_until(|| window.visible_dialog().is_none());
+    assert!(!view.updater.presented.get());
+    assert!(view.updater.pulse.borrow().is_none());
+    assert_eq!(action.label().as_deref(), Some("Install update…"));
+    assert!(!row.has_css_class("error"));
+    let toast = view.updater.notice.borrow().as_ref().unwrap().clone();
+    assert_eq!(toast.button_label().as_deref(), Some("Copy details"));
+    toast.emit_by_name::<()>("button-clicked", &[]);
+    let copied = Rc::new(RefCell::new(None));
+    action
+        .clipboard()
+        .read_text_async(None::<&gtk::gio::Cancellable>, {
+            let copied = Rc::clone(&copied);
+            move |result| {
+                copied.replace(Some(result.unwrap().unwrap().to_string()));
+            }
+        });
+    pump_until(|| copied.borrow().is_some());
+    let copied = copied.borrow();
+    let details = copied.as_deref().unwrap();
+    assert!(details.contains("No space left on device"));
+    assert!(!details.contains("private-value"));
+    assert!(details.contains("partial"));
+    assert_eq!(view.updater.row, row);
+    assert_eq!(view.updater.action, action);
     assert!(
         intents.borrow().is_empty(),
         "rendering must not submit intents"
     );
-    assert_eq!(view.updater.row, card_row);
-    assert_eq!(view.updater.action, action);
-    assert!(view
-        .rows
-        .borrow()
-        .iter()
-        .zip(&stable_rows)
-        .all(|(current, original)| current.row == *original));
     window.set_default_size(360, 700);
     pump_until(|| window.width() <= 360);
-    assert_narrow(&view);
+    assert!(view.widget().measure(gtk::Orientation::Horizontal, -1).0 <= 360);
     window.close();
 }

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -319,14 +319,11 @@ impl UpdaterView {
         render_updater_button(&self.cancel, &self.cancel_intent, install.cancel_action());
         self.actions
             .set_visible(install.action().is_some() || install.cancel_action().is_some());
-        let release = settings
-            .update_check()
-            .result()
-            .and_then(|report| report.available_release.as_ref());
+        let release = install.release_url();
         self.release
             .set_visible(!install.busy() && release.is_some());
         if let Some(release) = release {
-            self.release.set_uri(&release.url);
+            self.release.set_uri(release);
         }
         if !self.presented.get() {
             if let Some(parent) = self.row.root().and_downcast::<gtk::Window>() {
@@ -1169,7 +1166,7 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
 #[cfg(test)]
 fn updater_renderer_scenarios(application: &adw::Application) {
     use crate::controller_test_support::pump_until;
-    use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+    use lg_buddy::presentation::update_check::UpdateCheckReport;
     use lg_buddy::settings::ConfigEnvReader;
     use lg_buddy::settings_view::{BehaviorSetting, SettingsApplication};
     use lg_buddy::update_flow::{UpdateInstallOutcome, UpdateInstallTask};
@@ -1276,7 +1273,7 @@ fn updater_renderer_scenarios(application: &adw::Application) {
             Ok(UpdateCheckReport {
                 installed_version: "1.6.0".into(),
                 channel: UpdateChannel::Stable,
-                available_release: None,
+                update_available: false,
                 warning: None,
             }),
         )
@@ -1301,16 +1298,13 @@ fn updater_renderer_scenarios(application: &adw::Application) {
             Ok(UpdateCheckReport {
                 installed_version: "1.6.0".into(),
                 channel: UpdateChannel::Stable,
-                available_release: Some(AvailableUpdate {
-                    version: "1.7.0".into(),
-                    url: "https://example.test/releases/v1.7.0".into(),
-                }),
+                update_available: true,
                 warning: None,
             }),
         )
         .unwrap();
     view.render(model.presentation());
-    assert_eq!(row.title(), "Update available: 1.7.0");
+    assert_eq!(row.title(), "Update available");
     assert_eq!(action.label().as_deref(), Some("Install update…"));
     action.emit_clicked();
     assert_eq!(
@@ -1361,6 +1355,7 @@ fn updater_renderer_scenarios(application: &adw::Application) {
     assert_eq!(view.updater.title.text(), "Install LG Buddy 1.7.0?");
     assert!(!view.updater.progress.is_visible());
     assert!(view.updater.release.is_visible());
+    assert_eq!(view.updater.release.uri(), prepared().release().url());
     assert_eq!(
         view.updater.install.label().as_deref(),
         Some("Install and restart")

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -7,6 +7,7 @@ use lg_buddy::presentation::settings::{
     SettingsPresentation, SettingsRow, SettingsStatus,
 };
 use lg_buddy::presentation::update_check::UpdateCheckPresentation;
+use lg_buddy::presentation::update_install::UpdateInstallPresentation;
 use lg_buddy::settings_view::SettingsIntent;
 
 /// Stable native controls render application-owned values and commit policies.
@@ -132,7 +133,8 @@ impl SettingsView {
                 row.render(current, presentation.row_visible(current.setting()));
             }
         }
-        self.update_check.render(presentation.update_check());
+        self.update_check
+            .render(presentation.update_check(), presentation.update_install());
     }
 }
 
@@ -145,6 +147,13 @@ struct UpdateCheckView {
     release: gtk::LinkButton,
     error: adw::ActionRow,
     warning: adw::ActionRow,
+    install: adw::ActionRow,
+    install_action: gtk::Button,
+    install_action_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    install_cancel: gtk::Button,
+    install_cancel_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    install_spinner: gtk::Spinner,
+    install_error: adw::ActionRow,
 }
 
 impl UpdateCheckView {
@@ -157,6 +166,7 @@ impl UpdateCheckView {
         let check_intent = Rc::new(RefCell::new(None));
         check.connect_clicked({
             let check_intent = Rc::clone(&check_intent);
+            let on_intent = Rc::clone(&on_intent);
             move |_| {
                 let intent = check_intent.borrow().clone();
                 if let Some(intent) = intent {
@@ -193,6 +203,61 @@ impl UpdateCheckView {
         warning.set_accessible_role(gtk::AccessibleRole::Alert);
         warning.set_visible(false);
 
+        // This row is reused for the offer, explicit confirmation, progress,
+        // and post-install relaunch states. The presentation decides which
+        // controls are visible and enabled.
+        let install = detail_row("", "");
+        install.set_accessible_role(gtk::AccessibleRole::Status);
+        install.set_visible(false);
+        let install_action = gtk::Button::builder()
+            .visible(false)
+            .sensitive(false)
+            .build();
+        install_action.add_css_class("suggested-action");
+        install_action.set_valign(gtk::Align::Center);
+        let install_action_intent = Rc::new(RefCell::new(None));
+        install_action.connect_clicked({
+            let intent = Rc::clone(&install_action_intent);
+            let on_intent = Rc::clone(&on_intent);
+            move |_| {
+                let intent = intent.borrow().clone();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
+        install.add_suffix(&install_action);
+
+        let install_cancel = gtk::Button::builder()
+            .visible(false)
+            .sensitive(false)
+            .build();
+        install_cancel.add_css_class("flat");
+        install_cancel.set_valign(gtk::Align::Center);
+        let install_cancel_intent = Rc::new(RefCell::new(None));
+        install_cancel.connect_clicked({
+            let intent = Rc::clone(&install_cancel_intent);
+            let on_intent = Rc::clone(&on_intent);
+            move |_| {
+                let intent = intent.borrow().clone();
+                if let Some(intent) = intent {
+                    on_intent(intent);
+                }
+            }
+        });
+        install.add_suffix(&install_cancel);
+
+        let install_spinner = gtk::Spinner::new();
+        install_spinner.set_valign(gtk::Align::Center);
+        install_spinner.set_visible(false);
+        install_spinner.update_property(&[gtk::accessible::Property::Label("Installing update")]);
+        install.add_suffix(&install_spinner);
+
+        let install_error = detail_row("", "");
+        install_error.add_css_class("error");
+        install_error.set_accessible_role(gtk::AccessibleRole::Alert);
+        install_error.set_visible(false);
+
         Self {
             installed,
             check,
@@ -202,17 +267,30 @@ impl UpdateCheckView {
             release,
             error,
             warning,
+            install,
+            install_action,
+            install_action_intent,
+            install_cancel,
+            install_cancel_intent,
+            install_spinner,
+            install_error,
         }
     }
 
     fn attach(&self, group: &adw::PreferencesGroup) {
         group.add(&self.installed);
         group.add(&self.result);
+        group.add(&self.install);
+        group.add(&self.install_error);
         group.add(&self.error);
         group.add(&self.warning);
     }
 
-    fn render(&self, presentation: &UpdateCheckPresentation) {
+    fn render(
+        &self,
+        presentation: &UpdateCheckPresentation,
+        install_presentation: &UpdateInstallPresentation,
+    ) {
         self.installed
             .set_subtitle(presentation.installed_version_label());
         let action = presentation.check_action();
@@ -253,6 +331,68 @@ impl UpdateCheckView {
             self.error.set_visible(true);
         } else {
             self.error.set_visible(false);
+        }
+
+        self.render_install(install_presentation);
+    }
+
+    fn render_install(&self, presentation: &UpdateInstallPresentation) {
+        let title = presentation.title().unwrap_or("");
+        let description = presentation.description();
+        let action = presentation.action();
+        let cancel_action = presentation.cancel_action();
+        let visible = presentation.title().is_some()
+            || action.is_some()
+            || cancel_action.is_some()
+            || presentation.busy();
+
+        self.install.set_visible(visible);
+        self.install.set_title(title);
+        self.install.set_subtitle(description);
+        self.install.update_property(&[
+            gtk::accessible::Property::Label(title),
+            gtk::accessible::Property::Description(description),
+        ]);
+
+        if let Some(action) = action {
+            self.install_action.set_visible(true);
+            self.install_action.set_label(action.label());
+            self.install_action.set_sensitive(action.enabled());
+            self.install_action
+                .update_property(&[gtk::accessible::Property::Label(action.label())]);
+            self.install_action_intent.replace(Some(action.intent()));
+        } else {
+            self.install_action.set_visible(false);
+            self.install_action.set_sensitive(false);
+            self.install_action_intent.replace(None);
+        }
+
+        if let Some(action) = cancel_action {
+            self.install_cancel.set_visible(true);
+            self.install_cancel.set_label(action.label());
+            self.install_cancel.set_sensitive(action.enabled());
+            self.install_cancel
+                .update_property(&[gtk::accessible::Property::Label(action.label())]);
+            self.install_cancel_intent.replace(Some(action.intent()));
+        } else {
+            self.install_cancel.set_visible(false);
+            self.install_cancel.set_sensitive(false);
+            self.install_cancel_intent.replace(None);
+        }
+
+        self.install_spinner.set_visible(presentation.busy());
+        self.install_spinner.set_spinning(presentation.busy());
+
+        if let Some(error) = presentation.error() {
+            self.install_error.set_title(error.summary());
+            self.install_error.set_subtitle(error.detail());
+            self.install_error.update_property(&[
+                gtk::accessible::Property::Label(error.summary()),
+                gtk::accessible::Property::Description(error.detail()),
+            ]);
+            self.install_error.set_visible(true);
+        } else {
+            self.install_error.set_visible(false);
         }
     }
 }
@@ -1028,7 +1168,10 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
     use lg_buddy::settings::{ConfigEnvReader, SettingsStore};
     use lg_buddy::settings_view::{SettingsApplication, SettingsIntent, UpdateCheckError};
+    use lg_buddy::update_flow::{UpdateInstallFailure, UpdateInstallOutcome};
+    use lg_buddy::update_install::{InstalledUpdate, PreparedUpdateInstall, UpdateInstallStage};
     use lg_buddy::updates::UpdateChannel;
+    use lg_buddy::version::VersionInfo;
 
     let intents = Rc::new(RefCell::new(Vec::new()));
     let on_intent: Rc<dyn Fn(SettingsIntent)> = Rc::new({
@@ -1073,6 +1216,8 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     assert!(!view.update_check.result.is_visible());
     assert!(!view.update_check.error.is_visible());
     assert!(!view.update_check.warning.is_visible());
+    assert!(!view.update_check.install.is_visible());
+    assert!(!view.update_check.install_error.is_visible());
 
     let check = view.update_check.check.clone();
     assert_eq!(check.accessible_role(), gtk::AccessibleRole::Button);
@@ -1150,6 +1295,186 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
         intents.borrow().is_empty(),
         "rendering must not submit an intent"
     );
+
+    // An available release exposes the application-owned prepare action. The
+    // prepare state is busy and can be cancelled without the renderer making
+    // any workflow decisions of its own.
+    assert!(view.update_check.install.is_visible());
+    assert_eq!(
+        view.update_check.install_action.label().as_deref(),
+        Some("Install update…")
+    );
+    assert_eq!(
+        view.update_check.install.accessible_role(),
+        gtk::AccessibleRole::Status
+    );
+    assert_eq!(
+        view.update_check.install_action.accessible_role(),
+        gtk::AccessibleRole::Button
+    );
+    intents.borrow_mut().clear();
+    view.update_check.install_action.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::PrepareUpdateInstall],
+        "the available-release action must forward the prepare intent"
+    );
+    let preparing = model
+        .handle_intent(intents.borrow_mut().pop().unwrap())
+        .unwrap();
+    view.render(preparing.presentation());
+    assert!(view.update_check.install.is_visible());
+    assert!(view.update_check.install_spinner.is_visible());
+    assert!(!view.update_check.install_action.is_visible());
+    assert!(view.update_check.install_cancel.is_visible());
+    assert_eq!(
+        view.update_check.install_cancel.label().as_deref(),
+        Some("Cancel")
+    );
+    intents.borrow_mut().clear();
+    view.update_check.install_cancel.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::CancelUpdateInstall],
+        "the inline cancel control must forward the cancel intent"
+    );
+    let cancelled = model
+        .handle_intent(intents.borrow_mut().pop().unwrap())
+        .unwrap();
+    view.render(cancelled.presentation());
+    assert!(view.update_check.install.is_visible());
+    assert!(!view.update_check.install_spinner.is_visible());
+    assert!(!view.update_check.install_error.is_visible());
+    assert_eq!(
+        view.update_check.install_action.label().as_deref(),
+        Some("Install update…")
+    );
+
+    let preparing = model
+        .handle_intent(SettingsIntent::PrepareUpdateInstall)
+        .unwrap();
+    let install_operation = preparing.update_install_operation().unwrap().clone();
+    view.render(preparing.presentation());
+    let failed_install = model
+        .complete_update_install(&install_operation, Err(UpdateInstallFailure::stopped()))
+        .unwrap();
+    view.render(failed_install.presentation());
+    assert!(view.update_check.install.is_visible());
+    assert!(view.update_check.install_error.is_visible());
+    assert_eq!(
+        view.update_check.install_error.accessible_role(),
+        gtk::AccessibleRole::Alert
+    );
+    assert!(view.update_check.install_action.is_visible());
+    assert_eq!(
+        view.update_check.install_action.label().as_deref(),
+        Some("Retry update")
+    );
+    intents.borrow_mut().clear();
+    view.update_check.install_action.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::PrepareUpdateInstall],
+        "an installation failure must expose the application retry action"
+    );
+
+    let preparing = model
+        .handle_intent(SettingsIntent::PrepareUpdateInstall)
+        .unwrap();
+    let prepare_operation = preparing.update_install_operation().unwrap().clone();
+    view.render(preparing.presentation());
+    let prepared = PreparedUpdateInstall::from_parts(
+        VersionInfo::current(),
+        "1.7.0".parse().unwrap(),
+        UpdateChannel::Stable,
+        "https://example.test/releases/v1.7.0",
+        "v1.7.0",
+        "x86_64-unknown-linux-gnu",
+        "newer-commit",
+    );
+    let confirmation = model
+        .complete_update_install(
+            &prepare_operation,
+            Ok(UpdateInstallOutcome::Prepared(prepared)),
+        )
+        .unwrap();
+    view.render(confirmation.presentation());
+    assert_eq!(
+        view.update_check.install.title().as_str(),
+        "Install LG Buddy 1.7.0?"
+    );
+    assert_eq!(
+        view.update_check.install_action.label().as_deref(),
+        Some("Install and restart")
+    );
+    assert!(view.update_check.install_action.is_visible());
+    assert!(view.update_check.install_cancel.is_visible());
+    assert!(!view.update_check.install_spinner.is_visible());
+
+    intents.borrow_mut().clear();
+    view.update_check.install_action.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::ConfirmUpdateInstall],
+        "the confirmation control must forward the confirm intent"
+    );
+    let installing = model
+        .handle_intent(intents.borrow_mut().pop().unwrap())
+        .unwrap();
+    let install_operation = installing.update_install_operation().unwrap().clone();
+    view.render(installing.presentation());
+    assert!(view.update_check.install_spinner.is_visible());
+    assert!(!view.update_check.install_action.is_visible());
+    assert!(view.update_check.install_cancel.is_visible());
+
+    let acquiring = model
+        .update_install_progress(&install_operation, UpdateInstallStage::Acquiring)
+        .unwrap();
+    view.render(acquiring.presentation());
+    assert!(view.update_check.install_spinner.is_visible());
+    assert!(view
+        .update_check
+        .install
+        .subtitle()
+        .is_some_and(|text| text.contains("cancel")));
+    let installing_stage = model
+        .update_install_progress(&install_operation, UpdateInstallStage::Installing)
+        .unwrap();
+    view.render(installing_stage.presentation());
+    assert!(view.update_check.install_spinner.is_visible());
+    assert!(!view.update_check.install_cancel.is_visible());
+
+    let installed = InstalledUpdate::from_parts(
+        "1.7.0".parse().unwrap(),
+        UpdateChannel::Stable,
+        "v1.7.0",
+        "x86_64-unknown-linux-gnu",
+        "newer-commit",
+        "/unused/lg-buddy",
+        "/unused/lg-buddy-gui",
+    );
+    let restarting = model
+        .complete_update_install(
+            &install_operation,
+            Ok(UpdateInstallOutcome::Installed(installed)),
+        )
+        .unwrap();
+    let relaunch_operation = restarting.update_install_operation().unwrap().clone();
+    view.render(restarting.presentation());
+    assert!(view.update_check.install_spinner.is_visible());
+    assert!(!view.update_check.install_action.is_visible());
+    assert!(!view.update_check.install_cancel.is_visible());
+    assert_eq!(
+        view.update_check.install.title().as_str(),
+        "Restarting LG Buddy…"
+    );
+    let relaunched = model
+        .complete_update_install(&relaunch_operation, Ok(UpdateInstallOutcome::Relaunched))
+        .unwrap();
+    view.render(relaunched.presentation());
+    assert!(view.update_check.install.is_visible());
+    assert!(!view.update_check.install_spinner.is_visible());
+    assert!(!view.update_check.install_error.is_visible());
 
     let checking_again = model
         .handle_intent(SettingsIntent::CheckForUpdates)

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -6,8 +6,7 @@ use lg_buddy::presentation::settings::{
     SettingsCommitPolicy, SettingsEditStatus, SettingsEditor, SettingsFeedbackSeverity,
     SettingsPresentation, SettingsRow, SettingsStatus,
 };
-use lg_buddy::presentation::update_check::UpdateCheckPresentation;
-use lg_buddy::presentation::update_install::UpdateInstallPresentation;
+use lg_buddy::presentation::updater::UpdaterPresentation;
 use lg_buddy::settings_view::SettingsIntent;
 
 /// Stable native controls render application-owned values and commit policies.
@@ -20,7 +19,7 @@ pub(crate) struct SettingsView {
     status: adw::StatusPage,
     retry: gtk::Button,
     retry_intent: Rc<RefCell<Option<SettingsIntent>>>,
-    update_check: UpdateCheckView,
+    updater: UpdaterView,
 }
 
 impl SettingsView {
@@ -53,7 +52,7 @@ impl SettingsView {
         root.add_named(&status, Some("status"));
         root.add_named(&page, Some("settings"));
         root.set_visible_child_name("status");
-        let update_check = UpdateCheckView::new(Rc::clone(&on_intent));
+        let updater = UpdaterView::new(Rc::clone(&on_intent));
         Self {
             root,
             page,
@@ -63,7 +62,7 @@ impl SettingsView {
             status,
             retry,
             retry_intent,
-            update_check,
+            updater,
         }
     }
 
@@ -109,11 +108,11 @@ impl SettingsView {
                             native.add(&row.feedback);
                             self.rows.borrow_mut().push(row);
                         }
-                        if group.title() == "Updates" {
-                            self.update_check.attach(&native);
-                        }
                         self.page.add(&native);
                         self.groups.borrow_mut().push(native);
+                        if group.title() == "Updates" {
+                            self.page.add(&self.updater.group);
+                        }
                     }
                 }
                 self.render_rows(presentation);
@@ -133,93 +132,74 @@ impl SettingsView {
                 row.render(current, presentation.row_visible(current.setting()));
             }
         }
-        self.update_check
-            .render(presentation.update_check(), presentation.update_install());
+        self.updater.render(&presentation.updater());
     }
 }
 
-struct UpdateCheckView {
-    installed: adw::ActionRow,
-    check: gtk::Button,
-    check_intent: Rc<RefCell<Option<SettingsIntent>>>,
-    spinner: gtk::Spinner,
-    result: adw::ActionRow,
+/// One stable card renders the current step of the application-owned workflow.
+struct UpdaterView {
+    group: adw::PreferencesGroup,
+    row: adw::ActionRow,
+    action: gtk::Button,
+    action_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    cancel: gtk::Button,
+    cancel_intent: Rc<RefCell<Option<SettingsIntent>>>,
+    actions: gtk::Box,
+    footer: gtk::ListBoxRow,
     release: gtk::LinkButton,
-    error: adw::ActionRow,
-    warning: adw::ActionRow,
-    install: adw::ActionRow,
-    install_action: gtk::Button,
-    install_action_intent: Rc<RefCell<Option<SettingsIntent>>>,
-    install_cancel: gtk::Button,
-    install_cancel_intent: Rc<RefCell<Option<SettingsIntent>>>,
-    install_spinner: gtk::Spinner,
-    install_error: adw::ActionRow,
-    install_details: adw::ExpanderRow,
-    install_details_text: gtk::Label,
+    spinner: gtk::Spinner,
+    warning: gtk::Label,
+    details: adw::ExpanderRow,
+    details_text: gtk::Label,
 }
 
-impl UpdateCheckView {
+impl UpdaterView {
     fn new(on_intent: Rc<dyn Fn(SettingsIntent)>) -> Self {
-        let installed = detail_row("Installed version", "");
-        let check = gtk::Button::with_label("Check for updates");
-        check.add_css_class("suggested-action");
-        check.set_valign(gtk::Align::Center);
-        check.update_property(&[gtk::accessible::Property::Label("Check for updates")]);
-        let check_intent = Rc::new(RefCell::new(None));
-        check.connect_clicked({
-            let check_intent = Rc::clone(&check_intent);
-            let on_intent = Rc::clone(&on_intent);
-            move |_| {
-                let intent = check_intent.borrow().clone();
-                if let Some(intent) = intent {
-                    on_intent(intent);
-                }
-            }
-        });
+        let group = adw::PreferencesGroup::new();
+        let card = gtk::ListBox::new();
+        card.set_selection_mode(gtk::SelectionMode::None);
+        card.add_css_class("boxed-list");
+        let row = detail_row("", "");
+        row.set_title_lines(0);
+        row.set_accessible_role(gtk::AccessibleRole::Status);
         let spinner = gtk::Spinner::new();
         spinner.set_valign(gtk::Align::Center);
-        spinner.set_visible(false);
-        spinner.update_property(&[gtk::accessible::Property::Label("Checking for updates")]);
-        installed.add_suffix(&check);
-        installed.add_suffix(&spinner);
+        row.add_suffix(&spinner);
+        card.append(&row);
 
-        let result = detail_row("", "");
-        result.set_accessible_role(gtk::AccessibleRole::Status);
-        result.set_visible(false);
+        let warning = gtk::Label::builder()
+            .wrap(true)
+            .wrap_mode(gtk::pango::WrapMode::WordChar)
+            .selectable(true)
+            .xalign(0.0)
+            .margin_start(12)
+            .margin_end(12)
+            .margin_bottom(12)
+            .build();
+        warning.add_css_class("warning");
+        warning.set_accessible_role(gtk::AccessibleRole::Alert);
+        let footer_content = gtk::Box::new(gtk::Orientation::Vertical, 0);
+        footer_content.append(&warning);
+
+        let actions = gtk::Box::builder()
+            .orientation(gtk::Orientation::Horizontal)
+            .spacing(6)
+            .halign(gtk::Align::End)
+            .margin_start(12)
+            .margin_end(12)
+            .margin_bottom(12)
+            .build();
         let release = gtk::LinkButton::builder()
             .label("View release")
             .uri("https://github.com/Staphylococcus/LG_Buddy/releases")
-            .valign(gtk::Align::Center)
-            .visible(false)
             .build();
         release.update_property(&[gtk::accessible::Property::Label("View available release")]);
-        result.add_suffix(&release);
-
-        let error = detail_row("", "");
-        error.add_css_class("error");
-        error.set_accessible_role(gtk::AccessibleRole::Alert);
-        error.set_visible(false);
-
-        let warning = detail_row("", "");
-        warning.add_css_class("warning");
-        warning.set_accessible_role(gtk::AccessibleRole::Alert);
-        warning.set_visible(false);
-
-        // This row is reused for the offer, explicit confirmation, progress,
-        // and post-install relaunch states. The presentation decides which
-        // controls are visible and enabled.
-        let install = detail_row("", "");
-        install.set_accessible_role(gtk::AccessibleRole::Status);
-        install.set_visible(false);
-        let install_action = gtk::Button::builder()
-            .visible(false)
-            .sensitive(false)
-            .build();
-        install_action.add_css_class("suggested-action");
-        install_action.set_valign(gtk::Align::Center);
-        let install_action_intent = Rc::new(RefCell::new(None));
-        install_action.connect_clicked({
-            let intent = Rc::clone(&install_action_intent);
+        actions.append(&release);
+        let cancel = gtk::Button::new();
+        cancel.add_css_class("flat");
+        let cancel_intent = Rc::new(RefCell::new(None));
+        cancel.connect_clicked({
+            let intent = Rc::clone(&cancel_intent);
             let on_intent = Rc::clone(&on_intent);
             move |_| {
                 let intent = intent.borrow().clone();
@@ -228,18 +208,12 @@ impl UpdateCheckView {
                 }
             }
         });
-        install.add_suffix(&install_action);
-
-        let install_cancel = gtk::Button::builder()
-            .visible(false)
-            .sensitive(false)
-            .build();
-        install_cancel.add_css_class("flat");
-        install_cancel.set_valign(gtk::Align::Center);
-        let install_cancel_intent = Rc::new(RefCell::new(None));
-        install_cancel.connect_clicked({
-            let intent = Rc::clone(&install_cancel_intent);
-            let on_intent = Rc::clone(&on_intent);
+        actions.append(&cancel);
+        let action = gtk::Button::new();
+        action.add_css_class("suggested-action");
+        let action_intent = Rc::new(RefCell::new(None));
+        action.connect_clicked({
+            let intent = Rc::clone(&action_intent);
             move |_| {
                 let intent = intent.borrow().clone();
                 if let Some(intent) = intent {
@@ -247,25 +221,20 @@ impl UpdateCheckView {
                 }
             }
         });
-        install.add_suffix(&install_cancel);
+        actions.append(&action);
+        footer_content.append(&actions);
+        let footer = gtk::ListBoxRow::builder()
+            .activatable(false)
+            .selectable(false)
+            .child(&footer_content)
+            .build();
+        card.append(&footer);
 
-        let install_spinner = gtk::Spinner::new();
-        install_spinner.set_valign(gtk::Align::Center);
-        install_spinner.set_visible(false);
-        install_spinner.update_property(&[gtk::accessible::Property::Label("Installing update")]);
-        install.add_suffix(&install_spinner);
-
-        let install_error = detail_row("", "");
-        install_error.add_css_class("error");
-        install_error.set_accessible_role(gtk::AccessibleRole::Alert);
-        install_error.set_visible(false);
-
-        let install_details = adw::ExpanderRow::builder()
-            .title("Failure details")
+        let details = adw::ExpanderRow::builder()
             .use_markup(false)
             .visible(false)
             .build();
-        let install_details_text = gtk::Label::builder()
+        let details_text = gtk::Label::builder()
             .selectable(true)
             .wrap(true)
             .wrap_mode(gtk::pango::WrapMode::WordChar)
@@ -275,160 +244,97 @@ impl UpdateCheckView {
             .margin_top(12)
             .margin_bottom(12)
             .build();
-        install_details.add_row(&install_details_text);
-
+        details.add_row(&details_text);
+        card.append(&details);
+        group.add(&card);
         Self {
-            installed,
-            check,
-            check_intent,
-            spinner,
-            result,
+            group,
+            row,
+            action,
+            action_intent,
+            cancel,
+            cancel_intent,
+            actions,
+            footer,
             release,
-            error,
+            spinner,
             warning,
-            install,
-            install_action,
-            install_action_intent,
-            install_cancel,
-            install_cancel_intent,
-            install_spinner,
-            install_error,
-            install_details,
-            install_details_text,
+            details,
+            details_text,
         }
     }
 
-    fn attach(&self, group: &adw::PreferencesGroup) {
-        group.add(&self.installed);
-        group.add(&self.result);
-        group.add(&self.install);
-        group.add(&self.install_error);
-        group.add(&self.install_details);
-        group.add(&self.error);
-        group.add(&self.warning);
-    }
-
-    fn render(
-        &self,
-        presentation: &UpdateCheckPresentation,
-        install_presentation: &UpdateInstallPresentation,
-    ) {
-        self.installed
-            .set_subtitle(presentation.installed_version_label());
-        let action = presentation.check_action();
-        self.check_intent.replace(Some(action.intent()));
-        self.check.set_label(action.label());
-        self.check.set_sensitive(action.enabled());
-        self.check
-            .update_property(&[gtk::accessible::Property::Label(action.label())]);
-        self.spinner.set_visible(presentation.checking());
-        self.spinner.set_spinning(presentation.checking());
-
-        if let Some(report) = presentation.result() {
-            self.result.set_visible(true);
-            self.result.set_title(&report.title());
-            self.result.set_subtitle(&report.description());
-            if let Some(release) = report.available_release.as_ref() {
-                self.release.set_uri(&release.url);
-                self.release.set_visible(true);
-            } else {
-                self.release.set_visible(false);
-            }
-            if let Some(warning) = report.warning.as_deref() {
-                self.warning.set_title("Cache warning");
-                self.warning.set_subtitle(warning);
-                self.warning.set_visible(true);
-            } else {
-                self.warning.set_visible(false);
-            }
-        } else {
-            self.result.set_visible(false);
-            self.release.set_visible(false);
-            self.warning.set_visible(false);
-        }
-
-        if let Some(error) = presentation.error() {
-            self.error.set_title(error.summary());
-            self.error.set_subtitle(error.detail());
-            self.error.set_visible(true);
-        } else {
-            self.error.set_visible(false);
-        }
-
-        self.render_install(install_presentation);
-    }
-
-    fn render_install(&self, presentation: &UpdateInstallPresentation) {
-        let title = presentation.title().unwrap_or("");
-        let description = presentation.description();
-        let action = presentation.action();
-        let cancel_action = presentation.cancel_action();
-        let visible = presentation.title().is_some()
-            || action.is_some()
-            || cancel_action.is_some()
-            || presentation.busy();
-
-        self.install.set_visible(visible);
-        self.install.set_title(title);
-        self.install.set_subtitle(description);
-        self.install.update_property(&[
-            gtk::accessible::Property::Label(title),
-            gtk::accessible::Property::Description(description),
+    fn render(&self, presentation: &UpdaterPresentation) {
+        let action_had_focus = self.action.has_focus();
+        let cancel_had_focus = self.cancel.has_focus();
+        let release_had_focus = self.release.has_focus();
+        self.row.set_title(presentation.title());
+        self.row.set_subtitle(presentation.description());
+        self.row.update_property(&[
+            gtk::accessible::Property::Label(presentation.title()),
+            gtk::accessible::Property::Description(presentation.description()),
         ]);
-
-        if let Some(action) = action {
-            self.install_action.set_visible(true);
-            self.install_action.set_label(action.label());
-            self.install_action.set_sensitive(action.enabled());
-            self.install_action
-                .update_property(&[gtk::accessible::Property::Label(action.label())]);
-            self.install_action_intent.replace(Some(action.intent()));
+        if presentation.is_error() {
+            self.row.add_css_class("error");
         } else {
-            self.install_action.set_visible(false);
-            self.install_action.set_sensitive(false);
-            self.install_action_intent.replace(None);
+            self.row.remove_css_class("error");
         }
-
-        if let Some(action) = cancel_action {
-            self.install_cancel.set_visible(true);
-            self.install_cancel.set_label(action.label());
-            self.install_cancel.set_sensitive(action.enabled());
-            self.install_cancel
-                .update_property(&[gtk::accessible::Property::Label(action.label())]);
-            self.install_cancel_intent.replace(Some(action.intent()));
-        } else {
-            self.install_cancel.set_visible(false);
-            self.install_cancel.set_sensitive(false);
-            self.install_cancel_intent.replace(None);
+        for (button, intent, action) in [
+            (&self.action, &self.action_intent, presentation.action()),
+            (
+                &self.cancel,
+                &self.cancel_intent,
+                presentation.cancel_action(),
+            ),
+        ] {
+            button.set_visible(action.is_some());
+            button.set_sensitive(action.is_some_and(|action| action.enabled()));
+            button.set_label(action.map_or("", |action| action.label()));
+            button.update_property(&[gtk::accessible::Property::Label(
+                action.map_or("", |action| action.label()),
+            )]);
+            intent.replace(action.map(|action| action.intent()));
         }
-
-        self.install_spinner.set_visible(presentation.busy());
-        self.install_spinner.set_spinning(presentation.busy());
-
-        if let Some(error) = presentation.error() {
-            self.install_error.set_title(error.summary());
-            self.install_error.set_subtitle(error.detail());
-            self.install_error.update_property(&[
-                gtk::accessible::Property::Label(error.summary()),
-                gtk::accessible::Property::Description(error.detail()),
-            ]);
-            self.install_error.set_visible(true);
-        } else {
-            self.install_error.set_visible(false);
+        self.spinner.set_visible(presentation.busy());
+        self.spinner.set_spinning(presentation.busy());
+        self.spinner
+            .update_property(&[gtk::accessible::Property::Label(presentation.title())]);
+        self.release.set_visible(presentation.release().is_some());
+        if let Some(release) = presentation.release() {
+            self.release.set_uri(&release.url);
         }
+        let has_actions = presentation.action().is_some()
+            || presentation.cancel_action().is_some()
+            || presentation.release().is_some();
+        self.actions.set_visible(has_actions);
+        self.warning.set_visible(presentation.warning().is_some());
+        self.warning.set_text(presentation.warning().unwrap_or(""));
+        self.footer
+            .set_visible(has_actions || presentation.warning().is_some());
 
-        if let Some(details) = presentation.failure_details() {
-            if self.install_details_text.text().as_str() != details {
-                self.install_details.set_expanded(false);
-                self.install_details_text.set_text(details);
+        if let Some(details) = presentation.details() {
+            if self.details_text.text().as_str() != details {
+                self.details.set_expanded(false);
+                self.details_text.set_text(details);
             }
-            self.install_details
-                .set_title(presentation.failure_details_title());
-            self.install_details.set_visible(true);
+            self.details.set_title(presentation.details_title());
+            self.details.set_visible(true);
         } else {
-            self.install_details.set_expanded(false);
-            self.install_details.set_visible(false);
-            self.install_details_text.set_text("");
+            self.details.set_expanded(false);
+            self.details.set_visible(false);
+            self.details_text.set_text("");
+        }
+        // Follow a disappearing action within this card, without taking focus
+        // from another setting when an asynchronous completion arrives.
+        if (action_had_focus && !self.action.is_visible())
+            || (cancel_had_focus && !self.cancel.is_visible())
+            || (release_had_focus && !self.release.is_visible())
+        {
+            if self.action.is_visible() && self.action.is_sensitive() {
+                self.action.grab_focus();
+            } else if self.cancel.is_visible() && self.cancel.is_sensitive() {
+                self.cancel.grab_focus();
+            }
         }
     }
 }
@@ -593,7 +499,6 @@ impl NativeSettingRow {
         row.set_title_lines(0);
         row.set_subtitle_lines(0);
         let warning = gtk::Image::from_icon_name("dialog-warning-symbolic");
-        row.add_prefix(&warning);
         let problem = detail_row("", "");
         problem.add_css_class("error");
         problem.set_accessible_role(gtk::AccessibleRole::Alert);
@@ -720,8 +625,15 @@ impl NativeSettingRow {
                 self.feedback.remove_css_class(class);
             }
         }
-        self.warning
-            .set_visible(current.problem().is_some() || is_warning);
+        let show_warning = current.problem().is_some() || is_warning;
+        // An empty prefix box still reserves spacing in Adwaita. Attach the
+        // icon only when needed so ordinary rows retain their native inset.
+        if show_warning && self.warning.parent().is_none() {
+            self.row.add_prefix(&self.warning);
+        } else if !show_warning && self.warning.parent().is_some() {
+            self.row.remove(&self.warning);
+        }
+        self.warning.set_visible(show_warning);
         self.warning
             .set_tooltip_text(current.problem().or(is_warning.then_some(message)));
         let action = current.retry_apply_action();
@@ -816,7 +728,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .map(|row| row.row.clone())
         .collect();
     assert!(!rows.iter().any(|row| row.is::<adw::ExpanderRow>()));
-    assert!(!view.update_check.install_details.is_visible());
+    assert!(!view.updater.details.is_visible());
     assert_eq!(view.groups.borrow().len(), 3);
     assert_eq!(rows.len(), 7);
     assert!(widgets
@@ -1084,7 +996,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     );
     window.close();
     choice_row_click_opens_the_value_menu(application);
-    update_check_renderer_scenarios(application);
+    updater_renderer_scenarios(application);
 }
 
 #[cfg(test)]
@@ -1200,11 +1112,11 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
 }
 
 #[cfg(test)]
-fn update_check_renderer_scenarios(application: &adw::Application) {
+fn updater_renderer_scenarios(application: &adw::Application) {
     use crate::controller_test_support::pump_until;
     use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
     use lg_buddy::settings::{ConfigEnvReader, SettingsStore};
-    use lg_buddy::settings_view::{SettingsApplication, SettingsIntent, UpdateCheckError};
+    use lg_buddy::settings_view::{BehaviorSetting, SettingsApplication, UpdateCheckError};
     use lg_buddy::update_flow::UpdateInstallOutcome;
     use lg_buddy::update_install::{
         InstalledUpdate, PreparedUpdateInstall, UpdateInstallError, UpdateInstallStage,
@@ -1212,15 +1124,55 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     use lg_buddy::updates::UpdateChannel;
     use lg_buddy::version::VersionInfo;
 
+    fn title_x(row: &adw::ActionRow, root: &impl IsA<gtk::Widget>) -> f32 {
+        fn find(widget: &gtk::Widget, title: &str) -> Option<gtk::Label> {
+            if let Some(label) = widget.downcast_ref::<gtk::Label>() {
+                if label.text() == title {
+                    return Some(label.clone());
+                }
+            }
+            let mut child = widget.first_child();
+            while let Some(current) = child {
+                if let Some(label) = find(&current, title) {
+                    return Some(label);
+                }
+                child = current.next_sibling();
+            }
+            None
+        }
+        find(row.upcast_ref(), &row.title())
+            .unwrap()
+            .compute_bounds(root)
+            .unwrap()
+            .x()
+    }
+    fn prepared() -> PreparedUpdateInstall {
+        PreparedUpdateInstall::from_parts(
+            VersionInfo::current(),
+            "1.7.0".parse().unwrap(),
+            UpdateChannel::Stable,
+            "https://example.test/releases/v1.7.0",
+            "v1.7.0",
+            "x86_64-unknown-linux-gnu",
+            "newer-commit",
+        )
+    }
+    fn assert_narrow(view: &SettingsView) {
+        let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
+        assert!(
+            minimum <= 360,
+            "updater card must fit a narrow window: {minimum}"
+        );
+    }
+
     let intents = Rc::new(RefCell::new(Vec::new()));
-    let on_intent: Rc<dyn Fn(SettingsIntent)> = Rc::new({
+    let view = SettingsView::new(Rc::new({
         let intents = Rc::clone(&intents);
         move |intent| intents.borrow_mut().push(intent)
-    });
-    let view = SettingsView::new(on_intent);
+    }));
     let window = adw::ApplicationWindow::builder()
         .application(application)
-        .title("LG Buddy Update Check Renderer Test")
+        .title("LG Buddy Updater Renderer Test")
         .default_width(900)
         .default_height(700)
         .content(view.widget())
@@ -1230,63 +1182,65 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
         "/unused/config.env",
         "updates_channel=stable\n",
     ));
-    let ready = model
+    model
         .complete_read(
             opening.read_operation().unwrap(),
             Ok(SettingsPresentation::from_store(&store).groups().to_vec()),
         )
         .unwrap();
-    view.render(ready.presentation());
+    view.render(model.presentation());
     window.present();
-    pump_until(|| view.page.is_mapped() && view.groups.borrow().len() == 3);
-
+    pump_until(|| view.updater.row.is_mapped() && view.updater.row.width() > 0);
     let stable_rows: Vec<_> = view
         .rows
         .borrow()
         .iter()
         .map(|row| row.row.clone())
         .collect();
+    let card_row = view.updater.row.clone();
+    let action = view.updater.action.clone();
     assert_eq!(stable_rows.len(), 7);
-    assert_eq!(
-        view.update_check.installed.title().as_str(),
-        "Installed version"
-    );
-    assert!(!view.update_check.spinner.is_visible());
-    assert!(!view.update_check.result.is_visible());
-    assert!(!view.update_check.error.is_visible());
-    assert!(!view.update_check.warning.is_visible());
-    assert!(!view.update_check.install.is_visible());
-    assert!(!view.update_check.install_error.is_visible());
-    assert!(!view.update_check.install_details.is_visible());
+    assert_eq!(card_row.title().as_str(), "Installed version");
+    assert_eq!(action.label().as_deref(), Some("Check for updates"));
+    assert!(!view.updater.spinner.is_visible());
+    assert!(!view.updater.details.is_visible());
+    assert!(!view.updater.release.is_visible());
+    assert!(!view.updater.warning.is_visible());
+    assert_eq!(card_row.accessible_role(), gtk::AccessibleRole::Status);
 
-    let check = view.update_check.check.clone();
-    assert_eq!(check.accessible_role(), gtk::AccessibleRole::Button);
-    assert!(check.grab_focus());
+    // Compare native label allocations, not hard-coded padding or widget types.
+    let rows = view.rows.borrow();
+    for row in rows.iter().filter(|row| {
+        matches!(
+            row.presentation.borrow().setting(),
+            BehaviorSetting::UpdatesAutoCheck | BehaviorSetting::UpdatesChannel
+        )
+    }) {
+        assert!(row.warning.parent().is_none());
+        assert!(
+            (title_x(&row.row, &window) - title_x(&card_row, &window)).abs() < 1.0,
+            "updater and normal settings text must share their left edge: setting={}, updater={}",
+            title_x(&row.row, &window),
+            title_x(&card_row, &window)
+        );
+    }
+    drop(rows);
+
+    assert!(action.grab_focus());
+    action.emit_clicked();
+    assert_eq!(*intents.borrow(), vec![SettingsIntent::CheckForUpdates]);
     intents.borrow_mut().clear();
-    check.emit_clicked();
-    assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::CheckForUpdates],
-        "only activating Check should submit an update-check intent"
-    );
     let checking = model
-        .handle_intent(intents.borrow_mut().pop().unwrap())
+        .handle_intent(SettingsIntent::CheckForUpdates)
         .unwrap();
-    let operation = checking.update_check_operation().unwrap();
     view.render(checking.presentation());
-    assert!(view.update_check.spinner.is_visible());
-    assert_eq!(check.label().as_deref(), Some("Checking…"));
-    assert!(!check.is_sensitive());
-    assert!(
-        check.is_focusable(),
-        "checking must leave the Check button available to the keyboard focus ring"
-    );
-    assert!(
-        intents.borrow().is_empty(),
-        "rendering must not submit an intent"
-    );
+    assert!(view.updater.spinner.is_visible());
+    assert!(!action.is_sensitive());
+    assert_eq!(action.label().as_deref(), Some("Checking…"));
+    assert!(action.is_focusable());
+    assert!(intents.borrow().is_empty());
 
-    let available = UpdateCheckReport {
+    let report = UpdateCheckReport {
         installed_version: "1.6.0".into(),
         channel: UpdateChannel::Stable,
         available_release: Some(AvailableUpdate {
@@ -1295,109 +1249,100 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
         }),
         warning: Some("Cache <could not>& be refreshed.".into()),
     };
-    let success = model
-        .complete_update_check(operation, Ok(available))
+    model
+        .complete_update_check(checking.update_check_operation().unwrap(), Ok(report))
         .unwrap();
-    view.render(success.presentation());
-    assert!(!view.update_check.spinner.is_visible());
-    assert!(check.is_sensitive());
-    assert_eq!(check.label().as_deref(), Some("Check for updates"));
-    assert!(view.update_check.result.is_visible());
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Update available: 1.7.0");
+    assert_eq!(action.label().as_deref(), Some("Install update…"));
+    assert!(view.updater.release.is_visible());
     assert_eq!(
-        view.update_check.result.title().as_str(),
-        "Update available: 1.7.0"
-    );
-    assert!(view
-        .update_check
-        .result
-        .subtitle()
-        .is_some_and(|text| text.contains("stable") && text.contains("1.6.0")));
-    assert!(view.update_check.release.is_visible());
-    assert_eq!(
-        view.update_check.release.uri().as_str(),
+        view.updater.release.uri().as_str(),
         "https://example.test/releases/v1.7.0?name=release%3C1%3E"
     );
     assert_eq!(
-        view.update_check.release.accessible_role(),
-        gtk::AccessibleRole::Link
+        view.updater.warning.text().as_str(),
+        "Cache <could not>& be refreshed."
     );
-    assert!(view.update_check.warning.is_visible());
-    assert_eq!(
-        view.update_check.warning.accessible_role(),
-        gtk::AccessibleRole::Alert
-    );
-    assert!(view
-        .update_check
-        .warning
-        .subtitle()
-        .is_some_and(|text| text == "Cache <could not>& be refreshed."));
-    assert!(
-        intents.borrow().is_empty(),
-        "rendering must not submit an intent"
-    );
+    assert!(view.updater.warning.is_visible());
+    assert!(!view.updater.spinner.is_visible());
+    assert_narrow(&view);
 
-    // An available release exposes the application-owned prepare action. The
-    // prepare state is busy and can be cancelled without the renderer making
-    // any workflow decisions of its own.
-    assert!(view.update_check.install.is_visible());
-    assert_eq!(
-        view.update_check.install_action.label().as_deref(),
-        Some("Install update…")
-    );
-    assert_eq!(
-        view.update_check.install.accessible_role(),
-        gtk::AccessibleRole::Status
-    );
-    assert_eq!(
-        view.update_check.install_action.accessible_role(),
-        gtk::AccessibleRole::Button
-    );
-    intents.borrow_mut().clear();
-    view.update_check.install_action.emit_clicked();
+    assert!(action.grab_focus());
+    action.emit_clicked();
     assert_eq!(
         *intents.borrow(),
-        vec![SettingsIntent::PrepareUpdateInstall],
-        "the available-release action must forward the prepare intent"
-    );
-    let preparing = model
-        .handle_intent(intents.borrow_mut().pop().unwrap())
-        .unwrap();
-    view.render(preparing.presentation());
-    assert!(view.update_check.install.is_visible());
-    assert!(view.update_check.install_spinner.is_visible());
-    assert!(!view.update_check.install_action.is_visible());
-    assert!(view.update_check.install_cancel.is_visible());
-    assert_eq!(
-        view.update_check.install_cancel.label().as_deref(),
-        Some("Cancel")
+        vec![SettingsIntent::PrepareUpdateInstall]
     );
     intents.borrow_mut().clear();
-    view.update_check.install_cancel.emit_clicked();
-    assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::CancelUpdateInstall],
-        "the inline cancel control must forward the cancel intent"
-    );
-    let cancelled = model
-        .handle_intent(intents.borrow_mut().pop().unwrap())
+    model
+        .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();
-    view.render(cancelled.presentation());
-    assert!(view.update_check.install.is_visible());
-    assert!(!view.update_check.install_spinner.is_visible());
-    assert!(!view.update_check.install_error.is_visible());
-    assert_eq!(
-        view.update_check.install_action.label().as_deref(),
-        Some("Install update…")
-    );
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Preparing update…");
+    assert!(!action.is_visible());
+    assert!(view.updater.cancel.is_visible());
+    assert!(view.updater.cancel.has_focus());
+    assert!(!view.updater.release.is_visible());
+    assert!(!view.updater.warning.is_visible());
+    view.updater.cancel.emit_clicked();
+    assert_eq!(*intents.borrow(), vec![SettingsIntent::CancelUpdateInstall]);
+    intents.borrow_mut().clear();
+    model
+        .handle_intent(SettingsIntent::CancelUpdateInstall)
+        .unwrap();
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Update available: 1.7.0");
+    assert!(action.has_focus());
 
     let preparing = model
         .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();
-    let install_operation = preparing.update_install_operation().unwrap().clone();
-    view.render(preparing.presentation());
-    let failed_install = model
+    model
         .complete_update_install(
-            &install_operation,
+            preparing.update_install_operation().unwrap(),
+            Ok(UpdateInstallOutcome::Prepared(prepared())),
+        )
+        .unwrap();
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Install LG Buddy 1.7.0?");
+    assert_eq!(action.label().as_deref(), Some("Install and restart"));
+    assert!(view.updater.cancel.is_visible());
+    assert!(!view.updater.release.is_visible());
+    assert!(!view.updater.spinner.is_visible());
+    assert_narrow(&view);
+    action.emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![SettingsIntent::ConfirmUpdateInstall]
+    );
+    intents.borrow_mut().clear();
+    let installing = model
+        .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+        .unwrap();
+    let operation = installing.update_install_operation().unwrap();
+    model
+        .update_install_progress(operation, UpdateInstallStage::Acquiring)
+        .unwrap();
+    view.render(model.presentation());
+    assert_eq!(
+        card_row.title().as_str(),
+        "Downloading and verifying update…"
+    );
+    assert!(view.updater.spinner.is_visible());
+    assert!(view.updater.cancel.is_visible());
+    assert!(!action.is_visible());
+    model
+        .update_install_progress(operation, UpdateInstallStage::Installing)
+        .unwrap();
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Installing update…");
+    assert!(!view.updater.actions.is_visible());
+    assert!(!view.updater.cancel.is_visible());
+
+    model
+        .complete_update_install(
+            operation,
             Err(UpdateInstallError::InstallerFailedWithOutput {
                 code: Some(1),
                 output: "install: No space left on device\naccess_token=private-value".into(),
@@ -1406,115 +1351,51 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
             .into()),
         )
         .unwrap();
-    view.render(failed_install.presentation());
-    assert!(view.update_check.install.is_visible());
-    assert!(view.update_check.install_error.is_visible());
-    assert_eq!(
-        view.update_check.install_error.accessible_role(),
-        gtk::AccessibleRole::Alert
-    );
-    assert!(view.update_check.install_details.is_visible());
-    assert!(!view.update_check.install_details.is_expanded());
-    assert!(view.update_check.install_details_text.is_selectable());
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Could not install update");
+    assert!(card_row.has_css_class("error"));
+    assert_eq!(action.label().as_deref(), Some("Retry update"));
+    assert!(!view.updater.release.is_visible());
+    assert!(view.updater.details.is_visible());
+    assert!(!view.updater.details.is_expanded());
+    assert!(view.updater.details_text.is_selectable());
     assert!(view
-        .update_check
-        .install_details_text
+        .updater
+        .details_text
         .text()
         .contains("No space left on device"));
-    assert!(!view
-        .update_check
-        .install_details_text
-        .text()
-        .contains("private-value"));
-    view.update_check.install_details.set_expanded(true);
-    view.render(failed_install.presentation());
-    assert!(
-        view.update_check.install_details.is_expanded(),
-        "refresh must not collapse requested details"
-    );
-    assert!(
-        view.update_check.install_details_text.grab_focus(),
-        "details must be keyboard accessible for selection and copying"
-    );
-    assert!(view.update_check.install_action.is_visible());
-    assert_eq!(
-        view.update_check.install_action.label().as_deref(),
-        Some("Retry update")
-    );
-    intents.borrow_mut().clear();
-    view.update_check.install_action.emit_clicked();
+    assert!(!view.updater.details_text.text().contains("private-value"));
+    view.updater.details.set_expanded(true);
+    view.render(model.presentation());
+    assert!(view.updater.details.is_expanded());
+    assert!(view.updater.details_text.grab_focus());
+    assert_narrow(&view);
+    action.emit_clicked();
     assert_eq!(
         *intents.borrow(),
-        vec![SettingsIntent::PrepareUpdateInstall],
-        "an installation failure must expose the application retry action"
+        vec![SettingsIntent::PrepareUpdateInstall]
     );
-
+    intents.borrow_mut().clear();
     let preparing = model
         .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();
-    let prepare_operation = preparing.update_install_operation().unwrap().clone();
-    view.render(preparing.presentation());
-    let prepared = PreparedUpdateInstall::from_parts(
-        VersionInfo::current(),
-        "1.7.0".parse().unwrap(),
-        UpdateChannel::Stable,
-        "https://example.test/releases/v1.7.0",
-        "v1.7.0",
-        "x86_64-unknown-linux-gnu",
-        "newer-commit",
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Preparing update…");
+    assert!(!card_row.has_css_class("error"));
+    assert_eq!(view.updater.details.title().as_str(), "Last update failure");
+    assert!(
+        view.updater.details_text.has_focus(),
+        "progress must not steal diagnostic selection focus"
     );
-    let confirmation = model
+    model
         .complete_update_install(
-            &prepare_operation,
-            Ok(UpdateInstallOutcome::Prepared(prepared)),
+            preparing.update_install_operation().unwrap(),
+            Ok(UpdateInstallOutcome::Prepared(prepared())),
         )
         .unwrap();
-    view.render(confirmation.presentation());
-    assert_eq!(
-        view.update_check.install.title().as_str(),
-        "Install LG Buddy 1.7.0?"
-    );
-    assert_eq!(
-        view.update_check.install_action.label().as_deref(),
-        Some("Install and restart")
-    );
-    assert!(view.update_check.install_action.is_visible());
-    assert!(view.update_check.install_cancel.is_visible());
-    assert!(!view.update_check.install_spinner.is_visible());
-
-    intents.borrow_mut().clear();
-    view.update_check.install_action.emit_clicked();
-    assert_eq!(
-        *intents.borrow(),
-        vec![SettingsIntent::ConfirmUpdateInstall],
-        "the confirmation control must forward the confirm intent"
-    );
     let installing = model
-        .handle_intent(intents.borrow_mut().pop().unwrap())
+        .handle_intent(SettingsIntent::ConfirmUpdateInstall)
         .unwrap();
-    let install_operation = installing.update_install_operation().unwrap().clone();
-    view.render(installing.presentation());
-    assert!(view.update_check.install_spinner.is_visible());
-    assert!(!view.update_check.install_action.is_visible());
-    assert!(view.update_check.install_cancel.is_visible());
-
-    let acquiring = model
-        .update_install_progress(&install_operation, UpdateInstallStage::Acquiring)
-        .unwrap();
-    view.render(acquiring.presentation());
-    assert!(view.update_check.install_spinner.is_visible());
-    assert!(view
-        .update_check
-        .install
-        .subtitle()
-        .is_some_and(|text| text.contains("cancel")));
-    let installing_stage = model
-        .update_install_progress(&install_operation, UpdateInstallStage::Installing)
-        .unwrap();
-    view.render(installing_stage.presentation());
-    assert!(view.update_check.install_spinner.is_visible());
-    assert!(!view.update_check.install_cancel.is_visible());
-
     let installed = InstalledUpdate::from_parts(
         "1.7.0".parse().unwrap(),
         UpdateChannel::Stable,
@@ -1526,98 +1407,65 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     );
     let restarting = model
         .complete_update_install(
-            &install_operation,
+            installing.update_install_operation().unwrap(),
             Ok(UpdateInstallOutcome::Installed(installed)),
         )
         .unwrap();
-    let relaunch_operation = restarting.update_install_operation().unwrap().clone();
-    view.render(restarting.presentation());
-    assert!(view.update_check.install_spinner.is_visible());
-    assert!(!view.update_check.install_action.is_visible());
-    assert!(!view.update_check.install_cancel.is_visible());
-    assert_eq!(
-        view.update_check.install.title().as_str(),
-        "Restarting LG Buddy…"
-    );
-    let relaunched = model
-        .complete_update_install(&relaunch_operation, Ok(UpdateInstallOutcome::Relaunched))
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Restarting LG Buddy…");
+    assert!(!view.updater.actions.is_visible());
+    assert!(view.updater.spinner.is_visible());
+    model
+        .complete_update_install(
+            restarting.update_install_operation().unwrap(),
+            Err(lg_buddy::update_flow::UpdateInstallFailure::stopped()),
+        )
         .unwrap();
-    view.render(relaunched.presentation());
-    assert!(view.update_check.install.is_visible());
-    assert!(!view.update_check.install_spinner.is_visible());
-    assert!(!view.update_check.install_error.is_visible());
-
-    let checking_again = model
-        .handle_intent(SettingsIntent::CheckForUpdates)
-        .unwrap();
-    let operation = checking_again.update_check_operation().unwrap();
-    view.render(checking_again.presentation());
-    assert!(view.update_check.result.is_visible());
-    assert!(view.update_check.warning.is_visible());
-    let current = UpdateCheckReport {
-        installed_version: "1.6.0".into(),
-        channel: UpdateChannel::Stable,
-        available_release: None,
-        warning: None,
-    };
-    let current = model.complete_update_check(operation, Ok(current)).unwrap();
-    view.render(current.presentation());
-    assert!(view.update_check.result.is_visible());
-    assert_eq!(
-        view.update_check.result.title().as_str(),
-        "No newer release available"
-    );
-    assert!(!view.update_check.release.is_visible());
-    assert!(!view.update_check.warning.is_visible());
-
-    let checking_again = model
-        .handle_intent(SettingsIntent::CheckForUpdates)
-        .unwrap();
-    let operation = checking_again.update_check_operation().unwrap();
-    view.render(checking_again.presentation());
-    let failed = model
-        .complete_update_check(operation, Err(UpdateCheckError::stopped()))
-        .unwrap();
-    view.render(failed.presentation());
-    assert!(view.update_check.result.is_visible());
-    assert_eq!(
-        view.update_check.result.title().as_str(),
-        "No newer release available"
-    );
-    assert!(view.update_check.error.is_visible());
-    assert_eq!(
-        view.update_check.error.accessible_role(),
-        gtk::AccessibleRole::Alert
-    );
-    assert_eq!(check.label().as_deref(), Some("Retry check"));
-    assert!(check.is_sensitive());
-
-    intents.borrow_mut().clear();
-    check.emit_clicked();
+    view.render(model.presentation());
+    assert_eq!(action.label().as_deref(), Some("Retry restart"));
+    action.emit_clicked();
     assert_eq!(
         *intents.borrow(),
-        vec![SettingsIntent::CheckForUpdates],
-        "Retry check must reuse the application-owned intent"
+        vec![SettingsIntent::RelaunchUpdatedApplication]
     );
     intents.borrow_mut().clear();
-    view.render(failed.presentation());
+
+    // A check replaces the prior result or failure in the same card.
+    let checking = model
+        .handle_intent(SettingsIntent::CheckForUpdates)
+        .unwrap();
+    view.render(checking.presentation());
+    assert!(view.updater.spinner.is_visible());
+    assert!(!card_row.has_css_class("error"));
+    assert!(!view.updater.release.is_visible());
+    model
+        .complete_update_check(
+            checking.update_check_operation().unwrap(),
+            Err(UpdateCheckError::stopped()),
+        )
+        .unwrap();
+    view.render(model.presentation());
+    assert_eq!(card_row.title().as_str(), "Update check stopped");
+    assert_eq!(action.label().as_deref(), Some("Retry check"));
+    assert!(card_row.has_css_class("error"));
+    action.emit_clicked();
+    assert_eq!(*intents.borrow(), vec![SettingsIntent::CheckForUpdates]);
+    intents.borrow_mut().clear();
+    view.render(model.presentation());
     assert!(
         intents.borrow().is_empty(),
-        "rendering must not submit an intent"
+        "rendering must not submit intents"
     );
+    assert_eq!(view.updater.row, card_row);
+    assert_eq!(view.updater.action, action);
     assert!(view
         .rows
         .borrow()
         .iter()
         .zip(&stable_rows)
         .all(|(current, original)| current.row == *original));
-
     window.set_default_size(360, 700);
     pump_until(|| window.width() <= 360);
-    let (minimum, _, _, _) = view.widget().measure(gtk::Orientation::Horizontal, -1);
-    assert!(
-        minimum <= 360,
-        "update-check controls must fit a narrow window: {minimum}"
-    );
+    assert_narrow(&view);
     window.close();
 }

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -154,6 +154,8 @@ struct UpdateCheckView {
     install_cancel_intent: Rc<RefCell<Option<SettingsIntent>>>,
     install_spinner: gtk::Spinner,
     install_error: adw::ActionRow,
+    install_details: adw::ExpanderRow,
+    install_details_text: gtk::Label,
 }
 
 impl UpdateCheckView {
@@ -258,6 +260,23 @@ impl UpdateCheckView {
         install_error.set_accessible_role(gtk::AccessibleRole::Alert);
         install_error.set_visible(false);
 
+        let install_details = adw::ExpanderRow::builder()
+            .title("Failure details")
+            .use_markup(false)
+            .visible(false)
+            .build();
+        let install_details_text = gtk::Label::builder()
+            .selectable(true)
+            .wrap(true)
+            .wrap_mode(gtk::pango::WrapMode::WordChar)
+            .xalign(0.0)
+            .margin_start(12)
+            .margin_end(12)
+            .margin_top(12)
+            .margin_bottom(12)
+            .build();
+        install_details.add_row(&install_details_text);
+
         Self {
             installed,
             check,
@@ -274,6 +293,8 @@ impl UpdateCheckView {
             install_cancel_intent,
             install_spinner,
             install_error,
+            install_details,
+            install_details_text,
         }
     }
 
@@ -282,6 +303,7 @@ impl UpdateCheckView {
         group.add(&self.result);
         group.add(&self.install);
         group.add(&self.install_error);
+        group.add(&self.install_details);
         group.add(&self.error);
         group.add(&self.warning);
     }
@@ -393,6 +415,20 @@ impl UpdateCheckView {
             self.install_error.set_visible(true);
         } else {
             self.install_error.set_visible(false);
+        }
+
+        if let Some(details) = presentation.failure_details() {
+            if self.install_details_text.text().as_str() != details {
+                self.install_details.set_expanded(false);
+                self.install_details_text.set_text(details);
+            }
+            self.install_details
+                .set_title(presentation.failure_details_title());
+            self.install_details.set_visible(true);
+        } else {
+            self.install_details.set_expanded(false);
+            self.install_details.set_visible(false);
+            self.install_details_text.set_text("");
         }
     }
 }
@@ -779,7 +815,8 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .iter()
         .map(|row| row.row.clone())
         .collect();
-    assert!(!widgets.iter().any(|widget| widget.is::<adw::ExpanderRow>()));
+    assert!(!rows.iter().any(|row| row.is::<adw::ExpanderRow>()));
+    assert!(!view.update_check.install_details.is_visible());
     assert_eq!(view.groups.borrow().len(), 3);
     assert_eq!(rows.len(), 7);
     assert!(widgets
@@ -1168,8 +1205,10 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     use lg_buddy::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
     use lg_buddy::settings::{ConfigEnvReader, SettingsStore};
     use lg_buddy::settings_view::{SettingsApplication, SettingsIntent, UpdateCheckError};
-    use lg_buddy::update_flow::{UpdateInstallFailure, UpdateInstallOutcome};
-    use lg_buddy::update_install::{InstalledUpdate, PreparedUpdateInstall, UpdateInstallStage};
+    use lg_buddy::update_flow::UpdateInstallOutcome;
+    use lg_buddy::update_install::{
+        InstalledUpdate, PreparedUpdateInstall, UpdateInstallError, UpdateInstallStage,
+    };
     use lg_buddy::updates::UpdateChannel;
     use lg_buddy::version::VersionInfo;
 
@@ -1218,6 +1257,7 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     assert!(!view.update_check.warning.is_visible());
     assert!(!view.update_check.install.is_visible());
     assert!(!view.update_check.install_error.is_visible());
+    assert!(!view.update_check.install_details.is_visible());
 
     let check = view.update_check.check.clone();
     assert_eq!(check.accessible_role(), gtk::AccessibleRole::Button);
@@ -1356,7 +1396,15 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     let install_operation = preparing.update_install_operation().unwrap().clone();
     view.render(preparing.presentation());
     let failed_install = model
-        .complete_update_install(&install_operation, Err(UpdateInstallFailure::stopped()))
+        .complete_update_install(
+            &install_operation,
+            Err(UpdateInstallError::InstallerFailedWithOutput {
+                code: Some(1),
+                output: "install: No space left on device\naccess_token=private-value".into(),
+                mutation_started: true,
+            }
+            .into()),
+        )
         .unwrap();
     view.render(failed_install.presentation());
     assert!(view.update_check.install.is_visible());
@@ -1364,6 +1412,29 @@ fn update_check_renderer_scenarios(application: &adw::Application) {
     assert_eq!(
         view.update_check.install_error.accessible_role(),
         gtk::AccessibleRole::Alert
+    );
+    assert!(view.update_check.install_details.is_visible());
+    assert!(!view.update_check.install_details.is_expanded());
+    assert!(view.update_check.install_details_text.is_selectable());
+    assert!(view
+        .update_check
+        .install_details_text
+        .text()
+        .contains("No space left on device"));
+    assert!(!view
+        .update_check
+        .install_details_text
+        .text()
+        .contains("private-value"));
+    view.update_check.install_details.set_expanded(true);
+    view.render(failed_install.presentation());
+    assert!(
+        view.update_check.install_details.is_expanded(),
+        "refresh must not collapse requested details"
+    );
+    assert!(
+        view.update_check.install_details_text.grab_focus(),
+        "details must be keyboard accessible for selection and copying"
     );
     assert!(view.update_check.install_action.is_visible());
     assert_eq!(

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -167,6 +167,10 @@ impl ApplicationWindow {
         self.settings.render(presentation);
     }
 
+    pub(crate) fn show_update_notice(&self, notice: &lg_buddy::settings_view::UpdateNotice) {
+        self.settings.show_update_notice(notice, &self.toasts);
+    }
+
     pub(crate) fn dismiss_dialog(&self) -> bool {
         if let Some(dialog) = self.window.visible_dialog() {
             dialog.close();

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -96,6 +96,9 @@ impl Application {
         &mut self,
         intent: OverviewIntent,
     ) -> Option<ApplicationTransition> {
+        if intent == OverviewIntent::Cancel && !self.settings.can_close() {
+            return None;
+        }
         if self.tvs.is_managing() && intent != OverviewIntent::Cancel {
             return None;
         }
@@ -163,6 +166,27 @@ impl Application {
         >,
     ) -> Option<ApplicationTransition> {
         let transition = self.settings.complete_update_check(operation, result)?;
+        Some(self.settings_transition(transition))
+    }
+
+    pub fn update_install_progress(
+        &mut self,
+        operation: &crate::update_flow::UpdateInstallOperation,
+        stage: crate::update_install::UpdateInstallStage,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.settings.update_install_progress(operation, stage)?;
+        Some(self.settings_transition(transition))
+    }
+
+    pub fn complete_update_install(
+        &mut self,
+        operation: &crate::update_flow::UpdateInstallOperation,
+        result: Result<
+            crate::update_flow::UpdateInstallOutcome,
+            crate::update_flow::UpdateInstallFailure,
+        >,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.settings.complete_update_install(operation, result)?;
         Some(self.settings_transition(transition))
     }
 

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -29,6 +29,7 @@ pub mod sources;
 pub mod state;
 pub mod tv;
 pub mod tvs;
+pub mod update_flow;
 pub mod update_install;
 pub mod updates;
 pub mod upgrade_preflight;
@@ -88,6 +89,7 @@ pub enum Command {
     UpgradePreflight {
         candidate_root: PathBuf,
         repair_python: bool,
+        json: bool,
     },
 }
 
@@ -761,10 +763,13 @@ where
                     .as_ref(),
             );
             let mut repair_python = false;
+            let mut json = false;
             let mut unexpected = Vec::new();
             for argument in args {
                 if argument.as_ref() == "--repair-python" && !repair_python {
                     repair_python = true;
+                } else if argument.as_ref() == "--json" && !json {
+                    json = true;
                 } else {
                     unexpected.push(argument.as_ref().to_string());
                 }
@@ -772,6 +777,7 @@ where
             let command = Command::UpgradePreflight {
                 candidate_root,
                 repair_python,
+                json,
             };
             if !unexpected.is_empty() {
                 return Err(ParseError::UnexpectedArguments {
@@ -845,11 +851,22 @@ pub fn run_command<W: Write>(command: Command, writer: &mut W) -> Result<(), Run
         Command::UpgradePreflight {
             candidate_root,
             repair_python,
+            json,
         } => {
             let report =
                 crate::upgrade_preflight::candidate_host_preflight(&candidate_root, repair_python);
+            if json {
+                writeln!(
+                    writer,
+                    "{}",
+                    serde_json::to_string(&report.advice())
+                        .expect("preflight advice contains only serializable strings")
+                )?;
+            }
             if report.compatible() {
-                write!(writer, "{report}")?;
+                if !json {
+                    write!(writer, "{report}")?;
+                }
                 Ok(())
             } else {
                 Err(RunError::UpgradePreflight(report))
@@ -1680,6 +1697,7 @@ mod tests {
             Ok(ParseOutcome::Command(Command::UpgradePreflight {
                 candidate_root: PathBuf::from("/tmp/lg-buddy-candidate"),
                 repair_python: false,
+                json: false,
             }))
         );
         assert_eq!(
@@ -1691,6 +1709,7 @@ mod tests {
             Ok(ParseOutcome::Command(Command::UpgradePreflight {
                 candidate_root: PathBuf::from("/tmp/lg-buddy-candidate"),
                 repair_python: true,
+                json: false,
             }))
         );
     }
@@ -1981,6 +2000,27 @@ mod tests {
     }
 
     #[test]
+    fn candidate_preflight_accepts_structured_advice_with_repair_checks() {
+        assert_eq!(
+            parse_args([
+                "upgrade-preflight",
+                "/tmp/candidate",
+                "--json",
+                "--repair-python"
+            ]),
+            Ok(ParseOutcome::Command(Command::UpgradePreflight {
+                candidate_root: PathBuf::from("/tmp/candidate"),
+                repair_python: true,
+                json: true
+            }))
+        );
+        assert!(matches!(
+            parse_args(["upgrade-preflight", "/tmp/candidate", "--json", "--json"]),
+            Err(ParseError::UnexpectedArguments { .. })
+        ));
+    }
+
+    #[test]
     fn invalid_upgrade_preflight_command_is_rejected() {
         assert_eq!(
             parse_args(["upgrade-preflight"]),
@@ -1992,6 +2032,7 @@ mod tests {
                 command: Command::UpgradePreflight {
                     candidate_root: PathBuf::from("/tmp/candidate"),
                     repair_python: false,
+                    json: false,
                 },
                 arguments: vec!["extra".to_string()],
             })
@@ -2007,6 +2048,7 @@ mod tests {
                 command: Command::UpgradePreflight {
                     candidate_root: PathBuf::from("/tmp/candidate"),
                     repair_python: true,
+                    json: false,
                 },
                 arguments: vec!["--repair-python".to_string()],
             })

--- a/crates/lg-buddy/src/presentation/mod.rs
+++ b/crates/lg-buddy/src/presentation/mod.rs
@@ -5,3 +5,4 @@ pub mod settings;
 pub mod tvs;
 pub mod update_check;
 pub mod update_install;
+pub mod updater;

--- a/crates/lg-buddy/src/presentation/mod.rs
+++ b/crates/lg-buddy/src/presentation/mod.rs
@@ -4,3 +4,4 @@ pub mod pairing;
 pub mod settings;
 pub mod tvs;
 pub mod update_check;
+pub mod update_install;

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -179,9 +179,7 @@ impl SettingsPresentation {
         &self.update_install
     }
 
-    /// Compute the single update card from the check and installation facts.
-    /// The renderer receives the current workflow state with its precedence
-    /// already resolved by the application presentation layer.
+    /// Project the compact update row and its current semantic action.
     pub fn updater(&self) -> UpdaterPresentation {
         UpdaterPresentation::from_settings(self)
     }

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -1,6 +1,7 @@
 use crate::presentation::brightness::UserFacingError;
 use crate::presentation::update_check::UpdateCheckPresentation;
 use crate::presentation::update_install::UpdateInstallPresentation;
+use crate::presentation::updater::UpdaterPresentation;
 use crate::settings::{EffectiveSetting, SettingSource, SettingType, SettingValue, SettingsStore};
 use crate::settings_view::{BehaviorSetting, SettingsIntent};
 
@@ -176,6 +177,13 @@ impl SettingsPresentation {
 
     pub fn update_install(&self) -> &UpdateInstallPresentation {
         &self.update_install
+    }
+
+    /// Compute the single update card from the check and installation facts.
+    /// The renderer receives the current workflow state with its precedence
+    /// already resolved by the application presentation layer.
+    pub fn updater(&self) -> UpdaterPresentation {
+        UpdaterPresentation::from_settings(self)
     }
 
     pub(crate) fn update_install_mut(&mut self) -> &mut UpdateInstallPresentation {

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -1,5 +1,6 @@
 use crate::presentation::brightness::UserFacingError;
 use crate::presentation::update_check::UpdateCheckPresentation;
+use crate::presentation::update_install::UpdateInstallPresentation;
 use crate::settings::{EffectiveSetting, SettingSource, SettingType, SettingValue, SettingsStore};
 use crate::settings_view::{BehaviorSetting, SettingsIntent};
 
@@ -10,6 +11,7 @@ pub struct SettingsPresentation {
     groups: Vec<SettingsGroup>,
     retry_action: Option<SettingsAction>,
     update_check: UpdateCheckPresentation,
+    update_install: UpdateInstallPresentation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -111,6 +113,7 @@ impl SettingsPresentation {
             groups: Vec::new(),
             retry_action: None,
             update_check: UpdateCheckPresentation::default(),
+            update_install: UpdateInstallPresentation::default(),
         }
     }
 
@@ -120,6 +123,7 @@ impl SettingsPresentation {
             groups,
             retry_action: None,
             update_check: UpdateCheckPresentation::default(),
+            update_install: UpdateInstallPresentation::default(),
         }
     }
 
@@ -129,6 +133,7 @@ impl SettingsPresentation {
             groups,
             retry_action: Some(SettingsAction::new("Retry", true, SettingsIntent::Retry)),
             update_check: UpdateCheckPresentation::default(),
+            update_install: UpdateInstallPresentation::default(),
         }
     }
 
@@ -167,6 +172,14 @@ impl SettingsPresentation {
 
     pub(crate) fn update_check_mut(&mut self) -> &mut UpdateCheckPresentation {
         &mut self.update_check
+    }
+
+    pub fn update_install(&self) -> &UpdateInstallPresentation {
+        &self.update_install
+    }
+
+    pub(crate) fn update_install_mut(&mut self) -> &mut UpdateInstallPresentation {
+        &mut self.update_install
     }
 
     /// Keep dependent settings intact while only presenting controls that apply.

--- a/crates/lg-buddy/src/presentation/update_check.rs
+++ b/crates/lg-buddy/src/presentation/update_check.rs
@@ -4,36 +4,13 @@ use crate::settings_view::SettingsIntent;
 use crate::updates::UpdateChannel;
 use crate::version::VersionInfo;
 
-/// A completed check, including the channel actually used by discovery.
+/// Update availability on the checked channel, without an installation target.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdateCheckReport {
     pub installed_version: String,
     pub channel: UpdateChannel,
-    pub available_release: Option<AvailableUpdate>,
+    pub update_available: bool,
     pub warning: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct AvailableUpdate {
-    pub version: String,
-    pub url: String,
-}
-
-impl UpdateCheckReport {
-    pub fn title(&self) -> String {
-        match &self.available_release {
-            Some(release) => format!("Update available: {}", release.version),
-            None => "No newer release available".to_string(),
-        }
-    }
-
-    pub fn description(&self) -> String {
-        format!(
-            "Last successful check: {} channel, compared with installed version {}.",
-            self.channel.as_str(),
-            self.installed_version
-        )
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -99,6 +76,11 @@ impl UpdateCheckPresentation {
 
     pub(crate) fn start(&mut self) {
         self.checking = true;
+        self.error = None;
+    }
+
+    pub(crate) fn clear_result(&mut self) {
+        self.result = None;
         self.error = None;
     }
 

--- a/crates/lg-buddy/src/presentation/update_check.rs
+++ b/crates/lg-buddy/src/presentation/update_check.rs
@@ -40,6 +40,7 @@ impl UpdateCheckReport {
 pub struct UpdateCheckPresentation {
     installed_version_label: String,
     checking: bool,
+    install_active: bool,
     result: Option<UpdateCheckReport>,
     error: Option<UserFacingError>,
 }
@@ -54,6 +55,7 @@ impl Default for UpdateCheckPresentation {
                 version.channel().as_str()
             ),
             checking: false,
+            install_active: false,
             result: None,
             error: None,
         }
@@ -78,7 +80,7 @@ impl UpdateCheckPresentation {
             } else {
                 "Check for updates"
             },
-            !self.checking,
+            !self.checking && !self.install_active,
             SettingsIntent::CheckForUpdates,
         )
     }
@@ -89,6 +91,10 @@ impl UpdateCheckPresentation {
 
     pub fn error(&self) -> Option<&UserFacingError> {
         self.error.as_ref()
+    }
+
+    pub(crate) fn set_install_active(&mut self, active: bool) {
+        self.install_active = active;
     }
 
     pub(crate) fn start(&mut self) {

--- a/crates/lg-buddy/src/presentation/update_check.rs
+++ b/crates/lg-buddy/src/presentation/update_check.rs
@@ -41,10 +41,6 @@ pub struct UpdateCheckPresentation {
     installed_version_label: String,
     checking: bool,
     install_active: bool,
-    /// Whether the latest check was started after the current install state.
-    /// This lets the derived updater card distinguish a new successful check
-    /// from the older result that preceded an installation failure.
-    check_supersedes_install: bool,
     result: Option<UpdateCheckReport>,
     error: Option<UserFacingError>,
 }
@@ -60,7 +56,6 @@ impl Default for UpdateCheckPresentation {
             ),
             checking: false,
             install_active: false,
-            check_supersedes_install: false,
             result: None,
             error: None,
         }
@@ -99,19 +94,11 @@ impl UpdateCheckPresentation {
     }
 
     pub(crate) fn set_install_active(&mut self, active: bool) {
-        if active {
-            self.check_supersedes_install = false;
-        }
         self.install_active = active;
-    }
-
-    pub(crate) fn check_supersedes_install(&self) -> bool {
-        self.check_supersedes_install
     }
 
     pub(crate) fn start(&mut self) {
         self.checking = true;
-        self.check_supersedes_install = true;
         self.error = None;
     }
 

--- a/crates/lg-buddy/src/presentation/update_check.rs
+++ b/crates/lg-buddy/src/presentation/update_check.rs
@@ -41,6 +41,10 @@ pub struct UpdateCheckPresentation {
     installed_version_label: String,
     checking: bool,
     install_active: bool,
+    /// Whether the latest check was started after the current install state.
+    /// This lets the derived updater card distinguish a new successful check
+    /// from the older result that preceded an installation failure.
+    check_supersedes_install: bool,
     result: Option<UpdateCheckReport>,
     error: Option<UserFacingError>,
 }
@@ -56,6 +60,7 @@ impl Default for UpdateCheckPresentation {
             ),
             checking: false,
             install_active: false,
+            check_supersedes_install: false,
             result: None,
             error: None,
         }
@@ -94,11 +99,19 @@ impl UpdateCheckPresentation {
     }
 
     pub(crate) fn set_install_active(&mut self, active: bool) {
+        if active {
+            self.check_supersedes_install = false;
+        }
         self.install_active = active;
+    }
+
+    pub(crate) fn check_supersedes_install(&self) -> bool {
+        self.check_supersedes_install
     }
 
     pub(crate) fn start(&mut self) {
         self.checking = true;
+        self.check_supersedes_install = true;
         self.error = None;
     }
 

--- a/crates/lg-buddy/src/presentation/update_install.rs
+++ b/crates/lg-buddy/src/presentation/update_install.rs
@@ -11,6 +11,7 @@ pub struct UpdateInstallPresentation {
     pub(crate) busy: bool,
     pub(crate) error: Option<UserFacingError>,
     pub(crate) failure_details: Option<String>,
+    pub(crate) offer_channel_matches: Option<bool>,
 }
 
 impl UpdateInstallPresentation {
@@ -50,5 +51,9 @@ impl UpdateInstallPresentation {
         } else {
             "Last update failure"
         }
+    }
+
+    pub(crate) fn offer_channel_matches(&self) -> Option<bool> {
+        self.offer_channel_matches
     }
 }

--- a/crates/lg-buddy/src/presentation/update_install.rs
+++ b/crates/lg-buddy/src/presentation/update_install.rs
@@ -10,6 +10,7 @@ pub struct UpdateInstallPresentation {
     pub(crate) cancel_action: Option<SettingsAction>,
     pub(crate) busy: bool,
     pub(crate) error: Option<UserFacingError>,
+    pub(crate) failure_details: Option<String>,
 }
 
 impl UpdateInstallPresentation {
@@ -35,5 +36,19 @@ impl UpdateInstallPresentation {
 
     pub fn error(&self) -> Option<&UserFacingError> {
         self.error.as_ref()
+    }
+
+    /// Most recent failure in this application session, retained across retries.
+    /// Render on demand; the normal workflow uses the concise error above.
+    pub fn failure_details(&self) -> Option<&str> {
+        self.failure_details.as_deref()
+    }
+
+    pub fn failure_details_title(&self) -> &'static str {
+        if self.error.is_some() {
+            "Failure details"
+        } else {
+            "Last update failure"
+        }
     }
 }

--- a/crates/lg-buddy/src/presentation/update_install.rs
+++ b/crates/lg-buddy/src/presentation/update_install.rs
@@ -1,0 +1,39 @@
+use crate::presentation::brightness::UserFacingError;
+use crate::presentation::settings::SettingsAction;
+
+/// The current, explicitly requested installation workflow in Settings.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UpdateInstallPresentation {
+    pub(crate) title: Option<String>,
+    pub(crate) description: String,
+    pub(crate) action: Option<SettingsAction>,
+    pub(crate) cancel_action: Option<SettingsAction>,
+    pub(crate) busy: bool,
+    pub(crate) error: Option<UserFacingError>,
+}
+
+impl UpdateInstallPresentation {
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn action(&self) -> Option<&SettingsAction> {
+        self.action.as_ref()
+    }
+
+    pub fn cancel_action(&self) -> Option<&SettingsAction> {
+        self.cancel_action.as_ref()
+    }
+
+    pub fn busy(&self) -> bool {
+        self.busy
+    }
+
+    pub fn error(&self) -> Option<&UserFacingError> {
+        self.error.as_ref()
+    }
+}

--- a/crates/lg-buddy/src/presentation/update_install.rs
+++ b/crates/lg-buddy/src/presentation/update_install.rs
@@ -11,7 +11,8 @@ pub struct UpdateInstallPresentation {
     pub(crate) busy: bool,
     pub(crate) error: Option<UserFacingError>,
     pub(crate) failure_details: Option<String>,
-    pub(crate) offer_channel_matches: Option<bool>,
+    pub(crate) check_channel_matches: Option<bool>,
+    pub(crate) release_url: Option<String>,
 }
 
 impl UpdateInstallPresentation {
@@ -53,7 +54,11 @@ impl UpdateInstallPresentation {
         }
     }
 
-    pub(crate) fn offer_channel_matches(&self) -> Option<bool> {
-        self.offer_channel_matches
+    pub(crate) fn check_channel_matches(&self) -> Option<bool> {
+        self.check_channel_matches
+    }
+
+    pub fn release_url(&self) -> Option<&str> {
+        self.release_url.as_deref()
     }
 }

--- a/crates/lg-buddy/src/presentation/updater.rs
+++ b/crates/lg-buddy/src/presentation/updater.rs
@@ -1,0 +1,638 @@
+use crate::presentation::settings::{SettingsAction, SettingsPresentation};
+use crate::presentation::update_check::AvailableUpdate;
+use crate::settings_view::SettingsIntent;
+
+/// The one update card rendered by the Settings view.
+///
+/// `UpdateCheckPresentation` and `UpdateInstallPresentation` remain the
+/// application-owned workflow facts. This type is a derived, renderer-facing
+/// snapshot that resolves which one is visible at a given moment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdaterPresentation {
+    title: String,
+    description: String,
+    action: Option<SettingsAction>,
+    cancel_action: Option<SettingsAction>,
+    release: Option<AvailableUpdate>,
+    busy: bool,
+    is_error: bool,
+    warning: Option<String>,
+    details_title: String,
+    details: Option<String>,
+}
+
+impl UpdaterPresentation {
+    pub(crate) fn from_settings(settings: &SettingsPresentation) -> Self {
+        let check = settings.update_check();
+        let install = settings.update_install();
+        let details = install.failure_details().map(str::to_owned);
+        let details_title =
+            if check.checking() || check.error().is_some() || check.check_supersedes_install() {
+                "Last update failure".to_string()
+            } else {
+                install.failure_details_title().to_string()
+            };
+
+        // A prepared confirmation, download, installation, or process
+        // replacement owns the card even if an older check result is still in
+        // memory.
+        if install.busy() || install.cancel_action().is_some() {
+            return Self {
+                title: install.title().unwrap_or("Updating LG Buddy…").to_string(),
+                description: install.description().to_string(),
+                action: install.action().cloned(),
+                cancel_action: install.cancel_action().cloned(),
+                release: None,
+                busy: install.busy(),
+                is_error: false,
+                warning: None,
+                details_title,
+                details,
+            };
+        }
+
+        // A newly started or failed check masks both the old successful result
+        // and an older installation failure. This keeps the card from showing
+        // two unrelated workflows at once.
+        if check.checking() {
+            return Self {
+                title: "Checking for updates…".to_string(),
+                description: format!(
+                    "Checking the saved update channel against installed version {}.",
+                    check.installed_version_label()
+                ),
+                action: Some(check.check_action()),
+                cancel_action: None,
+                release: None,
+                busy: true,
+                is_error: false,
+                warning: None,
+                details_title,
+                details,
+            };
+        }
+
+        if let Some(error) = check.error() {
+            return Self {
+                title: error.summary().to_string(),
+                description: error.detail().to_string(),
+                action: Some(check.check_action()),
+                cancel_action: None,
+                release: None,
+                busy: false,
+                is_error: true,
+                warning: None,
+                details_title,
+                details,
+            };
+        }
+
+        // A completed check started after an installation failure is now the
+        // current workflow. Keep the old diagnostic available below the card,
+        // but let the new report own the title, release, and primary action.
+        if check.check_supersedes_install() {
+            if let Some(report) = check.result() {
+                return Self::completed_check(check, install, report, details_title, details);
+            }
+        }
+
+        // An installation failure is shown using its existing safe summary
+        // and detail. The internal "Update not completed" title is deliberately
+        // not surfaced as a second, duplicate failure row.
+        if let Some(error) = install.error() {
+            let action = install
+                .action()
+                .filter(|action| action.enabled())
+                .cloned()
+                .or_else(|| Some(check.check_action()));
+            return Self {
+                title: error.summary().to_string(),
+                description: error.detail().to_string(),
+                action,
+                cancel_action: None,
+                release: None,
+                busy: false,
+                is_error: true,
+                warning: None,
+                details_title,
+                details,
+            };
+        }
+
+        if let Some(report) = check.result() {
+            return Self::completed_check(check, install, report, details_title, details);
+        }
+
+        Self {
+            title: "Installed version".to_string(),
+            description: check.installed_version_label().to_string(),
+            action: Some(check.check_action()),
+            cancel_action: None,
+            release: None,
+            busy: false,
+            is_error: false,
+            warning: None,
+            details_title,
+            details,
+        }
+    }
+
+    fn completed_check(
+        check: &crate::presentation::update_check::UpdateCheckPresentation,
+        install: &crate::presentation::update_install::UpdateInstallPresentation,
+        report: &crate::presentation::update_check::UpdateCheckReport,
+        details_title: String,
+        details: Option<String>,
+    ) -> Self {
+        let can_install_offer = report.available_release.is_some()
+            && install.action().is_some_and(|action| {
+                action.enabled() && action.intent() == SettingsIntent::PrepareUpdateInstall
+            });
+        let action = if can_install_offer {
+            install.action().cloned()
+        } else {
+            // A changed channel, or a temporarily unavailable install action,
+            // must leave the user with a way to perform a fresh check instead
+            // of a disabled install control.
+            Some(check.check_action())
+        };
+
+        Self {
+            title: report.title(),
+            description: report.description(),
+            action,
+            cancel_action: None,
+            release: report.available_release.clone(),
+            busy: false,
+            is_error: false,
+            warning: report.warning.clone(),
+            details_title,
+            details,
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn action(&self) -> Option<&SettingsAction> {
+        self.action.as_ref()
+    }
+
+    pub fn cancel_action(&self) -> Option<&SettingsAction> {
+        self.cancel_action.as_ref()
+    }
+
+    pub fn release(&self) -> Option<&AvailableUpdate> {
+        self.release.as_ref()
+    }
+
+    pub fn busy(&self) -> bool {
+        self.busy
+    }
+
+    pub fn is_error(&self) -> bool {
+        self.is_error
+    }
+
+    pub fn warning(&self) -> Option<&str> {
+        self.warning.as_deref()
+    }
+
+    pub fn details_title(&self) -> &str {
+        &self.details_title
+    }
+
+    pub fn details(&self) -> Option<&str> {
+        self.details.as_deref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::presentation::settings::SettingsPresentation;
+    use crate::presentation::update_check::UpdateCheckReport;
+    use crate::settings::ConfigEnvReader;
+    use crate::settings_view::{SettingsApplication, SettingsIntent};
+    use crate::update_flow::{UpdateInstallFailure, UpdateInstallOperation, UpdateInstallOutcome};
+    use crate::update_install::{InstalledUpdate, UpdateInstallStage};
+    use crate::updates::UpdateChannel;
+    use crate::version::VersionInfo;
+
+    fn groups(channel: &str) -> Vec<crate::presentation::settings::SettingsGroup> {
+        let contents = format!("updates_channel={channel}\nupdates_auto_check=disabled\n");
+        let store = ConfigEnvReader::parse("/tmp/updater-card.env", &contents).into_store();
+        SettingsPresentation::from_store(&store).groups().to_vec()
+    }
+
+    fn application(channel: &str) -> SettingsApplication {
+        let (mut app, opening) = SettingsApplication::open();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups(channel)))
+            .unwrap();
+        app
+    }
+
+    fn report(channel: UpdateChannel, available: bool) -> UpdateCheckReport {
+        UpdateCheckReport {
+            installed_version: "1.6.0".into(),
+            channel,
+            available_release: available.then(|| AvailableUpdate {
+                version: "1.7.0".into(),
+                url: "https://example.test/v1.7.0".into(),
+            }),
+            warning: None,
+        }
+    }
+
+    fn check(
+        app: &mut SettingsApplication,
+        report: Result<UpdateCheckReport, crate::settings_view::UpdateCheckError>,
+    ) {
+        let operation = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        app.complete_update_check(operation, report).unwrap();
+    }
+
+    fn prepare(app: &mut SettingsApplication) -> UpdateInstallOperation {
+        app.handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .unwrap()
+            .update_install_operation()
+            .unwrap()
+            .clone()
+    }
+
+    fn prepared() -> crate::update_install::PreparedUpdateInstall {
+        crate::update_install::PreparedUpdateInstall::from_parts(
+            VersionInfo::current(),
+            "1.7.0".parse().unwrap(),
+            UpdateChannel::Stable,
+            "https://example.test/v1.7.0",
+            "v1.7.0",
+            "x86_64-unknown-linux-musl",
+            "a".repeat(40),
+        )
+    }
+
+    #[test]
+    fn application_transitions_render_one_card_through_install_failure_and_retry() {
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let offer = app.presentation().updater();
+        assert_eq!(offer.title(), "Update available: 1.7.0");
+        assert_eq!(
+            offer.action().map(SettingsAction::label),
+            Some("Install update…")
+        );
+        assert_eq!(
+            offer.release().map(|release| release.version.as_str()),
+            Some("1.7.0")
+        );
+
+        let preparation = prepare(&mut app);
+        let preparing = app.presentation().updater();
+        assert!(preparing.busy());
+        assert_eq!(
+            preparing.cancel_action().map(SettingsAction::label),
+            Some("Cancel")
+        );
+        app.complete_update_install(&preparation, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .unwrap();
+        let confirmation = app.presentation().updater();
+        assert_eq!(confirmation.title(), "Install LG Buddy 1.7.0?");
+        assert!(!confirmation.busy());
+        assert_eq!(
+            confirmation.action().map(SettingsAction::label),
+            Some("Install and restart")
+        );
+        assert_eq!(
+            confirmation.cancel_action().map(SettingsAction::label),
+            Some("Cancel")
+        );
+
+        let install = app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .unwrap()
+            .update_install_operation()
+            .unwrap()
+            .clone();
+        app.update_install_progress(&install, UpdateInstallStage::Acquiring)
+            .unwrap();
+        let progress = app.presentation().updater();
+        assert!(progress.busy());
+        assert_eq!(progress.action(), None);
+        assert_eq!(
+            progress.cancel_action().map(SettingsAction::label),
+            Some("Cancel")
+        );
+
+        app.update_install_progress(&install, UpdateInstallStage::Installing)
+            .unwrap();
+        assert_eq!(app.presentation().updater().cancel_action(), None);
+        let failed = app
+            .complete_update_install(
+                &install,
+                Err(UpdateInstallFailure {
+                    presentation: crate::presentation::brightness::UserFacingError::new(
+                        "Could not install update",
+                        "The installer failed.",
+                    ),
+                    diagnostic: "installer failed".into(),
+                    cancelled: false,
+                }),
+            )
+            .unwrap();
+        let failure = failed.presentation().updater();
+        assert!(failure.is_error());
+        assert_eq!(failure.title(), "Could not install update");
+        assert_eq!(failure.description(), "The installer failed.");
+        assert_eq!(
+            failure.action().map(SettingsAction::label),
+            Some("Retry update")
+        );
+        assert_eq!(failure.release(), None);
+        assert_eq!(failure.warning(), None);
+        assert_eq!(failure.details(), Some("installer failed"));
+
+        let details = failure.details().unwrap().to_owned();
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let groups = app.presentation().groups().to_vec();
+        app.complete_read(refresh.read_operation().unwrap(), Ok(groups))
+            .unwrap();
+        assert_eq!(
+            app.presentation().updater().details(),
+            Some(details.as_str())
+        );
+        let retry_operation = prepare(&mut app);
+        assert_eq!(
+            app.presentation().updater().details(),
+            Some(details.as_str())
+        );
+        app.handle_intent(SettingsIntent::CancelUpdateInstall)
+            .unwrap();
+        assert_eq!(
+            app.presentation().updater().details_title(),
+            "Last update failure"
+        );
+        assert_eq!(
+            app.presentation().updater().details(),
+            Some(details.as_str())
+        );
+        assert!(app
+            .complete_update_install(
+                &retry_operation,
+                Ok(UpdateInstallOutcome::Prepared(prepared()))
+            )
+            .is_none());
+
+        let retry = app.presentation().updater();
+        assert_eq!(
+            retry.action().map(SettingsAction::intent),
+            Some(SettingsIntent::PrepareUpdateInstall)
+        );
+    }
+
+    #[test]
+    fn checking_and_check_failure_mask_stale_result_and_install_failure() {
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let preparation = prepare(&mut app);
+        app.complete_update_install(
+            &preparation,
+            Err(UpdateInstallFailure {
+                presentation: crate::presentation::brightness::UserFacingError::new(
+                    "Install failed",
+                    "Try again.",
+                ),
+                diagnostic: "details".into(),
+                cancelled: false,
+            }),
+        )
+        .unwrap();
+        let check_operation = app.handle_intent(SettingsIntent::CheckForUpdates).unwrap();
+        let checking = check_operation.presentation().updater();
+        assert_eq!(checking.title(), "Checking for updates…");
+        assert!(!checking.is_error());
+        assert_eq!(checking.release(), None);
+        assert_eq!(checking.warning(), None);
+        assert_eq!(checking.details_title(), "Last update failure");
+
+        let operation = check_operation.update_check_operation().unwrap();
+        let failed = app
+            .complete_update_check(
+                operation,
+                Err(crate::settings_view::UpdateCheckError::stopped()),
+            )
+            .unwrap();
+        let check_failed = failed.presentation().updater();
+        assert!(check_failed.is_error());
+        assert_eq!(check_failed.title(), "Update check stopped");
+        assert_eq!(
+            check_failed.action().map(SettingsAction::label),
+            Some("Retry check")
+        );
+        assert_eq!(check_failed.details_title(), "Last update failure");
+    }
+
+    #[test]
+    fn channel_mismatch_uses_check_and_matching_channel_uses_install() {
+        let mut app = application("prerelease");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let mismatch = app.presentation().updater();
+        assert_eq!(
+            mismatch.action().map(SettingsAction::label),
+            Some("Check for updates")
+        );
+        assert_eq!(
+            mismatch.release().map(|release| release.version.as_str()),
+            Some("1.7.0")
+        );
+
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        assert_eq!(
+            app.presentation()
+                .updater()
+                .action()
+                .map(SettingsAction::label),
+            Some("Install update…")
+        );
+    }
+
+    #[test]
+    fn completed_check_without_release_clears_the_old_offer() {
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        assert_eq!(
+            app.presentation()
+                .updater()
+                .action()
+                .map(SettingsAction::label),
+            Some("Install update…")
+        );
+
+        let operation = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        let mut current = report(UpdateChannel::Stable, false);
+        current.warning = Some("Cache warning".into());
+        app.complete_update_check(operation, Ok(current)).unwrap();
+        let no_update = app.presentation().updater();
+        assert_eq!(no_update.title(), "No newer release available");
+        assert_eq!(no_update.release(), None);
+        assert_eq!(
+            no_update.action().map(SettingsAction::label),
+            Some("Check for updates")
+        );
+        assert_eq!(no_update.warning(), Some("Cache warning"));
+    }
+
+    #[test]
+    fn a_new_successful_check_owns_the_card_but_keeps_the_old_diagnostic() {
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let preparation = prepare(&mut app);
+        app.complete_update_install(
+            &preparation,
+            Err(UpdateInstallFailure {
+                presentation: crate::presentation::brightness::UserFacingError::new(
+                    "Install failed",
+                    "Try again.",
+                ),
+                diagnostic: "installer diagnostic".into(),
+                cancelled: false,
+            }),
+        )
+        .unwrap();
+
+        let operation = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        let mut current = report(UpdateChannel::Stable, false);
+        current.warning = Some("Cache warning".into());
+        app.complete_update_check(operation, Ok(current)).unwrap();
+
+        let card = app.presentation().updater();
+        assert_eq!(card.title(), "No newer release available");
+        assert!(!card.is_error());
+        assert_eq!(
+            card.action().map(SettingsAction::label),
+            Some("Check for updates")
+        );
+        assert_eq!(card.warning(), Some("Cache warning"));
+        assert_eq!(card.details_title(), "Last update failure");
+        assert_eq!(card.details(), Some("installer diagnostic"));
+    }
+
+    #[test]
+    fn failed_install_with_changed_channel_offers_a_fresh_check() {
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let preparation = prepare(&mut app);
+        app.complete_update_install(
+            &preparation,
+            Err(UpdateInstallFailure {
+                presentation: crate::presentation::brightness::UserFacingError::new(
+                    "Install failed",
+                    "Try again.",
+                ),
+                diagnostic: "installer diagnostic".into(),
+                cancelled: false,
+            }),
+        )
+        .unwrap();
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        app.complete_read(refresh.read_operation().unwrap(), Ok(groups("prerelease")))
+            .unwrap();
+        let card = app.presentation().updater();
+        assert!(card.is_error());
+        assert_eq!(
+            card.action().map(SettingsAction::label),
+            Some("Check for updates")
+        );
+        assert_eq!(
+            card.action().map(SettingsAction::intent),
+            Some(SettingsIntent::CheckForUpdates)
+        );
+    }
+
+    #[test]
+    fn warning_is_only_visible_with_completed_check_and_restart_failure_keeps_retry() {
+        let mut app = application("stable");
+        let operation = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        let mut checked = report(UpdateChannel::Stable, false);
+        checked.warning = Some("Cache warning".into());
+        app.complete_update_check(operation, Ok(checked)).unwrap();
+        assert_eq!(
+            app.presentation().updater().warning(),
+            Some("Cache warning")
+        );
+
+        let operation = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        assert_eq!(app.presentation().updater().warning(), None);
+        app.complete_update_check(
+            operation,
+            Err(crate::settings_view::UpdateCheckError::stopped()),
+        )
+        .unwrap();
+        assert_eq!(app.presentation().updater().warning(), None);
+
+        let mut app = application("stable");
+        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let preparation = prepare(&mut app);
+        app.complete_update_install(&preparation, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .unwrap();
+        let install = app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .unwrap()
+            .update_install_operation()
+            .unwrap()
+            .clone();
+        let installed = InstalledUpdate::from_parts(
+            "1.7.0".parse().unwrap(),
+            UpdateChannel::Stable,
+            "v1.7.0",
+            "x86_64-unknown-linux-musl",
+            "a".repeat(40),
+            "/unused/lg-buddy",
+            "/unused/lg-buddy-gui",
+        );
+        let restarting = app
+            .complete_update_install(&install, Ok(UpdateInstallOutcome::Installed(installed)))
+            .unwrap();
+        let relaunch = restarting.update_install_operation().unwrap().clone();
+        app.complete_update_install(&relaunch, Err(UpdateInstallFailure::stopped()))
+            .unwrap();
+        let restart_failure = app.presentation().updater();
+        assert!(restart_failure.is_error());
+        assert_eq!(restart_failure.title(), "Update stopped");
+        assert_eq!(
+            restart_failure.action().map(SettingsAction::label),
+            Some("Retry restart")
+        );
+        assert_eq!(
+            restart_failure.action().map(SettingsAction::intent),
+            Some(SettingsIntent::RelaunchUpdatedApplication)
+        );
+    }
+}

--- a/crates/lg-buddy/src/presentation/updater.rs
+++ b/crates/lg-buddy/src/presentation/updater.rs
@@ -35,15 +35,17 @@ impl UpdaterPresentation {
             }
         }
         let report = check.result().filter(|_| {
-            (install.offer_channel_matches() == Some(true) && check.error().is_none()) || active
+            (install.check_channel_matches() == Some(true) && check.error().is_none()) || active
         });
-        let release = report.and_then(|report| report.available_release.as_ref());
+        let available = report.is_some_and(|report| report.update_available);
         let mut row = Self {
-            title: release.map_or_else(
-                || "Installed version".into(),
-                |release| format!("Update available: {}", release.version),
-            ),
-            description: report.filter(|_| release.is_some()).map_or_else(
+            title: if available {
+                "Update available"
+            } else {
+                "Installed version"
+            }
+            .into(),
+            description: report.filter(|_| available).map_or_else(
                 || check.installed_version_label().to_owned(),
                 |report| format!("Installed version: {}", report.installed_version),
             ),
@@ -61,7 +63,7 @@ impl UpdaterPresentation {
                 false,
                 SettingsIntent::PrepareUpdateInstall,
             );
-        } else if release.is_some() {
+        } else if available {
             if let Some(action) = install.action() {
                 row.action =
                     SettingsAction::new("Install update…", action.enabled(), action.intent());
@@ -86,7 +88,7 @@ impl UpdaterPresentation {
 #[cfg(test)]
 mod tests {
     use crate::presentation::settings::SettingsPresentation;
-    use crate::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+    use crate::presentation::update_check::UpdateCheckReport;
     use crate::settings::ConfigEnvReader;
     use crate::settings_view::{SettingsApplication, SettingsIntent};
     use crate::update_flow::{UpdateInstallFailure, UpdateInstallOutcome};
@@ -110,10 +112,7 @@ mod tests {
         UpdateCheckReport {
             installed_version: "1.6.0".into(),
             channel,
-            available_release: available.then(|| AvailableUpdate {
-                version: "1.7.0".into(),
-                url: "https://example.test/v1.7.0".into(),
-            }),
+            update_available: available,
             warning: None,
         }
     }
@@ -166,7 +165,7 @@ mod tests {
         )
         .unwrap();
         let offer = app.presentation().updater();
-        assert_eq!(offer.title(), "Update available: 1.7.0");
+        assert_eq!(offer.title(), "Update available");
         assert_eq!(offer.description(), "Installed version: 1.6.0");
         assert_eq!(offer.action().label(), "Install update…");
         assert!(offer.action().enabled());
@@ -191,7 +190,7 @@ mod tests {
             .handle_intent(SettingsIntent::PrepareUpdateInstall)
             .unwrap();
         let row = preparing.presentation().updater();
-        assert_eq!(row.title(), "Update available: 1.7.0");
+        assert_eq!(row.title(), "Update available");
         assert_eq!(row.action().label(), "Install update…");
         assert_eq!(row.action().intent(), SettingsIntent::PrepareUpdateInstall);
         assert!(!row.action().enabled());
@@ -200,7 +199,7 @@ mod tests {
         app.complete_update_install(&operation, Ok(UpdateInstallOutcome::Prepared(prepared())))
             .unwrap();
         let confirmation = app.presentation().updater();
-        assert_eq!(confirmation.title(), "Update available: 1.7.0");
+        assert_eq!(confirmation.title(), "Update available");
         assert_eq!(confirmation.action().label(), "Install update…");
         assert_eq!(
             confirmation.action().intent(),
@@ -215,7 +214,7 @@ mod tests {
         complete_check(&mut app, Ok(report(UpdateChannel::Stable, true)));
         let transition = app.set_controls_available(false).unwrap();
         let row = transition.presentation().updater();
-        assert_eq!(row.title(), "Update available: 1.7.0");
+        assert_eq!(row.title(), "Update available");
         assert_eq!(row.action().label(), "Install update…");
         assert!(!row.action().enabled());
     }
@@ -243,7 +242,7 @@ mod tests {
         )
         .unwrap();
         let row = app.presentation().updater();
-        assert_eq!(row.title(), "Update available: 1.7.0");
+        assert_eq!(row.title(), "Update available");
         assert_eq!(row.action().label(), "Install update…");
         assert_eq!(row.action().intent(), SettingsIntent::PrepareUpdateInstall);
         assert!(app.presentation().update_install().error().is_some());

--- a/crates/lg-buddy/src/presentation/updater.rs
+++ b/crates/lg-buddy/src/presentation/updater.rs
@@ -1,174 +1,73 @@
 use crate::presentation::settings::{SettingsAction, SettingsPresentation};
-use crate::presentation::update_check::AvailableUpdate;
 use crate::settings_view::SettingsIntent;
 
-/// The one update card rendered by the Settings view.
+/// The compact update row rendered in Settings.
 ///
-/// `UpdateCheckPresentation` and `UpdateInstallPresentation` remain the
-/// application-owned workflow facts. This type is a derived, renderer-facing
-/// snapshot that resolves which one is visible at a given moment.
+/// Installation confirmation and progress remain in
+/// [`crate::presentation::update_install::UpdateInstallPresentation`]. This projection only exposes the row's
+/// title, concise description, and one semantic action.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct UpdaterPresentation {
     title: String,
     description: String,
-    action: Option<SettingsAction>,
-    cancel_action: Option<SettingsAction>,
-    release: Option<AvailableUpdate>,
-    busy: bool,
-    is_error: bool,
-    warning: Option<String>,
-    details_title: String,
-    details: Option<String>,
+    action: SettingsAction,
 }
 
 impl UpdaterPresentation {
     pub(crate) fn from_settings(settings: &SettingsPresentation) -> Self {
         let check = settings.update_check();
         let install = settings.update_install();
-        let details = install.failure_details().map(str::to_owned);
-        let details_title =
-            if check.checking() || check.error().is_some() || check.check_supersedes_install() {
-                "Last update failure".to_string()
-            } else {
-                install.failure_details_title().to_string()
-            };
-
-        // A prepared confirmation, download, installation, or process
-        // replacement owns the card even if an older check result is still in
-        // memory.
-        if install.busy() || install.cancel_action().is_some() {
-            return Self {
-                title: install.title().unwrap_or("Updating LG Buddy…").to_string(),
-                description: install.description().to_string(),
-                action: install.action().cloned(),
-                cancel_action: install.cancel_action().cloned(),
-                release: None,
-                busy: install.busy(),
-                is_error: false,
-                warning: None,
-                details_title,
-                details,
-            };
-        }
-
-        // A newly started or failed check masks both the old successful result
-        // and an older installation failure. This keeps the card from showing
-        // two unrelated workflows at once.
-        if check.checking() {
-            return Self {
-                title: "Checking for updates…".to_string(),
-                description: format!(
-                    "Checking the saved update channel against installed version {}.",
-                    check.installed_version_label()
-                ),
-                action: Some(check.check_action()),
-                cancel_action: None,
-                release: None,
-                busy: true,
-                is_error: false,
-                warning: None,
-                details_title,
-                details,
-            };
-        }
-
-        if let Some(error) = check.error() {
-            return Self {
-                title: error.summary().to_string(),
-                description: error.detail().to_string(),
-                action: Some(check.check_action()),
-                cancel_action: None,
-                release: None,
-                busy: false,
-                is_error: true,
-                warning: None,
-                details_title,
-                details,
-            };
-        }
-
-        // A completed check started after an installation failure is now the
-        // current workflow. Keep the old diagnostic available below the card,
-        // but let the new report own the title, release, and primary action.
-        if check.check_supersedes_install() {
-            if let Some(report) = check.result() {
-                return Self::completed_check(check, install, report, details_title, details);
+        let active = install.busy() || install.cancel_action().is_some();
+        if let Some(action) = install
+            .action()
+            .filter(|action| action.intent() == SettingsIntent::RelaunchUpdatedApplication)
+        {
+            if !check.checking() {
+                return Self {
+                    title: "Restart required".into(),
+                    description: "The update is installed. Restart LG Buddy to finish.".into(),
+                    action: SettingsAction::new(
+                        "Install update…",
+                        action.enabled(),
+                        action.intent(),
+                    ),
+                };
             }
         }
-
-        // An installation failure is shown using its existing safe summary
-        // and detail. The internal "Update not completed" title is deliberately
-        // not surfaced as a second, duplicate failure row.
-        if let Some(error) = install.error() {
-            let action = install
-                .action()
-                .filter(|action| action.enabled())
-                .cloned()
-                .or_else(|| Some(check.check_action()));
-            return Self {
-                title: error.summary().to_string(),
-                description: error.detail().to_string(),
-                action,
-                cancel_action: None,
-                release: None,
-                busy: false,
-                is_error: true,
-                warning: None,
-                details_title,
-                details,
-            };
-        }
-
-        if let Some(report) = check.result() {
-            return Self::completed_check(check, install, report, details_title, details);
-        }
-
-        Self {
-            title: "Installed version".to_string(),
-            description: check.installed_version_label().to_string(),
-            action: Some(check.check_action()),
-            cancel_action: None,
-            release: None,
-            busy: false,
-            is_error: false,
-            warning: None,
-            details_title,
-            details,
-        }
-    }
-
-    fn completed_check(
-        check: &crate::presentation::update_check::UpdateCheckPresentation,
-        install: &crate::presentation::update_install::UpdateInstallPresentation,
-        report: &crate::presentation::update_check::UpdateCheckReport,
-        details_title: String,
-        details: Option<String>,
-    ) -> Self {
-        let can_install_offer = report.available_release.is_some()
-            && install.action().is_some_and(|action| {
-                action.enabled() && action.intent() == SettingsIntent::PrepareUpdateInstall
-            });
-        let action = if can_install_offer {
-            install.action().cloned()
-        } else {
-            // A changed channel, or a temporarily unavailable install action,
-            // must leave the user with a way to perform a fresh check instead
-            // of a disabled install control.
-            Some(check.check_action())
+        let report = check.result().filter(|_| {
+            (install.offer_channel_matches() == Some(true) && check.error().is_none()) || active
+        });
+        let release = report.and_then(|report| report.available_release.as_ref());
+        let mut row = Self {
+            title: release.map_or_else(
+                || "Installed version".into(),
+                |release| format!("Update available: {}", release.version),
+            ),
+            description: report.filter(|_| release.is_some()).map_or_else(
+                || check.installed_version_label().to_owned(),
+                |report| format!("Installed version: {}", report.installed_version),
+            ),
+            action: SettingsAction::new(
+                "Check for updates",
+                check.check_action().enabled(),
+                SettingsIntent::CheckForUpdates,
+            ),
         };
-
-        Self {
-            title: report.title(),
-            description: report.description(),
-            action,
-            cancel_action: None,
-            release: report.available_release.clone(),
-            busy: false,
-            is_error: false,
-            warning: report.warning.clone(),
-            details_title,
-            details,
+        if check.checking() {
+            row.action = SettingsAction::new("Checking…", false, SettingsIntent::CheckForUpdates);
+        } else if active {
+            row.action = SettingsAction::new(
+                "Install update…",
+                false,
+                SettingsIntent::PrepareUpdateInstall,
+            );
+        } else if release.is_some() {
+            if let Some(action) = install.action() {
+                row.action =
+                    SettingsAction::new("Install update…", action.enabled(), action.intent());
+            }
         }
+        row
     }
 
     pub fn title(&self) -> &str {
@@ -179,54 +78,24 @@ impl UpdaterPresentation {
         &self.description
     }
 
-    pub fn action(&self) -> Option<&SettingsAction> {
-        self.action.as_ref()
-    }
-
-    pub fn cancel_action(&self) -> Option<&SettingsAction> {
-        self.cancel_action.as_ref()
-    }
-
-    pub fn release(&self) -> Option<&AvailableUpdate> {
-        self.release.as_ref()
-    }
-
-    pub fn busy(&self) -> bool {
-        self.busy
-    }
-
-    pub fn is_error(&self) -> bool {
-        self.is_error
-    }
-
-    pub fn warning(&self) -> Option<&str> {
-        self.warning.as_deref()
-    }
-
-    pub fn details_title(&self) -> &str {
-        &self.details_title
-    }
-
-    pub fn details(&self) -> Option<&str> {
-        self.details.as_deref()
+    pub fn action(&self) -> &SettingsAction {
+        &self.action
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::presentation::settings::SettingsPresentation;
-    use crate::presentation::update_check::UpdateCheckReport;
+    use crate::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
     use crate::settings::ConfigEnvReader;
     use crate::settings_view::{SettingsApplication, SettingsIntent};
-    use crate::update_flow::{UpdateInstallFailure, UpdateInstallOperation, UpdateInstallOutcome};
-    use crate::update_install::{InstalledUpdate, UpdateInstallStage};
+    use crate::update_flow::{UpdateInstallFailure, UpdateInstallOutcome};
     use crate::updates::UpdateChannel;
     use crate::version::VersionInfo;
 
     fn groups(channel: &str) -> Vec<crate::presentation::settings::SettingsGroup> {
         let contents = format!("updates_channel={channel}\nupdates_auto_check=disabled\n");
-        let store = ConfigEnvReader::parse("/tmp/updater-card.env", &contents).into_store();
+        let store = ConfigEnvReader::parse("/tmp/updater-row.env", &contents).into_store();
         SettingsPresentation::from_store(&store).groups().to_vec()
     }
 
@@ -249,24 +118,16 @@ mod tests {
         }
     }
 
-    fn check(
+    fn complete_check(
         app: &mut SettingsApplication,
-        report: Result<UpdateCheckReport, crate::settings_view::UpdateCheckError>,
-    ) {
+        result: Result<UpdateCheckReport, crate::settings_view::UpdateCheckError>,
+    ) -> crate::settings_view::SettingsTransition {
         let operation = app
             .handle_intent(SettingsIntent::CheckForUpdates)
             .unwrap()
             .update_check_operation()
             .unwrap();
-        app.complete_update_check(operation, report).unwrap();
-    }
-
-    fn prepare(app: &mut SettingsApplication) -> UpdateInstallOperation {
-        app.handle_intent(SettingsIntent::PrepareUpdateInstall)
-            .unwrap()
-            .update_install_operation()
-            .unwrap()
-            .clone()
+        app.complete_update_check(operation, result).unwrap()
     }
 
     fn prepared() -> crate::update_install::PreparedUpdateInstall {
@@ -282,357 +143,143 @@ mod tests {
     }
 
     #[test]
-    fn application_transitions_render_one_card_through_install_failure_and_retry() {
+    fn row_has_only_check_and_install_states() {
         let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let idle = app.presentation().updater();
+        assert_eq!(idle.title(), "Installed version");
+        assert_eq!(
+            idle.description(),
+            app.presentation().update_check().installed_version_label()
+        );
+        assert_eq!(idle.action().label(), "Check for updates");
+        assert!(idle.action().enabled());
+
+        let checking = app.handle_intent(SettingsIntent::CheckForUpdates).unwrap();
+        let checking_row = checking.presentation().updater();
+        assert_eq!(checking_row.title(), "Installed version");
+        assert_eq!(checking_row.action().label(), "Checking…");
+        assert!(!checking_row.action().enabled());
+
+        app.complete_update_check(
+            checking.update_check_operation().unwrap(),
+            Ok(report(UpdateChannel::Stable, true)),
+        )
+        .unwrap();
         let offer = app.presentation().updater();
         assert_eq!(offer.title(), "Update available: 1.7.0");
-        assert_eq!(
-            offer.action().map(SettingsAction::label),
-            Some("Install update…")
-        );
-        assert_eq!(
-            offer.release().map(|release| release.version.as_str()),
-            Some("1.7.0")
-        );
+        assert_eq!(offer.description(), "Installed version: 1.6.0");
+        assert_eq!(offer.action().label(), "Install update…");
+        assert!(offer.action().enabled());
+    }
 
-        let preparation = prepare(&mut app);
-        let preparing = app.presentation().updater();
-        assert!(preparing.busy());
-        assert_eq!(
-            preparing.cancel_action().map(SettingsAction::label),
-            Some("Cancel")
-        );
-        app.complete_update_install(&preparation, Ok(UpdateInstallOutcome::Prepared(prepared())))
+    #[test]
+    fn channel_mismatch_keeps_installed_row_and_requires_check() {
+        let mut app = application("prerelease");
+        complete_check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let row = app.presentation().updater();
+        assert_eq!(row.title(), "Installed version");
+        assert_eq!(row.action().label(), "Check for updates");
+        assert_eq!(row.action().intent(), SettingsIntent::CheckForUpdates);
+        assert!(row.action().enabled());
+    }
+
+    #[test]
+    fn busy_or_confirmation_disables_install_row_while_modal_owns_flow() {
+        let mut app = application("stable");
+        complete_check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let preparing = app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .unwrap();
+        let row = preparing.presentation().updater();
+        assert_eq!(row.title(), "Update available: 1.7.0");
+        assert_eq!(row.action().label(), "Install update…");
+        assert_eq!(row.action().intent(), SettingsIntent::PrepareUpdateInstall);
+        assert!(!row.action().enabled());
+
+        let operation = preparing.update_install_operation().unwrap().clone();
+        app.complete_update_install(&operation, Ok(UpdateInstallOutcome::Prepared(prepared())))
             .unwrap();
         let confirmation = app.presentation().updater();
-        assert_eq!(confirmation.title(), "Install LG Buddy 1.7.0?");
-        assert!(!confirmation.busy());
+        assert_eq!(confirmation.title(), "Update available: 1.7.0");
+        assert_eq!(confirmation.action().label(), "Install update…");
         assert_eq!(
-            confirmation.action().map(SettingsAction::label),
-            Some("Install and restart")
+            confirmation.action().intent(),
+            SettingsIntent::PrepareUpdateInstall
         );
-        assert_eq!(
-            confirmation.cancel_action().map(SettingsAction::label),
-            Some("Cancel")
-        );
+        assert!(!confirmation.action().enabled());
+    }
 
-        let install = app
-            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+    #[test]
+    fn matching_offer_remains_visible_when_controls_are_temporarily_disabled() {
+        let mut app = application("stable");
+        complete_check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let transition = app.set_controls_available(false).unwrap();
+        let row = transition.presentation().updater();
+        assert_eq!(row.title(), "Update available: 1.7.0");
+        assert_eq!(row.action().label(), "Install update…");
+        assert!(!row.action().enabled());
+    }
+
+    #[test]
+    fn install_failure_row_returns_install_retry_without_modal_fields() {
+        let mut app = application("stable");
+        complete_check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let preparation = app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
             .unwrap()
             .update_install_operation()
             .unwrap()
             .clone();
-        app.update_install_progress(&install, UpdateInstallStage::Acquiring)
-            .unwrap();
-        let progress = app.presentation().updater();
-        assert!(progress.busy());
-        assert_eq!(progress.action(), None);
-        assert_eq!(
-            progress.cancel_action().map(SettingsAction::label),
-            Some("Cancel")
-        );
-
-        app.update_install_progress(&install, UpdateInstallStage::Installing)
-            .unwrap();
-        assert_eq!(app.presentation().updater().cancel_action(), None);
-        let failed = app
-            .complete_update_install(
-                &install,
-                Err(UpdateInstallFailure {
-                    presentation: crate::presentation::brightness::UserFacingError::new(
-                        "Could not install update",
-                        "The installer failed.",
-                    ),
-                    diagnostic: "installer failed".into(),
-                    cancelled: false,
-                }),
-            )
-            .unwrap();
-        let failure = failed.presentation().updater();
-        assert!(failure.is_error());
-        assert_eq!(failure.title(), "Could not install update");
-        assert_eq!(failure.description(), "The installer failed.");
-        assert_eq!(
-            failure.action().map(SettingsAction::label),
-            Some("Retry update")
-        );
-        assert_eq!(failure.release(), None);
-        assert_eq!(failure.warning(), None);
-        assert_eq!(failure.details(), Some("installer failed"));
-
-        let details = failure.details().unwrap().to_owned();
-        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
-        let groups = app.presentation().groups().to_vec();
-        app.complete_read(refresh.read_operation().unwrap(), Ok(groups))
-            .unwrap();
-        assert_eq!(
-            app.presentation().updater().details(),
-            Some(details.as_str())
-        );
-        let retry_operation = prepare(&mut app);
-        assert_eq!(
-            app.presentation().updater().details(),
-            Some(details.as_str())
-        );
-        app.handle_intent(SettingsIntent::CancelUpdateInstall)
-            .unwrap();
-        assert_eq!(
-            app.presentation().updater().details_title(),
-            "Last update failure"
-        );
-        assert_eq!(
-            app.presentation().updater().details(),
-            Some(details.as_str())
-        );
-        assert!(app
-            .complete_update_install(
-                &retry_operation,
-                Ok(UpdateInstallOutcome::Prepared(prepared()))
-            )
-            .is_none());
-
-        let retry = app.presentation().updater();
-        assert_eq!(
-            retry.action().map(SettingsAction::intent),
-            Some(SettingsIntent::PrepareUpdateInstall)
-        );
-    }
-
-    #[test]
-    fn checking_and_check_failure_mask_stale_result_and_install_failure() {
-        let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
-        let preparation = prepare(&mut app);
         app.complete_update_install(
             &preparation,
             Err(UpdateInstallFailure {
                 presentation: crate::presentation::brightness::UserFacingError::new(
-                    "Install failed",
-                    "Try again.",
+                    "Could not install update",
+                    "The installer failed.",
                 ),
-                diagnostic: "details".into(),
+                diagnostic: "installer failed".into(),
                 cancelled: false,
             }),
         )
         .unwrap();
-        let check_operation = app.handle_intent(SettingsIntent::CheckForUpdates).unwrap();
-        let checking = check_operation.presentation().updater();
-        assert_eq!(checking.title(), "Checking for updates…");
-        assert!(!checking.is_error());
-        assert_eq!(checking.release(), None);
-        assert_eq!(checking.warning(), None);
-        assert_eq!(checking.details_title(), "Last update failure");
-
-        let operation = check_operation.update_check_operation().unwrap();
-        let failed = app
-            .complete_update_check(
-                operation,
-                Err(crate::settings_view::UpdateCheckError::stopped()),
-            )
-            .unwrap();
-        let check_failed = failed.presentation().updater();
-        assert!(check_failed.is_error());
-        assert_eq!(check_failed.title(), "Update check stopped");
-        assert_eq!(
-            check_failed.action().map(SettingsAction::label),
-            Some("Retry check")
-        );
-        assert_eq!(check_failed.details_title(), "Last update failure");
+        let row = app.presentation().updater();
+        assert_eq!(row.title(), "Update available: 1.7.0");
+        assert_eq!(row.action().label(), "Install update…");
+        assert_eq!(row.action().intent(), SettingsIntent::PrepareUpdateInstall);
+        assert!(app.presentation().update_install().error().is_some());
     }
 
     #[test]
-    fn channel_mismatch_uses_check_and_matching_channel_uses_install() {
-        let mut app = application("prerelease");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
-        let mismatch = app.presentation().updater();
-        assert_eq!(
-            mismatch.action().map(SettingsAction::label),
-            Some("Check for updates")
-        );
-        assert_eq!(
-            mismatch.release().map(|release| release.version.as_str()),
-            Some("1.7.0")
-        );
-
+    fn completed_check_notices_are_one_shot_and_repeated_failures_are_sanitized() {
         let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
+        let up_to_date = complete_check(&mut app, Ok(report(UpdateChannel::Stable, false)));
         assert_eq!(
-            app.presentation()
-                .updater()
-                .action()
-                .map(SettingsAction::label),
-            Some("Install update…")
+            up_to_date.update_notice().unwrap().title(),
+            "Already up to date"
         );
-    }
-
-    #[test]
-    fn completed_check_without_release_clears_the_old_offer() {
-        let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
-        assert_eq!(
-            app.presentation()
-                .updater()
-                .action()
-                .map(SettingsAction::label),
-            Some("Install update…")
-        );
-
-        let operation = app
-            .handle_intent(SettingsIntent::CheckForUpdates)
-            .unwrap()
-            .update_check_operation()
-            .unwrap();
-        let mut current = report(UpdateChannel::Stable, false);
-        current.warning = Some("Cache warning".into());
-        app.complete_update_check(operation, Ok(current)).unwrap();
-        let no_update = app.presentation().updater();
-        assert_eq!(no_update.title(), "No newer release available");
-        assert_eq!(no_update.release(), None);
-        assert_eq!(
-            no_update.action().map(SettingsAction::label),
-            Some("Check for updates")
-        );
-        assert_eq!(no_update.warning(), Some("Cache warning"));
-    }
-
-    #[test]
-    fn a_new_successful_check_owns_the_card_but_keeps_the_old_diagnostic() {
-        let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
-        let preparation = prepare(&mut app);
-        app.complete_update_install(
-            &preparation,
-            Err(UpdateInstallFailure {
-                presentation: crate::presentation::brightness::UserFacingError::new(
-                    "Install failed",
-                    "Try again.",
-                ),
-                diagnostic: "installer diagnostic".into(),
-                cancelled: false,
-            }),
-        )
-        .unwrap();
-
-        let operation = app
-            .handle_intent(SettingsIntent::CheckForUpdates)
-            .unwrap()
-            .update_check_operation()
-            .unwrap();
-        let mut current = report(UpdateChannel::Stable, false);
-        current.warning = Some("Cache warning".into());
-        app.complete_update_check(operation, Ok(current)).unwrap();
-
-        let card = app.presentation().updater();
-        assert_eq!(card.title(), "No newer release available");
-        assert!(!card.is_error());
-        assert_eq!(
-            card.action().map(SettingsAction::label),
-            Some("Check for updates")
-        );
-        assert_eq!(card.warning(), Some("Cache warning"));
-        assert_eq!(card.details_title(), "Last update failure");
-        assert_eq!(card.details(), Some("installer diagnostic"));
-    }
-
-    #[test]
-    fn failed_install_with_changed_channel_offers_a_fresh_check() {
-        let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
-        let preparation = prepare(&mut app);
-        app.complete_update_install(
-            &preparation,
-            Err(UpdateInstallFailure {
-                presentation: crate::presentation::brightness::UserFacingError::new(
-                    "Install failed",
-                    "Try again.",
-                ),
-                diagnostic: "installer diagnostic".into(),
-                cancelled: false,
-            }),
-        )
-        .unwrap();
+        assert!(up_to_date.update_notice().unwrap().details().is_none());
 
         let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
-        app.complete_read(refresh.read_operation().unwrap(), Ok(groups("prerelease")))
+        let refresh = app
+            .complete_read(refresh.read_operation().unwrap(), Ok(groups("stable")))
             .unwrap();
-        let card = app.presentation().updater();
-        assert!(card.is_error());
-        assert_eq!(
-            card.action().map(SettingsAction::label),
-            Some("Check for updates")
-        );
-        assert_eq!(
-            card.action().map(SettingsAction::intent),
-            Some(SettingsIntent::CheckForUpdates)
-        );
-    }
+        assert!(refresh.update_notice().is_none());
 
-    #[test]
-    fn warning_is_only_visible_with_completed_check_and_restart_failure_keeps_retry() {
-        let mut app = application("stable");
-        let operation = app
-            .handle_intent(SettingsIntent::CheckForUpdates)
-            .unwrap()
-            .update_check_operation()
-            .unwrap();
-        let mut checked = report(UpdateChannel::Stable, false);
-        checked.warning = Some("Cache warning".into());
-        app.complete_update_check(operation, Ok(checked)).unwrap();
-        assert_eq!(
-            app.presentation().updater().warning(),
-            Some("Cache warning")
-        );
+        let error = || {
+            crate::settings_view::UpdateCheckError::from(crate::updates::UpdatesError::Http {
+                url: "https://user:pass@example.test/release".into(),
+                message: "token=secret".into(),
+            })
+        };
+        let first = complete_check(&mut app, Err(error()));
+        let first_notice = first.update_notice().unwrap();
+        assert_eq!(first_notice.title(), "Could not check for updates");
+        let first_details = first_notice.details().unwrap();
+        assert!(first_details.contains("Check your internet connection"));
+        assert!(!first_details.contains("secret"));
+        assert!(!first_details.contains("user:pass"));
 
-        let operation = app
-            .handle_intent(SettingsIntent::CheckForUpdates)
-            .unwrap()
-            .update_check_operation()
-            .unwrap();
-        assert_eq!(app.presentation().updater().warning(), None);
-        app.complete_update_check(
-            operation,
-            Err(crate::settings_view::UpdateCheckError::stopped()),
-        )
-        .unwrap();
-        assert_eq!(app.presentation().updater().warning(), None);
-
-        let mut app = application("stable");
-        check(&mut app, Ok(report(UpdateChannel::Stable, true)));
-        let preparation = prepare(&mut app);
-        app.complete_update_install(&preparation, Ok(UpdateInstallOutcome::Prepared(prepared())))
-            .unwrap();
-        let install = app
-            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
-            .unwrap()
-            .update_install_operation()
-            .unwrap()
-            .clone();
-        let installed = InstalledUpdate::from_parts(
-            "1.7.0".parse().unwrap(),
-            UpdateChannel::Stable,
-            "v1.7.0",
-            "x86_64-unknown-linux-musl",
-            "a".repeat(40),
-            "/unused/lg-buddy",
-            "/unused/lg-buddy-gui",
-        );
-        let restarting = app
-            .complete_update_install(&install, Ok(UpdateInstallOutcome::Installed(installed)))
-            .unwrap();
-        let relaunch = restarting.update_install_operation().unwrap().clone();
-        app.complete_update_install(&relaunch, Err(UpdateInstallFailure::stopped()))
-            .unwrap();
-        let restart_failure = app.presentation().updater();
-        assert!(restart_failure.is_error());
-        assert_eq!(restart_failure.title(), "Update stopped");
-        assert_eq!(
-            restart_failure.action().map(SettingsAction::label),
-            Some("Retry restart")
-        );
-        assert_eq!(
-            restart_failure.action().map(SettingsAction::intent),
-            Some(SettingsIntent::RelaunchUpdatedApplication)
-        );
+        let second = complete_check(&mut app, Err(error()));
+        assert_eq!(second.update_notice(), first.update_notice());
     }
 }

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -17,6 +17,7 @@ use crate::settings::{
 };
 use crate::update_flow::{
     UpdateInstallApplication, UpdateInstallFailure, UpdateInstallOperation, UpdateInstallOutcome,
+    UpdateInstallTask,
 };
 use crate::update_install::UpdateInstallStage;
 
@@ -168,6 +169,30 @@ impl From<crate::updates::UpdatesError> for UpdateCheckError {
     }
 }
 
+/// A one-shot update result for a toolkit renderer to show as a toast.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateNotice {
+    title: String,
+    details: Option<String>,
+}
+
+impl UpdateNotice {
+    fn new(title: impl Into<String>, details: Option<String>) -> Self {
+        Self {
+            title: title.into(),
+            details,
+        }
+    }
+
+    pub fn title(&self) -> &str {
+        &self.title
+    }
+
+    pub fn details(&self) -> Option<&str> {
+        self.details.as_deref()
+    }
+}
+
 impl SettingsReadOperation {
     pub(crate) fn new(id: u64) -> Self {
         Self(id)
@@ -181,6 +206,7 @@ pub struct SettingsTransition {
     mutation_operation: Option<SettingsMutationOperation>,
     update_check_operation: Option<UpdateCheckOperation>,
     update_install_operation: Option<UpdateInstallOperation>,
+    update_notice: Option<UpdateNotice>,
     diagnostic: Option<String>,
 }
 
@@ -203,6 +229,10 @@ impl SettingsTransition {
 
     pub fn update_install_operation(&self) -> Option<&UpdateInstallOperation> {
         self.update_install_operation.as_ref()
+    }
+
+    pub fn update_notice(&self) -> Option<&UpdateNotice> {
+        self.update_notice.as_ref()
     }
 
     pub fn diagnostic(&self) -> Option<&str> {
@@ -377,6 +407,7 @@ impl SettingsApplication {
                 mutation_operation: None,
                 update_check_operation: None,
                 update_install_operation: None,
+                update_notice: None,
                 diagnostic: None,
             },
         )
@@ -618,11 +649,14 @@ impl SettingsApplication {
             return None;
         }
         self.pending_update_check = None;
+        let update_notice = update_check_notice(&result);
         let diagnostic = result.as_ref().err().map(|error| error.diagnostic.clone());
         self.presentation
             .update_check_mut()
             .complete(result.map_err(|error| error.presentation));
-        Some(self.transition(None, None, diagnostic))
+        let mut transition = self.transition(None, None, diagnostic);
+        transition.update_notice = update_notice;
+        Some(transition)
     }
 
     pub fn mutation_worker_stopped(
@@ -698,8 +732,20 @@ impl SettingsApplication {
             return None;
         }
         let (next, diagnostic) = self.update_install.complete(operation, result)?;
+        let notice = self.update_install.presentation().error().map(|error| {
+            let title = if matches!(operation.task(), UpdateInstallTask::Relaunch(_)) {
+                "Restart required"
+            } else {
+                error.summary()
+            };
+            UpdateNotice::new(
+                title,
+                notice_details(error, diagnostic.as_deref().unwrap_or("")),
+            )
+        });
         let mut transition = self.transition(None, None, diagnostic);
         transition.update_install_operation = next;
+        transition.update_notice = notice;
         Some(transition)
     }
 
@@ -840,8 +886,47 @@ impl SettingsApplication {
             mutation_operation,
             update_check_operation: None,
             update_install_operation: None,
+            update_notice: None,
             diagnostic,
         }
+    }
+}
+
+fn update_check_notice(
+    result: &Result<UpdateCheckReport, UpdateCheckError>,
+) -> Option<UpdateNotice> {
+    match result {
+        Ok(report) => {
+            if report.available_release.is_none() {
+                Some(UpdateNotice::new(
+                    "Already up to date",
+                    report.warning.as_deref().and_then(sanitized_notice_detail),
+                ))
+            } else {
+                report.warning.as_deref().map(|warning| {
+                    UpdateNotice::new("Update check warning", sanitized_notice_detail(warning))
+                })
+            }
+        }
+        Err(error) => Some(UpdateNotice::new(
+            error.presentation.summary(),
+            notice_details(&error.presentation, &error.diagnostic),
+        )),
+    }
+}
+
+fn sanitized_notice_detail(detail: &str) -> Option<String> {
+    let detail = crate::update_flow::retained_failure_details(detail);
+    (!detail.is_empty()).then_some(detail)
+}
+
+fn notice_details(error: &UserFacingError, diagnostic: &str) -> Option<String> {
+    let diagnostic = crate::update_flow::retained_failure_details(diagnostic);
+    match (error.detail().is_empty(), diagnostic.is_empty()) {
+        (true, true) => None,
+        (false, true) => Some(error.detail().to_string()),
+        (true, false) => Some(diagnostic),
+        (false, false) => Some(format!("{}\n\n{}", error.detail(), diagnostic)),
     }
 }
 

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -15,6 +15,10 @@ use crate::settings::{
     SettingsApplyOutcome, SettingsError, SettingsMutation, SettingsMutationFailure,
     SettingsMutationOutcome, SettingsMutationStage, SettingsStore,
 };
+use crate::update_flow::{
+    UpdateInstallApplication, UpdateInstallFailure, UpdateInstallOperation, UpdateInstallOutcome,
+};
+use crate::update_install::UpdateInstallStage;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BehaviorSetting {
@@ -59,6 +63,10 @@ pub enum SettingsIntent {
     Retry,
     Refresh,
     CheckForUpdates,
+    PrepareUpdateInstall,
+    ConfirmUpdateInstall,
+    CancelUpdateInstall,
+    RelaunchUpdatedApplication,
     SetEnabled {
         setting: BehaviorSetting,
         enabled: bool,
@@ -172,6 +180,7 @@ pub struct SettingsTransition {
     read_operation: Option<SettingsReadOperation>,
     mutation_operation: Option<SettingsMutationOperation>,
     update_check_operation: Option<UpdateCheckOperation>,
+    update_install_operation: Option<UpdateInstallOperation>,
     diagnostic: Option<String>,
 }
 
@@ -190,6 +199,10 @@ impl SettingsTransition {
 
     pub fn update_check_operation(&self) -> Option<UpdateCheckOperation> {
         self.update_check_operation
+    }
+
+    pub fn update_install_operation(&self) -> Option<&UpdateInstallOperation> {
+        self.update_install_operation.as_ref()
     }
 
     pub fn diagnostic(&self) -> Option<&str> {
@@ -338,6 +351,7 @@ pub struct SettingsApplication {
     queued_mutations: VecDeque<PendingMutation>,
     reconcile_mutation: Option<PendingMutation>,
     pending_update_check: Option<UpdateCheckOperation>,
+    update_install: UpdateInstallApplication,
 }
 
 impl SettingsApplication {
@@ -355,12 +369,14 @@ impl SettingsApplication {
                 queued_mutations: VecDeque::new(),
                 reconcile_mutation: None,
                 pending_update_check: None,
+                update_install: UpdateInstallApplication::default(),
             },
             SettingsTransition {
                 presentation,
                 read_operation: Some(operation),
                 mutation_operation: None,
                 update_check_operation: None,
+                update_install_operation: None,
                 diagnostic: None,
             },
         )
@@ -370,9 +386,24 @@ impl SettingsApplication {
         if self.closed {
             return None;
         }
+        self.sync_update_install();
+        if matches!(
+            intent,
+            SettingsIntent::PrepareUpdateInstall
+                | SettingsIntent::ConfirmUpdateInstall
+                | SettingsIntent::CancelUpdateInstall
+                | SettingsIntent::RelaunchUpdatedApplication
+        ) {
+            let report = self.presentation.update_check().result().cloned();
+            let operation = self.update_install.handle(intent, report.as_ref())?;
+            let mut transition = self.transition(None, None, None);
+            transition.update_install_operation = operation;
+            return Some(transition);
+        }
         match intent {
             SettingsIntent::CheckForUpdates
                 if self.pending_update_check.is_none()
+                    && !self.update_install.active()
                     && !self.presentation.groups().is_empty() =>
             {
                 let operation = UpdateCheckOperation(self.next_operation_id);
@@ -625,7 +656,9 @@ impl SettingsApplication {
     }
 
     pub fn is_mutating(&self) -> bool {
-        self.pending_mutation.is_some() || !self.queued_mutations.is_empty()
+        self.pending_mutation.is_some()
+            || !self.queued_mutations.is_empty()
+            || self.update_install.active()
     }
 
     pub fn set_controls_available(&mut self, available: bool) -> Option<SettingsTransition> {
@@ -637,7 +670,41 @@ impl SettingsApplication {
         Some(self.transition(None, None, None))
     }
 
+    pub fn update_install_active(&self) -> bool {
+        self.update_install.active()
+    }
+
+    pub fn can_close(&self) -> bool {
+        self.update_install.can_close()
+    }
+
+    pub fn update_install_progress(
+        &mut self,
+        operation: &UpdateInstallOperation,
+        stage: UpdateInstallStage,
+    ) -> Option<SettingsTransition> {
+        if self.closed || !self.update_install.progress(operation, stage) {
+            return None;
+        }
+        Some(self.transition(None, None, None))
+    }
+
+    pub fn complete_update_install(
+        &mut self,
+        operation: &UpdateInstallOperation,
+        result: Result<UpdateInstallOutcome, UpdateInstallFailure>,
+    ) -> Option<SettingsTransition> {
+        if self.closed {
+            return None;
+        }
+        let (next, diagnostic) = self.update_install.complete(operation, result)?;
+        let mut transition = self.transition(None, None, diagnostic);
+        transition.update_install_operation = next;
+        Some(transition)
+    }
+
     pub fn shutdown(&mut self) {
+        self.update_install.can_close();
         self.closed = true;
     }
 
@@ -647,6 +714,7 @@ impl SettingsApplication {
 
     fn can_edit(&self) -> bool {
         self.controls_available
+            && !self.update_install.active()
             && self.reconcile_mutation.is_none()
             && !self.presentation.groups().is_empty()
             && !matches!(self.state, SettingsApplicationState::Failed)
@@ -657,13 +725,7 @@ impl SettingsApplication {
         self.next_operation_id += 1;
         self.state = SettingsApplicationState::Loading(operation);
         self.presentation.mark_loading();
-        SettingsTransition {
-            presentation: self.presentation.clone(),
-            read_operation: Some(operation),
-            mutation_operation: None,
-            update_check_operation: None,
-            diagnostic: None,
-        }
+        self.transition(Some(operation), None, None)
     }
 
     fn begin_mutation(
@@ -729,17 +791,55 @@ impl SettingsApplication {
         Some(self.transition(None, operation, diagnostic))
     }
 
+    fn sync_update_install(&mut self) {
+        let channel = self
+            .presentation
+            .row(BehaviorSetting::UpdatesChannel)
+            .and_then(|row| match row.editor() {
+                SettingsEditor::Choice {
+                    options,
+                    selected: Some(selected),
+                } => options
+                    .get(*selected)
+                    .and_then(|choice| match choice.value() {
+                        "stable" => Some(crate::updates::UpdateChannel::Stable),
+                        "prerelease" => Some(crate::updates::UpdateChannel::Prerelease),
+                        _ => None,
+                    }),
+                _ => None,
+            });
+        let available = self.controls_available
+            && self.pending_mutation.is_none()
+            && self.queued_mutations.is_empty()
+            && self.reconcile_mutation.is_none()
+            && self.pending_update_check.is_none()
+            && matches!(self.state, SettingsApplicationState::Ready);
+        self.update_install.refresh_offer(
+            self.presentation.update_check().result(),
+            channel,
+            available,
+        );
+        *self.presentation.update_install_mut() = self.update_install.presentation().clone();
+        self.presentation
+            .set_controls_available(self.controls_available && !self.update_install.active());
+        self.presentation
+            .update_check_mut()
+            .set_install_active(self.update_install.active());
+    }
+
     fn transition(
-        &self,
+        &mut self,
         read_operation: Option<SettingsReadOperation>,
         mutation_operation: Option<SettingsMutationOperation>,
         diagnostic: Option<String>,
     ) -> SettingsTransition {
+        self.sync_update_install();
         SettingsTransition {
             presentation: self.presentation.clone(),
             read_operation,
             mutation_operation,
             update_check_operation: None,
+            update_install_operation: None,
             diagnostic,
         }
     }

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -9,7 +9,7 @@ use crate::presentation::settings::{
     SettingsEditStatus, SettingsEditor, SettingsFeedback, SettingsFeedbackSeverity, SettingsGroup,
     SettingsPresentation, SettingsRow,
 };
-use crate::presentation::update_check::{AvailableUpdate, UpdateCheckReport};
+use crate::presentation::update_check::UpdateCheckReport;
 use crate::settings::{
     execute_settings_mutation, retry_settings_apply, ConfigPathResolver, SettingsApplier,
     SettingsApplyOutcome, SettingsError, SettingsMutation, SettingsMutationFailure,
@@ -312,10 +312,7 @@ impl SettingsBackend for EnvironmentSettingsBackend {
         Ok(UpdateCheckReport {
             installed_version: result.current_version().to_string(),
             channel: result.check_channel(),
-            available_release: result.update_available().then(|| AvailableUpdate {
-                version: result.latest().version().to_string(),
-                url: result.latest().url().to_owned(),
-            }),
+            update_available: result.update_available(),
             warning: (!outcome.warnings().is_empty()).then(|| {
                 "The release check succeeded, but its cache could not be read or saved. A later check may need to download the release information again.".into()
             }),
@@ -425,8 +422,7 @@ impl SettingsApplication {
                 | SettingsIntent::CancelUpdateInstall
                 | SettingsIntent::RelaunchUpdatedApplication
         ) {
-            let report = self.presentation.update_check().result().cloned();
-            let operation = self.update_install.handle(intent, report.as_ref())?;
+            let operation = self.update_install.handle(intent)?;
             let mut transition = self.transition(None, None, None);
             transition.update_install_operation = operation;
             return Some(transition);
@@ -731,18 +727,25 @@ impl SettingsApplication {
         if self.closed {
             return None;
         }
+        let up_to_date = matches!(result, Ok(UpdateInstallOutcome::UpToDate))
+            && matches!(operation.task(), UpdateInstallTask::Prepare);
         let (next, diagnostic) = self.update_install.complete(operation, result)?;
-        let notice = self.update_install.presentation().error().map(|error| {
-            let title = if matches!(operation.task(), UpdateInstallTask::Relaunch(_)) {
-                "Restart required"
-            } else {
-                error.summary()
-            };
-            UpdateNotice::new(
-                title,
-                notice_details(error, diagnostic.as_deref().unwrap_or("")),
-            )
-        });
+        let notice = if up_to_date {
+            self.presentation.update_check_mut().clear_result();
+            Some(UpdateNotice::new("Already up to date", None))
+        } else {
+            self.update_install.presentation().error().map(|error| {
+                let title = if matches!(operation.task(), UpdateInstallTask::Relaunch(_)) {
+                    "Restart required"
+                } else {
+                    error.summary()
+                };
+                UpdateNotice::new(
+                    title,
+                    notice_details(error, diagnostic.as_deref().unwrap_or("")),
+                )
+            })
+        };
         let mut transition = self.transition(None, None, diagnostic);
         transition.update_install_operation = next;
         transition.update_notice = notice;
@@ -860,7 +863,7 @@ impl SettingsApplication {
             && self.reconcile_mutation.is_none()
             && self.pending_update_check.is_none()
             && matches!(self.state, SettingsApplicationState::Ready);
-        self.update_install.refresh_offer(
+        self.update_install.refresh_availability(
             self.presentation.update_check().result(),
             channel,
             available,
@@ -897,7 +900,7 @@ fn update_check_notice(
 ) -> Option<UpdateNotice> {
     match result {
         Ok(report) => {
-            if report.available_release.is_none() {
+            if !report.update_available {
                 Some(UpdateNotice::new(
                     "Already up to date",
                     report.warning.as_deref().and_then(sanitized_notice_detail),
@@ -1077,10 +1080,7 @@ mod tests {
         UpdateCheckReport {
             installed_version: "1.6.0".into(),
             channel,
-            available_release: Some(AvailableUpdate {
-                version: "1.7.0".into(),
-                url: "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0".into(),
-            }),
+            update_available: true,
             warning: None,
         }
     }
@@ -1123,7 +1123,7 @@ mod tests {
             .unwrap();
         let result = completed.presentation().update_check().result().unwrap();
         assert_eq!(result.channel, UpdateChannel::Stable);
-        assert!(result.description().contains("stable channel"));
+        assert!(result.update_available);
         assert_eq!(
             completed
                 .presentation()
@@ -1215,14 +1215,14 @@ mod tests {
             .update_check_operation()
             .unwrap();
         let mut current = update_report(UpdateChannel::Prerelease);
-        current.available_release = None;
+        current.update_available = false;
         current.warning = Some("Cache could not be saved.".into());
         let done = app
             .complete_update_check(third, Ok(current.clone()))
             .unwrap();
         assert_eq!(done.presentation().update_check().result(), Some(&current));
         assert!(done.presentation().update_check().error().is_none());
-        assert_eq!(current.title(), "No newer release available");
+        assert!(!current.update_available);
         let last = app
             .handle_intent(SettingsIntent::CheckForUpdates)
             .unwrap()

--- a/crates/lg-buddy/src/update_flow.rs
+++ b/crates/lg-buddy/src/update_flow.rs
@@ -80,7 +80,7 @@ impl UpdateInstallFailure {
 
     pub fn stopped() -> Self {
         Self {
-            presentation: UserFacingError::new("Update stopped", "The update did not finish. If installation had begun, the installation may be incomplete. Open Failure details before trying again."),
+            presentation: UserFacingError::new("Update stopped", "The update did not finish. If installation had begun, the installation may be incomplete. Review the error details before trying again."),
             diagnostic: "update installation worker stopped without a result".into(),
             cancelled: false,
         }
@@ -91,8 +91,15 @@ impl From<UpdateInstallError> for UpdateInstallFailure {
     fn from(error: UpdateInstallError) -> Self {
         let cancelled = matches!(error, UpdateInstallError::Cancelled);
         let detail = error.user_message();
+        let summary = match &error {
+            UpdateInstallError::InstallerFailedWithOutput {
+                mutation_started: true,
+                ..
+            } => "Update incomplete",
+            _ => "Could not install update",
+        };
         Self {
-            presentation: UserFacingError::new("Could not install update", &detail),
+            presentation: UserFacingError::new(summary, &detail),
             diagnostic: error.to_string(),
             cancelled,
         }
@@ -189,6 +196,8 @@ impl UpdateInstallApplication {
             return;
         }
         let offered = report.is_some_and(|report| report.available_release.is_some());
+        self.presentation.offer_channel_matches =
+            offered.then(|| report.is_some_and(|report| Some(report.channel) == channel));
         self.presentation.action = offered.then(|| {
             SettingsAction::new(
                 if self.presentation.error.is_some() {
@@ -406,7 +415,7 @@ impl UpdateInstallApplication {
 /// Retain only bounded plain text from updater diagnostics. The installer does
 /// not read TV credentials; also omit credential-bearing lines and URLs from
 /// subprocess/network errors so an on-demand view need not expose them.
-fn retained_failure_details(diagnostic: &str) -> String {
+pub(crate) fn retained_failure_details(diagnostic: &str) -> String {
     const LIMIT: usize = 64 * 1024;
     let mut result = String::new();
     for line in diagnostic.lines() {

--- a/crates/lg-buddy/src/update_flow.rs
+++ b/crates/lg-buddy/src/update_flow.rs
@@ -16,11 +16,7 @@ use crate::updates::UpdateChannel;
 
 #[derive(Debug, Clone)]
 pub enum UpdateInstallTask {
-    Prepare {
-        version: String,
-        url: String,
-        channel: UpdateChannel,
-    },
+    Prepare,
     Install {
         prepared: PreparedUpdateInstall,
         cancellation: UpdateInstallCancellation,
@@ -50,6 +46,7 @@ impl UpdateInstallOperation {
 #[derive(Debug)]
 pub enum UpdateInstallOutcome {
     Prepared(PreparedUpdateInstall),
+    UpToDate,
     Installed(InstalledUpdate),
     Relaunched,
 }
@@ -128,12 +125,13 @@ impl UpdateInstallBackend for EnvironmentUpdateInstallBackend {
         progress: &mut dyn FnMut(UpdateInstallStage),
     ) -> Result<UpdateInstallOutcome, UpdateInstallFailure> {
         match operation.task() {
-            UpdateInstallTask::Prepare {
-                version,
-                url,
-                channel,
-            } => prepare_gui_update(version, url, *channel)
-                .map(UpdateInstallOutcome::Prepared)
+            UpdateInstallTask::Prepare => prepare_gui_update()
+                .map(|prepared| {
+                    prepared.map_or(
+                        UpdateInstallOutcome::UpToDate,
+                        UpdateInstallOutcome::Prepared,
+                    )
+                })
                 .map_err(Into::into),
             UpdateInstallTask::Install {
                 prepared,
@@ -186,7 +184,7 @@ impl UpdateInstallApplication {
         }
     }
 
-    pub(crate) fn refresh_offer(
+    pub(crate) fn refresh_availability(
         &mut self,
         report: Option<&UpdateCheckReport>,
         channel: Option<UpdateChannel>,
@@ -195,8 +193,8 @@ impl UpdateInstallApplication {
         if self.active() || self.installed.is_some() {
             return;
         }
-        let offered = report.is_some_and(|report| report.available_release.is_some());
-        self.presentation.offer_channel_matches =
+        let offered = report.is_some_and(|report| report.update_available);
+        self.presentation.check_channel_matches =
             offered.then(|| report.is_some_and(|report| Some(report.channel) == channel));
         self.presentation.action = offered.then(|| {
             SettingsAction::new(
@@ -235,6 +233,7 @@ impl UpdateInstallApplication {
         self.presentation.busy = true;
         self.presentation.action = None;
         self.presentation.error = None;
+        self.presentation.release_url = None;
         self.cancelling = false;
         operation
     }
@@ -250,7 +249,6 @@ impl UpdateInstallApplication {
     pub(crate) fn handle(
         &mut self,
         intent: SettingsIntent,
-        report: Option<&UpdateCheckReport>,
     ) -> Option<Option<UpdateInstallOperation>> {
         match intent {
             SettingsIntent::PrepareUpdateInstall
@@ -261,16 +259,10 @@ impl UpdateInstallApplication {
                         .as_ref()
                         .is_some_and(SettingsAction::enabled) =>
             {
-                let report = report?;
-                let release = report.available_release.as_ref()?;
-                let operation = self.start(UpdateInstallTask::Prepare {
-                    version: release.version.clone(),
-                    url: release.url.clone(),
-                    channel: report.channel,
-                });
+                let operation = self.start(UpdateInstallTask::Prepare);
                 self.presentation.title = Some("Preparing update…".into());
                 self.presentation.description =
-                    "Checking this release and installation before confirmation.".into();
+                    "Finding the latest update for your saved channel.".into();
                 self.presentation.cancel_action = Some(cancel_action());
                 Some(Some(operation))
             }
@@ -324,7 +316,7 @@ impl UpdateInstallApplication {
             return false;
         }
         let (title, detail, cancellable) = match stage {
-            UpdateInstallStage::InitialPreflight | UpdateInstallStage::Discovering | UpdateInstallStage::Resolving | UpdateInstallStage::Offered => ("Preparing update…", "Checking this release and installation before confirmation.", true),
+            UpdateInstallStage::InitialPreflight | UpdateInstallStage::Discovering | UpdateInstallStage::Resolving | UpdateInstallStage::Offered => ("Preparing update…", "Finding the latest update for your saved channel.", true),
             UpdateInstallStage::Acquiring => ("Downloading and verifying update…", "You can cancel before installation begins.", true),
             UpdateInstallStage::CandidatePreflight => ("Checking installation compatibility…", "You can cancel before installation begins.", true),
             UpdateInstallStage::Installing => ("Installing update…", "Authorize the update when prompted. Keep LG Buddy open until installation finishes.", false),
@@ -349,13 +341,14 @@ impl UpdateInstallApplication {
         self.presentation.cancel_action = None;
         match result {
             Ok(UpdateInstallOutcome::Prepared(prepared))
-                if matches!(operation.task, UpdateInstallTask::Prepare { .. }) =>
+                if matches!(operation.task, UpdateInstallTask::Prepare) =>
             {
                 self.presentation.title = Some(format!(
                     "Install LG Buddy {}?",
                     prepared.identity().version()
                 ));
                 self.presentation.description = format!("{} channel. LG Buddy will request authorization, install this release, and restart. Your TV pairing and settings will be kept.", prepared.channel().as_str());
+                self.presentation.release_url = Some(prepared.release().url().to_owned());
                 self.prepared = Some(prepared);
                 self.presentation.action = Some(SettingsAction::new(
                     "Install and restart",
@@ -363,6 +356,11 @@ impl UpdateInstallApplication {
                     SettingsIntent::ConfirmUpdateInstall,
                 ));
                 self.presentation.cancel_action = Some(cancel_action());
+            }
+            Ok(UpdateInstallOutcome::UpToDate)
+                if matches!(operation.task, UpdateInstallTask::Prepare) =>
+            {
+                self.clear_presentation();
             }
             Ok(UpdateInstallOutcome::Installed(installed))
                 if matches!(operation.task, UpdateInstallTask::Install { .. }) =>
@@ -475,7 +473,6 @@ fn cancel_action() -> SettingsAction {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::presentation::update_check::AvailableUpdate;
     use crate::settings::ConfigEnvReader;
     use crate::settings_view::{BehaviorSetting, SettingsApplication};
     use crate::version::VersionInfo;
@@ -514,10 +511,7 @@ mod tests {
             Ok(UpdateCheckReport {
                 installed_version: "1.6.0".into(),
                 channel: UpdateChannel::Stable,
-                available_release: Some(AvailableUpdate {
-                    version: "1.7.0".into(),
-                    url: prepared().release().url().into(),
-                }),
+                update_available: true,
                 warning: None,
             }),
         )
@@ -531,6 +525,83 @@ mod tests {
             .update_install_operation()
             .unwrap()
             .clone()
+    }
+
+    #[test]
+    fn modal_selects_a_fresh_release_and_pins_only_the_confirmed_target() {
+        let mut app = offered();
+        let operation = prepare(&mut app);
+        assert!(matches!(operation.task(), UpdateInstallTask::Prepare));
+        let latest = PreparedUpdateInstall::from_parts(
+            VersionInfo::current(),
+            "1.7.1".parse().unwrap(),
+            UpdateChannel::Stable,
+            "https://example.test/releases/v1.7.1",
+            "v1.7.1",
+            "x86_64-unknown-linux-musl",
+            "b".repeat(40),
+        );
+        let confirmation = app
+            .complete_update_install(
+                &operation,
+                Ok(UpdateInstallOutcome::Prepared(latest.clone())),
+            )
+            .unwrap();
+        let dialog = confirmation.presentation().update_install();
+        assert_eq!(dialog.title(), Some("Install LG Buddy 1.7.1?"));
+        assert_eq!(dialog.release_url(), Some(latest.release().url()));
+        assert!(confirmation.update_install_operation().is_none());
+        let confirmed = app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .unwrap();
+        let UpdateInstallTask::Install { prepared, .. } =
+            confirmed.update_install_operation().unwrap().task()
+        else {
+            panic!("confirmation must start installation");
+        };
+        assert_eq!(prepared, &latest);
+    }
+
+    #[test]
+    fn no_qualifying_release_closes_the_modal_and_clears_old_availability_once() {
+        let mut app = offered();
+        let operation = prepare(&mut app);
+        let completion = app
+            .complete_update_install(&operation, Ok(UpdateInstallOutcome::UpToDate))
+            .unwrap();
+        assert!(completion.update_install_operation().is_none());
+        assert_eq!(
+            completion.update_notice().unwrap().title(),
+            "Already up to date"
+        );
+        assert!(completion.update_notice().unwrap().details().is_none());
+        assert!(!app.is_mutating());
+        assert!(!app.presentation().update_install().busy());
+        assert!(app
+            .presentation()
+            .update_install()
+            .cancel_action()
+            .is_none());
+        assert!(app.presentation().update_install().release_url().is_none());
+        assert!(app.presentation().update_check().result().is_none());
+        assert_eq!(
+            app.presentation().updater().action().intent(),
+            SettingsIntent::CheckForUpdates
+        );
+        assert!(app
+            .complete_update_install(&operation, Ok(UpdateInstallOutcome::UpToDate))
+            .is_none());
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let groups = app.presentation().groups().to_vec();
+        let refreshed = app
+            .complete_read(refresh.read_operation().unwrap(), Ok(groups))
+            .unwrap();
+        assert!(refreshed.update_notice().is_none());
+        assert_eq!(
+            refreshed.presentation().updater().action().label(),
+            "Check for updates"
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/update_flow.rs
+++ b/crates/lg-buddy/src/update_flow.rs
@@ -1,0 +1,656 @@
+//! Application-owned update installation and process handoff.
+
+use std::os::unix::process::CommandExt;
+use std::process::Command;
+
+use crate::presentation::brightness::UserFacingError;
+use crate::presentation::settings::SettingsAction;
+use crate::presentation::update_check::UpdateCheckReport;
+use crate::presentation::update_install::UpdateInstallPresentation;
+use crate::settings_view::SettingsIntent;
+use crate::update_install::{
+    install_gui_update, prepare_gui_update, InstalledUpdate, PreparedUpdateInstall,
+    UpdateInstallCancellation, UpdateInstallError, UpdateInstallStage,
+};
+use crate::updates::UpdateChannel;
+
+#[derive(Debug, Clone)]
+pub enum UpdateInstallTask {
+    Prepare {
+        version: String,
+        url: String,
+        channel: UpdateChannel,
+    },
+    Install {
+        prepared: PreparedUpdateInstall,
+        cancellation: UpdateInstallCancellation,
+    },
+    Relaunch(InstalledUpdate),
+}
+
+#[derive(Debug, Clone)]
+pub struct UpdateInstallOperation {
+    id: u64,
+    task: UpdateInstallTask,
+}
+
+impl PartialEq for UpdateInstallOperation {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for UpdateInstallOperation {}
+
+impl UpdateInstallOperation {
+    pub fn task(&self) -> &UpdateInstallTask {
+        &self.task
+    }
+}
+
+#[derive(Debug)]
+pub enum UpdateInstallOutcome {
+    Prepared(PreparedUpdateInstall),
+    Installed(InstalledUpdate),
+    Relaunched,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpdateInstallFailure {
+    pub presentation: UserFacingError,
+    pub diagnostic: String,
+    pub cancelled: bool,
+}
+
+impl UpdateInstallFailure {
+    pub fn worker_stopped(operation: &UpdateInstallOperation) -> Self {
+        if matches!(operation.task(), UpdateInstallTask::Install { cancellation, .. }
+            if !cancellation.can_cancel() && !cancellation.is_cancelled())
+        {
+            return Self::stopped();
+        }
+        Self {
+            presentation: UserFacingError::new(
+                "Update stopped",
+                "The update stopped before installation began. Try again.",
+            ),
+            diagnostic: "update preparation worker stopped without a result".into(),
+            cancelled: false,
+        }
+    }
+
+    pub fn stopped() -> Self {
+        Self {
+            presentation: UserFacingError::new("Update stopped", "The update did not finish. If installation had begun, the installation may be incomplete. Check the LG Buddy logs before trying again."),
+            diagnostic: "update installation worker stopped without a result".into(),
+            cancelled: false,
+        }
+    }
+}
+
+impl From<UpdateInstallError> for UpdateInstallFailure {
+    fn from(error: UpdateInstallError) -> Self {
+        let cancelled = matches!(error, UpdateInstallError::Cancelled);
+        let detail = error.user_message();
+        Self {
+            presentation: UserFacingError::new("Could not install update", &detail),
+            diagnostic: error.to_string(),
+            cancelled,
+        }
+    }
+}
+
+pub trait UpdateInstallBackend: Send + Sync + 'static {
+    fn run(
+        &self,
+        operation: &UpdateInstallOperation,
+        progress: &mut dyn FnMut(UpdateInstallStage),
+    ) -> Result<UpdateInstallOutcome, UpdateInstallFailure>;
+
+    /// Runs on the UI thread after the worker has verified both installed binaries.
+    /// A successful production handoff replaces this process, releasing its bus name.
+    fn relaunch(&self, installed: &InstalledUpdate) -> Result<(), UpdateInstallFailure>;
+}
+
+#[derive(Debug, Default)]
+pub struct EnvironmentUpdateInstallBackend;
+
+impl UpdateInstallBackend for EnvironmentUpdateInstallBackend {
+    fn run(
+        &self,
+        operation: &UpdateInstallOperation,
+        progress: &mut dyn FnMut(UpdateInstallStage),
+    ) -> Result<UpdateInstallOutcome, UpdateInstallFailure> {
+        match operation.task() {
+            UpdateInstallTask::Prepare {
+                version,
+                url,
+                channel,
+            } => prepare_gui_update(version, url, *channel)
+                .map(UpdateInstallOutcome::Prepared)
+                .map_err(Into::into),
+            UpdateInstallTask::Install {
+                prepared,
+                cancellation,
+            } => install_gui_update(prepared, cancellation, progress)
+                .map(UpdateInstallOutcome::Installed)
+                .map_err(Into::into),
+            UpdateInstallTask::Relaunch(_) => Err(UpdateInstallFailure::stopped()),
+        }
+    }
+
+    fn relaunch(&self, installed: &InstalledUpdate) -> Result<(), UpdateInstallFailure> {
+        let error = Command::new(installed.gui_path())
+            .arg("--gapplication-replace")
+            .exec();
+        Err(UpdateInstallFailure {
+            presentation: UserFacingError::new("Update installed; restart failed", "The installed application could not be started. Retry restarting, or close LG Buddy and open it from the application menu."),
+            diagnostic: format!("could not replace the running GUI with the installed GUI: {error}"),
+            cancelled: false,
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct UpdateInstallApplication {
+    next_id: u64,
+    pending: Option<UpdateInstallOperation>,
+    prepared: Option<PreparedUpdateInstall>,
+    installed: Option<InstalledUpdate>,
+    presentation: UpdateInstallPresentation,
+    cancelling: bool,
+}
+
+impl UpdateInstallApplication {
+    pub(crate) fn presentation(&self) -> &UpdateInstallPresentation {
+        &self.presentation
+    }
+
+    pub(crate) fn active(&self) -> bool {
+        self.pending.is_some() || self.prepared.is_some()
+    }
+
+    pub(crate) fn can_close(&self) -> bool {
+        match self.pending.as_ref().map(|operation| &operation.task) {
+            Some(UpdateInstallTask::Install { cancellation, .. }) => {
+                cancellation.is_cancelled() || cancellation.cancel()
+            }
+            Some(UpdateInstallTask::Relaunch(_)) => false,
+            _ => true,
+        }
+    }
+
+    pub(crate) fn refresh_offer(
+        &mut self,
+        report: Option<&UpdateCheckReport>,
+        channel: Option<UpdateChannel>,
+        available: bool,
+    ) {
+        if self.active() || self.installed.is_some() {
+            return;
+        }
+        let offered = report.is_some_and(|report| report.available_release.is_some());
+        self.presentation.action = offered.then(|| {
+            SettingsAction::new(
+                if self.presentation.error.is_some() {
+                    "Retry update"
+                } else {
+                    "Install update…"
+                },
+                available && report.is_some_and(|report| Some(report.channel) == channel),
+                SettingsIntent::PrepareUpdateInstall,
+            )
+        });
+        if offered && self.presentation.title.is_none() {
+            self.presentation.title = Some("Install update".into());
+        }
+        if !offered && self.presentation.error.is_none() {
+            self.presentation.title = None;
+        }
+        if self.presentation.error.is_none() {
+            self.presentation.description =
+                if offered && report.is_some_and(|report| Some(report.channel) != channel) {
+                    "Check for updates on the current channel before installing.".into()
+                } else {
+                    String::new()
+                };
+        }
+    }
+
+    fn start(&mut self, task: UpdateInstallTask) -> UpdateInstallOperation {
+        self.next_id += 1;
+        let operation = UpdateInstallOperation {
+            id: self.next_id,
+            task,
+        };
+        self.pending = Some(operation.clone());
+        self.presentation.busy = true;
+        self.presentation.action = None;
+        self.presentation.error = None;
+        self.cancelling = false;
+        operation
+    }
+
+    pub(crate) fn handle(
+        &mut self,
+        intent: SettingsIntent,
+        report: Option<&UpdateCheckReport>,
+    ) -> Option<Option<UpdateInstallOperation>> {
+        match intent {
+            SettingsIntent::PrepareUpdateInstall
+                if !self.active()
+                    && self
+                        .presentation
+                        .action
+                        .as_ref()
+                        .is_some_and(SettingsAction::enabled) =>
+            {
+                let report = report?;
+                let release = report.available_release.as_ref()?;
+                let operation = self.start(UpdateInstallTask::Prepare {
+                    version: release.version.clone(),
+                    url: release.url.clone(),
+                    channel: report.channel,
+                });
+                self.presentation.title = Some("Preparing update…".into());
+                self.presentation.description =
+                    "Checking this release and installation before confirmation.".into();
+                self.presentation.cancel_action = Some(cancel_action());
+                Some(Some(operation))
+            }
+            SettingsIntent::ConfirmUpdateInstall if self.pending.is_none() => {
+                let prepared = self.prepared.take()?;
+                let operation = self.start(UpdateInstallTask::Install {
+                    prepared,
+                    cancellation: UpdateInstallCancellation::default(),
+                });
+                self.presentation.title = Some("Downloading and verifying update…".into());
+                self.presentation.description = "You can cancel before installation begins.".into();
+                self.presentation.cancel_action = Some(cancel_action());
+                Some(Some(operation))
+            }
+            SettingsIntent::CancelUpdateInstall if self.active() && !self.cancelling => {
+                if let Some(UpdateInstallOperation {
+                    task: UpdateInstallTask::Install { cancellation, .. },
+                    ..
+                }) = &self.pending
+                {
+                    if !cancellation.cancel() {
+                        return None;
+                    }
+                    self.cancelling = true;
+                    self.presentation.title = Some("Cancelling update…".into());
+                    self.presentation.description = "Waiting for the current preparation step to finish. No installation will start.".into();
+                    self.presentation.cancel_action = None;
+                } else {
+                    self.pending = None;
+                    self.prepared = None;
+                    self.presentation = UpdateInstallPresentation::default();
+                }
+                Some(None)
+            }
+            SettingsIntent::RelaunchUpdatedApplication if self.pending.is_none() => {
+                let installed = self.installed.clone()?;
+                self.presentation.title = Some("Restarting LG Buddy…".into());
+                self.presentation.cancel_action = None;
+                Some(Some(self.start(UpdateInstallTask::Relaunch(installed))))
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn progress(
+        &mut self,
+        operation: &UpdateInstallOperation,
+        stage: UpdateInstallStage,
+    ) -> bool {
+        if self.pending.as_ref() != Some(operation) || self.cancelling {
+            return false;
+        }
+        let (title, detail, cancellable) = match stage {
+            UpdateInstallStage::InitialPreflight | UpdateInstallStage::Discovering | UpdateInstallStage::Resolving | UpdateInstallStage::Offered => ("Preparing update…", "Checking this release and installation before confirmation.", true),
+            UpdateInstallStage::Acquiring => ("Downloading and verifying update…", "You can cancel before installation begins.", true),
+            UpdateInstallStage::CandidatePreflight => ("Checking installation compatibility…", "You can cancel before installation begins.", true),
+            UpdateInstallStage::Installing => ("Installing update…", "Authorize the update when prompted. Keep LG Buddy open until installation finishes.", false),
+            UpdateInstallStage::VerifyingInstalled => ("Verifying installed update…", "LG Buddy will restart after verification.", false),
+        };
+        self.presentation.title = Some(title.into());
+        self.presentation.description = detail.into();
+        self.presentation.cancel_action = cancellable.then(cancel_action);
+        true
+    }
+
+    pub(crate) fn complete(
+        &mut self,
+        operation: &UpdateInstallOperation,
+        result: Result<UpdateInstallOutcome, UpdateInstallFailure>,
+    ) -> Option<(Option<UpdateInstallOperation>, Option<String>)> {
+        if self.pending.as_ref() != Some(operation) {
+            return None;
+        }
+        self.pending = None;
+        self.presentation.busy = false;
+        self.presentation.cancel_action = None;
+        match result {
+            Ok(UpdateInstallOutcome::Prepared(prepared))
+                if matches!(operation.task, UpdateInstallTask::Prepare { .. }) =>
+            {
+                self.presentation.title = Some(format!(
+                    "Install LG Buddy {}?",
+                    prepared.identity().version()
+                ));
+                self.presentation.description = format!("{} channel. LG Buddy will request authorization, install this release, and restart. Your TV pairing and settings will be kept.", prepared.channel().as_str());
+                self.prepared = Some(prepared);
+                self.presentation.action = Some(SettingsAction::new(
+                    "Install and restart",
+                    true,
+                    SettingsIntent::ConfirmUpdateInstall,
+                ));
+                self.presentation.cancel_action = Some(cancel_action());
+            }
+            Ok(UpdateInstallOutcome::Installed(installed))
+                if matches!(operation.task, UpdateInstallTask::Install { .. }) =>
+            {
+                self.installed = Some(installed.clone());
+                self.presentation.title = Some("Restarting LG Buddy…".into());
+                self.presentation.description = "The installed update was verified.".into();
+                return Some((
+                    Some(self.start(UpdateInstallTask::Relaunch(installed))),
+                    None,
+                ));
+            }
+            Ok(UpdateInstallOutcome::Relaunched)
+                if matches!(operation.task, UpdateInstallTask::Relaunch(_)) => {}
+            Ok(_) => return self.failed(UpdateInstallFailure::worker_stopped(operation)),
+            Err(error) if error.cancelled => {
+                self.presentation = UpdateInstallPresentation::default();
+            }
+            Err(error) => return self.failed(error),
+        }
+        Some((None, None))
+    }
+
+    fn failed(
+        &mut self,
+        error: UpdateInstallFailure,
+    ) -> Option<(Option<UpdateInstallOperation>, Option<String>)> {
+        self.presentation.title = Some(
+            if self.installed.is_some() {
+                "Restart required"
+            } else {
+                "Update not completed"
+            }
+            .into(),
+        );
+        self.presentation.description.clear();
+        self.presentation.error = Some(error.presentation);
+        if self.installed.is_some() {
+            self.presentation.action = Some(SettingsAction::new(
+                "Retry restart",
+                true,
+                SettingsIntent::RelaunchUpdatedApplication,
+            ));
+        }
+        Some((None, Some(error.diagnostic)))
+    }
+}
+
+fn cancel_action() -> SettingsAction {
+    SettingsAction::new("Cancel", true, SettingsIntent::CancelUpdateInstall)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::presentation::update_check::AvailableUpdate;
+    use crate::settings::ConfigEnvReader;
+    use crate::settings_view::{BehaviorSetting, SettingsApplication};
+    use crate::version::VersionInfo;
+
+    fn prepared() -> PreparedUpdateInstall {
+        PreparedUpdateInstall::from_parts(
+            VersionInfo::current(),
+            "1.7.0".parse().unwrap(),
+            UpdateChannel::Stable,
+            "https://github.com/Staphylococcus/LG_Buddy/releases/tag/v1.7.0",
+            "v1.7.0",
+            "x86_64-unknown-linux-musl",
+            "a".repeat(40),
+        )
+    }
+
+    fn offered() -> SettingsApplication {
+        let (mut app, opening) = SettingsApplication::open();
+        let store = ConfigEnvReader::parse(
+            "/tmp/unused-update-fixture.env",
+            "updates_auto_check=disabled\nupdates_channel=stable\n",
+        )
+        .into_store();
+        let groups = crate::presentation::settings::SettingsPresentation::from_store(&store)
+            .groups()
+            .to_vec();
+        app.complete_read(opening.read_operation().unwrap(), Ok(groups))
+            .unwrap();
+        let operation = app
+            .handle_intent(SettingsIntent::CheckForUpdates)
+            .unwrap()
+            .update_check_operation()
+            .unwrap();
+        app.complete_update_check(
+            operation,
+            Ok(UpdateCheckReport {
+                installed_version: "1.6.0".into(),
+                channel: UpdateChannel::Stable,
+                available_release: Some(AvailableUpdate {
+                    version: "1.7.0".into(),
+                    url: prepared().release().url().into(),
+                }),
+                warning: None,
+            }),
+        )
+        .unwrap();
+        app
+    }
+
+    fn prepare(app: &mut SettingsApplication) -> UpdateInstallOperation {
+        app.handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .unwrap()
+            .update_install_operation()
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn confirmation_is_required_and_cancelled_or_closed_preparations_cannot_start_an_install() {
+        let mut app = offered();
+        assert!(app
+            .presentation()
+            .update_install()
+            .action()
+            .unwrap()
+            .enabled());
+        let old = prepare(&mut app);
+        assert!(app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .is_none());
+        assert!(app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .is_none());
+        assert!(app.handle_intent(SettingsIntent::CheckForUpdates).is_none());
+        assert!(app
+            .handle_intent(SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::UpdatesAutoCheck,
+                enabled: true
+            })
+            .is_none());
+        app.handle_intent(SettingsIntent::CancelUpdateInstall)
+            .unwrap();
+        let current = prepare(&mut app);
+        assert!(app
+            .complete_update_install(&old, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .is_none());
+        let confirmation = app
+            .complete_update_install(&current, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .unwrap();
+        assert!(confirmation.update_install_operation().is_none());
+        assert_eq!(
+            confirmation
+                .presentation()
+                .update_install()
+                .action()
+                .unwrap()
+                .label(),
+            "Install and restart"
+        );
+        assert!(!confirmation
+            .presentation()
+            .update_check()
+            .check_action()
+            .enabled());
+        assert!(app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .is_none());
+        app.handle_intent(SettingsIntent::CancelUpdateInstall)
+            .unwrap();
+        assert!(app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .is_none());
+        let closing = prepare(&mut app);
+        app.shutdown();
+        assert!(app
+            .complete_update_install(&closing, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .is_none());
+    }
+
+    #[test]
+    fn cancellation_waits_for_cleanup_and_no_install_or_handoff_is_reported() {
+        let mut app = offered();
+        let preparation = prepare(&mut app);
+        app.complete_update_install(&preparation, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .unwrap();
+        let install = app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .unwrap()
+            .update_install_operation()
+            .unwrap()
+            .clone();
+        app.handle_intent(SettingsIntent::CancelUpdateInstall)
+            .unwrap();
+        let UpdateInstallTask::Install { cancellation, .. } = install.task() else {
+            panic!("install task");
+        };
+        assert!(cancellation.is_cancelled());
+        assert!(
+            app.is_mutating(),
+            "download cleanup must finish before a new operation"
+        );
+        assert!(
+            app.can_close(),
+            "an already cancelled download must not trap the window open"
+        );
+        assert!(app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .is_none());
+        let cancelled = app
+            .complete_update_install(&install, Err(UpdateInstallError::Cancelled.into()))
+            .unwrap();
+        assert!(cancelled.update_install_operation().is_none());
+        assert!(!app.is_mutating());
+        assert!(cancelled.presentation().update_install().error().is_none());
+    }
+
+    #[test]
+    fn failures_allow_retry_and_verified_success_requests_only_an_installed_gui_handoff() {
+        let mut app = offered();
+        let preparation = prepare(&mut app);
+        app.complete_update_install(&preparation, Err(UpdateInstallFailure::stopped()))
+            .unwrap();
+        assert_eq!(
+            app.presentation()
+                .update_install()
+                .action()
+                .unwrap()
+                .label(),
+            "Retry update"
+        );
+        let preparation = prepare(&mut app);
+        app.complete_update_install(&preparation, Ok(UpdateInstallOutcome::Prepared(prepared())))
+            .unwrap();
+        let install = app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .unwrap()
+            .update_install_operation()
+            .unwrap()
+            .clone();
+        let installed = InstalledUpdate::from_parts(
+            "1.7.0".parse().unwrap(),
+            UpdateChannel::Stable,
+            "v1.7.0",
+            "x86_64-unknown-linux-musl",
+            "a".repeat(40),
+            "/usr/bin/lg-buddy",
+            "/usr/bin/lg-buddy-gui",
+        );
+        let completion = app
+            .complete_update_install(
+                &install,
+                Ok(UpdateInstallOutcome::Installed(installed.clone())),
+            )
+            .unwrap();
+        let handoff = completion.update_install_operation().unwrap();
+        assert!(
+            matches!(handoff.task(), UpdateInstallTask::Relaunch(result) if result == &installed)
+        );
+        let failed = app
+            .complete_update_install(handoff, Err(UpdateInstallFailure::stopped()))
+            .unwrap();
+        assert_eq!(
+            failed
+                .presentation()
+                .update_install()
+                .action()
+                .unwrap()
+                .intent(),
+            SettingsIntent::RelaunchUpdatedApplication
+        );
+        assert!(app
+            .handle_intent(SettingsIntent::ConfirmUpdateInstall)
+            .is_none());
+    }
+
+    #[test]
+    fn an_old_channel_result_is_retained_but_cannot_be_installed() {
+        let mut app = offered();
+        let refresh = app
+            .handle_intent(SettingsIntent::Refresh)
+            .unwrap()
+            .read_operation()
+            .unwrap();
+        let store = ConfigEnvReader::parse(
+            "/tmp/unused-update-fixture.env",
+            "updates_channel=prerelease\n",
+        )
+        .into_store();
+        app.complete_read(
+            refresh,
+            Ok(
+                crate::presentation::settings::SettingsPresentation::from_store(&store)
+                    .groups()
+                    .to_vec(),
+            ),
+        )
+        .unwrap();
+        assert_eq!(
+            app.presentation().update_check().result().unwrap().channel,
+            UpdateChannel::Stable
+        );
+        assert!(!app
+            .presentation()
+            .update_install()
+            .action()
+            .unwrap()
+            .enabled());
+        assert!(app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .is_none());
+    }
+}

--- a/crates/lg-buddy/src/update_flow.rs
+++ b/crates/lg-buddy/src/update_flow.rs
@@ -80,7 +80,7 @@ impl UpdateInstallFailure {
 
     pub fn stopped() -> Self {
         Self {
-            presentation: UserFacingError::new("Update stopped", "The update did not finish. If installation had begun, the installation may be incomplete. Check the LG Buddy logs before trying again."),
+            presentation: UserFacingError::new("Update stopped", "The update did not finish. If installation had begun, the installation may be incomplete. Open Failure details before trying again."),
             diagnostic: "update installation worker stopped without a result".into(),
             cancelled: false,
         }
@@ -230,6 +230,14 @@ impl UpdateInstallApplication {
         operation
     }
 
+    fn clear_presentation(&mut self) {
+        let failure_details = self.presentation.failure_details.take();
+        self.presentation = UpdateInstallPresentation {
+            failure_details,
+            ..Default::default()
+        };
+    }
+
     pub(crate) fn handle(
         &mut self,
         intent: SettingsIntent,
@@ -284,7 +292,7 @@ impl UpdateInstallApplication {
                 } else {
                     self.pending = None;
                     self.prepared = None;
-                    self.presentation = UpdateInstallPresentation::default();
+                    self.clear_presentation();
                 }
                 Some(None)
             }
@@ -362,7 +370,7 @@ impl UpdateInstallApplication {
                 if matches!(operation.task, UpdateInstallTask::Relaunch(_)) => {}
             Ok(_) => return self.failed(UpdateInstallFailure::worker_stopped(operation)),
             Err(error) if error.cancelled => {
-                self.presentation = UpdateInstallPresentation::default();
+                self.clear_presentation();
             }
             Err(error) => return self.failed(error),
         }
@@ -382,6 +390,7 @@ impl UpdateInstallApplication {
             .into(),
         );
         self.presentation.description.clear();
+        self.presentation.failure_details = Some(retained_failure_details(&error.diagnostic));
         self.presentation.error = Some(error.presentation);
         if self.installed.is_some() {
             self.presentation.action = Some(SettingsAction::new(
@@ -392,6 +401,62 @@ impl UpdateInstallApplication {
         }
         Some((None, Some(error.diagnostic)))
     }
+}
+
+/// Retain only bounded plain text from updater diagnostics. The installer does
+/// not read TV credentials; also omit credential-bearing lines and URLs from
+/// subprocess/network errors so an on-demand view need not expose them.
+fn retained_failure_details(diagnostic: &str) -> String {
+    const LIMIT: usize = 64 * 1024;
+    let mut result = String::new();
+    for line in diagnostic.lines() {
+        let line: String = line
+            .chars()
+            .filter(|character| {
+                (!character.is_control() || *character == '\t')
+                    && !matches!(*character, '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}')
+            })
+            .collect();
+        let lower = line.to_ascii_lowercase();
+        let secret = [
+            "password",
+            "passwd",
+            "token",
+            "client-key",
+            "client_key",
+            "secret",
+            "authorization:",
+            "bearer ",
+        ]
+        .iter()
+        .any(|key| lower.contains(key));
+        let line = if secret {
+            "[Credential-bearing output omitted]".to_string()
+        } else {
+            line.split_inclusive(char::is_whitespace)
+                .map(|part| {
+                    if part.contains("://") {
+                        format!("[URL omitted]{}", &part[part.trim_end().len()..])
+                    } else {
+                        part.to_string()
+                    }
+                })
+                .collect()
+        };
+        let remaining = LIMIT.saturating_sub(result.len());
+        if line.len() + 1 > remaining {
+            let mut end = remaining;
+            while !line.is_char_boundary(end) {
+                end -= 1;
+            }
+            result.push_str(&line[..end]);
+            result.push_str("\n[Details truncated]");
+            break;
+        }
+        result.push_str(&line);
+        result.push('\n');
+    }
+    result.trim().to_string()
 }
 
 fn cancel_action() -> SettingsAction {
@@ -615,6 +680,77 @@ mod tests {
         assert!(app
             .handle_intent(SettingsIntent::ConfirmUpdateInstall)
             .is_none());
+    }
+
+    #[test]
+    fn failure_details_survive_refresh_retry_and_cancellation_without_terminal_output() {
+        let mut app = offered();
+        let operation = prepare(&mut app);
+        let failed = app
+            .complete_update_install(
+                &operation,
+                Err(UpdateInstallError::InstallerFailedWithOutput {
+                    code: Some(1),
+                    output: "install: cannot create regular file: No space left on device\naccess_token=private-value".into(),
+                    mutation_started: true,
+                }.into()),
+            )
+            .unwrap();
+        let details = failed
+            .presentation()
+            .update_install()
+            .failure_details()
+            .unwrap()
+            .to_string();
+        assert!(details.contains("No space left on device"));
+        assert!(details.contains("exit status 1"));
+        assert!(!details.contains("private-value"));
+        assert!(!failed
+            .presentation()
+            .update_install()
+            .error()
+            .unwrap()
+            .detail()
+            .contains("No space left"));
+
+        let refresh = app.handle_intent(SettingsIntent::Refresh).unwrap();
+        let groups = app.presentation().groups().to_vec();
+        app.complete_read(refresh.read_operation().unwrap(), Ok(groups))
+            .unwrap();
+        assert_eq!(
+            app.presentation().update_install().failure_details(),
+            Some(details.as_str())
+        );
+        prepare(&mut app);
+        assert!(app.presentation().update_install().error().is_none());
+        assert_eq!(
+            app.presentation().update_install().failure_details_title(),
+            "Last update failure"
+        );
+        app.handle_intent(SettingsIntent::CancelUpdateInstall)
+            .unwrap();
+        assert_eq!(
+            app.presentation().update_install().failure_details(),
+            Some(details.as_str())
+        );
+    }
+
+    #[test]
+    fn retained_failure_details_remove_credentials_urls_controls_and_bound_unicode_text() {
+        let details = super::retained_failure_details(
+            "install: No space left on device\npassword=hunter2\nAuthorization: Bearer abc\nclient-key=key123\nfetch failed https://user:pass@example.test/asset?signed=value\nordinary\0text\u{202e}",
+        );
+        for secret in ["hunter2", "abc", "key123", "user:pass", "signed=value"] {
+            assert!(!details.contains(secret), "leaked {secret}");
+        }
+        assert!(details.contains("No space left on device"));
+        assert!(details.contains("fetch failed [URL omitted]"));
+        assert!(details.contains("ordinarytext"));
+        assert!(!details.contains('\0'));
+        assert!(!details.contains('\u{202e}'));
+        let large = super::retained_failure_details(&"☃".repeat(30_000));
+        assert!(large.len() <= 64 * 1024 + "\n[Details truncated]".len());
+        assert!(large.ends_with("[Details truncated]"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/update_install.rs
+++ b/crates/lg-buddy/src/update_install.rs
@@ -279,11 +279,11 @@ impl UpdateInstallError {
             Self::InstallerFailedWithOutput {
                 mutation_started, ..
             } if *mutation_started => {
-                "The update installer failed after installation changes began. The installation may be partial. Open Failure details and address the cause before retrying."
+                "The update installer failed after installation changes began. The installation may be partial. Review the error details and address the cause before retrying."
                     .to_string()
             }
             Self::InstallerFailedWithOutput { .. } => {
-                "The update installer stopped before changing installed files. Open Failure details and address the cause before retrying."
+                "The update installer stopped before changing installed files. Review the error details and address the cause before retrying."
                     .to_string()
             }
             Self::InstalledIdentity(_) | Self::InstalledIdentityMismatch { .. } => {

--- a/crates/lg-buddy/src/update_install.rs
+++ b/crates/lg-buddy/src/update_install.rs
@@ -39,14 +39,6 @@ pub enum UpdateInstallError {
     Cancelled,
     AuthorizationDeclined,
     AuthorizationUnavailable(Option<i32>),
-    OfferChanged {
-        expected_version: String,
-        expected_url: String,
-        expected_channel: crate::updates::UpdateChannel,
-        actual_version: Option<String>,
-        actual_url: Option<String>,
-        actual_channel: Option<crate::updates::UpdateChannel>,
-    },
     ChannelChanged {
         prepared: crate::updates::UpdateChannel,
         current: crate::updates::UpdateChannel,
@@ -102,21 +94,6 @@ impl fmt::Display for UpdateInstallError {
                 formatter,
                 "upgrade authorization was unavailable{}",
                 render_exit_code(*code)
-            ),
-            Self::OfferChanged {
-                expected_version,
-                expected_url,
-                expected_channel,
-                actual_version,
-                actual_url,
-                actual_channel,
-            } => write!(
-                formatter,
-                "the offered release changed (expected {expected_version} ({}) at {expected_url}, found {} ({}) at {})",
-                expected_channel.as_str(),
-                actual_version.as_deref().unwrap_or("no update"),
-                actual_channel.map_or("unknown channel", |channel| channel.as_str()),
-                actual_url.as_deref().unwrap_or("unknown URL")
             ),
             Self::ChannelChanged { prepared, current } => write!(
                 formatter,
@@ -208,7 +185,6 @@ impl Error for UpdateInstallError {
             | Self::Cancelled
             | Self::AuthorizationDeclined
             | Self::AuthorizationUnavailable(_)
-            | Self::OfferChanged { .. }
             | Self::ChannelChanged { .. }
             | Self::ConfirmationRequiresTerminal
             | Self::TargetChanged { .. }
@@ -249,8 +225,8 @@ impl UpdateInstallError {
             Self::AuthorizationUnavailable(_) => {
                 "The desktop authorization agent could not authorize the update. Start LG Buddy from a normal desktop session and try again.".to_string()
             }
-            Self::OfferChanged { .. } | Self::ChannelChanged { .. } => {
-                "The offered update changed before installation. Check for updates again."
+            Self::ChannelChanged { .. } => {
+                "The saved update channel changed. Start the update again using the current preference."
                     .to_string()
             }
             Self::CandidatePreflightFailed(_) => {
@@ -290,7 +266,7 @@ impl UpdateInstallError {
                 "The installed files did not match the verified update identity.".to_string()
             }
             Self::TargetChanged { .. } => {
-                "The verified update changed before installation. Check for updates again."
+                "The release changed after confirmation. Start the update again to review the current release."
                     .to_string()
             }
             Self::ConfirmationRequiresTerminal | Self::ConfirmationIo(_) => {
@@ -697,42 +673,14 @@ impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
     }
 }
 
-/// Prepare a GUI-triggered update from the offer that is currently displayed.
-/// The release is discovered again and must still match the displayed version,
-/// URL, and channel before a prepared install is returned.
-pub fn prepare_gui_update(
-    expected_version: &str,
-    expected_url: &str,
-    expected_channel: crate::updates::UpdateChannel,
-) -> Result<PreparedUpdateInstall, UpdateInstallError> {
+/// Prepare a GUI-triggered update using the currently saved update channel.
+/// The release is discovered again so the confirmation dialog describes the
+/// latest qualifying release at the time it opens.
+pub fn prepare_gui_update() -> Result<Option<PreparedUpdateInstall>, UpdateInstallError> {
     let cancellation = UpdateInstallCancellation::new();
     let mut runtime = SystemUpdateInstallRuntime { require_gui: true };
     let current = runtime.current_version();
-    let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)?;
-    let Some(prepared) = prepared else {
-        return Err(UpdateInstallError::OfferChanged {
-            expected_version: expected_version.to_string(),
-            expected_url: expected_url.to_string(),
-            expected_channel,
-            actual_version: None,
-            actual_url: None,
-            actual_channel: None,
-        });
-    };
-    if prepared.release.version().to_string() != expected_version
-        || prepared.release.url() != expected_url
-        || prepared.channel() != expected_channel
-    {
-        return Err(UpdateInstallError::OfferChanged {
-            expected_version: expected_version.to_string(),
-            expected_url: expected_url.to_string(),
-            expected_channel,
-            actual_version: Some(prepared.release.version().to_string()),
-            actual_url: Some(prepared.release.url().to_string()),
-            actual_channel: Some(prepared.channel()),
-        });
-    }
-    Ok(prepared)
+    prepare_gui_update_with(&mut runtime, &cancellation, current)
 }
 
 /// Install a previously prepared and explicitly confirmed GUI update.
@@ -743,6 +691,17 @@ pub fn install_gui_update(
 ) -> Result<InstalledUpdate, UpdateInstallError> {
     let mut runtime = SystemUpdateInstallRuntime { require_gui: true };
     install_prepared_update_with(prepared, &mut runtime, cancellation, progress)
+}
+
+fn prepare_gui_update_with<R: UpdateInstallRuntime>(
+    runtime: &mut R,
+    cancellation: &UpdateInstallCancellation,
+    current: VersionInfo,
+) -> Result<Option<PreparedUpdateInstall>, UpdateInstallError> {
+    match prepare_update_install_with(runtime, cancellation, current) {
+        Err(UpdateInstallError::DowngradeRefused { .. }) => Ok(None),
+        result => result,
+    }
 }
 
 fn prepare_update_install_with<R: UpdateInstallRuntime>(
@@ -1162,9 +1121,10 @@ mod tests {
     use super::{
         candidate_preflight_command, classify_gui_installer_output, confirmation_is_yes,
         install_prepared_update_with, installed_binary_path_for_root, installer_command,
-        prepare_update_install_with, run_bounded_command, run_update_install_with, BundleView,
-        CompatibilityReport, InstalledUpdate, UpdateInstallCancellation, UpdateInstallError,
-        UpdateInstallRuntime, UpdateInstallStage, GUI_TARGET,
+        prepare_gui_update_with, prepare_update_install_with, run_bounded_command,
+        run_update_install_with, BundleView, CompatibilityReport, InstalledUpdate,
+        UpdateInstallCancellation, UpdateInstallError, UpdateInstallRuntime, UpdateInstallStage,
+        GUI_TARGET,
     };
     use crate::release_bundle::{BundleAcquisitionError, ReleaseIdentity};
     use crate::updates::{ReleaseInfo, UpdateChannel};
@@ -1210,6 +1170,7 @@ mod tests {
         current_version: &'static str,
         candidate_version: &'static str,
         saved_channel: UpdateChannel,
+        discovered_channel: Option<UpdateChannel>,
         confirmed: bool,
         failure: Option<Failure>,
         recheck: bool,
@@ -1227,6 +1188,7 @@ mod tests {
                 current_version: "1.4.0",
                 candidate_version,
                 saved_channel: UpdateChannel::Stable,
+                discovered_channel: None,
                 confirmed: true,
                 failure: None,
                 recheck: false,
@@ -1269,9 +1231,10 @@ mod tests {
         fn discover_candidate(
             &mut self,
             _current: VersionInfo,
-            _channel: UpdateChannel,
+            channel: UpdateChannel,
         ) -> Result<ReleaseInfo, UpdateInstallError> {
             self.events.borrow_mut().push("discover");
+            self.discovered_channel = Some(channel);
             Ok(ReleaseInfo::from_github(
                 Version::parse(self.candidate_version).unwrap(),
                 UpdateChannel::Stable,
@@ -1530,6 +1493,50 @@ mod tests {
         assert!(String::from_utf8(output)
             .unwrap()
             .contains("already up to date"));
+    }
+
+    #[test]
+    fn gui_preparation_uses_saved_channel_and_resolves_latest_without_acquiring() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.saved_channel = UpdateChannel::Prerelease;
+        let cancellation = UpdateInstallCancellation::new();
+        let current = runtime.current_version();
+
+        let prepared = prepare_gui_update_with(&mut runtime, &cancellation, current)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(runtime.discovered_channel, Some(UpdateChannel::Prerelease));
+        assert_eq!(prepared.channel(), UpdateChannel::Prerelease);
+        assert_eq!(prepared.release_channel(), UpdateChannel::Stable);
+        assert_eq!(
+            prepared.identity().version(),
+            &Version::parse("1.5.0").unwrap()
+        );
+        assert_eq!(
+            runtime.event_names(),
+            ["current", "initial_preflight", "discover", "resolve"]
+        );
+    }
+
+    #[test]
+    fn gui_preparation_returns_none_for_equal_or_older_release() {
+        for candidate_version in ["1.4.0", "1.3.0"] {
+            let mut runtime = FakeRuntime::new(candidate_version);
+            let cancellation = UpdateInstallCancellation::new();
+            let current = runtime.current_version();
+
+            let prepared = prepare_gui_update_with(&mut runtime, &cancellation, current).unwrap();
+
+            assert!(
+                prepared.is_none(),
+                "candidate {candidate_version} should not be offered"
+            );
+            assert_eq!(
+                runtime.event_names(),
+                ["current", "initial_preflight", "discover"]
+            );
+        }
     }
 
     #[test]

--- a/crates/lg-buddy/src/update_install.rs
+++ b/crates/lg-buddy/src/update_install.rs
@@ -1,8 +1,11 @@
 use std::error::Error;
 use std::fmt;
-use std::io::{self, BufRead, IsTerminal, Write};
+use std::io::{self, BufRead, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use std::thread;
 
 use semver::Version;
 
@@ -11,9 +14,13 @@ use crate::release_bundle::{
     verify_release_gui_binary_identity, BundleAcquisitionError, ReleaseIdentity,
     VerifiedReleaseBundle,
 };
-use crate::updates::{discover_install_candidate, ReleaseInfo, UpdatesError};
-use crate::upgrade_preflight::{current_host_preflight, CompatibilityReport};
+use crate::updates::{
+    discover_install_candidate_for_channel, ReleaseInfo, UpdateChannel, UpdatesError,
+};
+use crate::upgrade_preflight::{current_host_preflight, CompatibilityAdvice, CompatibilityReport};
 use crate::version::VersionInfo;
+
+const GUI_TARGET: &str = "x86_64-unknown-linux-gnu";
 
 #[derive(Debug)]
 pub enum UpdateInstallError {
@@ -29,6 +36,21 @@ pub enum UpdateInstallError {
         candidate: Version,
     },
     Output(io::Error),
+    Cancelled,
+    AuthorizationDeclined,
+    AuthorizationUnavailable(Option<i32>),
+    OfferChanged {
+        expected_version: String,
+        expected_url: String,
+        expected_channel: crate::updates::UpdateChannel,
+        actual_version: Option<String>,
+        actual_url: Option<String>,
+        actual_channel: Option<crate::updates::UpdateChannel>,
+    },
+    ChannelChanged {
+        prepared: crate::updates::UpdateChannel,
+        current: crate::updates::UpdateChannel,
+    },
     ConfirmationRequiresTerminal,
     ConfirmationIo(io::Error),
     TargetChanged {
@@ -36,9 +58,21 @@ pub enum UpdateInstallError {
         acquired: Box<ReleaseIdentity>,
     },
     CandidatePreflightLaunch(io::Error),
+    /// Legacy CLI refusal shape retained for callers that only need the exit
+    /// status. Graphical installs use [`Self::CandidatePreflightFailedWithAdvice`].
     CandidatePreflightFailed(Option<i32>),
+    CandidatePreflightFailedWithAdvice {
+        code: Option<i32>,
+        output: String,
+        advice: Option<String>,
+    },
     InstallerLaunch(io::Error),
     InstallerFailed(Option<i32>),
+    InstallerFailedWithOutput {
+        code: Option<i32>,
+        output: String,
+        mutation_started: bool,
+    },
     InstalledIdentity(BundleAcquisitionError),
     InstalledIdentityMismatch {
         expected: Box<ReleaseIdentity>,
@@ -60,6 +94,36 @@ impl fmt::Display for UpdateInstallError {
                 "refusing to downgrade LG Buddy from {current} to {candidate}"
             ),
             Self::Output(error) => write!(formatter, "could not write upgrade output: {error}"),
+            Self::Cancelled => formatter.write_str("upgrade cancelled before installation started"),
+            Self::AuthorizationDeclined => {
+                formatter.write_str("upgrade authorization was declined")
+            }
+            Self::AuthorizationUnavailable(code) => write!(
+                formatter,
+                "upgrade authorization was unavailable{}",
+                render_exit_code(*code)
+            ),
+            Self::OfferChanged {
+                expected_version,
+                expected_url,
+                expected_channel,
+                actual_version,
+                actual_url,
+                actual_channel,
+            } => write!(
+                formatter,
+                "the offered release changed (expected {expected_version} ({}) at {expected_url}, found {} ({}) at {})",
+                expected_channel.as_str(),
+                actual_version.as_deref().unwrap_or("no update"),
+                actual_channel.map_or("unknown channel", |channel| channel.as_str()),
+                actual_url.as_deref().unwrap_or("unknown URL")
+            ),
+            Self::ChannelChanged { prepared, current } => write!(
+                formatter,
+                "saved update channel changed after confirmation (prepared {}, current {})",
+                prepared.as_str(),
+                current.as_str()
+            ),
             Self::ConfirmationRequiresTerminal => write!(
                 formatter,
                 "upgrade confirmation requires an interactive terminal"
@@ -82,6 +146,13 @@ impl fmt::Display for UpdateInstallError {
                 "candidate upgrade preflight refused the host{}",
                 render_exit_code(*code)
             ),
+            Self::CandidatePreflightFailedWithAdvice { code, output, .. } => {
+                write!(formatter, "candidate upgrade preflight refused the host{}", render_exit_code(*code))?;
+                if !output.is_empty() {
+                    write!(formatter, ": {output}")?;
+                }
+                Ok(())
+            }
             Self::InstallerLaunch(error) => {
                 write!(formatter, "could not start the verified upgrade installer: {error}")
             }
@@ -90,6 +161,26 @@ impl fmt::Display for UpdateInstallError {
                 "verified upgrade installer failed{}",
                 render_exit_code(*code)
             ),
+            Self::InstallerFailedWithOutput {
+                code,
+                output,
+                mutation_started,
+            } => {
+                write!(
+                    formatter,
+                    "verified upgrade installer failed{}{}",
+                    render_exit_code(*code),
+                    if *mutation_started {
+                        " after installation changes began"
+                    } else {
+                        " before installation changes began"
+                    }
+                )?;
+                if !output.is_empty() {
+                    write!(formatter, ": {output}")?;
+                }
+                Ok(())
+            }
             Self::InstalledIdentity(error) => {
                 write!(formatter, "installed release identity verification failed: {error}")
             }
@@ -114,11 +205,106 @@ impl Error for UpdateInstallError {
             Self::InstalledIdentity(error) => Some(error),
             Self::InitialPreflight(_)
             | Self::DowngradeRefused { .. }
+            | Self::Cancelled
+            | Self::AuthorizationDeclined
+            | Self::AuthorizationUnavailable(_)
+            | Self::OfferChanged { .. }
+            | Self::ChannelChanged { .. }
             | Self::ConfirmationRequiresTerminal
             | Self::TargetChanged { .. }
             | Self::CandidatePreflightFailed(_)
+            | Self::CandidatePreflightFailedWithAdvice { .. }
             | Self::InstallerFailed(_)
+            | Self::InstallerFailedWithOutput { .. }
             | Self::InstalledIdentityMismatch { .. } => None,
+        }
+    }
+}
+
+impl UpdateInstallError {
+    /// A bounded, user-facing explanation that omits host paths and command
+    /// output. The `Display` implementation remains the diagnostic detail.
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::InitialPreflight(report) => {
+                let details = report
+                    .failures()
+                    .iter()
+                    .map(|failure| format!("{}: {}", failure.check, failure.remedy))
+                    .collect::<Vec<_>>();
+                if details.is_empty() {
+                    "This host is not ready for an LG Buddy upgrade.".to_string()
+                } else {
+                    format!(
+                        "This host is not ready for an LG Buddy upgrade: {}",
+                        details.join("; ")
+                    )
+                }
+            }
+            Self::Cancelled => "The upgrade was cancelled before installation started.".to_string(),
+            Self::AuthorizationDeclined => {
+                "Administrator authorization was declined; the upgrade was not installed."
+                    .to_string()
+            }
+            Self::AuthorizationUnavailable(_) => {
+                "The desktop authorization agent could not authorize the update. Start LG Buddy from a normal desktop session and try again.".to_string()
+            }
+            Self::OfferChanged { .. } | Self::ChannelChanged { .. } => {
+                "The offered update changed before installation. Check for updates again."
+                    .to_string()
+            }
+            Self::CandidatePreflightFailed(_) => {
+                "The downloaded update failed the host compatibility checks.".to_string()
+            }
+            Self::CandidatePreflightFailedWithAdvice { advice, .. } => {
+                if let Some(advice) = advice {
+                    format!(
+                        "The downloaded update failed the host compatibility checks. Details: {}",
+                        advice.replace('\n', "; ")
+                    )
+                } else {
+                    "The downloaded update failed the host compatibility checks.".to_string()
+                }
+            }
+            Self::CandidatePreflightLaunch(_) => {
+                "The downloaded update could not run its host compatibility checks.".to_string()
+            }
+            Self::InstallerFailed(_) => {
+                "The update installer could not complete; the installation may be partial."
+                    .to_string()
+            }
+            Self::InstallerLaunch(_) => {
+                "The update installer could not be started, so installed files were not changed. Check that the verified bundle is executable and retry.".to_string()
+            }
+            Self::InstallerFailedWithOutput {
+                mutation_started, ..
+            } if *mutation_started => {
+                "The update installer failed after installation changes began. The installation may be partial; correct the reported problem before retrying."
+                    .to_string()
+            }
+            Self::InstallerFailedWithOutput { .. } => {
+                "The update installer could not complete before changing installed files. Check the reported installer problem and retry."
+                    .to_string()
+            }
+            Self::InstalledIdentity(_) | Self::InstalledIdentityMismatch { .. } => {
+                "The installed files did not match the verified update identity.".to_string()
+            }
+            Self::TargetChanged { .. } => {
+                "The verified update changed before installation. Check for updates again."
+                    .to_string()
+            }
+            Self::ConfirmationRequiresTerminal | Self::ConfirmationIo(_) => {
+                "The update requires explicit confirmation in a terminal.".to_string()
+            }
+            Self::DowngradeRefused { .. } => {
+                "The available release is older than the installed version.".to_string()
+            }
+            Self::InvalidCurrentVersion { .. } => {
+                "The installed LG Buddy version could not be compared.".to_string()
+            }
+            Self::Updates(_) => "The release information could not be retrieved.".to_string(),
+            Self::Bundle(_) => "The release bundle could not be verified.".to_string(),
+            Self::Output(_) => "The upgrade result could not be reported.".to_string(),
         }
     }
 }
@@ -126,6 +312,220 @@ impl Error for UpdateInstallError {
 fn render_exit_code(code: Option<i32>) -> String {
     code.map(|code| format!(" with exit status {code}"))
         .unwrap_or_else(|| " after termination by signal".to_string())
+}
+
+const INSTALL_CANCELLATION_ACTIVE: u8 = 0;
+const INSTALL_CANCELLATION_CLAIMED: u8 = 1;
+const INSTALL_CANCELLATION_CANCELLED: u8 = 2;
+
+/// Cancellation shared by update-install workers.
+#[derive(Debug, Clone)]
+pub struct UpdateInstallCancellation {
+    state: Arc<AtomicU8>,
+}
+
+impl Default for UpdateInstallCancellation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl UpdateInstallCancellation {
+    pub fn new() -> Self {
+        Self {
+            state: Arc::new(AtomicU8::new(INSTALL_CANCELLATION_ACTIVE)),
+        }
+    }
+
+    /// Request cancellation. Returns false once cancellation was requested or
+    /// the installer boundary has been claimed.
+    pub fn cancel(&self) -> bool {
+        self.state
+            .compare_exchange(
+                INSTALL_CANCELLATION_ACTIVE,
+                INSTALL_CANCELLATION_CANCELLED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.state.load(Ordering::Acquire) == INSTALL_CANCELLATION_CANCELLED
+    }
+
+    pub fn can_cancel(&self) -> bool {
+        self.state.load(Ordering::Acquire) == INSTALL_CANCELLATION_ACTIVE
+    }
+
+    fn ensure_active(&self) -> Result<(), UpdateInstallError> {
+        if self.is_cancelled() {
+            Err(UpdateInstallError::Cancelled)
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Claim the point of no cancellation before invoking an installer.
+    ///
+    /// A successful claim makes subsequent [`Self::cancel`] calls return
+    /// `false`; callers must invoke this immediately before the operation that
+    /// may mutate the host.
+    pub fn claim_installer_boundary(&self) -> Result<(), UpdateInstallError> {
+        match self.state.compare_exchange(
+            INSTALL_CANCELLATION_ACTIVE,
+            INSTALL_CANCELLATION_CLAIMED,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => Ok(()),
+            Err(INSTALL_CANCELLATION_CANCELLED) => Err(UpdateInstallError::Cancelled),
+            Err(INSTALL_CANCELLATION_CLAIMED) => Err(UpdateInstallError::Cancelled),
+            Err(_) => Err(UpdateInstallError::Cancelled),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateInstallStage {
+    InitialPreflight,
+    Discovering,
+    Resolving,
+    Offered,
+    Acquiring,
+    CandidatePreflight,
+    Installing,
+    VerifyingInstalled,
+}
+
+/// A release offer whose identity was resolved before the user confirms it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedUpdateInstall {
+    current: VersionInfo,
+    release: ReleaseInfo,
+    target: ReleaseIdentity,
+    channel: UpdateChannel,
+}
+
+impl PreparedUpdateInstall {
+    /// Construct a typed offer for a non-networking caller or test fixture.
+    /// Production callers should prefer [`prepare_gui_update`].
+    pub fn from_parts(
+        current: VersionInfo,
+        version: Version,
+        channel: crate::updates::UpdateChannel,
+        url: impl Into<String>,
+        release_tag: impl Into<String>,
+        target: impl Into<String>,
+        commit: impl Into<String>,
+    ) -> Self {
+        let release_channel = if version.pre.is_empty() {
+            UpdateChannel::Stable
+        } else {
+            UpdateChannel::Prerelease
+        };
+        let release = ReleaseInfo::from_github(
+            version.clone(),
+            release_channel,
+            url.into(),
+            release_tag.into(),
+            Vec::new(),
+        );
+        let target = ReleaseIdentity::from_parts(
+            release.tag_name().to_string(),
+            version,
+            release_channel,
+            target,
+            commit,
+        );
+        Self {
+            current,
+            release,
+            target,
+            channel,
+        }
+    }
+
+    pub fn identity(&self) -> &ReleaseIdentity {
+        &self.target
+    }
+
+    pub fn current(&self) -> VersionInfo {
+        self.current
+    }
+
+    pub fn release(&self) -> &ReleaseInfo {
+        &self.release
+    }
+
+    pub fn target(&self) -> &ReleaseIdentity {
+        &self.target
+    }
+
+    pub fn channel(&self) -> crate::updates::UpdateChannel {
+        self.channel
+    }
+
+    pub fn release_channel(&self) -> crate::updates::UpdateChannel {
+        self.release.channel()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstalledUpdate {
+    identity: ReleaseIdentity,
+    gui_identity: ReleaseIdentity,
+    runtime_path: PathBuf,
+    gui_path: PathBuf,
+}
+
+impl InstalledUpdate {
+    /// Construct an installed-result record for a non-networking caller or
+    /// test fixture. Production callers receive this only after verification.
+    pub fn from_parts(
+        version: Version,
+        channel: crate::updates::UpdateChannel,
+        release_tag: impl Into<String>,
+        target: impl Into<String>,
+        commit: impl Into<String>,
+        runtime_path: impl Into<PathBuf>,
+        gui_path: impl Into<PathBuf>,
+    ) -> Self {
+        let release_tag = release_tag.into();
+        let target = target.into();
+        let commit = commit.into();
+        let identity = ReleaseIdentity::from_parts(
+            release_tag.clone(),
+            version.clone(),
+            channel,
+            target,
+            commit.clone(),
+        );
+        let gui_identity =
+            ReleaseIdentity::from_parts(release_tag, version, channel, GUI_TARGET, commit);
+        Self {
+            identity,
+            gui_identity,
+            runtime_path: runtime_path.into(),
+            gui_path: gui_path.into(),
+        }
+    }
+
+    pub fn identity(&self) -> &ReleaseIdentity {
+        &self.identity
+    }
+
+    pub fn gui_identity(&self) -> &ReleaseIdentity {
+        &self.gui_identity
+    }
+
+    pub fn runtime_path(&self) -> &Path {
+        &self.runtime_path
+    }
+
+    pub fn gui_path(&self) -> &Path {
+        &self.gui_path
+    }
 }
 
 trait BundleView {
@@ -142,10 +542,12 @@ trait UpdateInstallRuntime {
     type Bundle: BundleView;
 
     fn current_version(&mut self) -> VersionInfo;
+    fn current_channel(&mut self) -> Result<crate::updates::UpdateChannel, UpdateInstallError>;
     fn initial_preflight(&mut self) -> Result<(), UpdateInstallError>;
     fn discover_candidate(
         &mut self,
         current: VersionInfo,
+        channel: UpdateChannel,
     ) -> Result<ReleaseInfo, UpdateInstallError>;
     fn resolve_target(
         &mut self,
@@ -153,15 +555,20 @@ trait UpdateInstallRuntime {
     ) -> Result<ReleaseIdentity, UpdateInstallError>;
     fn confirm(&mut self) -> Result<bool, UpdateInstallError>;
     fn acquire(&mut self, release: &ReleaseInfo) -> Result<Self::Bundle, UpdateInstallError>;
+    fn recheck_installed_state(&mut self) -> Result<(), UpdateInstallError> {
+        Ok(())
+    }
     fn candidate_preflight(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError>;
     fn run_installer(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError>;
-    fn installed_identity(
+    fn installed_update(
         &mut self,
         expected: &ReleaseIdentity,
-    ) -> Result<ReleaseIdentity, UpdateInstallError>;
+    ) -> Result<InstalledUpdate, UpdateInstallError>;
 }
 
-struct SystemUpdateInstallRuntime;
+struct SystemUpdateInstallRuntime {
+    require_gui: bool,
+}
 
 impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
     type Bundle = VerifiedReleaseBundle;
@@ -170,8 +577,16 @@ impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
         VersionInfo::current()
     }
 
+    fn current_channel(&mut self) -> Result<crate::updates::UpdateChannel, UpdateInstallError> {
+        crate::updates::saved_update_channel().map_err(UpdateInstallError::Updates)
+    }
+
     fn initial_preflight(&mut self) -> Result<(), UpdateInstallError> {
-        let report = current_host_preflight();
+        let report = if self.require_gui {
+            crate::upgrade_preflight::current_gui_host_preflight()
+        } else {
+            current_host_preflight()
+        };
         if report.compatible() {
             Ok(())
         } else {
@@ -182,8 +597,10 @@ impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
     fn discover_candidate(
         &mut self,
         current: VersionInfo,
+        channel: UpdateChannel,
     ) -> Result<ReleaseInfo, UpdateInstallError> {
-        discover_install_candidate(current).map_err(UpdateInstallError::Updates)
+        discover_install_candidate_for_channel(current, channel)
+            .map_err(UpdateInstallError::Updates)
     }
 
     fn resolve_target(
@@ -191,6 +608,10 @@ impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
         release: &ReleaseInfo,
     ) -> Result<ReleaseIdentity, UpdateInstallError> {
         resolve_release_identity(release).map_err(UpdateInstallError::Bundle)
+    }
+
+    fn recheck_installed_state(&mut self) -> Result<(), UpdateInstallError> {
+        self.initial_preflight()
     }
 
     fn confirm(&mut self) -> Result<bool, UpdateInstallError> {
@@ -210,42 +631,236 @@ impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
     }
 
     fn candidate_preflight(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError> {
-        let status = candidate_preflight_command(bundle.root())
-            .status()
-            .map_err(UpdateInstallError::CandidatePreflightLaunch)?;
-        if status.success() {
-            Ok(())
+        if self.require_gui {
+            let output = run_bounded_command(candidate_preflight_command_with_json(bundle.root()))
+                .map_err(UpdateInstallError::CandidatePreflightLaunch)?;
+            if output.status.success() {
+                Ok(())
+            } else {
+                let (output, advice) = candidate_preflight_failure(&output);
+                Err(UpdateInstallError::CandidatePreflightFailedWithAdvice {
+                    code: output.0,
+                    output: output.1,
+                    advice,
+                })
+            }
         } else {
-            Err(UpdateInstallError::CandidatePreflightFailed(status.code()))
+            let status = candidate_preflight_command(bundle.root())
+                .status()
+                .map_err(UpdateInstallError::CandidatePreflightLaunch)?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(UpdateInstallError::CandidatePreflightFailed(status.code()))
+            }
         }
     }
 
     fn run_installer(&mut self, bundle: &Self::Bundle) -> Result<(), UpdateInstallError> {
-        let status = installer_command(bundle.root())
-            .status()
-            .map_err(UpdateInstallError::InstallerLaunch)?;
-        if status.success() {
-            Ok(())
+        let mut command = if self.require_gui {
+            gui_installer_command(bundle.root())
         } else {
-            Err(UpdateInstallError::InstallerFailed(status.code()))
+            installer_command(bundle.root())
+        };
+        if self.require_gui {
+            let output =
+                run_bounded_command(command).map_err(UpdateInstallError::InstallerLaunch)?;
+            classify_gui_installer_output(&output)
+        } else {
+            let status = command
+                .status()
+                .map_err(UpdateInstallError::InstallerLaunch)?;
+            if status.success() {
+                Ok(())
+            } else {
+                Err(UpdateInstallError::InstallerFailed(status.code()))
+            }
         }
     }
 
-    fn installed_identity(
+    fn installed_update(
         &mut self,
         expected: &ReleaseIdentity,
-    ) -> Result<ReleaseIdentity, UpdateInstallError> {
-        let identity = verify_release_binary_identity(&installed_binary_path(), expected)
+    ) -> Result<InstalledUpdate, UpdateInstallError> {
+        let runtime_path = installed_binary_path();
+        let gui_path = installed_gui_binary_path();
+        let identity = verify_release_binary_identity(&runtime_path, expected)
             .map_err(UpdateInstallError::InstalledIdentity)?;
-        verify_release_gui_binary_identity(&installed_gui_binary_path(), expected)
+        let gui_identity = verify_release_gui_binary_identity(&gui_path, expected)
             .map_err(UpdateInstallError::InstalledIdentity)?;
-        Ok(identity)
+        Ok(InstalledUpdate {
+            identity,
+            gui_identity,
+            runtime_path,
+            gui_path,
+        })
     }
+}
+
+/// Prepare a GUI-triggered update from the offer that is currently displayed.
+/// The release is discovered again and must still match the displayed version,
+/// URL, and channel before a prepared install is returned.
+pub fn prepare_gui_update(
+    expected_version: &str,
+    expected_url: &str,
+    expected_channel: crate::updates::UpdateChannel,
+) -> Result<PreparedUpdateInstall, UpdateInstallError> {
+    let cancellation = UpdateInstallCancellation::new();
+    let mut runtime = SystemUpdateInstallRuntime { require_gui: true };
+    let current = runtime.current_version();
+    let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)?;
+    let Some(prepared) = prepared else {
+        return Err(UpdateInstallError::OfferChanged {
+            expected_version: expected_version.to_string(),
+            expected_url: expected_url.to_string(),
+            expected_channel,
+            actual_version: None,
+            actual_url: None,
+            actual_channel: None,
+        });
+    };
+    if prepared.release.version().to_string() != expected_version
+        || prepared.release.url() != expected_url
+        || prepared.channel() != expected_channel
+    {
+        return Err(UpdateInstallError::OfferChanged {
+            expected_version: expected_version.to_string(),
+            expected_url: expected_url.to_string(),
+            expected_channel,
+            actual_version: Some(prepared.release.version().to_string()),
+            actual_url: Some(prepared.release.url().to_string()),
+            actual_channel: Some(prepared.channel()),
+        });
+    }
+    Ok(prepared)
+}
+
+/// Install a previously prepared and explicitly confirmed GUI update.
+pub fn install_gui_update(
+    prepared: &PreparedUpdateInstall,
+    cancellation: &UpdateInstallCancellation,
+    progress: &mut dyn FnMut(UpdateInstallStage),
+) -> Result<InstalledUpdate, UpdateInstallError> {
+    let mut runtime = SystemUpdateInstallRuntime { require_gui: true };
+    install_prepared_update_with(prepared, &mut runtime, cancellation, progress)
+}
+
+fn prepare_update_install_with<R: UpdateInstallRuntime>(
+    runtime: &mut R,
+    cancellation: &UpdateInstallCancellation,
+    current: VersionInfo,
+) -> Result<Option<PreparedUpdateInstall>, UpdateInstallError> {
+    cancellation.ensure_active()?;
+    runtime.initial_preflight()?;
+    cancellation.ensure_active()?;
+    let current_version = Version::parse(current.version()).map_err(|source| {
+        UpdateInstallError::InvalidCurrentVersion {
+            version: current.version().to_string(),
+            source,
+        }
+    })?;
+    let channel = runtime.current_channel()?;
+    let release = runtime.discover_candidate(current, channel)?;
+    cancellation.ensure_active()?;
+
+    match release.version().cmp(&current_version) {
+        std::cmp::Ordering::Equal => return Ok(None),
+        std::cmp::Ordering::Less => {
+            return Err(UpdateInstallError::DowngradeRefused {
+                current: current_version,
+                candidate: release.version().clone(),
+            });
+        }
+        std::cmp::Ordering::Greater => {}
+    }
+
+    let target = runtime.resolve_target(&release)?;
+    cancellation.ensure_active()?;
+    Ok(Some(PreparedUpdateInstall {
+        current,
+        release,
+        target,
+        channel,
+    }))
+}
+
+fn install_prepared_update_with<R: UpdateInstallRuntime>(
+    prepared: &PreparedUpdateInstall,
+    runtime: &mut R,
+    cancellation: &UpdateInstallCancellation,
+    progress: &mut dyn FnMut(UpdateInstallStage),
+) -> Result<InstalledUpdate, UpdateInstallError> {
+    cancellation.ensure_active()?;
+    let current_channel = runtime.current_channel()?;
+    if current_channel != prepared.channel() {
+        return Err(UpdateInstallError::ChannelChanged {
+            prepared: prepared.channel(),
+            current: current_channel,
+        });
+    }
+    cancellation.ensure_active()?;
+
+    progress(UpdateInstallStage::Acquiring);
+    cancellation.ensure_active()?;
+    let bundle = runtime.acquire(prepared.release())?;
+    cancellation.ensure_active()?;
+    if bundle.identity() != prepared.target() {
+        return Err(UpdateInstallError::TargetChanged {
+            confirmed: Box::new(prepared.target().clone()),
+            acquired: Box::new(bundle.identity().clone()),
+        });
+    }
+
+    // The confirmation may have been held while another process changed the
+    // installed layout. Recheck it while the verified bundle remains alive so
+    // stale offers cannot proceed to candidate checks or installation.
+    runtime.recheck_installed_state()?;
+    cancellation.ensure_active()?;
+
+    progress(UpdateInstallStage::CandidatePreflight);
+    cancellation.ensure_active()?;
+    runtime.candidate_preflight(&bundle)?;
+    cancellation.ensure_active()?;
+
+    // This compare-exchange is the final cancellation boundary. Once it wins,
+    // cancellation returns false and the installer may mutate the host.
+    cancellation.claim_installer_boundary()?;
+    progress(UpdateInstallStage::Installing);
+    runtime.run_installer(&bundle)?;
+
+    progress(UpdateInstallStage::VerifyingInstalled);
+    let installed = runtime.installed_update(bundle.identity())?;
+    if installed.identity() != bundle.identity() {
+        return Err(UpdateInstallError::InstalledIdentityMismatch {
+            expected: Box::new(bundle.identity().clone()),
+            observed: Box::new(installed.identity().clone()),
+        });
+    }
+    let expected_gui = ReleaseIdentity::from_parts(
+        bundle.identity().release_tag().to_string(),
+        bundle.identity().version().clone(),
+        bundle.identity().channel(),
+        GUI_TARGET,
+        bundle.identity().commit().to_string(),
+    );
+    if installed.gui_identity() != &expected_gui {
+        return Err(UpdateInstallError::InstalledIdentityMismatch {
+            expected: Box::new(expected_gui),
+            observed: Box::new(installed.gui_identity().clone()),
+        });
+    }
+    Ok(installed)
 }
 
 fn candidate_preflight_command(candidate_root: &Path) -> Command {
     let mut command = Command::new(candidate_root.join("lg-buddy"));
     command.arg("upgrade-preflight").arg(candidate_root);
+    command
+}
+
+fn candidate_preflight_command_with_json(candidate_root: &Path) -> Command {
+    let mut command = candidate_preflight_command(candidate_root);
+    command.arg("--json");
     command
 }
 
@@ -255,8 +870,208 @@ fn installer_command(candidate_root: &Path) -> Command {
     command
 }
 
+fn gui_installer_command(candidate_root: &Path) -> Command {
+    let mut command = installer_command(candidate_root);
+    command
+        .env("LG_BUDDY_AUTO_INSTALL_DEPS", "n")
+        .env("LG_BUDDY_NONINTERACTIVE", "1")
+        .env("LG_BUDDY_SUDO_CMD", "pkexec")
+        .stdin(Stdio::null());
+    // The install-root override is the supported isolated-install test
+    // environment. Outside it, inherited test/debug switches must not allow a
+    // graphical upgrade to publish without system integration actions.
+    if std::env::var_os("LG_BUDDY_INSTALL_ROOT").is_none() {
+        command
+            .env("LG_BUDDY_SKIP_SYSTEMD_ACTIONS", "0")
+            .env("LG_BUDDY_SKIP_PIP_INSTALL", "0");
+    }
+    command
+}
+
+fn installer_mutation_started(output: &str) -> bool {
+    output
+        .lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .any(|line| line == "LG_BUDDY_INSTALL_STATUS=mutation_started")
+}
+
+fn classify_gui_installer_output(output: &BoundedCommandOutput) -> Result<(), UpdateInstallError> {
+    if output.status.success() {
+        return Ok(());
+    }
+    let mutation_started =
+        output.stdout_mutation_started || installer_mutation_started(&output.stdout);
+    if !mutation_started && output.status.code() == Some(126) {
+        Err(UpdateInstallError::AuthorizationDeclined)
+    } else if !mutation_started && output.status.code() == Some(127) {
+        Err(UpdateInstallError::AuthorizationUnavailable(
+            output.status.code(),
+        ))
+    } else {
+        Err(UpdateInstallError::InstallerFailedWithOutput {
+            code: output.status.code(),
+            mutation_started,
+            output: output.diagnostic(),
+        })
+    }
+}
+
 fn confirmation_is_yes(answer: &str) -> bool {
     answer.trim() == "yes"
+}
+
+const MAX_CANDIDATE_PREFLIGHT_OUTPUT_BYTES: usize = 64 * 1024;
+
+struct BoundedCommandOutput {
+    status: ExitStatus,
+    stdout: String,
+    stderr: String,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+    stdout_mutation_started: bool,
+}
+
+impl BoundedCommandOutput {
+    fn diagnostic(&self) -> String {
+        bounded_combined_text(
+            &self.stdout,
+            &self.stderr,
+            self.stdout_truncated || self.stderr_truncated,
+        )
+    }
+}
+
+/// Run a diagnostic subprocess while draining both pipes. Each reader keeps
+/// only a bounded prefix, so a noisy candidate cannot exhaust memory or block
+/// waiting for the other pipe to be drained.
+fn run_bounded_command(mut command: Command) -> io::Result<BoundedCommandOutput> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().expect("piped stdout");
+    let stderr = child.stderr.take().expect("piped stderr");
+    let stdout_reader = thread::spawn(|| read_bounded(stdout));
+    let stderr_reader = thread::spawn(|| read_bounded(stderr));
+    let status = child.wait()?;
+    let (stdout, stdout_truncated, stdout_mutation_started) = join_bounded_reader(stdout_reader)?;
+    let (stderr, stderr_truncated, _) = join_bounded_reader(stderr_reader)?;
+
+    Ok(BoundedCommandOutput {
+        status,
+        stdout: String::from_utf8_lossy(&stdout).trim().to_string(),
+        stderr: String::from_utf8_lossy(&stderr).trim().to_string(),
+        stdout_truncated,
+        stderr_truncated,
+        stdout_mutation_started,
+    })
+}
+
+const INSTALL_MUTATION_STATUS: &[u8] = b"LG_BUDDY_INSTALL_STATUS=mutation_started";
+
+fn read_bounded(mut reader: impl Read) -> io::Result<(Vec<u8>, bool, bool)> {
+    let mut bytes = Vec::new();
+    let mut buffer = [0u8; 8192];
+    let mut truncated = false;
+    let mut line = Vec::new();
+    let mut mutation_started = false;
+    loop {
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            if line == INSTALL_MUTATION_STATUS
+                || (line.last() == Some(&b'\r')
+                    && line[..line.len() - 1] == INSTALL_MUTATION_STATUS[..])
+            {
+                mutation_started = true;
+            }
+            break;
+        }
+        for byte in &buffer[..read] {
+            if *byte == b'\n' {
+                if line == INSTALL_MUTATION_STATUS
+                    || (line.last() == Some(&b'\r')
+                        && line[..line.len() - 1] == INSTALL_MUTATION_STATUS[..])
+                {
+                    mutation_started = true;
+                }
+                line.clear();
+            } else if line.len() <= INSTALL_MUTATION_STATUS.len() {
+                line.push(*byte);
+            }
+        }
+        let remaining = MAX_CANDIDATE_PREFLIGHT_OUTPUT_BYTES.saturating_sub(bytes.len());
+        if remaining > 0 {
+            let keep = read.min(remaining);
+            bytes.extend_from_slice(&buffer[..keep]);
+            truncated |= keep < read;
+        } else {
+            truncated = true;
+        }
+    }
+    Ok((bytes, truncated, mutation_started))
+}
+
+fn join_bounded_reader(
+    reader: thread::JoinHandle<io::Result<(Vec<u8>, bool, bool)>>,
+) -> io::Result<(Vec<u8>, bool, bool)> {
+    reader
+        .join()
+        .map_err(|_| io::Error::other("bounded output reader panicked"))?
+}
+
+fn candidate_preflight_failure(
+    output: &BoundedCommandOutput,
+) -> ((Option<i32>, String), Option<String>) {
+    let advice = serde_json::from_str::<CompatibilityAdvice>(&output.stdout).ok();
+    let safe_advice = advice
+        .as_ref()
+        .filter(|advice| !advice.compatible && !advice.failures.is_empty())
+        .map(|advice| {
+            advice
+                .failures
+                .iter()
+                .map(|failure| format!("- {} Remedy: {}", failure.check, failure.remedy))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .unwrap_or_default();
+    let advice = (!safe_advice.is_empty()).then_some(safe_advice.clone());
+    let diagnostic = if output.stderr.is_empty() {
+        if advice.is_none() {
+            output.stdout.as_str()
+        } else {
+            ""
+        }
+    } else {
+        output.stderr.as_str()
+    };
+    let diagnostic = if !safe_advice.is_empty() && !diagnostic.is_empty() {
+        format!("[candidate diagnostic]\n{diagnostic}")
+    } else {
+        diagnostic.to_string()
+    };
+    let diagnostic = bounded_combined_text(
+        &safe_advice,
+        &diagnostic,
+        output.stdout_truncated || output.stderr_truncated,
+    );
+    ((output.status.code(), diagnostic), advice)
+}
+
+fn bounded_combined_text(first: &str, second: &str, source_truncated: bool) -> String {
+    let mut bytes = Vec::with_capacity(first.len() + second.len() + 1);
+    bytes.extend_from_slice(first.as_bytes());
+    if !first.is_empty() && !second.is_empty() {
+        bytes.push(b'\n');
+    }
+    bytes.extend_from_slice(second.as_bytes());
+    let truncated = source_truncated || bytes.len() > MAX_CANDIDATE_PREFLIGHT_OUTPUT_BYTES;
+    bytes.truncate(MAX_CANDIDATE_PREFLIGHT_OUTPUT_BYTES);
+    let mut text = String::from_utf8_lossy(&bytes).trim().to_string();
+    if truncated {
+        text.push_str(" [output truncated]");
+    }
+    text
 }
 
 fn installed_binary_path() -> PathBuf {
@@ -280,44 +1095,30 @@ fn installed_binary_path_for_root(install_root: Option<PathBuf>) -> PathBuf {
 }
 
 pub fn run_update_install<W: Write>(writer: &mut W) -> Result<(), UpdateInstallError> {
-    run_update_install_with(writer, &mut SystemUpdateInstallRuntime)
+    run_update_install_with(
+        writer,
+        &mut SystemUpdateInstallRuntime { require_gui: false },
+    )
 }
 
 fn run_update_install_with<W: Write, R: UpdateInstallRuntime>(
     writer: &mut W,
     runtime: &mut R,
 ) -> Result<(), UpdateInstallError> {
+    let cancellation = UpdateInstallCancellation::new();
     let current = runtime.current_version();
-    runtime.initial_preflight()?;
-    let current_version = Version::parse(current.version()).map_err(|source| {
-        UpdateInstallError::InvalidCurrentVersion {
-            version: current.version().to_string(),
-            source,
-        }
-    })?;
-    let release = runtime.discover_candidate(current)?;
+    let Some(prepared) = prepare_update_install_with(runtime, &cancellation, current)? else {
+        writeln!(
+            writer,
+            "LG Buddy {} ({}) is already up to date.",
+            current.version(),
+            current.channel().as_str()
+        )
+        .map_err(UpdateInstallError::Output)?;
+        return Ok(());
+    };
 
-    match release.version().cmp(&current_version) {
-        std::cmp::Ordering::Equal => {
-            writeln!(
-                writer,
-                "LG Buddy {} ({}) is already up to date.",
-                current.version(),
-                current.channel().as_str()
-            )
-            .map_err(UpdateInstallError::Output)?;
-            return Ok(());
-        }
-        std::cmp::Ordering::Less => {
-            return Err(UpdateInstallError::DowngradeRefused {
-                current: current_version,
-                candidate: release.version().clone(),
-            });
-        }
-        std::cmp::Ordering::Greater => {}
-    }
-
-    let confirmed_target = runtime.resolve_target(&release)?;
+    let current = prepared.current();
     writeln!(
         writer,
         "Current: {} ({}, commit {})",
@@ -329,12 +1130,13 @@ fn run_update_install_with<W: Write, R: UpdateInstallRuntime>(
     writeln!(
         writer,
         "Target: {} ({}, commit {})",
-        confirmed_target.version(),
-        confirmed_target.channel().as_str(),
-        confirmed_target.commit()
+        prepared.target().version(),
+        prepared.target().channel().as_str(),
+        prepared.target().commit()
     )
     .map_err(UpdateInstallError::Output)?;
-    writeln!(writer, "Release: {}", release.url()).map_err(UpdateInstallError::Output)?;
+    writeln!(writer, "Release: {}", prepared.release().url())
+        .map_err(UpdateInstallError::Output)?;
     write!(writer, "Type `yes` to install this update: ").map_err(UpdateInstallError::Output)?;
     writer.flush().map_err(UpdateInstallError::Output)?;
 
@@ -343,28 +1145,13 @@ fn run_update_install_with<W: Write, R: UpdateInstallRuntime>(
         return Ok(());
     }
 
-    let bundle = runtime.acquire(&release)?;
-    if bundle.identity() != &confirmed_target {
-        return Err(UpdateInstallError::TargetChanged {
-            confirmed: Box::new(confirmed_target),
-            acquired: Box::new(bundle.identity().clone()),
-        });
-    }
-    runtime.candidate_preflight(&bundle)?;
-    runtime.run_installer(&bundle)?;
-    let installed = runtime.installed_identity(bundle.identity())?;
-    if &installed != bundle.identity() {
-        return Err(UpdateInstallError::InstalledIdentityMismatch {
-            expected: Box::new(bundle.identity().clone()),
-            observed: Box::new(installed),
-        });
-    }
+    let installed = install_prepared_update_with(&prepared, runtime, &cancellation, &mut |_| {})?;
     writeln!(
         writer,
         "Installed: {} ({}, commit {})",
-        installed.version(),
-        installed.channel().as_str(),
-        installed.commit()
+        installed.identity().version(),
+        installed.identity().channel().as_str(),
+        installed.identity().commit()
     )
     .map_err(UpdateInstallError::Output)?;
     Ok(())
@@ -373,9 +1160,11 @@ fn run_update_install_with<W: Write, R: UpdateInstallRuntime>(
 #[cfg(test)]
 mod tests {
     use super::{
-        candidate_preflight_command, confirmation_is_yes, installed_binary_path_for_root,
-        installer_command, run_update_install_with, BundleView, UpdateInstallError,
-        UpdateInstallRuntime,
+        candidate_preflight_command, classify_gui_installer_output, confirmation_is_yes,
+        install_prepared_update_with, installed_binary_path_for_root, installer_command,
+        prepare_update_install_with, run_bounded_command, run_update_install_with, BundleView,
+        CompatibilityReport, InstalledUpdate, UpdateInstallCancellation, UpdateInstallError,
+        UpdateInstallRuntime, UpdateInstallStage, GUI_TARGET,
     };
     use crate::release_bundle::{BundleAcquisitionError, ReleaseIdentity};
     use crate::updates::{ReleaseInfo, UpdateChannel};
@@ -384,6 +1173,7 @@ mod tests {
     use std::cell::RefCell;
     use std::ffi::OsStr;
     use std::path::{Path, PathBuf};
+    use std::process::Command;
     use std::rc::Rc;
 
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -395,6 +1185,7 @@ mod tests {
         CandidatePreflight,
         Installer,
         InstalledIdentity,
+        Recheck,
     }
 
     struct FakeBundle {
@@ -418,8 +1209,10 @@ mod tests {
         events: Rc<RefCell<Vec<&'static str>>>,
         current_version: &'static str,
         candidate_version: &'static str,
+        saved_channel: UpdateChannel,
         confirmed: bool,
         failure: Option<Failure>,
+        recheck: bool,
         resolved_identity: ReleaseIdentity,
         acquired_identity: ReleaseIdentity,
         installed_identity: ReleaseIdentity,
@@ -433,8 +1226,10 @@ mod tests {
                 events,
                 current_version: "1.4.0",
                 candidate_version,
+                saved_channel: UpdateChannel::Stable,
                 confirmed: true,
                 failure: None,
+                recheck: false,
                 resolved_identity: identity.clone(),
                 acquired_identity: identity.clone(),
                 installed_identity: identity,
@@ -458,6 +1253,10 @@ mod tests {
             )
         }
 
+        fn current_channel(&mut self) -> Result<UpdateChannel, UpdateInstallError> {
+            Ok(self.saved_channel)
+        }
+
         fn initial_preflight(&mut self) -> Result<(), UpdateInstallError> {
             self.events.borrow_mut().push("initial_preflight");
             if self.failure == Some(Failure::Initial) {
@@ -470,6 +1269,7 @@ mod tests {
         fn discover_candidate(
             &mut self,
             _current: VersionInfo,
+            _channel: UpdateChannel,
         ) -> Result<ReleaseInfo, UpdateInstallError> {
             self.events.borrow_mut().push("discover");
             Ok(ReleaseInfo::from_github(
@@ -516,6 +1316,18 @@ mod tests {
             }
         }
 
+        fn recheck_installed_state(&mut self) -> Result<(), UpdateInstallError> {
+            if self.recheck {
+                self.events.borrow_mut().push("recheck");
+                if self.failure == Some(Failure::Recheck) {
+                    return Err(UpdateInstallError::InitialPreflight(
+                        CompatibilityReport::default(),
+                    ));
+                }
+            }
+            Ok(())
+        }
+
         fn candidate_preflight(
             &mut self,
             _bundle: &Self::Bundle,
@@ -537,17 +1349,29 @@ mod tests {
             }
         }
 
-        fn installed_identity(
+        fn installed_update(
             &mut self,
             _expected: &ReleaseIdentity,
-        ) -> Result<ReleaseIdentity, UpdateInstallError> {
+        ) -> Result<InstalledUpdate, UpdateInstallError> {
             self.events.borrow_mut().push("installed_identity");
             if self.failure == Some(Failure::InstalledIdentity) {
                 Err(UpdateInstallError::InstalledIdentity(
                     BundleAcquisitionError::Binary("mismatch".to_string()),
                 ))
             } else {
-                Ok(self.installed_identity.clone())
+                let gui_identity = ReleaseIdentity::from_parts(
+                    self.installed_identity.release_tag().to_string(),
+                    self.installed_identity.version().clone(),
+                    self.installed_identity.channel(),
+                    GUI_TARGET,
+                    self.installed_identity.commit().to_string(),
+                );
+                Ok(InstalledUpdate {
+                    identity: self.installed_identity.clone(),
+                    gui_identity,
+                    runtime_path: PathBuf::from("/usr/bin/lg-buddy"),
+                    gui_path: PathBuf::from("/usr/bin/lg-buddy-gui"),
+                })
             }
         }
     }
@@ -598,6 +1422,53 @@ mod tests {
         for answer in ["", "y", "YES", "yes please", "no"] {
             assert!(!confirmation_is_yes(answer), "accepted `{answer}`");
         }
+    }
+
+    fn installer_fixture(script: &str) -> super::BoundedCommandOutput {
+        let mut command = Command::new("sh");
+        command.arg("-c").arg(script);
+        run_bounded_command(command).unwrap()
+    }
+
+    #[test]
+    fn graphical_installer_status_distinguishes_authorization_and_partial_failures() {
+        let declined = installer_fixture("exit 126");
+        assert!(matches!(
+            classify_gui_installer_output(&declined),
+            Err(UpdateInstallError::AuthorizationDeclined)
+        ));
+
+        let unavailable = installer_fixture("exit 127");
+        assert!(matches!(
+            classify_gui_installer_output(&unavailable),
+            Err(UpdateInstallError::AuthorizationUnavailable(Some(127)))
+        ));
+
+        let partial =
+            installer_fixture("printf 'LG_BUDDY_INSTALL_STATUS=mutation_started\\n'; exit 126");
+        assert!(matches!(
+            classify_gui_installer_output(&partial),
+            Err(UpdateInstallError::InstallerFailedWithOutput {
+                mutation_started: true,
+                code: Some(126),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn graphical_installer_status_is_found_after_bounded_output_prefix() {
+        let output = installer_fixture(
+            "awk 'BEGIN { for (i = 0; i < 70000; i++) printf \"x\" }'; printf '\\nLG_BUDDY_INSTALL_STATUS=mutation_started\\n'; exit 126",
+        );
+        assert!(matches!(
+            classify_gui_installer_output(&output),
+            Err(UpdateInstallError::InstallerFailedWithOutput {
+                mutation_started: true,
+                code: Some(126),
+                ..
+            })
+        ));
     }
 
     #[test]
@@ -753,6 +1624,26 @@ mod tests {
     }
 
     #[test]
+    fn installed_state_is_rechecked_after_acquisition_before_candidate_preflight() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        let cancellation = UpdateInstallCancellation::new();
+        let current = runtime.current_version();
+        let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)
+            .unwrap()
+            .unwrap();
+        runtime.events.borrow_mut().clear();
+        runtime.recheck = true;
+        runtime.failure = Some(Failure::Recheck);
+
+        let error =
+            install_prepared_update_with(&prepared, &mut runtime, &cancellation, &mut |_| {})
+                .unwrap_err();
+
+        assert!(matches!(error, UpdateInstallError::InitialPreflight(_)));
+        assert_eq!(runtime.event_names(), ["acquire", "recheck", "drop_bundle"]);
+    }
+
+    #[test]
     fn candidate_refusal_stops_before_installer() {
         let mut runtime = FakeRuntime::new("1.5.0");
         runtime.failure = Some(Failure::CandidatePreflight);
@@ -872,6 +1763,127 @@ mod tests {
         assert!(output.contains("Current: 1.4.0 (stable, commit current-commit)"));
         assert!(output.contains("Target: 1.5.0 (stable, commit target-commit)"));
         assert!(output.contains("Installed: 1.5.0 (stable, commit target-commit)"));
+    }
+
+    #[test]
+    fn prerelease_selection_can_install_a_newer_stable_release() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        runtime.saved_channel = UpdateChannel::Prerelease;
+        let mut output = Vec::new();
+
+        run_update_install_with(&mut output, &mut runtime).unwrap();
+
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("Target: 1.5.0 (stable, commit target-commit)"));
+        assert!(output.contains("Installed: 1.5.0 (stable, commit target-commit)"));
+    }
+
+    #[test]
+    fn cancellation_before_acquisition_has_no_mutating_side_effects() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        let cancellation = UpdateInstallCancellation::new();
+        let current = runtime.current_version();
+        let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)
+            .unwrap()
+            .unwrap();
+        runtime.events.borrow_mut().clear();
+        assert!(cancellation.cancel());
+
+        let error =
+            install_prepared_update_with(&prepared, &mut runtime, &cancellation, &mut |_| {})
+                .unwrap_err();
+
+        assert!(matches!(error, UpdateInstallError::Cancelled));
+        assert!(runtime.event_names().is_empty());
+    }
+
+    #[test]
+    fn cancellation_during_candidate_preflight_stops_before_installer() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        let cancellation = UpdateInstallCancellation::new();
+        let current = runtime.current_version();
+        let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)
+            .unwrap()
+            .unwrap();
+        runtime.events.borrow_mut().clear();
+        let mut stages = Vec::new();
+
+        let error =
+            install_prepared_update_with(&prepared, &mut runtime, &cancellation, &mut |stage| {
+                stages.push(stage);
+                if stage == UpdateInstallStage::CandidatePreflight {
+                    assert!(cancellation.cancel());
+                }
+            })
+            .unwrap_err();
+
+        assert!(matches!(error, UpdateInstallError::Cancelled));
+        assert_eq!(
+            stages,
+            [
+                UpdateInstallStage::Acquiring,
+                UpdateInstallStage::CandidatePreflight,
+            ]
+        );
+        assert_eq!(runtime.event_names(), ["acquire", "drop_bundle"]);
+    }
+
+    #[test]
+    fn installer_boundary_claim_prevents_late_cancellation() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        let cancellation = UpdateInstallCancellation::new();
+        let current = runtime.current_version();
+        let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)
+            .unwrap()
+            .unwrap();
+        runtime.events.borrow_mut().clear();
+
+        let installed =
+            install_prepared_update_with(&prepared, &mut runtime, &cancellation, &mut |stage| {
+                if stage == UpdateInstallStage::Installing {
+                    assert!(!cancellation.cancel());
+                }
+            })
+            .unwrap();
+
+        assert_eq!(installed.identity(), prepared.identity());
+        assert!(!cancellation.can_cancel());
+        assert!(!cancellation.is_cancelled());
+        assert_eq!(
+            runtime.event_names(),
+            [
+                "acquire",
+                "candidate_preflight",
+                "installer",
+                "installed_identity",
+                "drop_bundle",
+            ]
+        );
+    }
+
+    #[test]
+    fn changed_saved_channel_is_rejected_before_acquisition() {
+        let mut runtime = FakeRuntime::new("1.5.0");
+        let cancellation = UpdateInstallCancellation::new();
+        let current = runtime.current_version();
+        let prepared = prepare_update_install_with(&mut runtime, &cancellation, current)
+            .unwrap()
+            .unwrap();
+        runtime.events.borrow_mut().clear();
+        runtime.saved_channel = UpdateChannel::Prerelease;
+
+        let error =
+            install_prepared_update_with(&prepared, &mut runtime, &cancellation, &mut |_| {})
+                .unwrap_err();
+
+        assert!(matches!(
+            error,
+            UpdateInstallError::ChannelChanged {
+                prepared: UpdateChannel::Stable,
+                current: UpdateChannel::Prerelease,
+            }
+        ));
+        assert!(runtime.event_names().is_empty());
     }
 
     #[test]

--- a/crates/lg-buddy/src/update_install.rs
+++ b/crates/lg-buddy/src/update_install.rs
@@ -279,11 +279,11 @@ impl UpdateInstallError {
             Self::InstallerFailedWithOutput {
                 mutation_started, ..
             } if *mutation_started => {
-                "The update installer failed after installation changes began. The installation may be partial; correct the reported problem before retrying."
+                "The update installer failed after installation changes began. The installation may be partial. Open Failure details and address the cause before retrying."
                     .to_string()
             }
             Self::InstallerFailedWithOutput { .. } => {
-                "The update installer could not complete before changing installed files. Check the reported installer problem and retry."
+                "The update installer stopped before changing installed files. Open Failure details and address the cause before retrying."
                     .to_string()
             }
             Self::InstalledIdentity(_) | Self::InstalledIdentityMismatch { .. } => {
@@ -934,8 +934,8 @@ struct BoundedCommandOutput {
 impl BoundedCommandOutput {
     fn diagnostic(&self) -> String {
         bounded_combined_text(
-            &self.stdout,
             &self.stderr,
+            &self.stdout,
             self.stdout_truncated || self.stderr_truncated,
         )
     }
@@ -1454,6 +1454,16 @@ mod tests {
                 ..
             })
         ));
+    }
+
+    #[test]
+    fn installer_diagnostics_prioritize_stderr_over_progress_output() {
+        let output = installer_fixture(
+            "printf '%70000s' progress; printf 'install: No space left on device\\n' >&2; exit 1",
+        );
+        let diagnostic = output.diagnostic();
+        assert!(diagnostic.starts_with("install: No space left on device"));
+        assert!(diagnostic.ends_with("[output truncated]"));
     }
 
     #[test]

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -1275,14 +1275,19 @@ pub fn check_for_updates() -> Result<UpdateCheckOutcome, UpdatesError> {
     )
 }
 
-pub(crate) fn discover_install_candidate(
-    current: VersionInfo,
-) -> Result<ReleaseInfo, UpdatesError> {
-    let client = UreqGitHubReleasesClient::default();
-    let settings = EnvUpdateSettings::from_env()?;
-    discover_install_candidate_with(current, &client, &settings)
+pub(crate) fn saved_update_channel() -> Result<UpdateChannel, UpdatesError> {
+    EnvUpdateSettings::from_env()?.channel()
 }
 
+pub(crate) fn discover_install_candidate_for_channel(
+    current: VersionInfo,
+    channel: UpdateChannel,
+) -> Result<ReleaseInfo, UpdatesError> {
+    let client = UreqGitHubReleasesClient::default();
+    check_updates(channel, current, &client).map(|result| result.latest)
+}
+
+#[cfg(test)]
 fn discover_install_candidate_with<C: GitHubReleasesClient, U: UpdateSettings>(
     current: VersionInfo,
     client: &C,

--- a/crates/lg-buddy/src/upgrade_preflight.rs
+++ b/crates/lg-buddy/src/upgrade_preflight.rs
@@ -478,7 +478,34 @@ pub struct CompatibilityReport {
     failures: Vec<CompatibilityFailure>,
 }
 
+/// Safe advice for the GUI; paths and raw host observations stay in diagnostics.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct CompatibilityAdvice {
+    pub compatible: bool,
+    pub failures: Vec<CompatibilityAdviceItem>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct CompatibilityAdviceItem {
+    pub check: String,
+    pub remedy: String,
+}
+
 impl CompatibilityReport {
+    pub(crate) fn advice(&self) -> CompatibilityAdvice {
+        CompatibilityAdvice {
+            compatible: self.compatible(),
+            failures: self
+                .failures
+                .iter()
+                .map(|failure| CompatibilityAdviceItem {
+                    check: failure.check.into(),
+                    remedy: failure.remedy.clone(),
+                })
+                .collect(),
+        }
+    }
+
     pub fn compatible(&self) -> bool {
         self.failures.is_empty()
     }
@@ -544,6 +571,19 @@ pub fn current_host_preflight() -> CompatibilityReport {
     evaluate_initial_preflight(&OsFilesystemFacts, &facts)
 }
 
+/// Evaluate the installed host from the graphical executable's process.
+///
+/// The GUI and CLI share the same installation layout and trust checks. The
+/// only process-specific differences are the executable that must be running
+/// and the fact that the GUI binary is required for a GUI-led upgrade.
+pub fn current_gui_host_preflight() -> CompatibilityReport {
+    let facts = match observe_current_process() {
+        Ok(facts) => facts,
+        Err(report) => return report,
+    };
+    evaluate_gui_initial_preflight(&OsFilesystemFacts, &facts)
+}
+
 pub fn candidate_host_preflight(candidate_root: &Path, repair_python: bool) -> CompatibilityReport {
     let facts = match observe_current_process() {
         Ok(facts) => facts,
@@ -604,13 +644,46 @@ pub fn evaluate_initial_preflight(
     filesystem: &impl FilesystemFacts,
     facts: &HostPreflightFacts,
 ) -> CompatibilityReport {
-    evaluate_installed_state(
+    evaluate_initial_preflight_for_process(
         filesystem,
         facts,
         &facts.layout.installed_executable(),
-        "running-executable",
         "run the release-bundle installation at /usr/bin/lg-buddy, or use the host's native package manager",
         false,
+    )
+}
+
+/// Evaluate the installed host for a GUI-led upgrade using the same checks as
+/// [`evaluate_initial_preflight`]. The installed GUI binary is mandatory so a
+/// successful handoff always has a verified target.
+pub fn evaluate_gui_initial_preflight(
+    filesystem: &impl FilesystemFacts,
+    facts: &HostPreflightFacts,
+) -> CompatibilityReport {
+    evaluate_initial_preflight_for_process(
+        filesystem,
+        facts,
+        &facts.layout.system_path("/usr/bin/lg-buddy-gui"),
+        "run the installed graphical executable at /usr/bin/lg-buddy-gui, or use the host's native package manager",
+        true,
+    )
+}
+
+fn evaluate_initial_preflight_for_process(
+    filesystem: &impl FilesystemFacts,
+    facts: &HostPreflightFacts,
+    expected_running_executable: &Path,
+    executable_remedy: &'static str,
+    require_gui: bool,
+) -> CompatibilityReport {
+    evaluate_installed_state(
+        filesystem,
+        facts,
+        expected_running_executable,
+        "running-executable",
+        executable_remedy,
+        false,
+        require_gui,
     )
 }
 
@@ -621,6 +694,7 @@ fn evaluate_installed_state(
     executable_check: &'static str,
     executable_remedy: &'static str,
     repair_python: bool,
+    require_gui: bool,
 ) -> CompatibilityReport {
     let mut checker = Checker::new(filesystem);
     let system_trust = TrustedRoot::strict(&facts.layout.system_root, facts.system_owner_uid);
@@ -679,13 +753,24 @@ fn evaluate_installed_state(
         "installed-layout",
     );
     for requirement in OPTIONAL_SYSTEM_PATH_REQUIREMENTS {
-        checker.check_optional_requirement(
-            &facts.layout.system_path(requirement.path),
-            facts.system_owner_uid,
-            Some(system_trust),
-            requirement.policy,
-            "installed-layout",
-        );
+        let path = facts.layout.system_path(requirement.path);
+        if require_gui && requirement.path == "/usr/bin/lg-buddy-gui" {
+            checker.check_requirement(
+                &path,
+                facts.system_owner_uid,
+                Some(system_trust),
+                requirement.policy,
+                "installed-layout",
+            );
+        } else {
+            checker.check_optional_requirement(
+                &path,
+                facts.system_owner_uid,
+                Some(system_trust),
+                requirement.policy,
+                "installed-layout",
+            );
+        }
     }
     if repair_python {
         for requirement in PYTHON_REPAIR_PATH_REQUIREMENTS {
@@ -803,6 +888,7 @@ pub fn evaluate_candidate_host_preflight(
         "candidate-executable",
         "run the preflight with the verified candidate binary from this bundle",
         repair_python,
+        false,
     );
     report.extend(evaluate_candidate_preflight(
         filesystem,
@@ -1567,6 +1653,28 @@ mod tests {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     #[test]
+    fn graphical_preflight_advice_excludes_paths_and_raw_observations() {
+        let mut report = CompatibilityReport::default();
+        report.refuse(
+            "installed-layout",
+            Some(PathBuf::from("/private/user-config")),
+            "raw observation that may contain private data",
+            "Restore the installed runtime before retrying.",
+        );
+        let json = serde_json::to_string(&report.advice()).unwrap();
+        assert!(!json.contains("/private"));
+        assert!(!json.contains("raw observation"));
+        let advice: CompatibilityAdvice = serde_json::from_str(&json).unwrap();
+        assert!(!advice.compatible);
+        assert_eq!(advice.failures.len(), 1);
+        assert_eq!(advice.failures[0].check, "installed-layout");
+        assert_eq!(
+            advice.failures[0].remedy,
+            "Restore the installed runtime before retrying."
+        );
+    }
+
+    #[test]
     fn supported_release_bundle_layout_passes_initial_and_candidate_preflights() {
         let fixture = InstalledFixture::new("supported");
         let filesystem = RootOwnedFilesystem(OsFilesystemFacts);
@@ -1616,6 +1724,34 @@ mod tests {
             "installed-layout",
             &icons,
             "found Symlink",
+        );
+    }
+
+    #[test]
+    fn gui_initial_preflight_requires_the_running_gui_and_installed_gui_binary() {
+        let mut fixture = InstalledFixture::new("required-installed-gui");
+        let gui = fixture.facts.layout.system_path("/usr/bin/lg-buddy-gui");
+        fixture.facts.running_executable = gui.clone();
+
+        let missing = evaluate_gui_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        assert_failure(
+            &missing,
+            "installed-layout",
+            &gui,
+            "required path is missing",
+        );
+
+        write_file(&gui, true);
+        let installed = evaluate_gui_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        assert!(installed.compatible(), "{}", installed.render());
+
+        fixture.facts.running_executable = fixture.facts.layout.installed_executable();
+        let cli_process = evaluate_gui_initial_preflight(&OsFilesystemFacts, &fixture.facts);
+        assert_failure(
+            &cli_process,
+            "running-executable",
+            &fixture.facts.layout.installed_executable(),
+            "not the expected runtime",
         );
     }
 

--- a/crates/lg-buddy/tests/update_handoff.rs
+++ b/crates/lg-buddy/tests/update_handoff.rs
@@ -1,0 +1,173 @@
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use lg_buddy::update_flow::{EnvironmentUpdateInstallBackend, UpdateInstallBackend};
+use lg_buddy::update_install::InstalledUpdate;
+use lg_buddy::updates::UpdateChannel;
+use semver::Version;
+
+const CHILD_ENV: &str = "LG_BUDDY_HANDOFF_CHILD";
+const MARKER_ENV: &str = "LG_BUDDY_HANDOFF_MARKER";
+const INSTALLED_GUI_ENV: &str = "LG_BUDDY_HANDOFF_INSTALLED_GUI";
+const DECOY_MARKER_ENV: &str = "LG_BUDDY_HANDOFF_DECOY_MARKER";
+
+#[test]
+fn handoff_successor_child() {
+    if std::env::var_os(CHILD_ENV).is_none() {
+        return;
+    }
+
+    let gui_path = std::env::var_os(INSTALLED_GUI_ENV)
+        .map(PathBuf::from)
+        .expect("handoff child needs the installed GUI path");
+    let installed = installed_update(&gui_path);
+    let result = EnvironmentUpdateInstallBackend.relaunch(&installed);
+    panic!("relaunch returned instead of exec: {result:?}");
+}
+
+#[test]
+fn relaunch_execs_the_verified_absolute_gui_and_preserves_identity() {
+    let temp = TestDirectory::new("lg-buddy-handoff");
+    let installed_dir = temp.path.join("installed");
+    let decoy_dir = temp.path.join("decoy");
+    fs::create_dir_all(&installed_dir).unwrap();
+    fs::create_dir_all(&decoy_dir).unwrap();
+
+    let marker = temp.path.join("successor.marker");
+    let decoy_marker = temp.path.join("decoy.marker");
+    let installed_gui = installed_dir.join("lg-buddy-gui");
+    let decoy_gui = decoy_dir.join("lg-buddy-gui");
+    write_successor(&installed_gui, false);
+    write_successor(&decoy_gui, true);
+
+    let child = Command::new(std::env::current_exe().unwrap())
+        .arg("--exact")
+        .arg("handoff_successor_child")
+        .arg("--nocapture")
+        .env(CHILD_ENV, "1")
+        .env(MARKER_ENV, &marker)
+        .env(INSTALLED_GUI_ENV, &installed_gui)
+        .env(DECOY_MARKER_ENV, &decoy_marker)
+        .env("LG_BUDDY_GUI", &decoy_gui)
+        .env("PATH", &decoy_dir)
+        .spawn()
+        .unwrap();
+    let child_pid = child.id();
+    let status = child.wait_with_output().unwrap();
+    assert!(
+        status.status.success(),
+        "handoff child failed: {}",
+        String::from_utf8_lossy(&status.stderr)
+    );
+
+    let report = fs::read_to_string(&marker).expect("the installed GUI must report its identity");
+    assert_eq!(report.lines().count(), 1, "only one successor may run");
+    let fields = parse_marker(&report);
+    assert_eq!(fields.get("count").map(String::as_str), Some("1"));
+    assert_eq!(
+        fields
+            .get("pid")
+            .and_then(|value| value.parse::<u32>().ok()),
+        Some(child_pid),
+        "the successor must replace the child process through exec"
+    );
+    assert_eq!(
+        fields.get("path").map(String::as_str),
+        Some(installed_gui.to_str().unwrap()),
+        "handoff must use the verified installed GUI path"
+    );
+    assert_eq!(fields.get("version").map(String::as_str), Some("1.7.0"));
+    assert_eq!(fields.get("channel").map(String::as_str), Some("stable"));
+    assert_eq!(
+        fields.get("target").map(String::as_str),
+        Some("x86_64-unknown-linux-gnu")
+    );
+    assert_eq!(
+        fields.get("commit").map(String::as_str),
+        Some("newer-commit")
+    );
+    assert_eq!(
+        fields.get("replace").map(String::as_str),
+        Some("--gapplication-replace"),
+        "handoff must request GApplication name replacement explicitly"
+    );
+    assert!(
+        !decoy_marker.exists(),
+        "LG_BUDDY_GUI and PATH decoys must not be used for handoff"
+    );
+
+    let missing = temp.path.join("missing-gui");
+    let error = EnvironmentUpdateInstallBackend
+        .relaunch(&installed_update(&missing))
+        .expect_err("a missing installed GUI must return an actionable error");
+    assert_eq!(
+        error.presentation.summary(),
+        "Update installed; restart failed"
+    );
+    assert!(error.presentation.detail().contains("could not be started"));
+    assert!(error
+        .diagnostic
+        .contains("could not replace the running GUI"));
+}
+
+fn installed_update(gui_path: &Path) -> InstalledUpdate {
+    InstalledUpdate::from_parts(
+        Version::parse("1.7.0").unwrap(),
+        UpdateChannel::Stable,
+        "v1.7.0",
+        "x86_64-unknown-linux-gnu",
+        "newer-commit",
+        "/unused/lg-buddy",
+        gui_path,
+    )
+}
+
+fn write_successor(path: &Path, decoy: bool) {
+    let body = if decoy {
+        "#!/bin/sh\nprintf 'decoy\\n' >> \"$LG_BUDDY_HANDOFF_DECOY_MARKER\"\n"
+    } else {
+        "#!/bin/sh\nprintf 'count=1 pid=%s path=%s version=1.7.0 channel=stable target=x86_64-unknown-linux-gnu commit=newer-commit replace=%s\\n' \"$$\" \"$0\" \"$1\" >> \"$LG_BUDDY_HANDOFF_MARKER\"\n"
+    };
+    fs::write(path, body).unwrap();
+    let mut permissions = fs::metadata(path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(path, permissions).unwrap();
+}
+
+fn parse_marker(report: &str) -> std::collections::HashMap<String, String> {
+    report
+        .lines()
+        .next()
+        .unwrap_or_default()
+        .split_whitespace()
+        .filter_map(|field| field.split_once('='))
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
+struct TestDirectory {
+    path: PathBuf,
+}
+
+impl TestDirectory {
+    fn new(prefix: &str) -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "{prefix}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+}
+
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -5,8 +5,9 @@ development tree. The application and GUI are a single Rust workspace, with
 the application owning state and the GTK crate rendering it.
 
 > The `v1.6.0` frontend covers Overview, TVs, Settings, first-TV pairing, and
-> About. The development tree also provides manual update checks in Settings.
-> First-run completion, update installation, and on-demand diagnostics remain
+> About. The development tree also provides manual update checks and
+> user-confirmed release-bundle installation in Settings.
+> First-run completion and on-demand diagnostics remain
 > tracked for `v1.7.0` in [issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129).
 
 ## Boundary
@@ -191,12 +192,31 @@ refreshes and edits. GTK runs the declared operation off the UI thread and rende
 its result, retry action, and native release link. A check neither installs an
 update nor changes preferences or sends a desktop notification.
 
+An available update offers **Install update…**. `update_flow.rs` owns preparing
+an offer, explicit confirmation, cancellation, progress, failures, and handoff;
+`update_install.rs` shares discovery, identity, acquisition, compatibility, and
+installation orchestration with the CLI. The confirmed release stays pinned,
+and a changed offer or saved channel requires another check and confirmation.
+GTK only renders actions and forwards worker results. Settings writes and TV
+profile changes are unavailable while an installation workflow is active.
+
+The installer runs as the regular user. Its graphical upgrade mode requests
+one `pkexec` authorization for the existing system-file and system-service
+operations. User service/configuration work remains unprivileged. Cancellation
+uses an atomic boundary before invoking the installer; after that, the window
+stays open for the result. Verified success replaces the current GUI process
+with the installed GUI. The incumbent allows standard GApplication replacement,
+and the successor requests it so bus-name teardown cannot turn the new process
+into a remote activation. Normal launches still reuse the existing window.
+A failed process replacement leaves the current window open with **Retry
+restart**, which does not repeat installation.
+
 There is no separate GUI surface for a resolved screen backend, service health,
-runtime state, or update installation progress. Normal successful setting changes
+or runtime state. Normal successful setting changes
 are silent. Feedback appears
 when a read, validation, persistence, or runtime apply result needs attention;
 an apply warning keeps the saved value and can offer **Retry apply**. The
-broader diagnostics and update installation UI is deferred as described at the top
+broader diagnostics UI is deferred as described at the top
 of this document.
 
 The main menu's **About LG Buddy** action is implemented by the native

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -183,11 +183,13 @@ governs restoration outside idle blanking. Invalid blanking values keep the
 dependent controls available for diagnosis.
 
 Settings exposes one native update row in the Updates group.
-`SettingsPresentation::updater()` projects its title, installed/available version,
+`SettingsPresentation::updater()` projects its title, installed version,
 and **Check for updates** or **Install update…** action. While a check runs, its
 button is disabled and labeled **Checking…**. Completed checks use the saved
-channel; an old-channel result cannot be installed. The check neither installs
-an update nor changes preferences or sends a desktop notification.
+channel and report only whether an update is available. The check retains no
+release version, URL, or installation target. A channel change requires a fresh
+availability check. Checking neither installs an update nor changes preferences
+or sends a desktop notification.
 
 `SettingsTransition::update_notice()` carries one-time completion feedback:
 already-current results, check errors, cache warnings, and installation errors.
@@ -198,7 +200,16 @@ for that particular completion.
 
 **Install update…** opens an `adw::Dialog` with confirmation, release link,
 current status, native progress bar, and the applicable action buttons.
-`update_flow.rs` owns preparing an offer, explicit confirmation, cancellation,
+Opening the dialog expresses intent to upgrade. Preparation reads the current
+saved channel and independently selects its latest qualifying release. That
+result supplies the confirmation version and release link, even if a newer
+release appeared since the availability check. If no newer release qualifies,
+the dialog closes, the row returns to **Check for updates**, and an **Already up
+to date** toast appears. The modal resolves the release identity before
+confirmation. Confirmation authorizes acquisition and installation of that
+exact release; later release changes cannot replace it.
+
+`update_flow.rs` owns preparation, explicit confirmation, cancellation,
 progress, failures, and handoff; `update_install.rs` shares discovery, pinned
 identity, acquisition, compatibility, and installation with the CLI. GTK only
 renders these facts and forwards semantic intents. The progress bar pulses

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -211,6 +211,13 @@ into a remote activation. Normal launches still reuse the existing window.
 A failed process replacement leaves the current window open with **Retry
 restart**, which does not repeat installation.
 
+The application retains bounded failure details for the current session,
+including across retries and Settings refreshes. A collapsed native expander
+exposes them on demand; normal error messages stay concise. Credential-bearing
+lines, URLs, and control characters are removed before retention. These details
+remain available through the application presentation for the future broader
+diagnostics readout, independently of the launcher's handling of stderr.
+
 There is no separate GUI surface for a resolved screen backend, service health,
 or runtime state. Normal successful setting changes
 are silent. Feedback appears

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -182,31 +182,33 @@ values while hiding them; Restore policy remains visible because it also
 governs restoration outside idle blanking. Invalid blanking values keep the
 dependent controls available for diagnosis.
 
-Settings also offers **Check for updates** in the Updates group, including the
-installed version. An explicit check uses the saved channel independently of
-automatic checks, reusing the CLI's discovery, comparison, and cache policy.
-The application owns checking, available-release, no-newer-release, failure,
-and cache-warning presentation. It rejects duplicate checks and retains the last
-successful result with the channel and version actually checked across settings
-refreshes and edits. GTK runs the declared operation off the UI thread and renders
-its result, retry action, and native release link. A check neither installs an
-update nor changes preferences or sends a desktop notification.
+Settings exposes one native update row in the Updates group.
+`SettingsPresentation::updater()` projects its title, installed/available version,
+and **Check for updates** or **Install update…** action. While a check runs, its
+button is disabled and labeled **Checking…**. Completed checks use the saved
+channel; an old-channel result cannot be installed. The check neither installs
+an update nor changes preferences or sends a desktop notification.
 
-An available update offers **Install update…**. `update_flow.rs` owns preparing
-an offer, explicit confirmation, cancellation, progress, failures, and handoff;
-`update_install.rs` shares discovery, identity, acquisition, compatibility, and
-installation orchestration with the CLI. The confirmed release stays pinned,
-and a changed offer or saved channel requires another check and confirmation.
-GTK only renders actions and forwards worker results. Settings writes and TV
-profile changes are unavailable while an installation workflow is active.
+`SettingsTransition::update_notice()` carries one-time completion feedback:
+already-current results, check errors, cache warnings, and installation errors.
+The window presents a toast with **Copy details** for failures. Refreshing or
+rerendering Settings does not replay notices, while a repeated failed operation
+produces a new notice. Toast actions copy the bounded, redacted details captured
+for that particular completion.
 
-`SettingsPresentation::updater()` selects one current card presentation from
-the check and installation state. Its title, description, actions, and progress
-replace the prior step in place; an old release offer or duplicate failure
-summary is not rendered alongside the active step. Automatic checks and the
-saved channel remain ordinary preference rows above this card. The renderer
-uses native action-row text spacing, and settings warning prefixes are attached
-only while a warning is present so ordinary row labels keep the same left edge.
+**Install update…** opens an `adw::Dialog` with confirmation, release link,
+current status, native progress bar, and the applicable action buttons.
+`update_flow.rs` owns preparing an offer, explicit confirmation, cancellation,
+progress, failures, and handoff; `update_install.rs` shares discovery, pinned
+identity, acquisition, compatibility, and installation with the CLI. GTK only
+renders these facts and forwards semantic intents. The progress bar pulses
+while work is pending; no percentage is invented. Dismissal requests application
+cancellation, which checks the actual installer boundary. Settings and TV
+profile changes stay unavailable during installation.
+
+The updater action occupies the same row as its status, using native text
+spacing. Empty warning prefixes are detached so ordinary setting labels retain
+the same left edge.
 
 The installer runs as the regular user. Its graphical upgrade mode requests
 one `pkexec` authorization for the existing system-file and system-service
@@ -216,15 +218,15 @@ stays open for the result. Verified success replaces the current GUI process
 with the installed GUI. The incumbent allows standard GApplication replacement,
 and the successor requests it so bus-name teardown cannot turn the new process
 into a remote activation. Normal launches still reuse the existing window.
-A failed process replacement leaves the current window open with **Retry
-restart**, which does not repeat installation.
+A failed process replacement closes the progress dialog and shows a failure
+toast. The Settings row identifies that a restart is required; its installation
+action retries process replacement without reinstalling.
 
 The application retains bounded failure details for the current session,
-including across retries and Settings refreshes. A collapsed native expander
-inside the updater card exposes them on demand; normal error messages stay
-concise. Credential-bearing lines, URLs, and control characters are removed
-before retention. These details remain available through the application presentation for the future broader
-diagnostics readout, independently of the launcher's handling of stderr.
+including across retries and Settings refreshes. Credential-bearing lines,
+URLs, and control characters are removed before retention. The error toast
+provides the details on demand, and the application presentation retains them
+for the future diagnostics readout independently of launcher stderr handling.
 
 There is no separate GUI surface for a resolved screen backend, service health,
 or runtime state. Normal successful setting changes

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -200,6 +200,14 @@ and a changed offer or saved channel requires another check and confirmation.
 GTK only renders actions and forwards worker results. Settings writes and TV
 profile changes are unavailable while an installation workflow is active.
 
+`SettingsPresentation::updater()` selects one current card presentation from
+the check and installation state. Its title, description, actions, and progress
+replace the prior step in place; an old release offer or duplicate failure
+summary is not rendered alongside the active step. Automatic checks and the
+saved channel remain ordinary preference rows above this card. The renderer
+uses native action-row text spacing, and settings warning prefixes are attached
+only while a warning is present so ordinary row labels keep the same left edge.
+
 The installer runs as the regular user. Its graphical upgrade mode requests
 one `pkexec` authorization for the existing system-file and system-service
 operations. User service/configuration work remains unprivileged. Cancellation
@@ -213,9 +221,9 @@ restart**, which does not repeat installation.
 
 The application retains bounded failure details for the current session,
 including across retries and Settings refreshes. A collapsed native expander
-exposes them on demand; normal error messages stay concise. Credential-bearing
-lines, URLs, and control characters are removed before retention. These details
-remain available through the application presentation for the future broader
+inside the updater card exposes them on demand; normal error messages stay
+concise. Credential-bearing lines, URLs, and control characters are removed
+before retention. These details remain available through the application presentation for the future broader
 diagnostics readout, independently of the launcher's handling of stderr.
 
 There is no separate GUI surface for a resolved screen backend, service health,

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -172,6 +172,14 @@ The checker assigns each target an installer-operation policy so replacement,
 directory mutation, recursive repair, exact drop-in, and candidate-input
 requirements cannot silently lose their operation-specific safeguards.
 
+The installed GUI uses the same compatibility checks with its own installed
+executable path; a source checkout or externally managed GUI cannot substitute
+for the mutable release-bundle installation. GUI updates keep confirmation and
+network work unprivileged, then use one graphical authorization for a bounded
+system-installation helper. User configuration and user service operations
+remain in the invoking user's process. CLI updates retain terminal confirmation
+and their existing sudo behavior.
+
 The extracted candidate exposes this second pass through the hidden
 `upgrade-preflight` installer entrypoint. `install.sh --upgrade` invokes it
 before sudo or installation writes, loads the existing config pointer and

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -180,8 +180,11 @@ until the check finishes. If LG Buddy is current, a brief **Already up to date**
 message appears. An available release changes the same row to **Install update…**.
 Changing the saved channel requires a fresh check before installation.
 
-Choose **Install update…** to open the update dialog. After preparing the
-release, the dialog shows its version, channel, and release link. Choose
+Choose **Install update…** to open the update dialog. It retrieves the latest
+qualifying release using your saved channel preference, then shows its version,
+channel, and release link. This may be a newer release than the one available
+when you checked. If no update qualifies, the dialog closes with an **Already up
+to date** message. Choose
 **Install and restart** to authorize the system installation. Pairing and
 settings are preserved. A pulsing progress bar and short status describe the
 current work; the installer does not provide a percentage.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -183,6 +183,23 @@ it checked, including while you change channels or retry. A cache warning can
 appear alongside a successful result; it does not mean the release check failed.
 Checking does not install anything or change your update preferences.
 
+For a supported release-bundle installation, choose **Install update…**, review
+its version and channel, then choose **Install and restart**. Approve the desktop
+authorization prompt to replace the installed files. Pairing and settings are
+preserved. After verifying both installed executables, LG Buddy restarts into
+the updated application. If restarting fails, use **Retry restart**.
+
+You can cancel while the update is being prepared or downloaded. Once
+installation starts, keep the application open until it finishes; cancelling
+the authorization prompt leaves the installation unchanged. A failure after
+installation changes begin is reported as potentially incomplete. Follow the
+reported recovery guidance before retrying. If you change release channels,
+check again before installing an offer from the new channel.
+
+This flow requires a compatible mutable release-bundle installation. Use the
+package manager for externally managed installations. Graphical authorization
+requires `pkexec` and a desktop authorization agent.
+
 The terminal equivalent is:
 
 ```bash

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -174,28 +174,32 @@ format, and compatibility behavior.
 ## Check for and install an update
 
 In **Settings → Updates**, choose **Check for updates**. This works even when
-automatic checks are off and uses your saved release channel. The app shows
-the installed version, then an available version with a release link or a
-message that no newer release is available. If a check fails, use **Retry check**.
+automatic checks are off and uses your saved release channel. One updater card
+below the update preferences shows the installed version, then replaces it with
+the check progress and result. An available version includes a release link and
+**Install update…**; otherwise the card reports that no newer release is available.
+If a check fails, its explanation and **Retry check** replace the previous result.
 
-The last successful result stays labelled with the channel and installed version
-it checked, including while you change channels or retry. A cache warning can
-appear alongside a successful result; it does not mean the release check failed.
+Completed results identify the channel and installed version they checked. After
+changing channels, use **Check for updates** before installing. A cache warning
+can appear inside the card alongside a successful result; it does not mean the
+release check failed.
 Checking does not install anything or change your update preferences.
 
 For a supported release-bundle installation, choose **Install update…**, review
 its version and channel, then choose **Install and restart**. Approve the desktop
 authorization prompt to replace the installed files. Pairing and settings are
-preserved. After verifying both installed executables, LG Buddy restarts into
+preserved. Confirmation, progress, and any failure replace each other in the same
+card. After verifying both installed executables, LG Buddy restarts into
 the updated application. If restarting fails, use **Retry restart**.
 
 You can cancel while the update is being prepared or downloaded. Once
 installation starts, keep the application open until it finishes; cancelling
 the authorization prompt leaves the installation unchanged. A failure after
 installation changes begin is reported as potentially incomplete. Follow the
-reported recovery guidance before retrying. Expand **Failure details** to inspect
-and select the retained error information without a terminal. The most recent
-failure remains available as **Last update failure** during retries in this
+reported recovery guidance before retrying. Expand **Failure details** inside
+the card to inspect and select the retained error information without a terminal.
+The most recent failure remains available as **Last update failure** during retries in this
 application session. If you change release channels,
 check again before installing an offer from the new channel.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -173,35 +173,31 @@ format, and compatibility behavior.
 <a id="updates"></a>
 ## Check for and install an update
 
-In **Settings → Updates**, choose **Check for updates**. This works even when
-automatic checks are off and uses your saved release channel. One updater card
-below the update preferences shows the installed version, then replaces it with
-the check progress and result. An available version includes a release link and
-**Install update…**; otherwise the card reports that no newer release is available.
-If a check fails, its explanation and **Retry check** replace the previous result.
+In **Settings → Updates**, the update row shows the installed version and
+**Check for updates**. Checking works even when automatic checks are off and
+uses your saved release channel. The button reads **Checking…** and is disabled
+until the check finishes. If LG Buddy is current, a brief **Already up to date**
+message appears. An available release changes the same row to **Install update…**.
+Changing the saved channel requires a fresh check before installation.
 
-Completed results identify the channel and installed version they checked. After
-changing channels, use **Check for updates** before installing. A cache warning
-can appear inside the card alongside a successful result; it does not mean the
-release check failed.
-Checking does not install anything or change your update preferences.
+Choose **Install update…** to open the update dialog. After preparing the
+release, the dialog shows its version, channel, and release link. Choose
+**Install and restart** to authorize the system installation. Pairing and
+settings are preserved. A pulsing progress bar and short status describe the
+current work; the installer does not provide a percentage.
 
-For a supported release-bundle installation, choose **Install update…**, review
-its version and channel, then choose **Install and restart**. Approve the desktop
-authorization prompt to replace the installed files. Pairing and settings are
-preserved. Confirmation, progress, and any failure replace each other in the same
-card. After verifying both installed executables, LG Buddy restarts into
-the updated application. If restarting fails, use **Retry restart**.
+You can cancel while preparing or downloading. Once installation starts, keep
+LG Buddy open until it finishes. Cancelling authorization leaves the
+installation unchanged. Success verifies both installed executables and
+restarts into the updated application.
 
-You can cancel while the update is being prepared or downloaded. Once
-installation starts, keep the application open until it finishes; cancelling
-the authorization prompt leaves the installation unchanged. A failure after
-installation changes begin is reported as potentially incomplete. Follow the
-reported recovery guidance before retrying. Expand **Failure details** inside
-the card to inspect and select the retained error information without a terminal.
-The most recent failure remains available as **Last update failure** during retries in this
-application session. If you change release channels,
-check again before installing an offer from the new channel.
+Check and installation errors appear as toasts with **Copy details**. This
+copies the explanation and diagnostic text for troubleshooting without a
+terminal. A failure after installation changes begin may leave a partial
+installation; follow the recovery guidance in those details before retrying.
+The installation dialog closes on failure, and **Install update…** offers
+another attempt. If installation succeeded but restarting failed, the row
+identifies the required restart and its action retries restarting only.
 
 This flow requires a compatible mutable release-bundle installation. Use the
 package manager for externally managed installations. Graphical authorization

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -193,7 +193,10 @@ You can cancel while the update is being prepared or downloaded. Once
 installation starts, keep the application open until it finishes; cancelling
 the authorization prompt leaves the installation unchanged. A failure after
 installation changes begin is reported as potentially incomplete. Follow the
-reported recovery guidance before retrying. If you change release channels,
+reported recovery guidance before retrying. Expand **Failure details** to inspect
+and select the retained error information without a terminal. The most recent
+failure remains available as **Last update failure** during retries in this
+application session. If you change release channels,
 check again before installing an offer from the new channel.
 
 This flow requires a compatible mutable release-bundle installation. Use the

--- a/install.sh
+++ b/install.sh
@@ -4,6 +4,7 @@
 set -e
 
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+ORIGINAL_SCRIPT_DIR="$SCRIPT_DIR"
 INSTALL_ROOT="${LG_BUDDY_INSTALL_ROOT:-}"
 INSTALL_ROOT="${INSTALL_ROOT%/}"
 SUDO_CMD="${LG_BUDDY_SUDO_CMD:-sudo}"
@@ -24,9 +25,17 @@ APP_ICON="$DEFAULT_APP_ICON"
 RUNTIME_BINARY_OVERRIDDEN=0
 GUI_BINARY_OVERRIDDEN=0
 UPGRADE_MODE=0
+SYSTEM_UPGRADE_MODE=0
 MUTATION_STARTED=0
 UPGRADE_COMPLETED=0
 GUI_BINARY_STAGED_TMP=""
+SYSTEM_UPGRADE_INSTALL_ROOT=""
+SYSTEM_UPGRADE_CANDIDATE_ROOT=""
+SYSTEM_UPGRADE_CONFIG_OVERRIDE=""
+SYSTEM_UPGRADE_NM_HOOK=""
+SYSTEM_UPGRADE_REPAIR_PYTHON="0"
+SYSTEM_UPGRADE_SKIP_PIP="0"
+SYSTEM_UPGRADE_SKIP_SYSTEMD="0"
 
 usage() {
     cat <<EOF
@@ -64,6 +73,21 @@ while [ "$#" -gt 0 ]; do
             UPGRADE_MODE=1
             shift
             ;;
+        --system-upgrade)
+            [ "$SYSTEM_UPGRADE_MODE" -eq 0 ] || usage
+            SYSTEM_UPGRADE_MODE=1
+            UPGRADE_MODE=1
+            shift
+            [ "$#" -eq 7 ] || usage
+            SYSTEM_UPGRADE_INSTALL_ROOT="$1"
+            SYSTEM_UPGRADE_CANDIDATE_ROOT="$2"
+            SYSTEM_UPGRADE_CONFIG_OVERRIDE="$3"
+            SYSTEM_UPGRADE_NM_HOOK="$4"
+            SYSTEM_UPGRADE_REPAIR_PYTHON="$5"
+            SYSTEM_UPGRADE_SKIP_PIP="$6"
+            SYSTEM_UPGRADE_SKIP_SYSTEMD="$7"
+            shift 7
+            ;;
         -h|--help)
             usage
             ;;
@@ -78,7 +102,7 @@ if [ "$UPGRADE_MODE" -eq 1 ] && { [ "$RUNTIME_BINARY_OVERRIDDEN" -eq 1 ] || [ "$
     exit 1
 fi
 
-if [ -n "$INSTALL_ROOT" ]; then
+if [ "$SYSTEM_UPGRADE_MODE" -eq 0 ] && [ -n "$INSTALL_ROOT" ]; then
     case "$INSTALL_ROOT" in
         /*) ;;
         *)
@@ -88,17 +112,17 @@ if [ -n "$INSTALL_ROOT" ]; then
     esac
 fi
 
-if [ "$(id -u)" -eq 0 ]; then
+if [ "$SYSTEM_UPGRADE_MODE" -eq 0 ] && [ "$(id -u)" -eq 0 ]; then
     echo "Error: Do not run this script with sudo. It will prompt for sudo when needed."
     exit 1
 fi
 
-if [ "$UPGRADE_MODE" -eq 1 ]; then
+if [ "$SYSTEM_UPGRADE_MODE" -eq 0 ] && [ "$UPGRADE_MODE" -eq 1 ]; then
     echo "Starting LG Buddy Upgrade"
-else
+elif [ "$SYSTEM_UPGRADE_MODE" -eq 0 ]; then
     echo "Starting LG Buddy Installation"
 fi
-if [ -n "$INSTALL_ROOT" ]; then
+if [ "$SYSTEM_UPGRADE_MODE" -eq 0 ] && [ -n "$INSTALL_ROOT" ]; then
     echo "Install root override: $INSTALL_ROOT"
 fi
 
@@ -110,6 +134,7 @@ SCREEN_IDLE_BLANK="enabled"
 SYSTEM_CONFIG_OVERRIDE_TMP=""
 CONFIG_POINTER_TMP=""
 NM_HOOK_TMP=""
+SYSTEM_UPGRADE_OUTPUT_TMP=""
 PM=""
 INSTALL_CMD=()
 
@@ -126,53 +151,70 @@ prefix_path() {
 run_privileged() {
     if [ "$SUDO_CMD" = "none" ]; then
         "$@"
+    elif [ "$SUDO_CMD" = "pkexec" ]; then
+        pkexec --disable-internal-agent "$@"
     else
         "$SUDO_CMD" "$@"
     fi
 }
 
-SYSTEM_BIN_DIR="$(prefix_path "/usr/bin")"
-RUNTIME_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy"
-GUI_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy-gui"
-VENV_DIR="${SYSTEM_BIN_DIR}/LG_Buddy_PIP"
-SYSTEM_LIB_DIR="$(prefix_path "/usr/lib/lg-buddy")"
-CONFIG_POINTER_PATH="${SYSTEM_LIB_DIR}/config-path"
-COMMON_HELPER_PATH="${SYSTEM_LIB_DIR}/common.sh"
-SYSTEM_SLEEP_HOOK_PATH="$(prefix_path "/usr/lib/systemd/system-sleep/LG_Buddy_sleep_hook")"
-SYSTEMD_SYSTEM_DIR="$(prefix_path "/etc/systemd/system")"
-SYSTEMD_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy.service"
-SYSTEMD_LIFECYCLE_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_lifecycle.service"
-SYSTEMD_WAKE_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_wake.service"
-SYSTEMD_SLEEP_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_sleep.service"
-SYSTEMD_SERVICE_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy.service.d"
-SYSTEMD_LIFECYCLE_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_lifecycle.service.d"
-SYSTEMD_WAKE_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_wake.service.d"
-SYSTEMD_SLEEP_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_sleep.service.d"
-TMPFILES_CONF_DIR="$(prefix_path "/etc/tmpfiles.d")"
-TMPFILES_CONF_PATH="${TMPFILES_CONF_DIR}/lg_buddy.conf"
-NM_PRE_DOWN_DIR="$(prefix_path "/etc/NetworkManager/dispatcher.d/pre-down.d")"
-NM_SLEEP_HOOK_PATH="${NM_PRE_DOWN_DIR}/LG_Buddy_sleep"
-NM_LIFECYCLE_HOOK_PATH="${NM_PRE_DOWN_DIR}/LG_Buddy_lifecycle"
-APPLICATIONS_DIR="$(prefix_path "/usr/share/applications")"
-DESKTOP_ENTRY_NAME="io.github.staphylococcus.LGBuddy.desktop"
-DESKTOP_ENTRY_PATH="${APPLICATIONS_DIR}/${DESKTOP_ENTRY_NAME}"
-LEGACY_DESKTOP_ENTRY_PATH="${APPLICATIONS_DIR}/LG_Buddy_Brightness.desktop"
-DESKTOP_ENTRY_SOURCE="${SCRIPT_DIR}/${DESKTOP_ENTRY_NAME}"
-if [ ! -f "$DESKTOP_ENTRY_SOURCE" ]; then
-    # Release archives retain this internal name for compatibility with
-    # updaters shipped before the application-ID filename was adopted.
-    DESKTOP_ENTRY_SOURCE="${SCRIPT_DIR}/LG_Buddy_Brightness.desktop"
-fi
-APP_ICON_DIR="$(prefix_path "/usr/share/icons/hicolor/scalable/apps")"
-APP_ICON_PATH="${APP_ICON_DIR}/${APP_ICON_NAME}"
-USER_DESKTOP_ENTRY_PATH="${HOME}/Desktop/${DESKTOP_ENTRY_NAME}"
-LEGACY_USER_DESKTOP_ENTRY_PATH="${HOME}/Desktop/LG_Buddy_Brightness.desktop"
-USER_SYSTEMD_DIR="${HOME}/.config/systemd/user"
-USER_SCREEN_SERVICE_PATH="${USER_SYSTEMD_DIR}/LG_Buddy_screen.service"
-USER_SCREEN_OVERRIDE_DIR="${USER_SYSTEMD_DIR}/LG_Buddy_screen.service.d"
-USER_UPDATE_CHECK_SERVICE_PATH="${USER_SYSTEMD_DIR}/LG_Buddy_update_check.service"
-USER_UPDATE_CHECK_TIMER_PATH="${USER_SYSTEMD_DIR}/LG_Buddy_update_check.timer"
-USER_UPDATE_CHECK_OVERRIDE_DIR="${USER_SYSTEMD_DIR}/LG_Buddy_update_check.service.d"
+prefix_install_root_path() {
+    local install_root="$1"
+    local path="$2"
+
+    if [ -n "$install_root" ]; then
+        printf '%s%s\n' "${install_root%/}" "$path"
+    else
+        printf '%s\n' "$path"
+    fi
+}
+
+initialize_install_paths() {
+    SYSTEM_BIN_DIR="$(prefix_path "/usr/bin")"
+    RUNTIME_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy"
+    GUI_INSTALL_PATH="${SYSTEM_BIN_DIR}/lg-buddy-gui"
+    VENV_DIR="${SYSTEM_BIN_DIR}/LG_Buddy_PIP"
+    SYSTEM_LIB_DIR="$(prefix_path "/usr/lib/lg-buddy")"
+    CONFIG_POINTER_PATH="${SYSTEM_LIB_DIR}/config-path"
+    COMMON_HELPER_PATH="${SYSTEM_LIB_DIR}/common.sh"
+    SYSTEM_SLEEP_HOOK_PATH="$(prefix_path "/usr/lib/systemd/system-sleep/LG_Buddy_sleep_hook")"
+    SYSTEMD_SYSTEM_DIR="$(prefix_path "/etc/systemd/system")"
+    SYSTEMD_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy.service"
+    SYSTEMD_LIFECYCLE_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_lifecycle.service"
+    SYSTEMD_WAKE_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_wake.service"
+    SYSTEMD_SLEEP_SERVICE_PATH="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_sleep.service"
+    SYSTEMD_SERVICE_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy.service.d"
+    SYSTEMD_LIFECYCLE_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_lifecycle.service.d"
+    SYSTEMD_WAKE_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_wake.service.d"
+    SYSTEMD_SLEEP_OVERRIDE_DIR="${SYSTEMD_SYSTEM_DIR}/LG_Buddy_sleep.service.d"
+    TMPFILES_CONF_DIR="$(prefix_path "/etc/tmpfiles.d")"
+    TMPFILES_CONF_PATH="${TMPFILES_CONF_DIR}/lg_buddy.conf"
+    NM_PRE_DOWN_DIR="$(prefix_path "/etc/NetworkManager/dispatcher.d/pre-down.d")"
+    NM_SLEEP_HOOK_PATH="${NM_PRE_DOWN_DIR}/LG_Buddy_sleep"
+    NM_LIFECYCLE_HOOK_PATH="${NM_PRE_DOWN_DIR}/LG_Buddy_lifecycle"
+    APPLICATIONS_DIR="$(prefix_path "/usr/share/applications")"
+    DESKTOP_ENTRY_NAME="io.github.staphylococcus.LGBuddy.desktop"
+    DESKTOP_ENTRY_PATH="${APPLICATIONS_DIR}/${DESKTOP_ENTRY_NAME}"
+    LEGACY_DESKTOP_ENTRY_PATH="${APPLICATIONS_DIR}/LG_Buddy_Brightness.desktop"
+    DESKTOP_ENTRY_SOURCE="${SCRIPT_DIR}/${DESKTOP_ENTRY_NAME}"
+    if [ ! -f "$DESKTOP_ENTRY_SOURCE" ]; then
+        # Release archives retain this internal name for compatibility with
+        # updaters shipped before the application-ID filename was adopted.
+        DESKTOP_ENTRY_SOURCE="${SCRIPT_DIR}/LG_Buddy_Brightness.desktop"
+    fi
+    APP_ICON_DIR="$(prefix_path "/usr/share/icons/hicolor/scalable/apps")"
+    APP_ICON_PATH="${APP_ICON_DIR}/${APP_ICON_NAME}"
+    USER_DESKTOP_ENTRY_PATH="${HOME}/Desktop/${DESKTOP_ENTRY_NAME}"
+    LEGACY_USER_DESKTOP_ENTRY_PATH="${HOME}/Desktop/LG_Buddy_Brightness.desktop"
+    USER_SYSTEMD_DIR="${HOME}/.config/systemd/user"
+    USER_SCREEN_SERVICE_PATH="${USER_SYSTEMD_DIR}/LG_Buddy_screen.service"
+    USER_SCREEN_OVERRIDE_DIR="${USER_SYSTEMD_DIR}/LG_Buddy_screen.service.d"
+    USER_UPDATE_CHECK_SERVICE_PATH="${USER_SYSTEMD_DIR}/LG_Buddy_update_check.service"
+    USER_UPDATE_CHECK_TIMER_PATH="${USER_SYSTEMD_DIR}/LG_Buddy_update_check.timer"
+    USER_UPDATE_CHECK_OVERRIDE_DIR="${USER_SYSTEMD_DIR}/LG_Buddy_update_check.service.d"
+}
+
+initialize_install_paths
 
 check_dep() {
     local label="$1"
@@ -352,6 +394,173 @@ cleanup_legacy_sleep_wake_handlers() {
     run_privileged rmdir "$SYSTEMD_SLEEP_OVERRIDE_DIR" 2>/dev/null || true
     run_privileged rm -f "$NM_SLEEP_HOOK_PATH"
     run_privileged rm -f "$SYSTEM_SLEEP_HOOK_PATH"
+}
+
+SYSTEM_UPGRADE_HELPER_MODE=0
+SYSTEM_UPGRADE_MUTATION_EMITTED=0
+
+system_upgrade_message() {
+    if [ "$SYSTEM_UPGRADE_HELPER_MODE" -eq 1 ]; then
+        echo "$*" >&2
+    else
+        echo "$*"
+    fi
+}
+
+system_upgrade_status() {
+    printf 'LG_BUDDY_INSTALL_STATUS=%s\n' "$1"
+}
+
+run_system_mutation_command() {
+    if [ "$SYSTEM_UPGRADE_HELPER_MODE" -eq 1 ]; then
+        if [ "$SYSTEM_UPGRADE_MUTATION_EMITTED" -eq 0 ]; then
+            system_upgrade_status mutation_started
+            SYSTEM_UPGRADE_MUTATION_EMITTED=1
+        fi
+        "$@" >&2
+    else
+        run_privileged "$@"
+    fi
+}
+
+perform_privileged_runtime_installation() {
+    if [ "$UPGRADE_MODE" -eq 0 ] || [ "$REPAIR_PYTHON_ENVIRONMENT" -eq 1 ]; then
+        MUTATION_STARTED=1
+        system_upgrade_message "Creating Python virtual environment at $VENV_DIR..."
+        # Recreate the helper venv so OS Python minor-version upgrades do not leave
+        # bscpylgtv installed under an interpreter-specific site-packages directory
+        # that the new `/usr/bin/python3` no longer reads.
+        run_system_mutation_command python3 -m venv --clear "$VENV_DIR"
+        system_upgrade_message "Done."
+
+        if [ "$SKIP_PIP_INSTALL" = "1" ]; then
+            system_upgrade_message "Skipping bscpylgtv installation because LG_BUDDY_SKIP_PIP_INSTALL=1."
+        else
+            system_upgrade_message "Installing bscpylgtv into the virtual environment..."
+            run_system_mutation_command "$VENV_DIR/bin/pip" install bscpylgtv
+            system_upgrade_message "Done."
+        fi
+    fi
+
+    MUTATION_STARTED=1
+    system_upgrade_message "Installing Rust runtime and support files..."
+    run_system_mutation_command install -m 755 "$RUNTIME_BINARY" "$RUNTIME_INSTALL_PATH"
+    run_system_mutation_command install -m 755 "$GUI_BINARY" "$GUI_INSTALL_PATH"
+    if [ "$UPGRADE_MODE" -eq 0 ]; then
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Startup"
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Shutdown"
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_On"
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Off"
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Monitor"
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_sleep_pre"
+        run_system_mutation_command rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Brightness"
+        run_system_mutation_command rm -f "$COMMON_HELPER_PATH"
+        run_system_mutation_command rm -f "$CONFIG_POINTER_PATH"
+        run_system_mutation_command rmdir "$SYSTEM_LIB_DIR" 2>/dev/null || true
+    fi
+    if [ "$UPGRADE_MODE" -eq 0 ]; then
+        run_system_mutation_command install -d "$SYSTEM_LIB_DIR"
+        run_system_mutation_command install -m 644 "$CONFIG_POINTER_TMP" "$CONFIG_POINTER_PATH"
+    fi
+    system_upgrade_message "Installing LG Buddy desktop entry..."
+    run_system_mutation_command install -d "$APPLICATIONS_DIR"
+    run_system_mutation_command install -m 644 "$DESKTOP_ENTRY_SOURCE" "$DESKTOP_ENTRY_PATH"
+    run_system_mutation_command rm -f "$LEGACY_DESKTOP_ENTRY_PATH"
+    run_system_mutation_command install -d "$APP_ICON_DIR"
+    run_system_mutation_command install -m 644 "$APP_ICON" "$APP_ICON_PATH"
+    system_upgrade_message "Done."
+
+}
+
+perform_privileged_services_installation() {
+    system_upgrade_message "Copying and enabling systemd services..."
+    run_system_mutation_command install -d "$SYSTEMD_SYSTEM_DIR"
+    run_system_mutation_command install -d "$TMPFILES_CONF_DIR"
+    run_system_mutation_command install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy.service" "$SYSTEMD_SERVICE_PATH"
+    run_system_mutation_command install -m 644 "$SCRIPT_DIR/systemd/lg_buddy.conf" "$TMPFILES_CONF_PATH"
+    run_system_mutation_command install -d "$SYSTEMD_SERVICE_OVERRIDE_DIR"
+    run_system_mutation_command install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_SERVICE_OVERRIDE_DIR}/config.conf"
+
+    if [ "$UPGRADE_MODE" -eq 0 ]; then
+        cleanup_legacy_sleep_wake_handlers
+    fi
+
+    run_system_mutation_command install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy_lifecycle.service" "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
+    run_system_mutation_command install -d "$SYSTEMD_LIFECYCLE_OVERRIDE_DIR"
+    run_system_mutation_command install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_LIFECYCLE_OVERRIDE_DIR}/config.conf"
+    run_system_mutation_command install -d "$NM_PRE_DOWN_DIR"
+    run_system_mutation_command install -m 755 "$NM_HOOK_TMP" "$NM_LIFECYCLE_HOOK_PATH"
+
+    if [ "$SKIP_SYSTEMD_ACTIONS" = "1" ]; then
+        system_upgrade_message "Skipping systemd tmpfiles and enable actions because LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1."
+    else
+        run_system_mutation_command systemd-tmpfiles --create "$TMPFILES_CONF_PATH"
+        run_system_mutation_command systemctl daemon-reload
+        run_system_mutation_command systemctl enable LG_Buddy.service
+        run_system_mutation_command systemctl enable LG_Buddy_lifecycle.service
+        run_system_mutation_command systemctl restart LG_Buddy_lifecycle.service
+    fi
+    system_upgrade_message "Done."
+}
+
+perform_privileged_installation() {
+    perform_privileged_runtime_installation
+    perform_privileged_services_installation
+}
+
+run_system_upgrade_helper() {
+    [ "$(id -u)" -eq 0 ] || exit 126
+    [ "$#" -eq 7 ] || exit 2
+
+    INSTALL_ROOT="$1"
+    SCRIPT_DIR="$2"
+    SYSTEM_CONFIG_OVERRIDE_TMP="$3"
+    NM_HOOK_TMP="$4"
+    REPAIR_PYTHON_ENVIRONMENT="$5"
+    SKIP_PIP_INSTALL="$6"
+    SKIP_SYSTEMD_ACTIONS="$7"
+
+    case "$INSTALL_ROOT" in
+        ""|/*) ;;
+        *) exit 2 ;;
+    esac
+    [ "$SCRIPT_DIR" = "$ORIGINAL_SCRIPT_DIR" ] || exit 2
+    [ -d "$SCRIPT_DIR" ] || exit 2
+    case "$SCRIPT_DIR:$SYSTEM_CONFIG_OVERRIDE_TMP:$NM_HOOK_TMP" in
+        /*:/*:/*) ;;
+        *) exit 2 ;;
+    esac
+    case "$REPAIR_PYTHON_ENVIRONMENT:$SKIP_PIP_INSTALL:$SKIP_SYSTEMD_ACTIONS" in
+        0:0:0|0:0:1|0:1:0|0:1:1|1:0:0|1:0:1|1:1:0|1:1:1) ;;
+        *) exit 2 ;;
+    esac
+
+    PATH=/run/current-system/sw/bin:/run/wrappers/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    export PATH
+    SYSTEM_UPGRADE_HELPER_MODE=1
+    UPGRADE_MODE=1
+    RUNTIME_BINARY="$SCRIPT_DIR/lg-buddy"
+    GUI_BINARY="$SCRIPT_DIR/docs/lg-buddy-gui-$GUI_TARGET"
+    APP_ICON="$SCRIPT_DIR/docs/$APP_ICON_NAME"
+    DESKTOP_ENTRY_SOURCE="$SCRIPT_DIR/$DESKTOP_ENTRY_NAME"
+    if [ ! -f "$DESKTOP_ENTRY_SOURCE" ]; then
+        DESKTOP_ENTRY_SOURCE="$SCRIPT_DIR/LG_Buddy_Brightness.desktop"
+    fi
+    for source in \
+        "$RUNTIME_BINARY" "$GUI_BINARY" "$APP_ICON" "$DESKTOP_ENTRY_SOURCE" \
+        "$SYSTEM_CONFIG_OVERRIDE_TMP" "$NM_HOOK_TMP"; do
+        [ -f "$source" ] || exit 2
+        [ ! -L "$source" ] || exit 2
+        [ -r "$source" ] || exit 2
+    done
+    [ -x "$RUNTIME_BINARY" ] || exit 2
+    [ -x "$GUI_BINARY" ] || exit 2
+    initialize_install_paths
+    SYSTEM_UPGRADE_MUTATION_EMITTED=0
+
+    system_upgrade_status authorized
+    perform_privileged_installation
+    system_upgrade_status root_complete
 }
 
 resolve_runtime_binary() {
@@ -564,6 +773,10 @@ cleanup() {
         rm -f "$NM_HOOK_TMP"
     fi
 
+    if [ -n "$SYSTEM_UPGRADE_OUTPUT_TMP" ]; then
+        rm -f "$SYSTEM_UPGRADE_OUTPUT_TMP"
+    fi
+
     if [ -n "$GUI_BINARY_STAGED_TMP" ]; then
         rm -f "$GUI_BINARY_STAGED_TMP"
     fi
@@ -576,6 +789,18 @@ cleanup() {
     trap - EXIT
     exit "$status"
 }
+
+if [ "$SYSTEM_UPGRADE_MODE" -eq 1 ]; then
+    run_system_upgrade_helper \
+        "$SYSTEM_UPGRADE_INSTALL_ROOT" \
+        "$SYSTEM_UPGRADE_CANDIDATE_ROOT" \
+        "$SYSTEM_UPGRADE_CONFIG_OVERRIDE" \
+        "$SYSTEM_UPGRADE_NM_HOOK" \
+        "$SYSTEM_UPGRADE_REPAIR_PYTHON" \
+        "$SYSTEM_UPGRADE_SKIP_PIP" \
+        "$SYSTEM_UPGRADE_SKIP_SYSTEMD"
+    exit $?
+fi
 
 trap cleanup EXIT
 
@@ -705,52 +930,51 @@ fi
 
 prepare_installation_files
 
-# 4. CREATE VIRTUAL ENVIRONMENT
-if [ "$UPGRADE_MODE" -eq 0 ] || [ "$REPAIR_PYTHON_ENVIRONMENT" -eq 1 ]; then
-    MUTATION_STARTED=1
-    echo "Creating Python virtual environment at $VENV_DIR..."
-    # Recreate the helper venv so OS Python minor-version upgrades do not leave
-    # bscpylgtv installed under an interpreter-specific site-packages directory
-    # that the new `/usr/bin/python3` no longer reads.
-    run_privileged python3 -m venv --clear "$VENV_DIR"
-    echo "Done."
+if [ "$UPGRADE_MODE" -eq 1 ] && [ "$SUDO_CMD" = "pkexec" ]; then
+    echo "Requesting graphical authorization for system installation changes..."
+    SYSTEM_UPGRADE_OUTPUT_TMP="$(mktemp)"
+    HELPER_STATUS=0
+    set +e
+    run_privileged "$BASH" "$SCRIPT_DIR/install.sh" --system-upgrade \
+        "$INSTALL_ROOT" \
+        "$SCRIPT_DIR" \
+        "$SYSTEM_CONFIG_OVERRIDE_TMP" \
+        "$NM_HOOK_TMP" \
+        "$REPAIR_PYTHON_ENVIRONMENT" \
+        "$SKIP_PIP_INSTALL" \
+        "$SKIP_SYSTEMD_ACTIONS" | tee "$SYSTEM_UPGRADE_OUTPUT_TMP"
+    HELPER_STATUS="${PIPESTATUS[0]}"
+    set -e
 
-    if [ "$SKIP_PIP_INSTALL" = "1" ]; then
-        echo "Skipping bscpylgtv installation because LG_BUDDY_SKIP_PIP_INSTALL=1."
-    else
-        echo "Installing bscpylgtv into the virtual environment..."
-        run_privileged "$VENV_DIR/bin/pip" install bscpylgtv
-        echo "Done."
+    if [ "$HELPER_STATUS" -ne 0 ]; then
+        if grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=mutation_started' "$SYSTEM_UPGRADE_OUTPUT_TMP"; then
+            MUTATION_STARTED=1
+        elif [ "$HELPER_STATUS" -eq 126 ]; then
+            echo "Graphical authorization was cancelled; no installation changes were made." >&2
+        elif [ "$HELPER_STATUS" -eq 127 ]; then
+            echo "Graphical authorization failed or no authentication agent was available; no installation changes were made." >&2
+        else
+            echo "The authorized system installation helper failed before installation changes began." >&2
+        fi
+        exit "$HELPER_STATUS"
     fi
+
+    if grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=mutation_started' "$SYSTEM_UPGRADE_OUTPUT_TMP"; then
+        MUTATION_STARTED=1
+    fi
+    if ! grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=root_complete' "$SYSTEM_UPGRADE_OUTPUT_TMP"; then
+        echo "The authorized system installation helper did not report completion." >&2
+        exit 1
+    fi
+    MUTATION_STARTED=1
 fi
 
-# 6. INSTALL RUST RUNTIME AND SUPPORT FILES
-MUTATION_STARTED=1
-echo "Installing Rust runtime and support files..."
-run_privileged install -m 755 "$RUNTIME_BINARY" "$RUNTIME_INSTALL_PATH"
-run_privileged install -m 755 "$GUI_BINARY" "$GUI_INSTALL_PATH"
-if [ "$UPGRADE_MODE" -eq 0 ]; then
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Startup"
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Shutdown"
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_On"
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Off"
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Screen_Monitor"
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_sleep_pre"
-    run_privileged rm -f "${SYSTEM_BIN_DIR}/LG_Buddy_Brightness"
-    run_privileged rm -f "$COMMON_HELPER_PATH"
-    run_privileged rm -f "$CONFIG_POINTER_PATH"
-    run_privileged rmdir "$SYSTEM_LIB_DIR" 2>/dev/null || true
+# 4. CREATE VIRTUAL ENVIRONMENT
+if [ "$UPGRADE_MODE" -ne 1 ] || [ "$SUDO_CMD" != "pkexec" ]; then
+    perform_privileged_runtime_installation
 fi
-if [ "$UPGRADE_MODE" -eq 0 ]; then
-    run_privileged install -d "$SYSTEM_LIB_DIR"
-    run_privileged install -m 644 "$CONFIG_POINTER_TMP" "$CONFIG_POINTER_PATH"
-fi
-echo "Installing LG Buddy desktop entry..."
-run_privileged install -d "$APPLICATIONS_DIR"
-run_privileged install -m 644 "$DESKTOP_ENTRY_SOURCE" "$DESKTOP_ENTRY_PATH"
-run_privileged rm -f "$LEGACY_DESKTOP_ENTRY_PATH"
-run_privileged install -d "$APP_ICON_DIR"
-run_privileged install -m 644 "$APP_ICON" "$APP_ICON_PATH"
+
+# The desktop file on the user's desktop belongs to the installing user.
 if [ "$UPGRADE_MODE" -eq 0 ]; then
     cp "$DESKTOP_ENTRY_SOURCE" "$USER_DESKTOP_ENTRY_PATH" 2>/dev/null || true
     rm -f "$LEGACY_USER_DESKTOP_ENTRY_PATH"
@@ -760,35 +984,9 @@ elif [ -f "$USER_DESKTOP_ENTRY_PATH" ] || [ -f "$LEGACY_USER_DESKTOP_ENTRY_PATH"
 fi
 echo "Done."
 
-# 7. SETUP SYSTEMD SERVICES
-echo "Copying and enabling systemd services..."
-run_privileged install -d "$SYSTEMD_SYSTEM_DIR"
-run_privileged install -d "$TMPFILES_CONF_DIR"
-run_privileged install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy.service" "$SYSTEMD_SERVICE_PATH"
-run_privileged install -m 644 "$SCRIPT_DIR/systemd/lg_buddy.conf" "$TMPFILES_CONF_PATH"
-run_privileged install -d "$SYSTEMD_SERVICE_OVERRIDE_DIR"
-run_privileged install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_SERVICE_OVERRIDE_DIR}/config.conf"
-
-if [ "$UPGRADE_MODE" -eq 0 ]; then
-    cleanup_legacy_sleep_wake_handlers
+if [ "$UPGRADE_MODE" -ne 1 ] || [ "$SUDO_CMD" != "pkexec" ]; then
+    perform_privileged_services_installation
 fi
-
-run_privileged install -m 644 "$SCRIPT_DIR/systemd/LG_Buddy_lifecycle.service" "$SYSTEMD_LIFECYCLE_SERVICE_PATH"
-run_privileged install -d "$SYSTEMD_LIFECYCLE_OVERRIDE_DIR"
-run_privileged install -m 644 "$SYSTEM_CONFIG_OVERRIDE_TMP" "${SYSTEMD_LIFECYCLE_OVERRIDE_DIR}/config.conf"
-run_privileged install -d "$NM_PRE_DOWN_DIR"
-run_privileged install -m 755 "$NM_HOOK_TMP" "$NM_LIFECYCLE_HOOK_PATH"
-
-if [ "$SKIP_SYSTEMD_ACTIONS" = "1" ]; then
-    echo "Skipping systemd tmpfiles and enable actions because LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1."
-else
-    run_privileged systemd-tmpfiles --create "$TMPFILES_CONF_PATH"
-    run_privileged systemctl daemon-reload
-    run_privileged systemctl enable LG_Buddy.service
-    run_privileged systemctl enable LG_Buddy_lifecycle.service
-    run_privileged systemctl restart LG_Buddy_lifecycle.service
-fi
-echo "Done."
 
 # 8. INSTALL USER SERVICES
 echo "Installing background update check user timer..."
@@ -862,6 +1060,9 @@ if [ "$UPGRADE_MODE" -eq 1 ]; then
     UPGRADE_COMPLETED=1
     echo "Upgrade complete!"
     echo "$INSTALLED_VERSION_OUTPUT"
+    if [ "$SUDO_CMD" = "pkexec" ]; then
+        system_upgrade_status complete
+    fi
 else
     echo "Installation complete!"
     echo "The user-session service has been installed."

--- a/scripts/test-gui-launch.sh
+++ b/scripts/test-gui-launch.sh
@@ -3,10 +3,12 @@
 set -euo pipefail
 umask 0022
 
-GUI_BINARY="${1:-./target/debug/lg-buddy-gui}"
+LAUNCH_BINARY="${1:-./target/debug/lg-buddy}"
+GUI_BINARY="${2:-$(dirname "$LAUNCH_BINARY")/lg-buddy-gui}"
 APPLICATION_ID="io.github.staphylococcus.LGBuddy"
 WINDOW_TITLE="LG Buddy"
 GUI_PID=""
+REPLACEMENT_PID=""
 WINDOW_IDS=()
 
 fail() {
@@ -19,9 +21,14 @@ cleanup() {
         kill "$GUI_PID"
         wait "$GUI_PID" 2>/dev/null || true
     fi
+    if [ -n "$REPLACEMENT_PID" ] && kill -0 "$REPLACEMENT_PID" 2>/dev/null; then
+        kill "$REPLACEMENT_PID"
+        wait "$REPLACEMENT_PID" 2>/dev/null || true
+    fi
 }
 trap cleanup EXIT
 
+[ -x "$LAUNCH_BINARY" ] || fail "GUI launcher is not executable: $LAUNCH_BINARY"
 [ -x "$GUI_BINARY" ] || fail "GUI binary is not executable: $GUI_BINARY"
 [ -n "${DISPLAY:-}" ] || fail "DISPLAY is required for the GUI launch smoke test."
 [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || fail "A D-Bus session is required for the GUI launch smoke test."
@@ -29,7 +36,7 @@ command -v gapplication >/dev/null || fail "gapplication is required for the GUI
 command -v xdotool >/dev/null || fail "xdotool is required for the GUI launch smoke test."
 
 ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
-    "$GUI_BINARY" &
+    "$LAUNCH_BINARY" &
 GUI_PID=$!
 
 for ((attempt = 0; attempt < 300; attempt++)); do
@@ -50,13 +57,43 @@ done
 [ "${#WINDOW_IDS[@]}" -eq 1 ] || fail "GUI did not present Overview."
 
 ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
-    "$GUI_BINARY" brightness
+    "$LAUNCH_BINARY" brightness
 kill -0 "$GUI_PID" 2>/dev/null || fail "Reactivation replaced the running GUI process."
 mapfile -t WINDOW_IDS < <(
     xdotool search --onlyvisible --name "^${WINDOW_TITLE}$" 2>/dev/null || true
 )
 [ "${#WINDOW_IDS[@]}" -eq 1 ] || fail "Reactivation did not preserve one Overview window."
 
-gapplication action "$APPLICATION_ID" quit
-wait "$GUI_PID"
+ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+    "$GUI_BINARY" --gapplication-replace &
+REPLACEMENT_PID=$!
+
+for ((attempt = 0; attempt < 300; attempt++)); do
+    if ! kill -0 "$REPLACEMENT_PID" 2>/dev/null; then
+        status=0
+        wait "$REPLACEMENT_PID" || status=$?
+        fail "GApplication replacement exited before taking over the primary instance with status $status."
+    fi
+    if ! kill -0 "$GUI_PID" 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+if kill -0 "$GUI_PID" 2>/dev/null; then
+    fail "GApplication replacement did not displace the incumbent GUI instance."
+fi
+wait "$GUI_PID" || fail "The incumbent GUI did not exit cleanly after replacement."
 GUI_PID=""
+for ((attempt = 0; attempt < 300; attempt++)); do
+    mapfile -t WINDOW_IDS < <(
+        xdotool search --onlyvisible --name "^${WINDOW_TITLE}$" 2>/dev/null || true
+    )
+    [ "${#WINDOW_IDS[@]}" -eq 1 ] && break
+    sleep 0.1
+done
+[ "${#WINDOW_IDS[@]}" -eq 1 ] || fail "GApplication replacement did not preserve one Overview window."
+
+gapplication action "$APPLICATION_ID" quit
+wait "$REPLACEMENT_PID"
+REPLACEMENT_PID=""

--- a/scripts/test-installed-gui.sh
+++ b/scripts/test-installed-gui.sh
@@ -71,7 +71,7 @@ grep -F -x -q 'Terminal=false' "$DESKTOP_ENTRY" || fail "Desktop entry would ope
 cmp -s "$REPOSITORY_ROOT/data/icons/hicolor/scalable/apps/io.github.staphylococcus.LGBuddy.svg" "$APP_ICON" || fail "Installed application icon differs from the source asset."
 
 export LG_BUDDY_CONFIG="$CONFIG_FILE"
-bash "$SCRIPT_DIR/test-gui-launch.sh" "$INSTALLED_RUNTIME"
+bash "$SCRIPT_DIR/test-gui-launch.sh" "$INSTALLED_RUNTIME" "$INSTALLED_GUI"
 bash "$SCRIPT_DIR/test-release-gui-behavior.sh" "$INSTALLED_RUNTIME" "$CONFIG_FILE"
 
 mkdir -p "$(dirname "$NATIVE_TOKEN")"

--- a/scripts/test-installer-graphical-auth.sh
+++ b/scripts/test-installer-graphical-auth.sh
@@ -12,9 +12,9 @@ INSTALL_SCRIPT="$REPOSITORY_ROOT/install.sh"
     exit 1
 }
 
-if ! unshare -Ur true >/dev/null 2>&1; then
-    echo "Skipping graphical installer smoke: unprivileged user namespaces are unavailable."
-    exit 0
+if ! command -v unshare >/dev/null 2>&1 || ! unshare -Ur true >/dev/null 2>&1; then
+    echo "Graphical installer smoke requires unprivileged user namespaces."
+    exit 1
 fi
 
 WORK_DIR="$(mktemp -d)"
@@ -97,13 +97,9 @@ case "${LG_BUDDY_GRAPHICAL_AUTH_MODE:?}" in
         exec unshare -Ur "$@"
         ;;
     accepted126)
-        # Replace only the helper namespace's first fixed PATH directory so
-        # the real install command can return 126 after copying one file.
-        unshare -Ur -m sh -c '
-            mount --bind "$1" /run/current-system/sw/bin
-            shift
-            exec "$@"
-        ' sh "${LG_BUDDY_GRAPHICAL_AUTH_STUB_DIR:?}" "$@"
+        # BASH_ENV injects the failure after the real install utility copies
+        # the first file without masking the helper's utility search paths.
+        exec unshare -Ur env BASH_ENV="${LG_BUDDY_GRAPHICAL_AUTH_BASH_ENV:?}" "$@"
         ;;
     *)
         exit 2
@@ -117,15 +113,12 @@ REAL_INSTALL="$(command -v install)"
     echo "Could not locate the host install utility for the isolated command stub."
     exit 1
 }
-cat >"$STUB_DIR/install" <<'EOF'
-#!/bin/sh
-set -eu
-"${LG_BUDDY_GRAPHICAL_AUTH_REAL_INSTALL:?}" "$@"
-if [ "${LG_BUDDY_GRAPHICAL_AUTH_MODE:-}" = accepted126 ]; then
-    exit 126
-fi
+cat >"$STUB_DIR/bash-env" <<'EOF'
+install() {
+    "${LG_BUDDY_GRAPHICAL_AUTH_REAL_INSTALL:?}" "$@"
+    return 126
+}
 EOF
-chmod 755 "$STUB_DIR/install"
 
 prepare_fixture() {
     local root="$1"
@@ -167,7 +160,7 @@ run_upgrade() {
     LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1 \
     LG_BUDDY_SKIP_PIP_INSTALL=1 \
     LG_BUDDY_GUI_RUNTIME_PROBE="$STUB_DIR/gui-runtime-probe" \
-    LG_BUDDY_GRAPHICAL_AUTH_STUB_DIR="$STUB_DIR" \
+    LG_BUDDY_GRAPHICAL_AUTH_BASH_ENV="$STUB_DIR/bash-env" \
     LG_BUDDY_GRAPHICAL_AUTH_REAL_INSTALL="$REAL_INSTALL" \
     LG_BUDDY_GRAPHICAL_AUTH_MODE="$mode" \
         bash "$BUNDLE/install.sh" --upgrade </dev/null >"$output" 2>&1

--- a/scripts/test-installer-graphical-auth.sh
+++ b/scripts/test-installer-graphical-auth.sh
@@ -1,0 +1,240 @@
+#!/bin/bash
+
+set -euo pipefail
+umask 0022
+
+SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+REPOSITORY_ROOT="$(dirname "$SCRIPT_DIR")"
+INSTALL_SCRIPT="$REPOSITORY_ROOT/install.sh"
+
+[ "$(id -u)" -ne 0 ] || {
+    echo "Graphical installer smoke must run as a regular user."
+    exit 1
+}
+
+if ! unshare -Ur true >/dev/null 2>&1; then
+    echo "Skipping graphical installer smoke: unprivileged user namespaces are unavailable."
+    exit 0
+fi
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+BUNDLE="$WORK_DIR/bundle"
+STUB_DIR="$WORK_DIR/stubs"
+mkdir -p "$BUNDLE/docs" "$BUNDLE/systemd" "$STUB_DIR"
+cp "$INSTALL_SCRIPT" "$BUNDLE/install.sh"
+chmod 755 "$BUNDLE/install.sh"
+
+cat >"$BUNDLE/lg-buddy" <<'EOF'
+#!/bin/sh
+set -eu
+case "${1:-}" in
+    --version)
+        printf '%s\n' '1.7.0'
+        ;;
+    upgrade-preflight)
+        exit 0
+        ;;
+    settings)
+        case "${3:-}" in
+            tv.platform) printf '%s\n' lg_webos ;;
+            screen.idle_blank) printf '%s\n' enabled ;;
+            screen.backend) printf '%s\n' auto ;;
+            system.sleep_wake_policy) printf '%s\n' enabled ;;
+            updates.auto_check) printf '%s\n' enabled ;;
+            updates.channel) printf '%s\n' stable ;;
+            *) exit 1 ;;
+        esac
+        ;;
+    *) exit 1 ;;
+esac
+EOF
+cat >"$BUNDLE/docs/lg-buddy-gui-x86_64-unknown-linux-gnu" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${1:-}" = --version ] || exit 1
+printf '%s\n' '1.7.0'
+EOF
+cat >"$BUNDLE/LG_Buddy_Brightness.desktop" <<'EOF'
+[Desktop Entry]
+Name=LG Buddy
+Exec=/usr/bin/lg-buddy
+Icon=io.github.staphylococcus.LGBuddy
+Terminal=false
+Type=Application
+EOF
+cat >"$BUNDLE/docs/io.github.staphylococcus.LGBuddy.svg" <<'EOF'
+<svg xmlns="http://www.w3.org/2000/svg" width="1" height="1"/>
+EOF
+for source in \
+    LG_Buddy.service LG_Buddy_lifecycle.service lg_buddy.conf \
+    LG_Buddy_screen.service LG_Buddy_update_check.service LG_Buddy_update_check.timer; do
+    printf '%s\n' "$source" >"$BUNDLE/systemd/$source"
+done
+chmod 755 "$BUNDLE/lg-buddy" "$BUNDLE/docs/lg-buddy-gui-x86_64-unknown-linux-gnu"
+chmod 644 "$BUNDLE/LG_Buddy_Brightness.desktop" "$BUNDLE/docs/io.github.staphylococcus.LGBuddy.svg"
+
+cat >"$STUB_DIR/gui-runtime-probe" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+chmod 755 "$STUB_DIR/gui-runtime-probe"
+
+cat >"$STUB_DIR/pkexec" <<'EOF'
+#!/bin/sh
+set -eu
+[ "${1:-}" = --disable-internal-agent ] || exit 2
+shift
+case "${LG_BUDDY_GRAPHICAL_AUTH_MODE:?}" in
+    cancelled)
+        exit 126
+        ;;
+    unavailable)
+        exit 127
+        ;;
+    accepted)
+        exec unshare -Ur "$@"
+        ;;
+    accepted126)
+        # Replace only the helper namespace's first fixed PATH directory so
+        # the real install command can return 126 after copying one file.
+        unshare -Ur -m sh -c '
+            mount --bind "$1" /run/current-system/sw/bin
+            shift
+            exec "$@"
+        ' sh "${LG_BUDDY_GRAPHICAL_AUTH_STUB_DIR:?}" "$@"
+        ;;
+    *)
+        exit 2
+        ;;
+esac
+EOF
+chmod 755 "$STUB_DIR/pkexec"
+
+REAL_INSTALL="$(command -v install)"
+[ -x "$REAL_INSTALL" ] || {
+    echo "Could not locate the host install utility for the isolated command stub."
+    exit 1
+}
+cat >"$STUB_DIR/install" <<'EOF'
+#!/bin/sh
+set -eu
+"${LG_BUDDY_GRAPHICAL_AUTH_REAL_INSTALL:?}" "$@"
+if [ "${LG_BUDDY_GRAPHICAL_AUTH_MODE:-}" = accepted126 ]; then
+    exit 126
+fi
+EOF
+chmod 755 "$STUB_DIR/install"
+
+prepare_fixture() {
+    local root="$1"
+    local home="$2"
+    mkdir -p \
+        "$root/usr/bin" "$root/usr/lib/lg-buddy" \
+        "$root/etc" "$root/usr/share" \
+        "$home/.config/lg-buddy" "$home/Desktop"
+    printf '%s\n' "$home/.config/lg-buddy/config.env" >"$root/usr/lib/lg-buddy/config-path"
+    cat >"$home/.config/lg-buddy/config.env" <<'EOF'
+tvs_primary_platform=lg_webos
+screen_idle_blank=enabled
+screen_backend=auto
+system_sleep_wake_policy=enabled
+updates_auto_check=enabled
+updates_channel=stable
+EOF
+}
+
+run_upgrade() {
+    local scenario="$1"
+    local mode="$2"
+    local root="$WORK_DIR/$scenario/root"
+    local home="$WORK_DIR/$scenario/home"
+    local output="$WORK_DIR/$scenario/output"
+    mkdir -p "$WORK_DIR/$scenario"
+    prepare_fixture "$root" "$home"
+    if [ "$scenario" = partial ]; then
+        rm -rf "$root/usr/share"
+        printf '%s\n' obstructed >"$root/usr/share"
+    fi
+    set +e
+    PATH="$STUB_DIR:$PATH" \
+    HOME="$home" \
+    XDG_CONFIG_HOME="$home/.config" \
+    LG_BUDDY_INSTALL_ROOT="$root" \
+    LG_BUDDY_SUDO_CMD=pkexec \
+    LG_BUDDY_NONINTERACTIVE=1 \
+    LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1 \
+    LG_BUDDY_SKIP_PIP_INSTALL=1 \
+    LG_BUDDY_GUI_RUNTIME_PROBE="$STUB_DIR/gui-runtime-probe" \
+    LG_BUDDY_GRAPHICAL_AUTH_STUB_DIR="$STUB_DIR" \
+    LG_BUDDY_GRAPHICAL_AUTH_REAL_INSTALL="$REAL_INSTALL" \
+    LG_BUDDY_GRAPHICAL_AUTH_MODE="$mode" \
+        bash "$BUNDLE/install.sh" --upgrade </dev/null >"$output" 2>&1
+    RUN_STATUS=$?
+    set -e
+}
+
+run_upgrade cancelled cancelled
+[ "$RUN_STATUS" -eq 126 ] || { echo "Cancelled auth returned $RUN_STATUS."; exit 1; }
+grep -F -q 'Graphical authorization was cancelled' "$WORK_DIR/cancelled/output"
+! grep -F -q 'LG_BUDDY_INSTALL_STATUS=' "$WORK_DIR/cancelled/output"
+[ ! -e "$WORK_DIR/cancelled/root/usr/bin/lg-buddy" ] || {
+    echo "Cancelled auth mutated the installation root."
+    exit 1
+}
+
+run_upgrade unavailable unavailable
+[ "$RUN_STATUS" -eq 127 ] || { echo "Unavailable auth returned $RUN_STATUS."; exit 1; }
+grep -F -q 'no authentication agent was available' "$WORK_DIR/unavailable/output"
+! grep -F -q 'LG_BUDDY_INSTALL_STATUS=' "$WORK_DIR/unavailable/output"
+
+run_upgrade partial accepted
+[ "$RUN_STATUS" -ne 0 ] || { echo "Partial helper unexpectedly succeeded."; exit 1; }
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=authorized' "$WORK_DIR/partial/output"
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=mutation_started' "$WORK_DIR/partial/output"
+! grep -F -q 'LG_BUDDY_INSTALL_STATUS=root_complete' "$WORK_DIR/partial/output"
+grep -F -q 'The installation may be partial' "$WORK_DIR/partial/output"
+[ -x "$WORK_DIR/partial/root/usr/bin/lg-buddy" ] || {
+    echo "Partial helper did not leave the expected first mutation."
+    exit 1
+}
+
+run_upgrade partial126 accepted126
+[ "$RUN_STATUS" -eq 126 ] || { echo "Post-mutation status returned $RUN_STATUS instead of 126."; exit 1; }
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=authorized' "$WORK_DIR/partial126/output"
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=mutation_started' "$WORK_DIR/partial126/output"
+! grep -F -q 'LG_BUDDY_INSTALL_STATUS=root_complete' "$WORK_DIR/partial126/output"
+! grep -F -q 'Graphical authorization was cancelled' "$WORK_DIR/partial126/output"
+grep -F -q 'The installation may be partial' "$WORK_DIR/partial126/output"
+[ ! -e "$WORK_DIR/partial126/root/usr/bin/lg-buddy-gui" ] || {
+    echo "Post-mutation command unexpectedly completed the GUI copy."
+    exit 1
+}
+[ -x "$WORK_DIR/partial126/root/usr/bin/lg-buddy" ] || {
+    echo "Post-mutation status did not retain the root-phase mutation."
+    exit 1
+}
+
+run_upgrade success accepted
+[ "$RUN_STATUS" -eq 0 ] || { echo "Accepted auth returned $RUN_STATUS."; exit 1; }
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=authorized' "$WORK_DIR/success/output"
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=mutation_started' "$WORK_DIR/success/output"
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=root_complete' "$WORK_DIR/success/output"
+grep -F -x -q 'LG_BUDDY_INSTALL_STATUS=complete' "$WORK_DIR/success/output"
+grep -F -q 'Upgrade complete!' "$WORK_DIR/success/output"
+[ -x "$WORK_DIR/success/root/usr/bin/lg-buddy" ]
+[ -x "$WORK_DIR/success/root/usr/bin/lg-buddy-gui" ]
+
+EXPECTED_CONFIG="$WORK_DIR/expected-config"
+cat >"$EXPECTED_CONFIG" <<'EOF'
+tvs_primary_platform=lg_webos
+screen_idle_blank=enabled
+screen_backend=auto
+system_sleep_wake_policy=enabled
+updates_auto_check=enabled
+updates_channel=stable
+EOF
+cmp -s "$WORK_DIR/success/home/.config/lg-buddy/config.env" "$EXPECTED_CONFIG"
+
+echo "Graphical installer authorization smoke passed: cancelled=126 unavailable=127 partial=failed post-mutation-126=126 success=0."

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -286,6 +286,11 @@ cleanup() {
 
 trap cleanup EXIT
 
+# Keep the graphical authorization boundary covered by the canonical release
+# smoke lane. The focused test uses isolated fixtures and never invokes the
+# host's authentication agent or installation paths.
+bash "$SCRIPT_DIR/test-installer-graphical-auth.sh"
+
 EXTRACT_DIR="$WORK_DIR/extracted"
 INSTALL_ROOT="$WORK_DIR/root"
 HOME_DIR="$WORK_DIR/home"
@@ -606,7 +611,7 @@ fi
 assert_cli_surface "$INSTALLED_BINARY"
 
 if [ -n "${DISPLAY:-}" ]; then
-    bash "$SCRIPT_DIR/test-gui-launch.sh" "$INSTALLED_BINARY"
+    bash "$SCRIPT_DIR/test-gui-launch.sh" "$INSTALLED_BINARY" "$INSTALLED_GUI"
     bash "$SCRIPT_DIR/test-release-gui-behavior.sh" "$INSTALLED_BINARY" "$CONFIG_FILE"
 fi
 


### PR DESCRIPTION
## Summary

An available update in Settings previously required a terminal to install. Add a confirmed GUI installation flow over the same release discovery, pinned identity, acquisition, compatibility checks, installer, and final identity verification used by the CLI.

The installer requests one graphical authorization for system files and services; user configuration and service operations stay unprivileged. The application owns progress, cancellation, failures, and handoff. GTK renders those states and runs the declared work off its UI thread.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

Settings → Updates has one native row with its status on the left and **Check for updates** or **Install update…** on the right. A check disables the same button and labels it **Checking…**. Checking reports only availability, without retaining a target version or URL. Availability changes the row; already-current results and failures use toasts. Error toasts offer **Copy details** with bounded, redacted diagnostics. Settings refreshes do not repeat completion messages.

**Install update…** opens a native dialog that independently retrieves the latest qualifying release using the saved channel preference. Its discovered version and release link are shown for confirmation, so a newer release appearing after the check does not leave an obsolete installation target. If no newer release qualifies, the dialog closes, clears previous availability, and shows **Already up to date**. Confirmation authorizes installation of the exact resolved release; later target changes still cannot replace it. A pulsing progress bar indicates pending work without inventing a percentage. Preparation and download can be cancelled. Once installation starts, the dialog stays open until an outcome and distinguishes declined authorization from a potentially incomplete installation. Failure closes the dialog, shows a toast, and returns to the install action.

Success verifies both installed binaries and replaces the running GUI while preserving one window. A failed handoff is identified in the row; retrying runs only process replacement. Pairing, configuration, and update preferences are preserved. The flow supports mutable release-bundle installations; externally managed installations retain their existing refusal and package-manager guidance. CLI confirmation and sudo behavior remain available.

## Validation

- Full core suite: 943 unit tests passed, 1 ignored; 134 acceptance scenarios and all integration tests passed.
- Display-backed GTK suite passed on Ubuntu 24.04 (GTK 4.14.5 / libadwaita 1.5.0) and the newer local toolkit, including completion before the dialog opens, fresh modal release selection, no-qualifying-update recovery, confirmation, cancellation at the actual installer boundary, concurrent/stale operations, authorization refusal, restart retry, keyboard focus, clipboard redaction, and narrow layouts. Real widget bounds verify a single updater row and aligned titles.
- 17 updater screenshots, including narrow layouts and no-qualifying-update recovery, were captured from the production GTK renderer with simulated results. The changed states were visually reviewed.
- Workspace Clippy passed with warnings denied; formatting and shell syntax checks passed.
- Installed GUI smoke passed, including normal reactivation, GApplication replacement, GUI interactions, and configuration/credential preservation.
- Isolated graphical-installer fixtures passed for authorization cancellation/unavailability, partial failure (including exit 126 after mutation), and successful installation. The fixture also passed on Ubuntu 24.04 and is mandatory in CI/release bundle smoke, with explicit namespace setup on disposable Ubuntu runners. Subprocess handoff coverage verifies the installed executable path and process replacement.

Graphical authorization was exercised through isolated process/namespace fixtures, not a live desktop polkit prompt. Release-bundle and cross-distribution checks also run in CI.

## Related Issue

Fixes #199
