### PR TITLE
Add on-demand diagnostics and report export

### DIFF
--- a/crates/lg-buddy-gui/src/diagnostics.rs
+++ b/crates/lg-buddy-gui/src/diagnostics.rs
@@ -1,0 +1,483 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use adw::prelude::*;
+use lg_buddy::diagnostics_view::{DiagnosticsIntent, DiagnosticsPresentation};
+
+/// Native renderer for the on-demand diagnostics dialog.
+///
+/// The report and all status decisions belong to the application. This view
+/// only presents those values and forwards the semantic actions supplied by
+/// the application controller.
+pub(crate) struct DiagnosticsView {
+    dialog: adw::Dialog,
+    report: gtk::TextView,
+    status: gtk::Label,
+    #[cfg(test)]
+    close: gtk::Button,
+    refresh: gtk::Button,
+    copy: gtk::Button,
+    save: gtk::Button,
+    #[cfg(test)]
+    actions: gtk::FlowBox,
+    presented: Rc<Cell<bool>>,
+    suppress_close: Rc<Cell<bool>>,
+}
+
+impl DiagnosticsView {
+    pub(crate) fn new(on_intent: Rc<dyn Fn(DiagnosticsIntent)>) -> Self {
+        let presented = Rc::new(Cell::new(false));
+        let suppress_close = Rc::new(Cell::new(false));
+
+        let report = gtk::TextView::builder()
+            .editable(false)
+            .cursor_visible(false)
+            .accepts_tab(false)
+            .wrap_mode(gtk::WrapMode::WordChar)
+            .monospace(true)
+            .hexpand(true)
+            .vexpand(true)
+            .top_margin(12)
+            .bottom_margin(12)
+            .left_margin(12)
+            .right_margin(12)
+            .build();
+        report.set_focusable(true);
+        report.update_property(&[gtk::accessible::Property::Label("Diagnostic report")]);
+
+        let report_heading = gtk::Label::builder()
+            .label("Diagnostic report")
+            .xalign(0.0)
+            .build();
+        report_heading.add_css_class("title-3");
+
+        let status = gtk::Label::builder()
+            .xalign(0.0)
+            .wrap(true)
+            .wrap_mode(gtk::pango::WrapMode::WordChar)
+            .hexpand(true)
+            .visible(false)
+            .build();
+        status.set_accessible_role(gtk::AccessibleRole::Status);
+
+        let scroller = gtk::ScrolledWindow::builder()
+            .hscrollbar_policy(gtk::PolicyType::Never)
+            .vexpand(true)
+            .hexpand(true)
+            .propagate_natural_height(false)
+            .child(&report)
+            .build();
+        scroller.update_property(&[gtk::accessible::Property::Label("Diagnostic report")]);
+
+        let content = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .spacing(12)
+            .margin_start(20)
+            .margin_end(20)
+            .margin_top(20)
+            .margin_bottom(20)
+            .hexpand(true)
+            .vexpand(true)
+            .build();
+        content.append(&status);
+        content.append(&report_heading);
+        content.append(&scroller);
+
+        let close = gtk::Button::with_label("Close");
+        close.connect_clicked({
+            let on_intent = Rc::clone(&on_intent);
+            move |_| on_intent(DiagnosticsIntent::Close)
+        });
+        let refresh = gtk::Button::with_label("Refresh");
+        refresh.connect_clicked({
+            let on_intent = Rc::clone(&on_intent);
+            move |_| on_intent(DiagnosticsIntent::Refresh)
+        });
+        let copy = gtk::Button::with_label("Copy");
+        copy.connect_clicked({
+            let on_intent = Rc::clone(&on_intent);
+            move |_| on_intent(DiagnosticsIntent::Copy)
+        });
+        let save = gtk::Button::with_label("Save…");
+        save.connect_clicked({
+            let on_intent = Rc::clone(&on_intent);
+            move |_| on_intent(DiagnosticsIntent::Save)
+        });
+        for button in [&close, &refresh, &copy, &save] {
+            button.set_width_request(80);
+        }
+
+        // FlowBox wraps the actions on narrow windows while retaining native
+        // button focus and ordering.
+        let actions = gtk::FlowBox::builder()
+            .selection_mode(gtk::SelectionMode::None)
+            .min_children_per_line(1)
+            .max_children_per_line(4)
+            .column_spacing(6)
+            .row_spacing(6)
+            .halign(gtk::Align::Fill)
+            .hexpand(true)
+            .build();
+        actions.insert(&close, -1);
+        actions.insert(&refresh, -1);
+        actions.insert(&copy, -1);
+        actions.insert(&save, -1);
+
+        let header = adw::HeaderBar::builder()
+            .show_start_title_buttons(false)
+            .show_end_title_buttons(false)
+            .build();
+        let toolbar = adw::ToolbarView::builder().content(&content).build();
+        toolbar.add_top_bar(&header);
+        let actions_bar = gtk::Box::builder()
+            .orientation(gtk::Orientation::Vertical)
+            .margin_start(20)
+            .margin_end(20)
+            .margin_top(12)
+            .margin_bottom(20)
+            .build();
+        actions_bar.append(&actions);
+        toolbar.add_bottom_bar(&actions_bar);
+
+        let dialog = adw::Dialog::builder()
+            .title("Diagnostics")
+            .content_width(720)
+            .content_height(560)
+            .child(&toolbar)
+            .build();
+        dialog.connect_closed({
+            let on_intent = Rc::clone(&on_intent);
+            let presented = Rc::clone(&presented);
+            let suppress_close = Rc::clone(&suppress_close);
+            move |_| {
+                presented.set(false);
+                if !suppress_close.replace(false) {
+                    on_intent(DiagnosticsIntent::Close);
+                }
+            }
+        });
+
+        Self {
+            dialog,
+            report,
+            status,
+            #[cfg(test)]
+            close,
+            refresh,
+            copy,
+            save,
+            #[cfg(test)]
+            actions,
+            presented,
+            suppress_close,
+        }
+    }
+
+    pub(crate) fn render(
+        &self,
+        parent: &adw::ApplicationWindow,
+        presentation: &DiagnosticsPresentation,
+    ) {
+        let report_text = presentation
+            .report_text()
+            .unwrap_or("No diagnostic report has been collected yet.");
+        let buffer = self.report.buffer();
+        let start = buffer.start_iter();
+        let end = buffer.end_iter();
+        if buffer.text(&start, &end, false).as_str() != report_text {
+            buffer.set_text(report_text);
+        }
+
+        let status = if let Some(error) = presentation.error() {
+            Some(error.to_owned())
+        } else if presentation.collecting() {
+            Some("Collecting diagnostics…".to_owned())
+        } else if presentation.saving() {
+            Some("Saving diagnostics…".to_owned())
+        } else {
+            presentation
+                .collected_at()
+                .map(|collected_at| format!("Collected {collected_at}"))
+        };
+        self.status.set_text(status.as_deref().unwrap_or(""));
+        self.status.set_visible(status.is_some());
+        self.status
+            .set_accessible_role(if presentation.error().is_some() {
+                gtk::AccessibleRole::Alert
+            } else {
+                gtk::AccessibleRole::Status
+            });
+
+        self.refresh.set_sensitive(presentation.can_refresh());
+        self.copy.set_sensitive(presentation.can_export());
+        self.save.set_sensitive(presentation.can_export());
+
+        if presentation.visible() {
+            if !self.presented.replace(true) {
+                self.dialog.present(Some(parent));
+            }
+        } else if self.presented.replace(false) {
+            self.suppress_close.set(true);
+            self.dialog.force_close();
+        }
+    }
+
+    #[cfg(test)]
+    fn report(&self) -> &gtk::TextView {
+        &self.report
+    }
+
+    #[cfg(test)]
+    fn refresh(&self) -> &gtk::Button {
+        &self.refresh
+    }
+
+    #[cfg(test)]
+    fn close(&self) -> &gtk::Button {
+        &self.close
+    }
+
+    #[cfg(test)]
+    fn copy(&self) -> &gtk::Button {
+        &self.copy
+    }
+
+    #[cfg(test)]
+    fn save(&self) -> &gtk::Button {
+        &self.save
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
+    use crate::controller_test_support::pump_until;
+    use lg_buddy::diagnostics::{DiagnosticSection, DiagnosticsReport};
+    use lg_buddy::diagnostics_view::{DiagnosticsApplication, DiagnosticsError};
+    use std::cell::RefCell;
+    use std::path::PathBuf;
+
+    fn action_row_positions(actions: &gtk::FlowBox) -> Vec<i32> {
+        let mut positions = Vec::new();
+        let mut child = actions.first_child();
+        while let Some(child_widget) = child {
+            positions.push(child_widget.allocation().y());
+            child = child_widget.next_sibling();
+        }
+        positions
+    }
+
+    let intents = Rc::new(RefCell::new(Vec::new()));
+    let view = DiagnosticsView::new(Rc::new({
+        let intents = Rc::clone(&intents);
+        move |intent| intents.borrow_mut().push(intent)
+    }));
+    let wide_window = adw::ApplicationWindow::builder()
+        .application(application)
+        .default_width(800)
+        .default_height(600)
+        .build();
+    wide_window.present();
+
+    assert!(view.report().is_focusable());
+    assert_eq!(view.report().wrap_mode(), gtk::WrapMode::WordChar);
+    assert!(!view.report().is_editable());
+    assert_eq!(view.dialog.title(), "Diagnostics");
+    assert_eq!(view.close().label().as_deref(), Some("Close"));
+    assert_eq!(view.refresh().label().as_deref(), Some("Refresh"));
+    assert_eq!(view.copy().label().as_deref(), Some("Copy"));
+    assert_eq!(view.save().label().as_deref(), Some("Save…"));
+
+    let mut model = DiagnosticsApplication::default();
+    let opening = model.handle_intent(DiagnosticsIntent::Open).unwrap();
+    view.render(&wide_window, opening.presentation());
+    pump_until(|| {
+        let positions = action_row_positions(&view.actions);
+        view.report().width() > 400
+            && positions.len() == 4
+            && positions.iter().all(|position| *position == positions[0])
+            && view
+                .dialog
+                .child()
+                .map(|child| child.is_mapped())
+                .unwrap_or(false)
+    });
+    assert!(view.presented.get());
+    assert!(!view.refresh().is_sensitive());
+    assert!(!view.copy().is_sensitive());
+    assert!(view.report().width() > 400);
+    assert_eq!(view.actions.max_children_per_line(), 4);
+    assert_eq!(view.actions.min_children_per_line(), 1);
+    let wide_action_rows = action_row_positions(&view.actions);
+    assert_eq!(wide_action_rows.len(), 4);
+    assert!(wide_action_rows
+        .iter()
+        .all(|position| *position == wide_action_rows[0]));
+    assert_eq!(view.status.text(), "Collecting diagnostics…");
+
+    let completed = model
+        .complete_read(
+            opening.read_operation().unwrap(),
+            Ok(DiagnosticsReport::new(
+                1_000,
+                vec![DiagnosticSection::new("Application", "safe fixture")],
+            )),
+        )
+        .unwrap();
+    view.render(&wide_window, completed.presentation());
+    assert!(view.copy().is_sensitive());
+    assert!(view.save().is_sensitive());
+    let text = view
+        .report()
+        .buffer()
+        .text(
+            &view.report().buffer().start_iter(),
+            &view.report().buffer().end_iter(),
+            false,
+        )
+        .to_string();
+    assert_eq!(Some(text.as_str()), completed.presentation().report_text());
+
+    let buffer = view.report().buffer();
+    let start = buffer.start_iter();
+    let mut bound = start;
+    bound.forward_chars(6);
+    buffer.select_range(&start, &bound);
+    assert!(buffer.selection_bounds().is_some());
+    view.render(&wide_window, completed.presentation());
+    assert!(
+        buffer.selection_bounds().is_some(),
+        "an unchanged report must preserve the user's selection"
+    );
+
+    // Native dismissal emits Close. Feeding that intent back through the
+    // application and rendering its transition must not emit a second Close.
+    intents.borrow_mut().clear();
+    view.dialog.close();
+    pump_until(|| intents.borrow().contains(&DiagnosticsIntent::Close));
+    assert_eq!(*intents.borrow(), vec![DiagnosticsIntent::Close]);
+    let closed = model
+        .handle_intent(DiagnosticsIntent::Close)
+        .expect("native close transition");
+    intents.borrow_mut().clear();
+    view.render(&wide_window, closed.presentation());
+    pump_until(|| !view.presented.get() && !view.suppress_close.get());
+    assert!(intents.borrow().is_empty());
+    wide_window.close();
+
+    let narrow_window = adw::ApplicationWindow::builder()
+        .application(application)
+        .default_width(350)
+        .default_height(600)
+        .build();
+    narrow_window.present();
+    let reopened = model
+        .handle_intent(DiagnosticsIntent::Open)
+        .expect("reopening diagnostics");
+    view.render(&narrow_window, reopened.presentation());
+    pump_until(|| {
+        let positions = action_row_positions(&view.actions);
+        view.presented.get()
+            && view.report().width() > 0
+            && view.report().width() < 350
+            && positions.len() == 4
+            && positions.iter().any(|position| *position != positions[0])
+    });
+    assert!(view.presented.get());
+    assert!(view.report().width() > 0);
+    assert!(view.report().width() < 350);
+    let narrow_action_rows = action_row_positions(&view.actions);
+    assert_eq!(narrow_action_rows.len(), 4);
+    assert!(narrow_action_rows
+        .iter()
+        .any(|position| *position != narrow_action_rows[0]));
+    let reopened_completed = model
+        .complete_read(
+            reopened.read_operation().unwrap(),
+            Ok(DiagnosticsReport::new(
+                1_001,
+                vec![DiagnosticSection::new("Application", "safe fixture")],
+            )),
+        )
+        .unwrap();
+    view.render(&narrow_window, reopened_completed.presentation());
+
+    let refresh = model
+        .handle_intent(DiagnosticsIntent::Refresh)
+        .expect("refresh transition");
+    view.render(&narrow_window, refresh.presentation());
+    assert_eq!(view.status.text(), "Collecting diagnostics…");
+    assert!(!view.refresh().is_sensitive());
+    let failed = model
+        .complete_read(
+            refresh.read_operation().unwrap(),
+            Err(DiagnosticsError::collection_stopped()),
+        )
+        .unwrap();
+    view.render(&narrow_window, failed.presentation());
+    assert!(view.status.is_visible());
+    assert_eq!(
+        view.status.text(),
+        "Collection stopped unexpectedly. Refresh to try again."
+    );
+    assert_eq!(view.status.accessible_role(), gtk::AccessibleRole::Alert);
+    assert!(view.copy().is_sensitive());
+    assert!(view.save().is_sensitive());
+
+    let choosing = model
+        .handle_intent(DiagnosticsIntent::Save)
+        .expect("save chooser transition");
+    view.render(&narrow_window, choosing.presentation());
+    let saving = model
+        .handle_intent(DiagnosticsIntent::SaveDestination {
+            request: choosing.save_request().unwrap(),
+            path: Some(PathBuf::from("diagnostics.txt")),
+        })
+        .expect("save transition");
+    view.render(&narrow_window, saving.presentation());
+    assert_eq!(view.status.text(), "Saving diagnostics…");
+    assert!(!view.refresh().is_sensitive());
+    assert!(!view.copy().is_sensitive());
+    let saved = model
+        .complete_save(saving.save_operation().unwrap(), Ok(()))
+        .unwrap();
+    view.render(&narrow_window, saved.presentation());
+
+    intents.borrow_mut().clear();
+    view.refresh().emit_clicked();
+    view.copy().emit_clicked();
+    view.save().emit_clicked();
+    assert_eq!(
+        *intents.borrow(),
+        vec![
+            DiagnosticsIntent::Refresh,
+            DiagnosticsIntent::Copy,
+            DiagnosticsIntent::Save,
+        ]
+    );
+
+    // Application-driven dismissal is asynchronous in libadwaita. Its
+    // closed signal must be suppressed, and the same widget must reopen once
+    // the close callback has completed.
+    intents.borrow_mut().clear();
+    let hidden = model
+        .handle_intent(DiagnosticsIntent::Close)
+        .expect("application close transition");
+    view.render(&narrow_window, hidden.presentation());
+    pump_until(|| !view.presented.get() && !view.suppress_close.get());
+    assert!(intents.borrow().is_empty());
+    assert!(!view.presented.get());
+
+    let reopened = model
+        .handle_intent(DiagnosticsIntent::Open)
+        .expect("reopen after application close");
+    view.render(&narrow_window, reopened.presentation());
+    pump_until(|| view.presented.get() && view.report().width() > 0);
+    assert!(view.presented.get());
+
+    let hidden = model
+        .handle_intent(DiagnosticsIntent::Close)
+        .expect("final close transition");
+    view.render(&narrow_window, hidden.presentation());
+    pump_until(|| !view.presented.get() && !view.suppress_close.get());
+    narrow_window.close();
+}

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -1,3 +1,4 @@
+mod diagnostics;
 mod overview;
 mod pairing;
 mod settings;
@@ -17,6 +18,11 @@ use lg_buddy::application::{Application, ApplicationTransition, OverviewCompleti
 use lg_buddy::audio::{AudioWriteError, AudioWriteFailure};
 use lg_buddy::brightness::{
     BrightnessReadError, BrightnessReadFailure, BrightnessWriteError, BrightnessWriteFailure,
+};
+use lg_buddy::diagnostics_view::{
+    DiagnosticsBackend, DiagnosticsError, DiagnosticsIntent, DiagnosticsReadOperation,
+    DiagnosticsSaveOperation, DiagnosticsSaveRequest, DiagnosticsTransition,
+    EnvironmentDiagnosticsBackend,
 };
 use lg_buddy::navigation::ApplicationPage;
 use lg_buddy::overview::{
@@ -181,6 +187,7 @@ struct ApplicationController {
     pairing_backend: Arc<dyn PairingBackend>,
     settings_backend: Arc<dyn SettingsBackend>,
     update_install_backend: Arc<dyn UpdateInstallBackend>,
+    diagnostics_backend: Arc<dyn DiagnosticsBackend>,
     backend: Arc<dyn OverviewBackend>,
     closed: Cell<bool>,
 }
@@ -226,6 +233,26 @@ impl ApplicationController {
         settings_backend: Arc<dyn SettingsBackend>,
         update_install_backend: Arc<dyn UpdateInstallBackend>,
     ) -> (Rc<Self>, ApplicationTransition) {
+        Self::with_all_backends(
+            gtk_application,
+            backend,
+            tvs_backend,
+            pairing_backend,
+            settings_backend,
+            update_install_backend,
+            Arc::new(EnvironmentDiagnosticsBackend),
+        )
+    }
+
+    fn with_all_backends(
+        gtk_application: &adw::Application,
+        backend: Arc<dyn OverviewBackend>,
+        tvs_backend: Arc<dyn TvsBackend>,
+        pairing_backend: Arc<dyn PairingBackend>,
+        settings_backend: Arc<dyn SettingsBackend>,
+        update_install_backend: Arc<dyn UpdateInstallBackend>,
+        diagnostics_backend: Arc<dyn DiagnosticsBackend>,
+    ) -> (Rc<Self>, ApplicationTransition) {
         let (application, opening) = Application::open();
         let controller = Rc::new_cyclic(|controller| {
             let on_intent: overview::IntentHandler = Rc::new({
@@ -260,11 +287,20 @@ impl ApplicationController {
                     }
                 }
             });
+            let on_diagnostics = Rc::new({
+                let controller = controller.clone();
+                move |intent| {
+                    if let Some(controller) = controller.upgrade() {
+                        Self::handle_diagnostics_intent(&controller, intent);
+                    }
+                }
+            });
             Self {
                 tvs_backend,
                 pairing_backend,
                 settings_backend,
                 update_install_backend,
+                diagnostics_backend,
                 application: RefCell::new(application),
                 gtk_application: gtk_application.clone(),
                 window: window::ApplicationWindow::new(
@@ -273,6 +309,7 @@ impl ApplicationController {
                     on_tvs,
                     on_settings,
                     on_navigation,
+                    on_diagnostics,
                 ),
                 backend,
                 closed: Cell::new(false),
@@ -313,6 +350,138 @@ impl ApplicationController {
         if let Some(overview) = transition.overview() {
             Self::render_overview_transition(controller, overview);
         }
+        if let Some(diagnostics) = transition.diagnostics() {
+            Self::render_diagnostics_transition(controller, diagnostics);
+        }
+    }
+
+    fn handle_diagnostics_intent(controller: &Rc<Self>, intent: DiagnosticsIntent) {
+        let transition = controller
+            .application
+            .borrow_mut()
+            .handle_diagnostics_intent(intent);
+        if let Some(transition) = transition {
+            Self::apply_transition(controller, transition);
+        }
+    }
+
+    fn render_diagnostics_transition(controller: &Rc<Self>, transition: &DiagnosticsTransition) {
+        if controller.closed.get() {
+            return;
+        }
+        controller
+            .window
+            .render_diagnostics(transition.presentation());
+        if let Some(text) = transition.clipboard_text() {
+            controller.window.window().clipboard().set_text(text);
+        }
+        if let Some(message) = transition.toast() {
+            controller.window.show_toast(message);
+        }
+        if let Some(operation) = transition.read_operation() {
+            Self::start_diagnostics_read(controller, operation.clone());
+        }
+        if let Some(request) = transition.save_request() {
+            Self::choose_diagnostics_destination(controller, request);
+        }
+        if let Some(operation) = transition.save_operation() {
+            Self::start_diagnostics_save(controller, operation.clone());
+        }
+    }
+
+    fn start_diagnostics_read(controller: &Rc<Self>, operation: DiagnosticsReadOperation) {
+        let backend = Arc::clone(&controller.diagnostics_backend);
+        let (sender, receiver) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let _ = sender.send(backend.collect());
+        });
+        let controller = Rc::downgrade(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || {
+            let Some(controller) = controller.upgrade().filter(|value| !value.closed.get()) else {
+                return glib::ControlFlow::Break;
+            };
+            let result = match receiver.try_recv() {
+                Ok(result) => result,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    Err(DiagnosticsError::collection_stopped())
+                }
+            };
+            let transition = controller
+                .application
+                .borrow_mut()
+                .complete_diagnostics_read(&operation, result);
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
+            }
+            glib::ControlFlow::Break
+        });
+    }
+
+    fn choose_diagnostics_destination(controller: &Rc<Self>, request: DiagnosticsSaveRequest) {
+        let dialog = gtk::FileDialog::builder()
+            .title("Save Diagnostic Report")
+            .initial_name("lg-buddy-diagnostics.txt")
+            .modal(true)
+            .build();
+        let weak_controller = Rc::downgrade(controller);
+        dialog.save(
+            Some(&controller.window.window()),
+            None::<&gtk::gio::Cancellable>,
+            move |result| {
+                let Some(controller) = weak_controller.upgrade() else {
+                    return;
+                };
+                let intent = match result {
+                    Ok(file) => match file.path() {
+                        Some(path) => DiagnosticsIntent::SaveDestination {
+                            request,
+                            path: Some(path),
+                        },
+                        None => DiagnosticsIntent::SaveSelectionFailed(request),
+                    },
+                    Err(error)
+                        if error.matches(gtk::DialogError::Dismissed)
+                            || error.matches(gtk::DialogError::Cancelled) =>
+                    {
+                        DiagnosticsIntent::SaveDestination {
+                            request,
+                            path: None,
+                        }
+                    }
+                    Err(_) => DiagnosticsIntent::SaveSelectionFailed(request),
+                };
+                Self::handle_diagnostics_intent(&controller, intent);
+            },
+        );
+    }
+
+    fn start_diagnostics_save(controller: &Rc<Self>, operation: DiagnosticsSaveOperation) {
+        let backend = Arc::clone(&controller.diagnostics_backend);
+        let worker_operation = operation.clone();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        // An accepted export finishes even if its dialog or window closes.
+        let application_hold = controller.gtk_application.hold();
+        thread::spawn(move || {
+            let _ = sender.send(backend.save(&worker_operation));
+        });
+        let controller = Rc::clone(controller);
+        glib::timeout_add_local(Duration::from_millis(10), move || {
+            let result = match receiver.try_recv() {
+                Ok(result) => result,
+                Err(mpsc::TryRecvError::Empty) => return glib::ControlFlow::Continue,
+                Err(mpsc::TryRecvError::Disconnected) => Err(DiagnosticsError::save_failed()),
+            };
+            let transition = controller
+                .application
+                .borrow_mut()
+                .complete_diagnostics_save(&operation, result);
+            if let Some(transition) = transition {
+                Self::apply_transition(&controller, transition);
+            }
+            let _ = &application_hold;
+            glib::ControlFlow::Break
+        });
     }
 
     fn render_overview_transition(controller: &Rc<Self>, transition: &OverviewTransition) {
@@ -1205,6 +1374,15 @@ pub(crate) mod controller_test_support {
                 return true;
             }
         }
+        if let Some(view) = widget.downcast_ref::<gtk::TextView>() {
+            let buffer = view.buffer();
+            if buffer
+                .text(&buffer.start_iter(), &buffer.end_iter(), false)
+                .contains(expected)
+            {
+                return true;
+            }
+        }
         let mut child = widget.first_child();
         while let Some(current) = child {
             if widget_contains_text(&current, expected) {
@@ -1248,6 +1426,7 @@ pub(crate) mod controller_test_support {
         run_settings_write_scenario();
         run_manual_update_check_scenario();
         run_update_install_scenario();
+        run_diagnostics_scenario();
 
         let (backend, controls) = BlockingBackend::new();
         let application = test_application("Blocking");
@@ -1500,6 +1679,105 @@ pub(crate) mod controller_test_support {
         pump_until(|| widget_contains_text(native.upcast_ref(), "120"));
         controller.shutdown();
         controller.window.close();
+    }
+
+    fn run_diagnostics_scenario() {
+        use lg_buddy::diagnostics::{DiagnosticSection, DiagnosticsReport};
+        use lg_buddy::diagnostics_view::{DiagnosticsBackend, DiagnosticsError, DiagnosticsIntent};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct Collector {
+            calls: AtomicUsize,
+            replies: Mutex<mpsc::Receiver<DiagnosticsReport>>,
+        }
+        impl DiagnosticsBackend for Collector {
+            fn collect(&self) -> Result<DiagnosticsReport, DiagnosticsError> {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(self.replies.lock().unwrap().recv().unwrap())
+            }
+        }
+
+        let (reply_tx, reply_rx) = mpsc::channel();
+        let backend = Arc::new(Collector {
+            calls: AtomicUsize::new(0),
+            replies: Mutex::new(reply_rx),
+        });
+        let application = test_application("Diagnostics");
+        let (controller, opening) = ApplicationController::with_all_backends(
+            &application,
+            Arc::new(PanicBackend),
+            Arc::new(EmptyTvsBackend),
+            Arc::new(lg_buddy::pairing::EnvironmentPairingBackend),
+            Arc::new(DefaultSettingsBackend),
+            Arc::new(lg_buddy::update_flow::EnvironmentUpdateInstallBackend),
+            backend.clone(),
+        );
+        assert!(opening.diagnostics().is_none());
+        assert!(!opening.navigation().tabs_visible());
+        controller.present();
+        pump_for(Duration::from_millis(30));
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 0);
+        let native = controller.window.window();
+        native.activate_action("win.diagnostics", None).unwrap();
+        pump_until(|| backend.calls.load(Ordering::SeqCst) == 1);
+        assert!(widget_contains_text(
+            native.upcast_ref(),
+            "Collecting diagnostics"
+        ));
+        ApplicationController::handle_diagnostics_intent(&controller, DiagnosticsIntent::Refresh);
+        pump_for(Duration::from_millis(30));
+        assert_eq!(backend.calls.load(Ordering::SeqCst), 1);
+
+        let report = DiagnosticsReport::new(
+            1_000,
+            vec![
+                DiagnosticSection::new("Application", "Fixture diagnostics"),
+                DiagnosticSection::new("TV observation", "No TV configured"),
+                DiagnosticSection::new("Services", "Inspection unavailable"),
+            ],
+        );
+        reply_tx.send(report.clone()).unwrap();
+        pump_until(|| widget_contains_text(native.upcast_ref(), "Fixture diagnostics"));
+        ApplicationController::handle_diagnostics_intent(&controller, DiagnosticsIntent::Copy);
+        let copied = glib::MainContext::default()
+            .block_on(native.clipboard().read_text_future())
+            .unwrap();
+        assert_eq!(copied.as_deref(), Some(report.text()));
+
+        // Supply the native chooser's completion directly so this scenario
+        // exercises the real export worker without interacting with a portal.
+        let request = controller
+            .application
+            .borrow_mut()
+            .handle_diagnostics_intent(DiagnosticsIntent::Save)
+            .unwrap()
+            .diagnostics()
+            .unwrap()
+            .save_request()
+            .unwrap();
+        let path = std::env::temp_dir().join(format!(
+            "lg-buddy-diagnostics-controller-{}.txt",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&path);
+        ApplicationController::handle_diagnostics_intent(
+            &controller,
+            DiagnosticsIntent::SaveDestination {
+                request,
+                path: Some(path.clone()),
+            },
+        );
+        pump_until(|| std::fs::read_to_string(&path).ok().as_deref() == Some(report.text()));
+        pump_for(Duration::from_millis(30));
+        std::fs::remove_file(path).unwrap();
+
+        ApplicationController::handle_diagnostics_intent(&controller, DiagnosticsIntent::Refresh);
+        pump_until(|| backend.calls.load(Ordering::SeqCst) == 2);
+        ApplicationController::handle_diagnostics_intent(&controller, DiagnosticsIntent::Close);
+        reply_tx.send(report).unwrap();
+        pump_for(Duration::from_millis(30));
+        controller.shutdown();
+        native.close();
     }
 
     fn run_manual_update_check_scenario() {

--- a/crates/lg-buddy-gui/src/overview.rs
+++ b/crates/lg-buddy-gui/src/overview.rs
@@ -742,6 +742,7 @@ mod tests {
         late_brightness_respects_focus(&application);
         crate::tvs::run_renderer_scenarios(&application);
         crate::settings::run_renderer_scenarios(&application);
+        crate::diagnostics::run_renderer_scenarios(&application);
         crate::controller_test_support::run_scenario();
     }
 }

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -2,6 +2,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use adw::prelude::*;
+use lg_buddy::diagnostics_view::{DiagnosticsIntent, DiagnosticsPresentation};
 use lg_buddy::navigation::ApplicationPage;
 use lg_buddy::overview::OverviewIntent;
 use lg_buddy::presentation::overview::OverviewPresentation;
@@ -15,6 +16,7 @@ pub(crate) struct ApplicationWindow {
     overview: crate::overview::OverviewView,
     tvs: crate::tvs::TvsView,
     settings: crate::settings::SettingsView,
+    diagnostics: crate::diagnostics::DiagnosticsView,
     pairing: crate::pairing::PairingView,
     toasts: adw::ToastOverlay,
     stack: adw::ViewStack,
@@ -34,6 +36,7 @@ impl ApplicationWindow {
         on_tvs: Rc<dyn Fn(TvsIntent)>,
         on_settings: Rc<dyn Fn(SettingsIntent)>,
         on_navigation: Rc<dyn Fn(ApplicationPage)>,
+        on_diagnostics: Rc<dyn Fn(DiagnosticsIntent)>,
     ) -> Self {
         let window = adw::ApplicationWindow::builder()
             .application(application)
@@ -57,10 +60,17 @@ impl ApplicationWindow {
             }
         });
         window.add_action(&about);
+        let diagnostics_action = gtk::gio::SimpleAction::new("diagnostics", None);
+        diagnostics_action.connect_activate({
+            let on_diagnostics = Rc::clone(&on_diagnostics);
+            move |_, _| on_diagnostics(DiagnosticsIntent::Open)
+        });
+        window.add_action(&diagnostics_action);
         let overview = crate::overview::OverviewView::new(&window, Rc::clone(&on_overview));
         let tvs = crate::tvs::TvsView::new(Rc::clone(&on_tvs));
         let pairing = crate::pairing::PairingView::new(on_tvs);
         let settings = crate::settings::SettingsView::new(on_settings);
+        let diagnostics = crate::diagnostics::DiagnosticsView::new(on_diagnostics);
         let stack = adw::ViewStack::new();
         stack.set_hhomogeneous(false);
         stack.set_vhomogeneous(false);
@@ -96,6 +106,7 @@ impl ApplicationWindow {
             .build();
         let header = adw::HeaderBar::builder().title_widget(&switcher).build();
         let menu = gtk::gio::Menu::new();
+        menu.append(Some("Diagnostics"), Some("win.diagnostics"));
         menu.append(Some("About LG Buddy"), Some("win.about"));
         let menu_button = gtk::MenuButton::builder()
             .icon_name("open-menu-symbolic")
@@ -153,6 +164,7 @@ impl ApplicationWindow {
             overview,
             tvs,
             settings,
+            diagnostics,
             pairing,
             toasts,
             stack,
@@ -177,6 +189,10 @@ impl ApplicationWindow {
 
     pub(crate) fn render_settings(&self, presentation: &SettingsPresentation) {
         self.settings.render(presentation);
+    }
+
+    pub(crate) fn render_diagnostics(&self, presentation: &DiagnosticsPresentation) {
+        self.diagnostics.render(&self.window, presentation);
     }
 
     pub(crate) fn show_update_notice(&self, notice: &lg_buddy::settings_view::UpdateNotice) {
@@ -234,7 +250,6 @@ impl ApplicationWindow {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn window(&self) -> gtk::Window {
         self.window.clone().upcast()
     }

--- a/crates/lg-buddy/src/application.rs
+++ b/crates/lg-buddy/src/application.rs
@@ -4,6 +4,11 @@
 
 use crate::audio::{AudioWriteError, AudioWriteOutcome};
 use crate::brightness::{BrightnessReadError, BrightnessWriteError, BrightnessWriteOutcome};
+use crate::diagnostics::DiagnosticsReport;
+use crate::diagnostics_view::{
+    DiagnosticsApplication, DiagnosticsError, DiagnosticsIntent, DiagnosticsReadOperation,
+    DiagnosticsSaveOperation, DiagnosticsTransition,
+};
 use crate::navigation::Navigation;
 use crate::overview::{
     AudioReadError, OverviewApplication, OverviewAudioReadOperation, OverviewAudioWriteOperation,
@@ -54,6 +59,7 @@ pub struct ApplicationTransition {
     overview: Option<OverviewTransition>,
     tvs: Option<TvsTransition>,
     settings: Option<SettingsTransition>,
+    diagnostics: Option<DiagnosticsTransition>,
     navigation: Navigation,
 }
 
@@ -73,12 +79,17 @@ impl ApplicationTransition {
     pub fn settings(&self) -> Option<&SettingsTransition> {
         self.settings.as_ref()
     }
+
+    pub fn diagnostics(&self) -> Option<&DiagnosticsTransition> {
+        self.diagnostics.as_ref()
+    }
 }
 
 pub struct Application {
     overview: OverviewApplication,
     tvs: TvsApplication,
     settings: SettingsApplication,
+    diagnostics: DiagnosticsApplication,
     navigation: Navigation,
     pairing_behaviors: Vec<BehaviorSetting>,
     pairing_settings_read: Option<SettingsReadOperation>,
@@ -95,6 +106,7 @@ impl Application {
                 overview,
                 tvs,
                 settings,
+                diagnostics: DiagnosticsApplication::default(),
                 navigation: Navigation::default(),
                 pairing_behaviors: Vec::new(),
                 pairing_settings_read: None,
@@ -104,6 +116,7 @@ impl Application {
                 overview: Some(overview_opening),
                 tvs: Some(tvs_opening),
                 settings: Some(settings_opening),
+                diagnostics: None,
                 navigation: Navigation::default(),
             },
         )
@@ -161,6 +174,55 @@ impl Application {
                 .or_else(|| Some(self.transition(None, None, None))),
             _ => Some(self.transition(None, None, None)),
         }
+    }
+
+    pub fn handle_diagnostics_intent(
+        &mut self,
+        intent: DiagnosticsIntent,
+    ) -> Option<ApplicationTransition> {
+        if self.closed {
+            return None;
+        }
+        if matches!(intent, DiagnosticsIntent::Open | DiagnosticsIntent::Refresh) {
+            if let Some(details) = self
+                .settings
+                .presentation()
+                .update_install()
+                .failure_details()
+            {
+                self.diagnostics
+                    .record_failure("Last update failure", details);
+            }
+        }
+        let transition = self.diagnostics.handle_intent(intent)?;
+        Some(self.diagnostics_transition(transition))
+    }
+
+    pub fn complete_diagnostics_read(
+        &mut self,
+        operation: &DiagnosticsReadOperation,
+        result: Result<DiagnosticsReport, DiagnosticsError>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.diagnostics.complete_read(operation, result)?;
+        Some(self.diagnostics_transition(transition))
+    }
+
+    pub fn complete_diagnostics_save(
+        &mut self,
+        operation: &DiagnosticsSaveOperation,
+        result: Result<(), DiagnosticsError>,
+    ) -> Option<ApplicationTransition> {
+        let transition = self.diagnostics.complete_save(operation, result)?;
+        Some(self.diagnostics_transition(transition))
+    }
+
+    fn diagnostics_transition(
+        &mut self,
+        diagnostics: DiagnosticsTransition,
+    ) -> ApplicationTransition {
+        let mut transition = self.transition(None, None, None);
+        transition.diagnostics = Some(diagnostics);
+        transition
     }
 
     pub fn complete_settings_read(
@@ -245,6 +307,27 @@ impl Application {
     }
 
     fn settings_transition(&mut self, transition: SettingsTransition) -> ApplicationTransition {
+        if let crate::presentation::settings::SettingsStatus::Failed(error) =
+            transition.presentation().status()
+        {
+            self.diagnostics.record_failure("Settings", error.summary());
+        }
+        for row in transition
+            .presentation()
+            .groups()
+            .iter()
+            .flat_map(|group| group.rows())
+        {
+            if let Some(feedback) = row.feedback() {
+                self.diagnostics
+                    .record_failure(row.title(), feedback.message());
+            }
+        }
+        if transition.diagnostic().is_some() {
+            if let Some(notice) = transition.update_notice() {
+                self.diagnostics.record_failure("Updates", notice.title());
+            }
+        }
         self.transition(None, None, Some(transition))
     }
 
@@ -352,18 +435,78 @@ impl Application {
         self.overview.shutdown();
         self.tvs.shutdown();
         self.settings.shutdown();
+        self.diagnostics.shutdown();
     }
 
     fn overview_transition(&mut self, transition: OverviewTransition) -> ApplicationTransition {
+        if transition.diagnostic().is_some() {
+            if let OverviewFrontendUpdate::Present(presentation) = transition.update() {
+                use crate::presentation::brightness::BrightnessStatus;
+                use crate::presentation::overview::{AudioStatus, TvSummaryStatus};
+                for (context, error) in [
+                    (
+                        "TV connection",
+                        match presentation.summary().status() {
+                            TvSummaryStatus::Failed(error) => Some(error),
+                            _ => None,
+                        },
+                    ),
+                    (
+                        "Brightness",
+                        match presentation.brightness().status() {
+                            BrightnessStatus::Failed(error) => Some(error),
+                            _ => None,
+                        },
+                    ),
+                    (
+                        "Audio",
+                        match presentation.audio().status() {
+                            AudioStatus::Failed(error) => Some(error),
+                            _ => None,
+                        },
+                    ),
+                ] {
+                    if let Some(error) = error {
+                        self.diagnostics.record_failure(
+                            context,
+                            &format!("{} {}", error.summary(), error.detail()),
+                        );
+                    }
+                }
+            }
+        }
         if matches!(transition.update(), OverviewFrontendUpdate::Close) {
             self.closed = true;
             self.tvs.shutdown();
             self.settings.shutdown();
+            self.diagnostics.shutdown();
         }
         self.transition(Some(transition), None, None)
     }
 
     fn tvs_transition(&mut self, transition: TvsTransition) -> ApplicationTransition {
+        if let crate::presentation::tvs::TvsStatus::Failed(error) =
+            transition.presentation().status()
+        {
+            self.diagnostics
+                .record_failure("TV profiles", error.summary());
+        }
+        if let Some(error) = transition
+            .presentation()
+            .pairing()
+            .and_then(|pairing| pairing.error())
+        {
+            self.diagnostics.record_failure(
+                "Pairing",
+                &format!("{} {}", error.summary(), error.detail()),
+            );
+        }
+        if let Some(error) = transition.presentation().management_error() {
+            self.diagnostics.record_failure(
+                "TV settings",
+                &format!("{} {}", error.summary(), error.detail()),
+            );
+        }
         if transition.profile_changed() && transition.presentation().profiles().is_empty() {
             self.pairing_behaviors.clear();
             self.pairing_settings_read = None;
@@ -412,6 +555,7 @@ impl Application {
             overview,
             tvs,
             settings,
+            diagnostics: None,
             navigation: self.navigation.clone(),
         }
     }
@@ -424,6 +568,68 @@ mod tests {
     use crate::overview::{OverviewOperation, OverviewSummaryFailure};
     use crate::pairing::PairingIntent;
     use crate::tvs::{TvCredentialState, TvId};
+
+    #[test]
+    fn diagnostics_is_available_before_pairing_and_does_not_change_navigation() {
+        let (mut app, opening) = Application::open();
+        assert!(opening.diagnostics().is_none());
+        let diagnostics = app
+            .handle_diagnostics_intent(DiagnosticsIntent::Open)
+            .unwrap();
+        assert_eq!(diagnostics.navigation(), opening.navigation());
+        assert!(!diagnostics.navigation().tabs_visible());
+        assert!(diagnostics.overview().is_none());
+        assert!(diagnostics.settings().is_none());
+        assert!(diagnostics.tvs().is_none());
+        let operation = diagnostics.diagnostics().unwrap().read_operation().unwrap();
+        app.shutdown();
+        assert!(app
+            .complete_diagnostics_read(operation, Ok(DiagnosticsReport::new(0, vec![])))
+            .is_none());
+        assert!(app
+            .handle_diagnostics_intent(DiagnosticsIntent::Open)
+            .is_none());
+    }
+
+    #[test]
+    fn diagnostics_retains_safe_failure_summaries_without_raw_worker_output() {
+        let (mut app, opening) = Application::open();
+        let operation = opening
+            .overview()
+            .unwrap()
+            .operations()
+            .iter()
+            .find_map(|operation| match operation {
+                OverviewOperation::ReadSummary(operation) => Some(*operation),
+                _ => None,
+            })
+            .unwrap();
+        app.complete_overview(OverviewCompletion::Summary(
+            operation,
+            Err(OverviewSummaryError::new(
+                OverviewSummaryFailure::Internal,
+                "raw private protocol payload that must stay out of the report",
+            )),
+        ))
+        .unwrap();
+        let opened = app
+            .handle_diagnostics_intent(DiagnosticsIntent::Open)
+            .unwrap();
+        let report = app
+            .complete_diagnostics_read(
+                opened.diagnostics().unwrap().read_operation().unwrap(),
+                Ok(DiagnosticsReport::new(0, vec![])),
+            )
+            .unwrap();
+        let text = report
+            .diagnostics()
+            .unwrap()
+            .presentation()
+            .report_text()
+            .unwrap();
+        assert!(text.contains("TV connection"));
+        assert!(!text.contains("raw private protocol"));
+    }
 
     fn pairing() -> (Application, ApplicationTransition, PairingOperation) {
         let (mut application, opening) = Application::open();

--- a/crates/lg-buddy/src/diagnostics.rs
+++ b/crates/lg-buddy/src/diagnostics.rs
@@ -14,7 +14,7 @@ use std::process::{ChildStdout, Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use crate::config::ScreenBackend;
+use crate::config::{ScreenBackend, TvPlatform};
 use crate::settings::{ConfigPathResolver, SettingValue, SettingsStore};
 use crate::tvs::{EnvironmentTvsBackend, TvCredentialState, TvsBackend};
 use crate::version::VersionInfo;
@@ -353,7 +353,6 @@ fn gnome_name_has_owner(command: &str, name: &str) -> Option<bool> {
         vec![
             "--user",
             "--no-pager",
-            "--quiet",
             "call",
             "org.freedesktop.DBus",
             "/org/freedesktop/DBus",
@@ -498,10 +497,11 @@ fn tv_section_from_backend(backend: &impl TvsBackend) -> DiagnosticSection {
         body.push_str(credential_observation(profile.credentials()));
         body.push('\n');
 
-        // The existing backend uses stored-credential-only authentication and a
-        // three-second model-read timeout.  It never starts pairing here.
-        match profile.credentials() {
-            TvCredentialState::Stored | TvCredentialState::LocalFile => {
+        // Only native webOS enforces stored-credential-only authentication.
+        // A compatibility credential file may lack a key for this TV, causing
+        // its model read to initiate pairing instead.
+        match (profile.platform(), profile.credentials()) {
+            (TvPlatform::LgWebOs, TvCredentialState::Stored) => {
                 match backend.read_model_name(profile) {
                     Ok(model) => {
                         body.push_str("credential-scoped model read: succeeded (model=");
@@ -513,6 +513,9 @@ fn tv_section_from_backend(backend: &impl TvsBackend) -> DiagnosticSection {
                     ),
                 }
             }
+            (TvPlatform::Bscpylgtv, _) => body.push_str(
+                "credential-scoped model read: skipped because the compatibility backend cannot guarantee a read without pairing\n",
+            ),
             _ => body.push_str(
                 "credential-scoped model read: skipped because no usable local credential was observed\n",
             ),
@@ -543,15 +546,24 @@ fn credential_observation(state: TvCredentialState) -> &'static str {
 
 fn journal_section() -> DiagnosticSection {
     let journalctl = command_path("LG_BUDDY_JOURNALCTL", "journalctl");
+    journal_section_from_command(&journalctl)
+}
+
+fn journal_section_from_command(journalctl: &PathBuf) -> DiagnosticSection {
     let mut body = String::new();
     let mut any_available = false;
     let mut actions = BTreeSet::new();
 
     for (scope, units) in [
-        (ServiceScope::User, [SCREEN_UNIT, UPDATE_TIMER]),
-        (ServiceScope::System, [LIFECYCLE_UNIT, ""]),
+        (
+            ServiceScope::User,
+            [SCREEN_UNIT, UPDATE_TIMER, "LG_Buddy_update_check.service"].as_slice(),
+        ),
+        (
+            ServiceScope::System,
+            [LIFECYCLE_UNIT, "LG_Buddy.service"].as_slice(),
+        ),
     ] {
-        let units = units.iter().copied().filter(|unit| !unit.is_empty());
         let mut args = Vec::new();
         if scope == ServiceScope::User {
             args.push("--user");
@@ -562,7 +574,7 @@ fn journal_section() -> DiagnosticSection {
         }
         args.extend(["--no-pager", "--quiet", "--lines=20", "--output=cat"]);
 
-        match run_bounded(&journalctl, &args, COMMAND_TIMEOUT) {
+        match run_bounded(journalctl, &args, COMMAND_TIMEOUT) {
             CommandResult {
                 status: Some(_),
                 stdout,
@@ -748,10 +760,13 @@ fn classify_journal(output: &[u8]) -> Vec<&'static str> {
     let text = String::from_utf8_lossy(output).to_ascii_lowercase();
     let mut classes = BTreeSet::new();
     for line in text.lines() {
-        if line.contains("failed") || line.contains("error") || line.contains("panic") {
+        let failed = line.contains("failed") || line.contains("error") || line.contains("panic");
+        if failed {
             classes.insert("error");
         }
-        if line.contains("timeout") || line.contains("timed out") {
+        // A configured timeout (for example the healthy swayidle startup
+        // message) is not evidence that an operation timed out.
+        if line.contains("timed out") || (failed && line.contains("timeout")) {
             classes.insert("timeout");
         }
         if line.contains("denied") || line.contains("permission") {
@@ -1074,6 +1089,144 @@ mod tests {
             classify_journal(b"failed: token=secret\nconnection refused\npermission denied\n");
         assert_eq!(classes, vec!["connectivity", "error", "permission"]);
         assert!(!classes.iter().any(|class| class.contains("secret")));
+    }
+
+    #[test]
+    fn journal_timeout_classification_requires_a_failure() {
+        assert!(
+            classify_journal(b"LG Buddy Monitor: Using swayidle backend (timeout: 300s).\n")
+                .is_empty()
+        );
+        assert_eq!(
+            classify_journal(b"LG_Buddy_screen.service: Failed with result 'timeout'.\n"),
+            vec!["error", "timeout"]
+        );
+        assert_eq!(
+            classify_journal(b"bscpylgtvcommand timed out after 3s\n"),
+            vec!["timeout"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn busctl_owner_queries_preserve_positive_and_negative_replies() {
+        let path = fixture_script(
+            "busctl-owner",
+            r#"for arg in "$@"; do
+    [ "$arg" = "--quiet" ] && exit 0
+    name="$arg"
+done
+case "$name" in
+    org.gnome.Shell) printf 'b true\n' ;;
+    org.gnome.ScreenSaver) printf 'b false\n' ;;
+    *) exit 1 ;;
+esac"#,
+        );
+        let command = path.to_str().expect("fixture path");
+        assert_eq!(gnome_name_has_owner(command, "org.gnome.Shell"), Some(true));
+        assert_eq!(
+            gnome_name_has_owner(command, "org.gnome.ScreenSaver"),
+            Some(false)
+        );
+        assert_eq!(gnome_name_has_owner(command, "org.gnome.Unknown"), None);
+        fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn journal_includes_update_worker_and_startup_failures_in_their_scopes() {
+        let path = fixture_script(
+            "journal-worker-failures",
+            r#"scope=system
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --user) scope=user ;;
+        -u)
+            shift
+            case "$scope:$1" in
+                user:LG_Buddy_screen.service)
+                    printf 'LG Buddy Monitor: Using swayidle backend (timeout: 300s).\n' ;;
+                user:LG_Buddy_update_check.service)
+                    printf 'permission denied: private-update-detail\n' ;;
+                system:LG_Buddy.service)
+                    printf 'connection refused: private-startup-detail\n' ;;
+            esac ;;
+    esac
+    shift
+done"#,
+        );
+        let section = journal_section_from_command(&path);
+        let body = section.body();
+        assert!(body.contains("user journal (up to 20 entries; capture capped at 16 KiB): failure markers observed: permission"));
+        assert!(body.contains("system journal (up to 20 entries; capture capped at 16 KiB): failure markers observed: connectivity"));
+        assert!(!body.contains("timeout"));
+        assert!(!body.contains("private-update-detail"));
+        assert!(!body.contains("private-startup-detail"));
+        fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[test]
+    fn tv_diagnostics_only_probe_native_profiles_with_stored_credentials() {
+        use crate::config::HdmiInput;
+        use crate::tvs::TvProfile;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        struct ProfileBackend {
+            profile: TvProfile,
+            reads: AtomicUsize,
+        }
+
+        impl TvsBackend for ProfileBackend {
+            fn read_profiles(&self) -> Result<Vec<TvProfile>, TvsReadError> {
+                Ok(vec![self.profile.clone()])
+            }
+
+            fn read_model_name(&self, profile: &TvProfile) -> Result<String, TvsReadError> {
+                assert_eq!(profile.platform(), TvPlatform::LgWebOs);
+                assert_eq!(profile.credentials(), TvCredentialState::Stored);
+                self.reads.fetch_add(1, Ordering::Relaxed);
+                Ok("OLED fixture".to_string())
+            }
+        }
+
+        for platform in [TvPlatform::Bscpylgtv, TvPlatform::LgWebOs] {
+            for credentials in [
+                TvCredentialState::Stored,
+                TvCredentialState::LocalFile,
+                TvCredentialState::Missing,
+                TvCredentialState::Malformed,
+                TvCredentialState::Unreadable,
+                TvCredentialState::Unknown,
+            ] {
+                let backend = ProfileBackend {
+                    profile: TvProfile::new(
+                        "primary",
+                        "Fixture TV",
+                        "192.0.2.42".parse().unwrap(),
+                        "aa:bb:cc:dd:ee:ff".parse().unwrap(),
+                        HdmiInput::Hdmi1,
+                        platform,
+                        credentials,
+                    ),
+                    reads: AtomicUsize::new(0),
+                };
+                let section = tv_section_from_backend(&backend);
+                if platform == TvPlatform::LgWebOs && credentials == TvCredentialState::Stored {
+                    assert_eq!(backend.reads.load(Ordering::Relaxed), 1);
+                    assert!(section.body().contains("model read: succeeded"));
+                    assert!(section.body().contains("OLED fixture"));
+                } else {
+                    assert_eq!(backend.reads.load(Ordering::Relaxed), 0);
+                    assert!(section.body().contains("model read: skipped"));
+                    assert!(!section.body().contains("OLED fixture"));
+                }
+                if platform == TvPlatform::Bscpylgtv {
+                    assert!(section
+                        .body()
+                        .contains("cannot guarantee a read without pairing"));
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/lg-buddy/src/diagnostics.rs
+++ b/crates/lg-buddy/src/diagnostics.rs
@@ -1,0 +1,1235 @@
+//! On-demand, read-only diagnostics for the graphical application.
+//!
+//! This module deliberately produces a small, typed snapshot.  It does not
+//! read raw configuration or journal messages into the report, and it never
+//! starts a service, changes a setting, or attempts TV pairing.
+
+use std::collections::BTreeSet;
+use std::env;
+use std::io::{self, Read};
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use std::process::{ChildStdout, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use crate::config::ScreenBackend;
+use crate::settings::{ConfigPathResolver, SettingValue, SettingsStore};
+use crate::tvs::{EnvironmentTvsBackend, TvCredentialState, TvsBackend};
+use crate::version::VersionInfo;
+
+const MAX_SECTION_BYTES: usize = 8 * 1024;
+const MAX_REPORT_BYTES: usize = 32 * 1024;
+const MAX_COMMAND_BYTES: usize = 16 * 1024;
+const MAX_SESSION_FINDINGS: usize = 24;
+const MAX_SESSION_FINDING_BYTES: usize = 1024;
+const MAX_TV_MODEL_BYTES: usize = 512;
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(1);
+
+const SCREEN_UNIT: &str = "LG_Buddy_screen.service";
+const UPDATE_TIMER: &str = "LG_Buddy_update_check.timer";
+const LIFECYCLE_UNIT: &str = "LG_Buddy_lifecycle.service";
+
+/// One bounded, sanitized diagnostics section.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticSection {
+    title: &'static str,
+    body: String,
+}
+
+impl DiagnosticSection {
+    pub fn new(title: &'static str, body: impl Into<String>) -> Self {
+        Self {
+            title,
+            body: safe_text(&body.into(), MAX_SECTION_BYTES),
+        }
+    }
+
+    pub fn title(&self) -> &'static str {
+        self.title
+    }
+
+    pub fn body(&self) -> &str {
+        &self.body
+    }
+}
+
+/// A complete diagnostics snapshot ready for display, copying, or saving.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsReport {
+    text: String,
+    collected_at: String,
+    sections: Vec<DiagnosticSection>,
+}
+
+impl DiagnosticsReport {
+    pub fn new(collected_at_unix_seconds: u64, sections: Vec<DiagnosticSection>) -> Self {
+        let collected_at = format_utc_timestamp(collected_at_unix_seconds);
+        let text = render_report(&collected_at, &sections);
+        Self {
+            text,
+            collected_at,
+            sections,
+        }
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn collected_at(&self) -> &str {
+        &self.collected_at
+    }
+
+    pub fn sections(&self) -> &[DiagnosticSection] {
+        &self.sections
+    }
+
+    /// Add findings owned by the GUI session without allowing them to become
+    /// an unbounded or credential-bearing extension of the report.
+    pub fn with_session_findings(mut self, findings: &[String]) -> Self {
+        if findings.is_empty() {
+            return self;
+        }
+
+        let mut body = String::new();
+        for finding in findings.iter().take(MAX_SESSION_FINDINGS) {
+            let finding = safe_text(finding, MAX_SESSION_FINDING_BYTES);
+            if finding.is_empty() {
+                continue;
+            }
+            body.push_str("- ");
+            body.push_str(&finding);
+            body.push('\n');
+        }
+        if body.is_empty() {
+            return self;
+        }
+
+        self.sections
+            .push(DiagnosticSection::new("Session findings", body));
+        self.text = render_report(&self.collected_at, &self.sections);
+        self
+    }
+}
+
+/// Production diagnostics collector.  Collection is synchronous so the GUI
+/// can put it behind its existing worker boundary.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct EnvironmentDiagnosticsCollector;
+
+impl EnvironmentDiagnosticsCollector {
+    /// Collect a useful partial report even when individual host interfaces
+    /// are unavailable. External command probes have a finite timeout; the
+    /// backend section uses conservative session observations rather than
+    /// calling an unbounded compositor/DBus probe.
+    pub fn collect(&self) -> DiagnosticsReport {
+        let collected_at = current_unix_seconds();
+        DiagnosticsReport::new(
+            collected_at,
+            vec![
+                application_section(),
+                settings_section(),
+                backend_section(),
+                services_section(),
+                tv_section(),
+                journal_section(),
+                recovery_section(),
+            ],
+        )
+    }
+}
+
+fn application_section() -> DiagnosticSection {
+    let version = VersionInfo::current();
+    let mut body = String::new();
+    body.push_str("version: ");
+    body.push_str(version.version());
+    body.push('\n');
+    body.push_str("channel: ");
+    body.push_str(version.channel().as_str());
+    body.push('\n');
+    body.push_str("commit: ");
+    body.push_str(version.commit().unwrap_or("unknown"));
+    body.push('\n');
+    body.push_str("target OS: ");
+    body.push_str(env::consts::OS);
+    body.push('\n');
+    body.push_str("target architecture: ");
+    body.push_str(env::consts::ARCH);
+    body.push('\n');
+    DiagnosticSection::new("Application and build", body)
+}
+
+fn settings_section() -> DiagnosticSection {
+    let path = match ConfigPathResolver::resolve_from_env() {
+        Ok(path) => path,
+        Err(_) => {
+            return DiagnosticSection::new(
+                "Effective settings",
+                "Settings are unavailable: no configuration path could be resolved.\nAction: configure a TV, then retry diagnostics.",
+            )
+        }
+    };
+
+    let store = match SettingsStore::load(&path) {
+        Ok(store) => store,
+        Err(_) => {
+            return DiagnosticSection::new(
+                "Effective settings",
+                "Settings are unavailable: the configuration could not be read.\nAction: check the configuration access and retry diagnostics.",
+            )
+        }
+    };
+
+    settings_section_from_store(&store)
+}
+
+fn settings_section_from_store(store: &SettingsStore) -> DiagnosticSection {
+    let mut body = String::new();
+    body.push_str("configuration: resolved and readable\n");
+    let mut invalid = false;
+    for setting in store.all_effective() {
+        body.push_str(setting.key_name());
+        body.push_str(" = ");
+        match (setting.value(), setting.invalid_value()) {
+            (_, Some(_)) => {
+                invalid = true;
+                body.push_str("invalid (raw value omitted; expected ");
+                body.push_str(&setting.definition().value_type().expected());
+                body.push(')');
+            }
+            (Some(value), None) => body.push_str(&safe_setting_value(value)),
+            (None, None) => body.push_str("missing"),
+        }
+        body.push_str(" [source: ");
+        body.push_str(setting.source().as_str());
+        body.push_str("]\n");
+    }
+    if setting_value(store, "screen.idle_blank") == Some("disabled") {
+        body.push_str("Finding: screen.idle_blank is intentionally disabled; screen blanking is not expected.\n");
+    }
+    if setting_value(store, "system.sleep_wake_policy") == Some("disabled") {
+        body.push_str("Finding: system.sleep_wake_policy is intentionally disabled; TV sleep/wake control is not expected.\n");
+    }
+    if invalid {
+        body.push_str("Finding: one or more settings are invalid; behavior using them is not confirmed.\nAction: change the affected setting to an accepted value in Settings.\n");
+    }
+    DiagnosticSection::new("Effective settings", body)
+}
+
+fn backend_section() -> DiagnosticSection {
+    let session = match env::var("XDG_SESSION_TYPE").as_deref() {
+        Ok("wayland") => "wayland",
+        Ok("x11") => "x11",
+        Ok(_) => "unknown session type",
+        Err(_) => "session type unavailable",
+    };
+    let mut body = format!("session type: {session}\n");
+
+    let store = ConfigPathResolver::resolve_from_env()
+        .ok()
+        .and_then(|path| SettingsStore::load(path).ok());
+    let override_value = env::var("LG_BUDDY_SCREEN_BACKEND").ok();
+    match diagnostic_configured_backend(override_value.as_deref(), store.as_ref()) {
+        Ok(configured) => {
+            body.push_str("configured backend: ");
+            body.push_str(configured.as_str());
+            body.push('\n');
+            body.push_str(&conservative_backend_observation(configured, session));
+        }
+        Err(error) => {
+            body.push_str("configured backend: invalid or unavailable\n");
+            body.push_str("configuration finding: ");
+            body.push_str(error);
+            body.push('\n');
+            body.push_str("Action: choose auto, gnome, wayland, or swayidle in Settings.\n");
+        }
+    }
+    DiagnosticSection::new("Desktop capability and fallback", body)
+}
+
+fn diagnostic_configured_backend(
+    override_value: Option<&str>,
+    store: Option<&SettingsStore>,
+) -> Result<ScreenBackend, &'static str> {
+    if let Some(value) = override_value {
+        return value
+            .parse()
+            .map_err(|_| "invalid backend override (raw value omitted)");
+    }
+    let store = store.ok_or("screen.backend could not be read")?;
+    setting_value(store, "screen.backend")
+        .and_then(|value| value.parse().ok())
+        .ok_or("screen.backend is invalid (raw value omitted)")
+}
+
+fn conservative_backend_observation(configured: ScreenBackend, session: &str) -> String {
+    let mut body = String::new();
+    body.push_str("swayidle fallback command: ");
+    body.push_str(if command_available("swayidle") {
+        "available in PATH\n"
+    } else {
+        "not found in PATH\n"
+    });
+
+    body.push_str("GNOME session interfaces: ");
+    let gnome = gnome_interface_observation();
+    body.push_str(&gnome);
+
+    match configured {
+        ScreenBackend::Wayland => {
+            if session == "wayland" {
+                body.push_str("capability observation: Wayland session matches the configured backend; compositor idle capability was not probed.\n");
+            } else {
+                body.push_str("capability observation: configured Wayland backend does not match the current session type.\n");
+            }
+        }
+        ScreenBackend::Gnome => {
+            body.push_str("capability observation: GNOME session interfaces above are the bounded availability check; this does not prove a running screen service is using GNOME.\n");
+        }
+        ScreenBackend::Swayidle => {
+            if !command_available("swayidle") {
+                body.push_str("capability finding: swayidle command was not found in PATH.\nAction: install swayidle or choose auto, gnome, or wayland in Settings, then use Retry apply.\n");
+            }
+        }
+        ScreenBackend::Auto => {
+            body.push_str("capability observation: automatic selection is configured; GNOME names and swayidle availability above are bounded observations. Native Wayland registry probing was omitted because its roundtrip is not bounded and may consume an inherited socket.\n");
+        }
+    }
+    body.push_str("These are current capability observations, not proof that a running service is using the backend.\n");
+    body
+}
+
+fn gnome_interface_observation() -> String {
+    let command = if command_available("gdbus") {
+        Some("gdbus")
+    } else if command_available("busctl") {
+        Some("busctl")
+    } else {
+        None
+    };
+    let Some(command) = command else {
+        return "unavailable (neither gdbus nor busctl is installed)\n".to_string();
+    };
+
+    let names = [
+        ("GNOME Shell", "org.gnome.Shell"),
+        ("GNOME ScreenSaver", "org.gnome.ScreenSaver"),
+        ("GNOME IdleMonitor", "org.gnome.Mutter.IdleMonitor"),
+    ];
+    let mut body = format!("using {command}: ");
+    for (index, (label, name)) in names.iter().enumerate() {
+        if index > 0 {
+            body.push_str(", ");
+        }
+        body.push_str(label);
+        body.push('=');
+        match gnome_name_has_owner(command, name) {
+            Some(true) => body.push_str("owner-present"),
+            Some(false) => body.push_str("no-owner"),
+            None => body.push_str("unavailable"),
+        }
+    }
+    body.push('\n');
+    body
+}
+
+fn gnome_name_has_owner(command: &str, name: &str) -> Option<bool> {
+    let args = if command == "gdbus" {
+        vec![
+            "call",
+            "--session",
+            "--dest",
+            "org.freedesktop.DBus",
+            "--object-path",
+            "/org/freedesktop/DBus",
+            "--method",
+            "org.freedesktop.DBus.NameHasOwner",
+            name,
+        ]
+    } else {
+        vec![
+            "--user",
+            "--no-pager",
+            "--quiet",
+            "call",
+            "org.freedesktop.DBus",
+            "/org/freedesktop/DBus",
+            "org.freedesktop.DBus",
+            "NameHasOwner",
+            "s",
+            name,
+        ]
+    };
+    let result = run_bounded(&PathBuf::from(command), &args, COMMAND_TIMEOUT);
+    if result.timed_out || result.unavailable || result.status != Some(0) {
+        return None;
+    }
+    let output = String::from_utf8_lossy(&result.stdout).to_ascii_lowercase();
+    if output.contains("true") {
+        Some(true)
+    } else if output.contains("false") {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+fn services_section() -> DiagnosticSection {
+    let systemctl = command_path("LG_BUDDY_SYSTEMCTL", "systemctl");
+    let mut body = String::new();
+    body.push_str("State fields are read independently: load, active, substate, and enabled.\n");
+    let mut action_needed = false;
+    let mut failed_units = Vec::new();
+    let timer_expectation = match setting_is_enabled("updates.auto_check") {
+        Some(true) => "expected enabled while updates.auto_check=enabled",
+        Some(false) => "intentionally disabled by updates.auto_check=disabled",
+        None => {
+            "expected timer state is unavailable because updates.auto_check is invalid or missing"
+        }
+    };
+
+    for (scope, unit, expectation) in [
+        (
+            ServiceScope::User,
+            SCREEN_UNIT,
+            "long-running monitor; active status is separate from the idle blanking policy",
+        ),
+        (ServiceScope::User, UPDATE_TIMER, timer_expectation),
+        (
+            ServiceScope::User,
+            "LG_Buddy_update_check.service",
+            "oneshot worker; inactive between timer fires is expected",
+        ),
+        (
+            ServiceScope::System,
+            "LG_Buddy.service",
+            "startup/shutdown oneshot; inactive before a startup run is expected",
+        ),
+        (
+            ServiceScope::System,
+            LIFECYCLE_UNIT,
+            "long-running sleep/wake monitor; active status is separate from the sleep/wake policy",
+        ),
+    ] {
+        let observation = systemd_unit_observation(&systemctl, scope, unit);
+        body.push_str(scope.label());
+        body.push(' ');
+        body.push_str(unit);
+        body.push_str(": ");
+        body.push_str(&observation.text);
+        body.push_str(" (expectation: ");
+        body.push_str(expectation);
+        body.push(')');
+        body.push('\n');
+        if observation.action_needed {
+            action_needed = true;
+            failed_units.push(unit);
+        }
+    }
+    if action_needed {
+        for unit in failed_units {
+            match unit {
+                SCREEN_UNIT => body.push_str("Action for screen service: if screen blanking is wanted, enable screen.idle_blank in Settings and choose Retry apply after fixing the service.\n"),
+                UPDATE_TIMER | "LG_Buddy_update_check.service" => body.push_str("Action for update checks: choose the updates.auto_check setting in Settings and choose Retry apply after fixing the timer or worker.\n"),
+                LIFECYCLE_UNIT => body.push_str("Action for sleep/wake: if TV sleep/wake control is wanted, enable system.sleep_wake_policy in Settings and choose Retry apply after fixing the lifecycle service.\n"),
+                "LG_Buddy.service" => body.push_str("Action for startup service: inspect the installed startup unit before relying on automatic startup/shutdown handling.\n"),
+                _ => {}
+            }
+        }
+    }
+    DiagnosticSection::new("Relevant service and timer state", body)
+}
+
+fn setting_is_enabled(key: &str) -> Option<bool> {
+    let path = ConfigPathResolver::resolve_from_env().ok()?;
+    let store = SettingsStore::load(path).ok()?;
+    match setting_value(&store, key) {
+        Some("enabled") => Some(true),
+        Some("disabled") => Some(false),
+        _ => None,
+    }
+}
+
+fn setting_value(store: &SettingsStore, key: &str) -> Option<&'static str> {
+    store.effective_by_name(key).ok()?.value()?.as_enum()
+}
+
+fn tv_section() -> DiagnosticSection {
+    let backend = EnvironmentTvsBackend;
+    tv_section_from_backend(&backend)
+}
+
+fn tv_section_from_backend(backend: &impl TvsBackend) -> DiagnosticSection {
+    let profiles = match backend.read_profiles() {
+        Ok(profiles) => profiles,
+        Err(_) => {
+            return DiagnosticSection::new(
+                "TV observation",
+                "TV profile inspection is unavailable: saved configuration or local credential metadata could not be read.\nAction: check the saved TV settings, or unpair and pair again.\nNo credential or protocol data was collected.",
+            )
+        }
+    };
+
+    if profiles.is_empty() {
+        return DiagnosticSection::new(
+            "TV observation",
+            "No TV profile is configured. Connectivity and runtime behavior were not tested.\nAction: pair a TV from the TVs page.",
+        );
+    }
+
+    let mut body = String::new();
+    for profile in profiles.iter().take(4) {
+        let profile_id = profile.id().to_string();
+        body.push_str("profile ");
+        body.push_str(&safe_text(&profile_id, 128));
+        body.push_str(": address=");
+        body.push_str(&profile.address().to_string());
+        body.push_str(", input=");
+        body.push_str(profile.input_label());
+        body.push_str(", platform=");
+        body.push_str(profile.platform_label());
+        body.push_str(", local credential state=");
+        body.push_str(profile.credentials().label());
+        body.push('\n');
+        body.push_str("credential observation: ");
+        body.push_str(credential_observation(profile.credentials()));
+        body.push('\n');
+
+        // The existing backend uses stored-credential-only authentication and a
+        // three-second model-read timeout.  It never starts pairing here.
+        match profile.credentials() {
+            TvCredentialState::Stored | TvCredentialState::LocalFile => {
+                match backend.read_model_name(profile) {
+                    Ok(model) => {
+                        body.push_str("credential-scoped model read: succeeded (model=");
+                        body.push_str(&safe_text(&model, MAX_TV_MODEL_BYTES));
+                        body.push_str(")\n");
+                    }
+                    Err(_) => body.push_str(
+                        "credential-scoped model read: unavailable; connectivity or authentication was not confirmed\n",
+                    ),
+                }
+            }
+            _ => body.push_str(
+                "credential-scoped model read: skipped because no usable local credential was observed\n",
+            ),
+        }
+    }
+    body.push_str("A reachable TV or successful model read does not prove screen automation or sleep/wake behavior.\n");
+    DiagnosticSection::new("TV observation", body)
+}
+
+fn credential_observation(state: TvCredentialState) -> &'static str {
+    match state {
+        TvCredentialState::Stored => {
+            "A native credential is stored locally; current TV access is not established."
+        }
+        TvCredentialState::Missing => "No local credential was found.",
+        TvCredentialState::LocalFile => {
+            "A compatibility credential file is present locally; authentication is not verified."
+        }
+        TvCredentialState::Malformed => {
+            "A local credential is malformed; authentication is not verified."
+        }
+        TvCredentialState::Unreadable => {
+            "A local credential could not be read; authentication is not verified."
+        }
+        TvCredentialState::Unknown => "The local credential state could not be determined.",
+    }
+}
+
+fn journal_section() -> DiagnosticSection {
+    let journalctl = command_path("LG_BUDDY_JOURNALCTL", "journalctl");
+    let mut body = String::new();
+    let mut any_available = false;
+    let mut actions = BTreeSet::new();
+
+    for (scope, units) in [
+        (ServiceScope::User, [SCREEN_UNIT, UPDATE_TIMER]),
+        (ServiceScope::System, [LIFECYCLE_UNIT, ""]),
+    ] {
+        let units = units.iter().copied().filter(|unit| !unit.is_empty());
+        let mut args = Vec::new();
+        if scope == ServiceScope::User {
+            args.push("--user");
+        }
+        for unit in units {
+            args.push("-u");
+            args.push(unit);
+        }
+        args.extend(["--no-pager", "--quiet", "--lines=20", "--output=cat"]);
+
+        match run_bounded(&journalctl, &args, COMMAND_TIMEOUT) {
+            CommandResult {
+                status: Some(_),
+                stdout,
+                timed_out: false,
+                unavailable: false,
+            } => {
+                any_available = true;
+                let classes = classify_journal(&stdout);
+                body.push_str(scope.label());
+                body.push_str(" journal (up to 20 entries; capture capped at 16 KiB): ");
+                if stdout.is_empty() {
+                    body.push_str("no accessible entries; the unit may have no history or journal access may be restricted");
+                } else if classes.is_empty() {
+                    body.push_str(
+                        "no classified failure markers in the accessible captured entries",
+                    );
+                } else {
+                    body.push_str("failure markers observed: ");
+                    body.push_str(&classes.join(", "));
+                    actions.insert("Use the affected setting's Retry apply action after fixing the reported failure.");
+                }
+                body.push('\n');
+            }
+            result if result.timed_out => {
+                body.push_str(scope.label());
+                body.push_str(" journal: unavailable (timed out)\n");
+            }
+            _ => {
+                body.push_str(scope.label());
+                body.push_str(" journal: unavailable (journal access failed)\n");
+            }
+        }
+    }
+    body.push_str(
+        "Raw journal messages are omitted; only conservative failure classes are retained.\n",
+    );
+    if !any_available {
+        body.push_str("Recent failure details could not be inspected in this session.\n");
+    }
+    for action in actions {
+        body.push_str("Action: ");
+        body.push_str(action);
+        body.push('\n');
+    }
+    DiagnosticSection::new("Recent failure observations", body)
+}
+
+fn recovery_section() -> DiagnosticSection {
+    DiagnosticSection::new(
+        "Known recovery actions",
+        "Invalid settings: change the affected value in Settings.\nScreen service failure: fix the service, enable screen.idle_blank if desired, then choose Retry apply.\nSleep/wake service failure: fix the lifecycle service, enable system.sleep_wake_policy if desired, then choose Retry apply.\nUpdate timer failure: fix the timer or worker, then choose Retry apply for updates.auto_check.\nTV authentication or saved-profile failure: unpair the TV and pair it again.\nDiagnostics never performs these recovery actions automatically.",
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ServiceScope {
+    User,
+    System,
+}
+
+impl ServiceScope {
+    fn label(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::System => "system",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct UnitObservation {
+    text: String,
+    action_needed: bool,
+}
+
+fn systemd_unit_observation(
+    systemctl: &PathBuf,
+    scope: ServiceScope,
+    unit: &str,
+) -> UnitObservation {
+    let mut args = Vec::new();
+    if scope == ServiceScope::User {
+        args.push("--user");
+    }
+    args.extend([
+        "show",
+        "--no-pager",
+        "--property=LoadState,ActiveState,SubState,UnitFileState",
+        unit,
+    ]);
+
+    let result = run_bounded(systemctl, &args, COMMAND_TIMEOUT);
+    if result.timed_out {
+        return UnitObservation {
+            text: "inspection unavailable (timed out)".to_string(),
+            action_needed: false,
+        };
+    }
+    if result.unavailable {
+        return UnitObservation {
+            text: "inspection unavailable (systemctl not found)".to_string(),
+            action_needed: false,
+        };
+    }
+
+    let values = parse_unit_properties(&result.stdout);
+    if values.is_empty() {
+        return UnitObservation {
+            text: "inspection unavailable (unit state was not reported)".to_string(),
+            action_needed: false,
+        };
+    }
+    let load = allowlisted_unit_value(values.get("LoadState").map(String::as_str), "unknown");
+    let active = allowlisted_unit_value(values.get("ActiveState").map(String::as_str), "unknown");
+    let substate = allowlisted_unit_value(values.get("SubState").map(String::as_str), "unknown");
+    let enabled =
+        allowlisted_unit_value(values.get("UnitFileState").map(String::as_str), "unknown");
+    let action_needed = matches!(load, "not-found" | "error" | "bad")
+        || matches!(active, "failed")
+        || matches!(enabled, "masked");
+    UnitObservation {
+        text: format!("load={load}, active={active}, substate={substate}, enabled={enabled}"),
+        action_needed,
+    }
+}
+
+fn parse_unit_properties(output: &[u8]) -> std::collections::BTreeMap<String, String> {
+    let output = String::from_utf8_lossy(output);
+    output
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .filter(|(key, _)| {
+            matches!(
+                *key,
+                "LoadState" | "ActiveState" | "SubState" | "UnitFileState"
+            )
+        })
+        .map(|(key, value)| (key.to_string(), value.to_string()))
+        .collect()
+}
+
+fn allowlisted_unit_value(value: Option<&str>, unknown: &'static str) -> &'static str {
+    match value {
+        Some("loaded") => "loaded",
+        Some("not-found") => "not-found",
+        Some("bad") => "bad",
+        Some("active") => "active",
+        Some("inactive") => "inactive",
+        Some("failed") => "failed",
+        Some("activating") => "activating",
+        Some("deactivating") => "deactivating",
+        Some("reloading") => "reloading",
+        Some("running") => "running",
+        Some("dead") => "dead",
+        Some("exited") => "exited",
+        Some("waiting") => "waiting",
+        Some("auto-restart") => "auto-restart",
+        Some("start-pre") => "start-pre",
+        Some("start") => "start",
+        Some("start-post") => "start-post",
+        Some("stop") => "stop",
+        Some("stop-sigterm") => "stop-sigterm",
+        Some("stop-post") => "stop-post",
+        Some("final-sigterm") => "final-sigterm",
+        Some("listening") => "listening",
+        Some("elapsed") => "elapsed",
+        Some("plugged") => "plugged",
+        Some("mounted") => "mounted",
+        Some("condition") => "condition",
+        Some("enabled") => "enabled",
+        Some("disabled") => "disabled",
+        Some("masked") => "masked",
+        Some("static") => "static",
+        Some("indirect") => "indirect",
+        Some("generated") => "generated",
+        Some("transient") => "transient",
+        Some("linked") => "linked",
+        Some(_) | None => unknown,
+    }
+}
+
+fn classify_journal(output: &[u8]) -> Vec<&'static str> {
+    let text = String::from_utf8_lossy(output).to_ascii_lowercase();
+    let mut classes = BTreeSet::new();
+    for line in text.lines() {
+        if line.contains("failed") || line.contains("error") || line.contains("panic") {
+            classes.insert("error");
+        }
+        if line.contains("timeout") || line.contains("timed out") {
+            classes.insert("timeout");
+        }
+        if line.contains("denied") || line.contains("permission") {
+            classes.insert("permission");
+        }
+        if line.contains("refused") || line.contains("unreachable") {
+            classes.insert("connectivity");
+        }
+        if line.contains("authentication") || line.contains("unauthorized") {
+            classes.insert("authentication");
+        }
+    }
+    classes.into_iter().collect()
+}
+
+fn command_path(variable: &str, fallback: &str) -> PathBuf {
+    env::var_os(variable)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(fallback))
+}
+
+#[derive(Debug)]
+struct CommandResult {
+    status: Option<i32>,
+    stdout: Vec<u8>,
+    timed_out: bool,
+    unavailable: bool,
+}
+
+fn run_bounded(program: &PathBuf, args: &[&str], timeout: Duration) -> CommandResult {
+    let mut child = match Command::new(program)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(_) => {
+            return CommandResult {
+                status: None,
+                stdout: Vec::new(),
+                timed_out: false,
+                unavailable: true,
+            }
+        }
+    };
+
+    let deadline = Instant::now() + timeout;
+    let stdout = child.stdout.take().expect("piped stdout");
+    let reader = thread::spawn(move || read_bounded_stdout(stdout, deadline));
+    let mut timed_out = false;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status.code(),
+            Ok(None) if Instant::now() >= deadline => {
+                timed_out = true;
+                let _ = child.kill();
+                break child.wait().ok().and_then(|status| status.code());
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(10)),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+        }
+    };
+    // The reader uses the same absolute deadline as the child. In
+    // particular, a descendant that inherited stdout cannot make this join
+    // wait beyond the collection timeout.
+    let stdout = reader.join().unwrap_or_default();
+    CommandResult {
+        status,
+        stdout,
+        timed_out,
+        unavailable: false,
+    }
+}
+
+fn read_bounded_stdout(mut stdout: ChildStdout, deadline: Instant) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        let fd = stdout.as_raw_fd();
+        // A nonblocking descriptor lets this reader honor the deadline even
+        // after the direct child exits while a descendant retains the pipe.
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+        if flags < 0 || unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            return Vec::new();
+        }
+
+        let mut output = Vec::new();
+        let mut buffer = [0_u8; 1024];
+        while output.len() < MAX_COMMAND_BYTES + 1 {
+            match stdout.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(read) => {
+                    let remaining = MAX_COMMAND_BYTES + 1 - output.len();
+                    output.extend_from_slice(&buffer[..read.min(remaining)]);
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        break;
+                    }
+                    thread::sleep(Duration::from_millis(5));
+                }
+                Err(_) => break,
+            }
+        }
+        output
+    }
+
+    #[cfg(not(unix))]
+    {
+        // LG Buddy's supported hosts are Unix. Keep a capped fallback for
+        // other targets; the child is still terminated by the parent deadline.
+        let mut limited = stdout.take((MAX_COMMAND_BYTES + 1) as u64);
+        let mut output = Vec::new();
+        let _ = limited.read_to_end(&mut output);
+        output
+    }
+}
+
+fn safe_setting_value(value: SettingValue) -> String {
+    // SettingValue can only contain typed, registry-validated values.  Keep
+    // this helper explicit so future secret-bearing setting types cannot be
+    // accidentally rendered by a broad Debug or raw-config formatter.
+    match value {
+        SettingValue::Enum(value) => value.to_string(),
+        SettingValue::Integer(value) => value.to_string(),
+        SettingValue::Ipv4(value) => value.to_string(),
+        SettingValue::MacAddress(value) => value.to_string(),
+    }
+}
+
+fn command_available(command: &str) -> bool {
+    if command.contains(std::path::MAIN_SEPARATOR) {
+        return std::path::Path::new(command).is_file();
+    }
+    env::var_os("PATH")
+        .map(|path| env::split_paths(&path).any(|directory| directory.join(command).is_file()))
+        .unwrap_or(false)
+}
+
+fn safe_text(input: &str, max_bytes: usize) -> String {
+    let mut result = String::new();
+    for line in input.lines() {
+        let line = if contains_secret_marker(line) {
+            "[Credential-bearing output omitted]".to_string()
+        } else {
+            let sanitized = line
+                .chars()
+                .map(|character| {
+                    if character == '\t' || character == ' ' || !character.is_control() {
+                        character
+                    } else {
+                        ' '
+                    }
+                })
+                .filter(|character| !matches!(*character, '\u{202a}'..='\u{202e}' | '\u{2066}'..='\u{2069}'))
+                .collect::<String>();
+            redact_urls(&sanitized)
+        };
+        if line.is_empty() && result.is_empty() {
+            continue;
+        }
+        result.push_str(&line);
+        result.push('\n');
+        if result.len() > max_bytes {
+            break;
+        }
+    }
+    truncate_string(result, max_bytes)
+}
+
+fn redact_urls(line: &str) -> String {
+    line.split_whitespace()
+        .map(|part| {
+            if part.contains("://") {
+                "[URL omitted]"
+            } else {
+                part
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn contains_secret_marker(line: &str) -> bool {
+    let lower = line.to_ascii_lowercase();
+    [
+        "password",
+        "passwd",
+        "token",
+        "client-key",
+        "client_key",
+        "secret",
+        "cookie",
+        "authorization:",
+        "bearer ",
+    ]
+    .iter()
+    .any(|marker| lower.contains(marker))
+}
+
+fn truncate_string(mut value: String, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value;
+    }
+    const MARKER: &str = "\n[Output truncated]";
+    if max_bytes <= MARKER.len() {
+        value.truncate(max_bytes);
+        return value;
+    }
+    let mut boundary = max_bytes - MARKER.len();
+    while boundary > 0 && !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+    value.push_str(MARKER);
+    value
+}
+
+fn render_report(collected_at: &str, sections: &[DiagnosticSection]) -> String {
+    let mut text = String::new();
+    text.push_str("LG Buddy diagnostics\n");
+    text.push_str("Collected at: ");
+    text.push_str(collected_at);
+    text.push_str("\n\n");
+    for section in sections {
+        text.push_str(section.title());
+        text.push_str(":\n");
+        text.push_str(section.body());
+        if !section.body().ends_with('\n') {
+            text.push('\n');
+        }
+        text.push('\n');
+    }
+    truncate_string(text, MAX_REPORT_BYTES)
+}
+
+fn current_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn format_utc_timestamp(seconds: u64) -> String {
+    const SECONDS_PER_DAY: u64 = 86_400;
+    let days = seconds / SECONDS_PER_DAY;
+    let day_seconds = seconds % SECONDS_PER_DAY;
+
+    // Gregorian civil date conversion, using only integer arithmetic so
+    // diagnostics does not need a date/time dependency.
+    let z = days as i128 + 719_468;
+    let era = (if z >= 0 { z } else { z - 146_096 }) / 146_097;
+    let day_of_era = z - era * 146_097;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let mut year = year_of_era + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let month_part = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * month_part + 2) / 5 + 1;
+    let month = month_part + if month_part < 10 { 3 } else { -9 };
+    year += if month <= 2 { 1 } else { 0 };
+
+    let hour = day_seconds / 3_600;
+    let minute = (day_seconds % 3_600) / 60;
+    let second = day_seconds % 60;
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}Z")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::{ConfigEnvReader, SettingsStore};
+    use crate::tvs::{TvsBackend, TvsReadError};
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn report_is_bounded_and_session_findings_are_sanitized() {
+        let report = DiagnosticsReport::new(
+            123,
+            vec![DiagnosticSection::new(
+                "Test",
+                format!("token=secret\n{}", "x".repeat(MAX_SECTION_BYTES + 100)),
+            )],
+        )
+        .with_session_findings(&["permission denied".to_string(), "bearer abc".to_string()]);
+
+        assert_eq!(report.collected_at(), "1970-01-01T00:02:03Z");
+        assert!(report.text().len() <= MAX_REPORT_BYTES);
+        assert!(!report.text().contains("secret"));
+        assert!(!report.text().contains("bearer abc"));
+        assert!(report.text().contains("Credential-bearing output omitted"));
+    }
+
+    #[test]
+    fn unit_parser_keeps_only_typed_state_fields() {
+        let values = parse_unit_properties(
+            b"LoadState=loaded\nActiveState=failed\nSubState=dead\nUnitFileState=enabled\nMESSAGE=token=secret\n",
+        );
+        assert_eq!(values.get("LoadState").map(String::as_str), Some("loaded"));
+        assert_eq!(
+            values.get("ActiveState").map(String::as_str),
+            Some("failed")
+        );
+        assert!(!values.contains_key("MESSAGE"));
+        assert_eq!(
+            allowlisted_unit_value(values.get("UnitFileState").map(String::as_str), "unknown"),
+            "enabled"
+        );
+    }
+
+    #[test]
+    fn journal_classification_does_not_return_messages() {
+        let classes =
+            classify_journal(b"failed: token=secret\nconnection refused\npermission denied\n");
+        assert_eq!(classes, vec!["connectivity", "error", "permission"]);
+        assert!(!classes.iter().any(|class| class.contains("secret")));
+    }
+
+    #[test]
+    fn safe_text_replaces_controls_and_credential_lines() {
+        let text = safe_text("ok\npassword=hunter2\n\u{202e}evil", 1024);
+        assert!(text.contains("ok"));
+        assert!(text.contains("Credential-bearing output omitted"));
+        assert!(!text.contains("hunter2"));
+        assert!(!text.contains('\u{202e}'));
+    }
+
+    #[cfg(unix)]
+    fn fixture_script(name: &str, body: &str) -> std::path::PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "lg-buddy-diagnostics-{name}-{}",
+            std::process::id()
+        ));
+        fs::write(&path, format!("#!/bin/sh\n{body}\n")).expect("fixture script");
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o700)).expect("script mode");
+        path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_command_caps_output() {
+        let path = fixture_script(
+            "large-output",
+            "i=0; while [ $i -lt 2000 ]; do printf 'safe-state\\n'; i=$((i + 1)); done",
+        );
+        let started = Instant::now();
+        let result = run_bounded(&path, &[], COMMAND_TIMEOUT);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(result.stdout.len() <= MAX_COMMAND_BYTES + 1);
+        fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bounded_command_does_not_join_a_descendant_holding_stdout() {
+        let path = fixture_script("inherited-pipe", "(sleep 30) & exit 0");
+        let started = Instant::now();
+        let result = run_bounded(&path, &[], COMMAND_TIMEOUT);
+        assert!(started.elapsed() < Duration::from_secs(2));
+        assert!(!result.unavailable);
+        fs::remove_file(path).expect("remove fixture");
+    }
+
+    #[test]
+    fn report_timestamp_is_human_readable_utc() {
+        assert_eq!(format_utc_timestamp(0), "1970-01-01T00:00:00Z");
+        assert_eq!(format_utc_timestamp(86_400), "1970-01-02T00:00:00Z");
+        assert_eq!(format_utc_timestamp(1_609_459_200), "2021-01-01T00:00:00Z");
+    }
+
+    #[test]
+    fn partial_sections_explain_missing_configuration() {
+        let store = SettingsStore::from_reader(ConfigEnvReader::parse(
+            "/fixture/config.env",
+            "screen_idle_blank=credential-secret\n",
+        ));
+        let settings = settings_section_from_store(&store);
+        assert!(settings.body().contains("screen.idle_blank = invalid"));
+        assert!(settings.body().contains("raw value omitted"));
+        assert!(!settings.body().contains("credential-secret"));
+
+        struct EmptyTvs;
+        impl TvsBackend for EmptyTvs {
+            fn read_profiles(&self) -> Result<Vec<crate::tvs::TvProfile>, TvsReadError> {
+                Ok(Vec::new())
+            }
+
+            fn read_model_name(
+                &self,
+                _profile: &crate::tvs::TvProfile,
+            ) -> Result<String, TvsReadError> {
+                Err(TvsReadError::internal("model read was not expected"))
+            }
+        }
+
+        struct FailingTvs;
+        impl TvsBackend for FailingTvs {
+            fn read_profiles(&self) -> Result<Vec<crate::tvs::TvProfile>, TvsReadError> {
+                Err(TvsReadError::internal("credential-secret"))
+            }
+
+            fn read_model_name(
+                &self,
+                _profile: &crate::tvs::TvProfile,
+            ) -> Result<String, TvsReadError> {
+                Err(TvsReadError::internal("credential-secret"))
+            }
+        }
+
+        let empty_tv = tv_section_from_backend(&EmptyTvs);
+        assert!(empty_tv.body().contains("No TV profile is configured"));
+        let failed_tv = tv_section_from_backend(&FailingTvs);
+        assert!(failed_tv.body().contains("inspection is unavailable"));
+        assert!(!failed_tv.body().contains("credential-secret"));
+    }
+
+    #[test]
+    fn backend_setting_remains_visible_when_an_unrelated_setting_is_invalid() {
+        let store = SettingsStore::from_reader(ConfigEnvReader::parse(
+            "/fixture/config.env",
+            "screen_backend=gnome\ntvs_primary_ip=invalid\n",
+        ));
+        assert!(store
+            .effective_by_name("tv.ip")
+            .unwrap()
+            .invalid_value()
+            .is_some());
+        assert_eq!(
+            diagnostic_configured_backend(None, Some(&store)),
+            Ok(ScreenBackend::Gnome)
+        );
+        assert_eq!(
+            diagnostic_configured_backend(Some("wayland"), Some(&store)),
+            Ok(ScreenBackend::Wayland)
+        );
+        let invalid = SettingsStore::from_reader(ConfigEnvReader::parse(
+            "/fixture/config.env",
+            "screen_backend=private-invalid-value\n",
+        ));
+        assert!(diagnostic_configured_backend(None, Some(&invalid)).is_err());
+        assert!(
+            diagnostic_configured_backend(Some("private-invalid-value"), Some(&store)).is_err()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn systemd_fixture_distinguishes_enabled_and_active_states() {
+        let path = fixture_script(
+            "systemd-states",
+            "unit=\"$4\"; [ \"$1\" = \"--user\" ] && unit=\"$5\"; case \"$unit\" in active.service) printf 'LoadState=loaded\\nActiveState=active\\nSubState=running\\nUnitFileState=disabled\\n' ;; inactive.service) printf 'LoadState=loaded\\nActiveState=inactive\\nSubState=dead\\nUnitFileState=enabled\\n' ;; timer.service) printf 'LoadState=loaded\\nActiveState=active\\nSubState=waiting\\nUnitFileState=enabled\\n' ;; esac",
+        );
+        let active = systemd_unit_observation(&path, ServiceScope::System, "active.service");
+        assert_eq!(
+            active.text,
+            "load=loaded, active=active, substate=running, enabled=disabled"
+        );
+        assert!(!active.action_needed);
+
+        let inactive = systemd_unit_observation(&path, ServiceScope::System, "inactive.service");
+        assert_eq!(
+            inactive.text,
+            "load=loaded, active=inactive, substate=dead, enabled=enabled"
+        );
+        assert!(!inactive.action_needed);
+
+        let timer = systemd_unit_observation(&path, ServiceScope::User, "timer.service");
+        assert_eq!(
+            timer.text,
+            "load=loaded, active=active, substate=waiting, enabled=enabled"
+        );
+        assert!(!timer.action_needed);
+        fs::remove_file(path).expect("remove fixture");
+    }
+}

--- a/crates/lg-buddy/src/diagnostics_view.rs
+++ b/crates/lg-buddy/src/diagnostics_view.rs
@@ -1,0 +1,497 @@
+//! On-demand diagnostics workflow. Hosts execute reads, clipboard writes and
+//! file selection; the application owns the report and export snapshot.
+
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::diagnostics::{DiagnosticsReport, EnvironmentDiagnosticsCollector};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiagnosticsIntent {
+    Open,
+    Refresh,
+    Close,
+    Copy,
+    Save,
+    SaveDestination {
+        request: DiagnosticsSaveRequest,
+        path: Option<PathBuf>,
+    },
+    SaveSelectionFailed(DiagnosticsSaveRequest),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsReadOperation {
+    id: u64,
+    session_findings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DiagnosticsSaveRequest(u64);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsSaveOperation {
+    request: DiagnosticsSaveRequest,
+    path: PathBuf,
+    report: DiagnosticsReport,
+}
+
+impl DiagnosticsSaveOperation {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn text(&self) -> &str {
+        self.report.text()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsError(String);
+
+impl DiagnosticsError {
+    pub fn collection_stopped() -> Self {
+        Self("Collection stopped unexpectedly. Refresh to try again.".into())
+    }
+
+    pub fn save_failed() -> Self {
+        Self("Could not save the report. Choose a writable location with enough free space and try again.".into())
+    }
+}
+
+pub trait DiagnosticsBackend: Send + Sync + 'static {
+    fn collect(&self) -> Result<DiagnosticsReport, DiagnosticsError>;
+
+    fn save(&self, operation: &DiagnosticsSaveOperation) -> Result<(), DiagnosticsError> {
+        save_report(operation.path(), operation.text()).map_err(|_| DiagnosticsError::save_failed())
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct EnvironmentDiagnosticsBackend;
+
+impl DiagnosticsBackend for EnvironmentDiagnosticsBackend {
+    fn collect(&self) -> Result<DiagnosticsReport, DiagnosticsError> {
+        Ok(EnvironmentDiagnosticsCollector.collect())
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DiagnosticsPresentation {
+    visible: bool,
+    collecting: bool,
+    saving: bool,
+    choosing_save: bool,
+    report: Option<DiagnosticsReport>,
+    error: Option<String>,
+}
+
+impl DiagnosticsPresentation {
+    pub fn visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn collecting(&self) -> bool {
+        self.collecting
+    }
+
+    pub fn saving(&self) -> bool {
+        self.saving
+    }
+
+    pub fn report_text(&self) -> Option<&str> {
+        self.report.as_ref().map(DiagnosticsReport::text)
+    }
+
+    pub fn collected_at(&self) -> Option<&str> {
+        self.report.as_ref().map(DiagnosticsReport::collected_at)
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error.as_deref()
+    }
+
+    pub fn can_refresh(&self) -> bool {
+        self.visible && !self.collecting && !self.saving && !self.choosing_save
+    }
+
+    pub fn can_export(&self) -> bool {
+        self.can_refresh() && self.report.is_some()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsTransition {
+    presentation: DiagnosticsPresentation,
+    read: Option<DiagnosticsReadOperation>,
+    choose_save: Option<DiagnosticsSaveRequest>,
+    save: Option<DiagnosticsSaveOperation>,
+    clipboard_text: Option<String>,
+    toast: Option<&'static str>,
+}
+
+impl DiagnosticsTransition {
+    pub fn presentation(&self) -> &DiagnosticsPresentation {
+        &self.presentation
+    }
+
+    pub fn read_operation(&self) -> Option<&DiagnosticsReadOperation> {
+        self.read.as_ref()
+    }
+
+    pub fn save_request(&self) -> Option<DiagnosticsSaveRequest> {
+        self.choose_save
+    }
+
+    pub fn save_operation(&self) -> Option<&DiagnosticsSaveOperation> {
+        self.save.as_ref()
+    }
+
+    pub fn clipboard_text(&self) -> Option<&str> {
+        self.clipboard_text.as_deref()
+    }
+
+    pub fn toast(&self) -> Option<&str> {
+        self.toast
+    }
+}
+
+#[derive(Default)]
+pub struct DiagnosticsApplication {
+    presentation: DiagnosticsPresentation,
+    next_id: u64,
+    pending_read: Option<u64>,
+    pending_save: Option<(DiagnosticsSaveRequest, DiagnosticsReport)>,
+    closed: bool,
+    recent_findings: Vec<String>,
+}
+
+impl DiagnosticsApplication {
+    /// Only application-owned user-facing summaries belong here. Protocol
+    /// frames and arbitrary subprocess/configuration output must not be retained.
+    pub(crate) fn record_failure(&mut self, context: &str, message: &str) {
+        let finding: String = format!("{context}: {message}").chars().take(1024).collect();
+        if self.recent_findings.contains(&finding) {
+            return;
+        }
+        self.recent_findings.push(finding);
+        if self.recent_findings.len() > 12 {
+            self.recent_findings.remove(0);
+        }
+    }
+
+    pub fn handle_intent(&mut self, intent: DiagnosticsIntent) -> Option<DiagnosticsTransition> {
+        if self.closed {
+            return None;
+        }
+        match intent {
+            DiagnosticsIntent::Open if !self.presentation.visible => {
+                self.presentation.visible = true;
+                Some(self.begin_read())
+            }
+            DiagnosticsIntent::Refresh if self.presentation.can_refresh() => {
+                Some(self.begin_read())
+            }
+            DiagnosticsIntent::Close if self.presentation.visible => {
+                self.presentation.visible = false;
+                self.presentation.collecting = false;
+                self.presentation.saving = false;
+                self.presentation.choosing_save = false;
+                self.pending_read = None;
+                self.pending_save = None;
+                Some(self.transition())
+            }
+            DiagnosticsIntent::Copy if self.presentation.can_export() => {
+                let mut transition = self.transition();
+                transition.clipboard_text = self.presentation.report_text().map(str::to_string);
+                transition.toast = Some("Diagnostic report copied");
+                Some(transition)
+            }
+            DiagnosticsIntent::Save if self.presentation.can_export() => {
+                let request = DiagnosticsSaveRequest(self.next_id);
+                self.next_id += 1;
+                self.pending_save = Some((request, self.presentation.report.clone()?));
+                self.presentation.choosing_save = true;
+                self.presentation.error = None;
+                let mut transition = self.transition();
+                transition.choose_save = Some(request);
+                Some(transition)
+            }
+            DiagnosticsIntent::SaveDestination { request, path }
+                if self.presentation.choosing_save && self.save_matches(request) =>
+            {
+                self.presentation.choosing_save = false;
+                let mut transition = self.transition();
+                if let Some(path) = path {
+                    self.presentation.saving = true;
+                    transition.presentation = self.presentation.clone();
+                    transition.save = Some(DiagnosticsSaveOperation {
+                        request,
+                        path,
+                        report: self.pending_save.as_ref()?.1.clone(),
+                    });
+                } else {
+                    self.pending_save = None;
+                }
+                Some(transition)
+            }
+            DiagnosticsIntent::SaveSelectionFailed(request)
+                if self.presentation.choosing_save && self.save_matches(request) =>
+            {
+                self.pending_save = None;
+                self.presentation.choosing_save = false;
+                self.presentation.error = Some(
+                    "Could not select a local save location. Try again or copy the report.".into(),
+                );
+                Some(self.transition())
+            }
+            _ => None,
+        }
+    }
+
+    pub fn complete_read(
+        &mut self,
+        operation: &DiagnosticsReadOperation,
+        result: Result<DiagnosticsReport, DiagnosticsError>,
+    ) -> Option<DiagnosticsTransition> {
+        if self.closed || self.pending_read != Some(operation.id) {
+            return None;
+        }
+        self.pending_read = None;
+        self.presentation.collecting = false;
+        match result {
+            Ok(report) => {
+                self.presentation.report =
+                    Some(report.with_session_findings(&operation.session_findings))
+            }
+            Err(error) => self.presentation.error = Some(error.0),
+        }
+        Some(self.transition())
+    }
+
+    pub fn complete_save(
+        &mut self,
+        operation: &DiagnosticsSaveOperation,
+        result: Result<(), DiagnosticsError>,
+    ) -> Option<DiagnosticsTransition> {
+        if self.closed || !self.presentation.saving || !self.save_matches(operation.request) {
+            return None;
+        }
+        self.pending_save = None;
+        self.presentation.saving = false;
+        let mut transition = self.transition();
+        match result {
+            Ok(()) => transition.toast = Some("Diagnostic report saved"),
+            Err(error) => {
+                self.presentation.error = Some(error.0);
+                transition.presentation = self.presentation.clone();
+            }
+        }
+        Some(transition)
+    }
+
+    pub fn shutdown(&mut self) {
+        self.closed = true;
+        self.pending_read = None;
+        self.pending_save = None;
+    }
+
+    fn save_matches(&self, request: DiagnosticsSaveRequest) -> bool {
+        self.pending_save
+            .as_ref()
+            .is_some_and(|(pending, _)| *pending == request)
+    }
+
+    fn begin_read(&mut self) -> DiagnosticsTransition {
+        let operation = DiagnosticsReadOperation {
+            id: self.next_id,
+            session_findings: self.recent_findings.clone(),
+        };
+        self.next_id += 1;
+        self.pending_read = Some(operation.id);
+        self.presentation.collecting = true;
+        self.presentation.error = None;
+        let mut transition = self.transition();
+        transition.read = Some(operation);
+        transition
+    }
+
+    fn transition(&self) -> DiagnosticsTransition {
+        DiagnosticsTransition {
+            presentation: self.presentation.clone(),
+            read: None,
+            choose_save: None,
+            save: None,
+            clipboard_text: None,
+            toast: None,
+        }
+    }
+}
+
+fn save_report(path: &Path, text: &str) -> std::io::Result<()> {
+    static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+    let parent = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or(Path::new("."));
+    let temporary = parent.join(format!(
+        ".lg-buddy-diagnostics-{}-{}.tmp",
+        std::process::id(),
+        NEXT_TEMP.fetch_add(1, Ordering::Relaxed)
+    ));
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&temporary)?;
+    let result = (|| {
+        file.write_all(text.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diagnostics::DiagnosticSection;
+
+    fn report(label: &str) -> DiagnosticsReport {
+        DiagnosticsReport::new(1_000, vec![DiagnosticSection::new("Application", label)])
+    }
+
+    fn ready(app: &mut DiagnosticsApplication) -> DiagnosticsTransition {
+        let opened = app.handle_intent(DiagnosticsIntent::Open).unwrap();
+        app.complete_read(opened.read_operation().unwrap(), Ok(report("fixture")))
+            .unwrap()
+    }
+
+    #[test]
+    fn collection_is_on_demand_and_close_rejects_stale_results() {
+        let mut app = DiagnosticsApplication::default();
+        assert!(!app.presentation.visible());
+        assert!(app.pending_read.is_none());
+        let opening = app.handle_intent(DiagnosticsIntent::Open).unwrap();
+        assert!(!opening.presentation().can_export());
+        assert!(app.handle_intent(DiagnosticsIntent::Refresh).is_none());
+        app.handle_intent(DiagnosticsIntent::Close).unwrap();
+        let reopening = app.handle_intent(DiagnosticsIntent::Open).unwrap();
+        assert!(app
+            .complete_read(opening.read_operation().unwrap(), Ok(report("old")))
+            .is_none());
+        let completed = app
+            .complete_read(reopening.read_operation().unwrap(), Ok(report("new")))
+            .unwrap();
+        assert!(completed
+            .presentation()
+            .report_text()
+            .unwrap()
+            .contains("new"));
+        app.shutdown();
+        assert!(app.handle_intent(DiagnosticsIntent::Open).is_none());
+    }
+
+    #[test]
+    fn copy_and_save_use_the_visible_report_and_cancel_is_quiet() {
+        let mut app = DiagnosticsApplication::default();
+        let loaded = ready(&mut app);
+        let copy = app.handle_intent(DiagnosticsIntent::Copy).unwrap();
+        assert_eq!(copy.clipboard_text(), loaded.presentation().report_text());
+        let choosing = app.handle_intent(DiagnosticsIntent::Save).unwrap();
+        assert!(app.handle_intent(DiagnosticsIntent::Refresh).is_none());
+        let cancelled = app
+            .handle_intent(DiagnosticsIntent::SaveDestination {
+                request: choosing.save_request().unwrap(),
+                path: None,
+            })
+            .unwrap();
+        assert!(cancelled.presentation().error().is_none());
+        assert!(cancelled.presentation().can_export());
+        let choosing = app.handle_intent(DiagnosticsIntent::Save).unwrap();
+        let saving = app
+            .handle_intent(DiagnosticsIntent::SaveDestination {
+                request: choosing.save_request().unwrap(),
+                path: Some(PathBuf::from("report.txt")),
+            })
+            .unwrap();
+        assert_eq!(
+            Some(saving.save_operation().unwrap().text()),
+            copy.clipboard_text()
+        );
+        assert!(saving.presentation().saving());
+        let failed = app
+            .complete_save(
+                saving.save_operation().unwrap(),
+                Err(DiagnosticsError::save_failed()),
+            )
+            .unwrap();
+        assert!(failed.presentation().can_export());
+        assert!(failed.presentation().error().is_some());
+        assert_eq!(failed.presentation().report_text(), copy.clipboard_text());
+    }
+
+    #[test]
+    fn failed_refresh_keeps_the_previous_report_available_for_export() {
+        let mut app = DiagnosticsApplication::default();
+        let loaded = ready(&mut app);
+        let refresh = app.handle_intent(DiagnosticsIntent::Refresh).unwrap();
+        let failed = app
+            .complete_read(
+                refresh.read_operation().unwrap(),
+                Err(DiagnosticsError::collection_stopped()),
+            )
+            .unwrap();
+        assert!(failed.presentation().can_export());
+        assert!(failed.presentation().error().is_some());
+        assert_eq!(
+            failed.presentation().report_text(),
+            loaded.presentation().report_text()
+        );
+    }
+
+    #[test]
+    fn cancelled_file_dialog_cannot_save_after_reopening() {
+        let mut app = DiagnosticsApplication::default();
+        ready(&mut app);
+        let choosing = app.handle_intent(DiagnosticsIntent::Save).unwrap();
+        app.handle_intent(DiagnosticsIntent::Close).unwrap();
+        ready(&mut app);
+        assert!(app
+            .handle_intent(DiagnosticsIntent::SaveDestination {
+                request: choosing.save_request().unwrap(),
+                path: Some(PathBuf::from("obsolete.txt")),
+            })
+            .is_none());
+    }
+
+    #[test]
+    fn export_replaces_a_report_atomically_and_preserves_destination_on_failure() {
+        let root = std::env::temp_dir().join(format!(
+            "lg-buddy-diagnostics-export-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let destination = root.join("report.txt");
+        fs::write(&destination, "previous report").unwrap();
+        save_report(&destination, report("safe report").text()).unwrap();
+        assert_eq!(
+            fs::read_to_string(&destination).unwrap(),
+            report("safe report").text()
+        );
+        let directory = root.join("directory");
+        fs::create_dir(&directory).unwrap();
+        assert!(save_report(&directory, "replacement").is_err());
+        assert!(directory.is_dir());
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -7,6 +7,8 @@ pub mod backend;
 pub mod brightness;
 pub mod commands;
 pub mod config;
+pub mod diagnostics;
+pub mod diagnostics_view;
 pub mod events;
 pub mod lifecycle;
 pub mod navigation;

--- a/docs/development.md
+++ b/docs/development.md
@@ -89,7 +89,8 @@ GUI for pairing. Pairing then attempts the default Idle Blanking and TV Sleep &
 Wake behaviors; unavailable or declined behaviors stay off and can be retried in
 Settings. `configure.sh` remains an explicit headless setup path: run it before
 `install.sh`. Configured installations and upgrades retain their saved settings.
-On-demand diagnostics and complete journey verification remain tracked in
+The application menu offers on-demand diagnostics with Refresh, Copy, and Save.
+Complete journey verification remains tracked in
 [issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129).
 
 Official release builds inject version identity into the binary:

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -8,8 +8,8 @@ the application owning state and the GTK crate rendering it.
 > About. The development tree also provides manual update checks and
 > user-confirmed release-bundle installation in Settings, and first-run pairing
 > with default behavior activation. Unavailable or declined behaviors remain off
-> and can be retried in Settings. On-demand diagnostics remain
-> tracked for `v1.7.0` in [issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129).
+> and can be retried in Settings. The app menu provides on-demand diagnostics
+> with report viewing, refresh, copying, and saving.
 
 ## Boundary
 
@@ -18,7 +18,7 @@ flowchart LR
     LAUNCH["lg-buddy launcher"] --> GUI["lg-buddy-gui"]
 
     subgraph APP["lg-buddy application"]
-        MODEL["Application\nOverviewApplication\nTvsApplication\nSettingsApplication"]
+        MODEL["Application\nOverviewApplication\nTvsApplication\nSettingsApplication\nDiagnosticsApplication"]
         PRESENT["presentation/*\ntyped state and actions"]
         MODEL --> PRESENT
     end
@@ -257,15 +257,36 @@ The application retains bounded failure details for the current session,
 including across retries and Settings refreshes. Credential-bearing lines,
 URLs, and control characters are removed before retention. The error toast
 provides the details on demand, and the application presentation retains them
-for the future diagnostics readout independently of launcher stderr handling.
+for the diagnostics readout independently of launcher stderr handling.
 
-There is no separate GUI surface for a resolved screen backend, service health,
-or runtime state. Normal successful setting changes
+Resolved screen backend, service health, and runtime observations belong in
+Diagnostics. Normal successful setting changes
 are silent. Feedback appears
 when a read, validation, persistence, or runtime apply result needs attention;
-an apply warning keeps the saved value and can offer **Retry apply**. The
-broader diagnostics UI is deferred as described at the top
-of this document.
+an apply warning keeps the saved value and can offer **Retry apply**.
+
+## Diagnostics
+
+The app menu's **Diagnostics** action is available before pairing, including
+when navigation tabs are hidden. It opens a native dialog and starts a read-only
+snapshot. **Refresh** collects again; **Copy** and **Save…** export exactly the
+bounded, sanitized report shown in the dialog. A failed refresh retains the
+previous report and collection time. File chooser cancellation is silent, and
+save failures leave the report available to copy or save elsewhere.
+
+`diagnostics.rs` collects build identity, typed effective settings, desktop
+capabilities, separate systemd state fields, TV observations, and bounded recent
+failure findings. Unavailable observations remain explicit partial results.
+Capability probes are not treated as proof of what a running service uses; TV
+connectivity is not proof of automation. Raw configuration values, credentials,
+protocol frames, and journal messages are excluded from the report.
+
+`diagnostics_view.rs` owns collection, export snapshots, and stale-completion
+handling. `Application` adds retained user-facing failures from the current GUI
+session. The GTK controller runs workers, writes the clipboard, and selects a
+save destination; the dialog renders report and action state. Closing it
+invalidates pending UI completions, while an accepted file export can finish.
+There is no automatic collection or generic repair action.
 
 The main menu's **About LG Buddy** action is implemented by the native
 `adw::AboutDialog`. It supplies the application name and icon, version, links,

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -280,6 +280,9 @@ failure findings. Unavailable observations remain explicit partial results.
 Capability probes are not treated as proof of what a running service uses; TV
 connectivity is not proof of automation. Raw configuration values, credentials,
 protocol frames, and journal messages are excluded from the report.
+Native TV model reads require stored credentials. Compatibility profiles expose
+local credential metadata only, because that backend cannot guarantee a model
+read without initiating pairing.
 
 `diagnostics_view.rs` owns collection, export snapshots, and stale-completion
 handling. `Application` adds retained user-facing failures from the current GUI

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -343,6 +343,15 @@ installed executable and preservation of existing configuration. Complete
 assembled-journey verification remains tracked in
 [#201](https://github.com/Staphylococcus/LG_Buddy/issues/201).
 
+Diagnostics tests cover on-demand collection before pairing, partial reports,
+service-state distinctions, bounded subprocess reads, and credential exclusion.
+Application tests cover retained safe failures, refresh/close races, exact
+copy/save snapshots, chooser cancellation, and failed exports. Native GTK
+scenarios exercise the menu, collection responsiveness, report selection,
+keyboard focus, adaptive layout, clipboard contents, and file export through
+the worker boundary. Tests inject probes and reports without changing live
+services or querying a real TV.
+
 The focused release-manifest suite covers deterministic serialization, schema
 and critical-field handling, duplicate and missing fields, canonical identity
 formats, archive layout, and runtime/GUI target and identity mismatches. The

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -255,8 +255,17 @@ information, and open the project issue form. The terminal equivalent is:
 lg-buddy --version
 ```
 
-When reporting a problem, include the version, what you expected, what happened,
-and the relevant command output. These checks usually identify the next step:
+Open **Diagnostics** from the app menu to collect a troubleshooting report,
+even before a TV is paired. Use **Refresh** for a new snapshot, **Copy** for the
+clipboard, or **Save…** for a text file. The report includes settings, desktop
+capabilities, service states, and available failure findings. A failed inspection
+leaves the other results available. Collection does not change settings, start
+services, or pair a TV.
+
+The report excludes credentials and raw logs, but includes local TV addresses
+and configuration details. Review it before sharing. When reporting a problem,
+include what you expected, what happened, and the report. These additional
+checks can help identify the next step:
 
 | Problem | Check |
 | --- | --- |


### PR DESCRIPTION
Adds **Diagnostics** to the app menu, including before pairing. The dialog collects a report on demand and provides Refresh, Copy, and Save. Failed inspections retain useful partial results; failed refreshes and exports preserve the previous report. Normal Overview and Settings stay uncluttered.

The application owns the report, workflow, recovery guidance, and export snapshot. Reports include build identity, typed settings, desktop capability observations, separate systemd state fields, TV observations, and bounded recent failure findings. Credentials, raw protocol frames, and raw journal messages are excluded. Native Wayland registry probing is explicitly unavailable because the existing probe has no bounded roundtrip; GNOME interfaces and fallback command availability are inspected.

Validation:
- Full core suite: 971 unit tests, all integration tests, and 134 behavior scenarios passed; one hardware test remains ignored.
- Ubuntu 24.04 GTK suite passed, covering menu access before pairing, responsive collection, narrow/wide layouts, dismissal, clipboard contents, and file export.
- Workspace formatting and strict Clippy passed.
- Production collector smoke with isolated config/command fixtures confirmed partial results and credential exclusion.

Closes #200.
