### PR TITLE
test(gui): verify the complete installed setup and update journey

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,11 +239,11 @@ jobs:
           - name: Fedora 43
             image: fedora:43
             package_manager: dnf
-            setup: dnf install -y at-spi2-core binutils curl dbus-x11 findutils glib2 gobject-introspection gsettings-desktop-schemas gtk4 gzip libadwaita libglvnd-gles polkit python3 python3-pyatspi shadow-utils strace tar util-linux which xdotool xorg-x11-server-Xvfb xorg-x11-xauth xwd zenity
+            setup: dnf install -y at-spi2-core binutils curl dbus-x11 findutils glib2 gobject-introspection gsettings-desktop-schemas gtk4 gzip libadwaita libglvnd-gles polkit procps-ng python3 python3-pyatspi shadow-utils strace tar util-linux which xdotool xorg-x11-server-Xvfb xorg-x11-xauth xwd zenity
           - name: Arch current
             image: archlinux:latest
             package_manager: pacman
-            setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita polkit python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd zenity
+            setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita polkit procps-ng python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd zenity
     container:
       image: ${{ matrix.image }}
       options: --security-opt seccomp=unconfined

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,13 @@ jobs:
       - name: Run display-backed GTK test suite
         run: |
           cargo build -p lg-buddy -p lg-buddy-gui
+          cargo build --locked -p lg-buddy --example gui_journey_tv
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy
-          dbus-run-session -- xvfb-run -a bash ./scripts/test-installed-gui.sh ./target/debug/lg-buddy ./target/debug/lg-buddy-gui
+          dbus-run-session -- xvfb-run -a bash ./scripts/test-installed-gui.sh \
+              ./target/debug/lg-buddy \
+              ./target/debug/lg-buddy-gui \
+              ./target/debug/examples/gui_journey_tv
           dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 cargo test -p lg-buddy-gui -- --test-threads=1
 
       - name: Run clippy
@@ -59,8 +63,11 @@ jobs:
 
       - name: Validate shell scripts
         run: |
-          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-installer-first-run.sh scripts/test-installer-gui-dependencies.sh scripts/test-installer-graphical-auth.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
-          python3 -m py_compile scripts/test-release-gui-accessibility.py scripts/xwd_mean.py
+          bash -n install.sh uninstall.sh configure.sh bin/LG_Buddy_Common scripts/build-release-bundle.sh scripts/test-gui-launch.sh scripts/test-installed-gui.sh scripts/test-installer-first-run.sh scripts/test-installer-gui-dependencies.sh scripts/test-installer-graphical-auth.sh scripts/test-release-bundle.sh scripts/test-release-gui-behavior.sh scripts/test-release-gui-journey.sh scripts/test-release-linkage.sh scripts/test-cross-version-upgrade.sh scripts/test-production-upgrade-canary.sh scripts/publish-release-assets.sh
+          python3 -m py_compile scripts/test-release-gui-accessibility.py scripts/xwd_mean.py tools/mock_github_gui.py
+
+      - name: Validate deterministic GUI GitHub fixture
+        run: python3 scripts/test_mock_github_gui.py
 
       - name: Run first-run installer smoke
         run: bash ./scripts/test-installer-first-run.sh
@@ -120,6 +127,16 @@ jobs:
           umask 0002
           ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --gui-target x86_64-unknown-linux-gnu --version "$SMOKE_VERSION" --output-dir dist
 
+      - name: Build GUI journey fixtures
+        env:
+          LG_BUDDY_BUILD_COMMIT: ${{ github.sha }}
+          LG_BUDDY_RELEASE_VERSION: "0.0.0"
+        run: |
+          cargo build --locked -p lg-buddy -p lg-buddy-gui --features gui-test-fixtures
+          cargo build --locked -p lg-buddy --example gui_journey_tv --target x86_64-unknown-linux-musl
+          mkdir -p target/gui-journey-fixtures
+          cp target/debug/lg-buddy target/debug/lg-buddy-gui target/x86_64-unknown-linux-musl/debug/examples/gui_journey_tv target/gui-journey-fixtures/
+
       - name: Enable graphical authorization smoke namespaces
         # Ubuntu 24.04 may restrict unprivileged user namespaces through
         # AppArmor. Relax only that disposable runner setting for the
@@ -133,7 +150,9 @@ jobs:
 
       - name: Smoke test release bundle
         run: |
-          dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 ./scripts/test-release-bundle.sh \
+          dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+              LG_BUDDY_GUI_TV_FIXTURE="$PWD/target/gui-journey-fixtures/gui_journey_tv" \
+              ./scripts/test-release-bundle.sh \
               --skip-pip-install \
               --work-dir "$RUNNER_TEMP/release-bundle-smoke" \
               --archive "dist/lg-buddy-${SMOKE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
@@ -142,6 +161,15 @@ jobs:
               --expected-channel prerelease \
               --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ github.sha }}"
+
+      - name: Smoke test installed GUI journey
+        run: |
+          dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+              bash ./scripts/test-installed-gui.sh \
+              target/gui-journey-fixtures/lg-buddy \
+              target/gui-journey-fixtures/lg-buddy-gui \
+              target/gui-journey-fixtures/gui_journey_tv \
+              "dist/lg-buddy-${SMOKE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
 
       - name: Download pinned cross-version baseline
         run: |
@@ -190,6 +218,14 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+      - name: Upload GUI journey fixtures for supported-distro checks
+        uses: actions/upload-artifact@v6
+        with:
+          name: ci-gui-journey-fixtures
+          path: target/gui-journey-fixtures/*
+          if-no-files-found: error
+          retention-days: 7
+
   bundle-supported-distros:
     needs: bundle-smoke-test
     runs-on: ubuntu-24.04
@@ -210,6 +246,7 @@ jobs:
             setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita polkit python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd zenity
     container:
       image: ${{ matrix.image }}
+      options: --security-opt seccomp=unconfined
 
     steps:
       - name: Install ${{ matrix.name }} prerequisites
@@ -224,6 +261,12 @@ jobs:
           name: ci-release-bundle
           path: dist
 
+      - name: Download GUI journey fixtures
+        uses: actions/download-artifact@v7
+        with:
+          name: ci-gui-journey-fixtures
+          path: gui-journey-fixtures
+
       - name: Install and launch the packaged GUI on ${{ matrix.name }}
         shell: bash
         run: |
@@ -232,6 +275,7 @@ jobs:
           extraction="$(mktemp -d)"
           tar --no-same-owner -C "$extraction" -xzf "$archive"
           bundle="$(find "$extraction" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+          chmod 755 gui-journey-fixtures/*
           chmod -R a+rX "$extraction" "$GITHUB_WORKSPACE"
           runuser -u tester -- bash ./scripts/test-release-linkage.sh \
               "$bundle/lg-buddy" \
@@ -246,6 +290,13 @@ jobs:
               bash ./scripts/test-installed-gui.sh \
               "$bundle/lg-buddy" \
               "$bundle/docs/lg-buddy-gui-x86_64-unknown-linux-gnu"
+          runuser -u tester -- dbus-run-session -- xvfb-run -a -s "-screen 0 1920x1080x24" \
+              env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals LG_BUDDY_TEST_PLATFORM_CONTRACT=1 \
+              bash ./scripts/test-installed-gui.sh \
+              "$GITHUB_WORKSPACE/gui-journey-fixtures/lg-buddy" \
+              "$GITHUB_WORKSPACE/gui-journey-fixtures/lg-buddy-gui" \
+              "$GITHUB_WORKSPACE/gui-journey-fixtures/gui_journey_tv" \
+              "$archive"
 
       - name: Upgrade the pinned baseline on ${{ matrix.name }}
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,16 @@ jobs:
       - name: Create release bundle
         run: ./scripts/build-release-bundle.sh --target x86_64-unknown-linux-musl --gui-target x86_64-unknown-linux-gnu --version "${{ needs.validate.outputs.version }}" --output-dir dist
 
+      - name: Build GUI journey fixtures
+        env:
+          LG_BUDDY_BUILD_COMMIT: ${{ needs.validate.outputs.head_sha }}
+          LG_BUDDY_RELEASE_VERSION: "0.0.0"
+        run: |
+          cargo build --locked -p lg-buddy -p lg-buddy-gui --features gui-test-fixtures
+          cargo build --locked -p lg-buddy --example gui_journey_tv --target x86_64-unknown-linux-musl
+          mkdir -p target/gui-journey-fixtures
+          cp target/debug/lg-buddy target/debug/lg-buddy-gui target/x86_64-unknown-linux-musl/debug/examples/gui_journey_tv target/gui-journey-fixtures/
+
       - name: Enable graphical authorization smoke namespaces
         # Ubuntu 24.04 may restrict unprivileged user namespaces through
         # AppArmor. Relax only that disposable runner setting for the
@@ -117,7 +127,9 @@ jobs:
 
       - name: Smoke test release bundle
         run: |
-          dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 ./scripts/test-release-bundle.sh \
+          dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+              LG_BUDDY_GUI_TV_FIXTURE="$PWD/target/gui-journey-fixtures/gui_journey_tv" \
+              ./scripts/test-release-bundle.sh \
               --skip-pip-install \
               --work-dir "$RUNNER_TEMP/release-bundle-smoke" \
               --archive "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz" \
@@ -126,6 +138,15 @@ jobs:
               --expected-channel "${{ needs.validate.outputs.channel }}" \
               --expected-target x86_64-unknown-linux-musl \
               --expected-commit "${{ needs.validate.outputs.head_sha }}"
+
+      - name: Smoke test installed GUI journey
+        run: |
+          dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
+              bash ./scripts/test-installed-gui.sh \
+              target/gui-journey-fixtures/lg-buddy \
+              target/gui-journey-fixtures/lg-buddy-gui \
+              target/gui-journey-fixtures/gui_journey_tv \
+              "dist/lg-buddy-${{ needs.validate.outputs.version }}-x86_64-unknown-linux-musl.tar.gz"
 
       - name: Download pinned cross-version baseline
         run: |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ these distributions, with your confirmation. Older desktops that need the
 deprecated `swayidle` integration must install `swayidle` separately.
 
 The shell installer supports conventional Linux installations with writable
-system locations. First-class NixOS packaging is tracked in
+system locations. Official NixOS support is planned for 3.0.0; see
 [issue #24](https://github.com/Staphylococcus/LG_Buddy/issues/24).
 
 ## Install
@@ -96,16 +96,22 @@ system locations. First-class NixOS packaging is tracked in
 
    The installer requests elevated access when needed.
 
-3. The installed app opens to **Pair a TV**. Enter the TV's IP address, MAC
+3. The installed app opens to **Pair a TV**. Until a TV is saved, **TVs** is
+   the only page and the other tabs are hidden. Enter the TV's IP address, MAC
    address, and HDMI input. Keep the TV on and approve its pairing request
    with the remote.
 4. After pairing, LG Buddy attempts its default Idle Blanking and TV Sleep &
-   Wake behaviors. It asks for authorization only when a system operation needs
-   it. If a behavior cannot be activated or authorization is declined, that
-   behavior stays off; enable it later in **Settings** to retry.
+   Wake behaviors. There is no separate confirmation for each service; LG Buddy
+   asks for desktop authorization only when a system operation needs it. The TV
+   remains saved if authorization is declined or activation is unavailable, and
+   the affected behavior stays off. Enable it later in **Settings** to retry.
 
-For terminal-only setup, run `./configure.sh` before `./install.sh`. Installing
-with an existing TV configuration preserves its saved preferences.
+After installation, use **TVs** to change the HDMI input and **Settings** to
+change blanking, sleep and wake, desktop integration, or update preferences.
+Installing with an existing TV configuration preserves its saved preferences.
+
+For a headless setup, run `./configure.sh` before `./install.sh`; the user guide
+keeps the command-line alternatives for scripts and machines without the GUI.
 
 <a id="quick-start"></a>
 
@@ -121,22 +127,24 @@ with an existing TV configuration preserves its saved preferences.
 - [Use terminal commands](docs/user-guide.md#common-commands) for shortcuts,
   scripts, or a desktop without the GUI.
 
-To rerun setup or change installed service wiring, run `./configure.sh` from
-the extracted release archive.
+For installed GUI reconfiguration, use **TVs** and **Settings**. The headless
+`configure.sh` path is for setup before installation; command-line alternatives
+are listed in the [user guide](docs/user-guide.md#common-commands).
 
-## Update
+## Update from the installed app
 
 Read what changed in the [release notes on GitHub](https://github.com/Staphylococcus/LG_Buddy/releases).
 
-To install the next release while keeping your settings and pairing, run as
-your regular user:
+To check manually, open **Settings → Updates** and choose **Check for updates**.
+The row disables and reads **Checking…** while it works, shows an up-to-date
+toast when no release qualifies, and changes to **Install update…** when one is
+available. The install dialog resolves the newest qualifying release for the
+saved channel, shows its version and channel, and displays indeterminate
+progress while it downloads, verifies, installs, and restarts. Your settings and
+TV pairing are preserved.
 
-```bash
-lg-buddy updates install
-```
-
-Review the offered version and confirm to proceed. For preview releases,
-automatic check preferences, or older installations, see
+For preview releases, automatic check preferences, older installations, or a
+headless update path, see
 [Update LG Buddy](docs/user-guide.md#updates).
 
 <a id="documentation"></a>

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -4,6 +4,9 @@ version = "1.6.0"
 edition = "2021"
 publish = false
 
+[features]
+gui-test-fixtures = ["lg-buddy/gui-test-fixtures"]
+
 [dependencies]
 adw = { package = "libadwaita", version = "0.9.2", features = ["gtk_v4_10", "v1_5"] }
 gtk = { package = "gtk4", version = "0.11.4", features = ["v4_10"] }

--- a/crates/lg-buddy-gui/src/diagnostics.rs
+++ b/crates/lg-buddy-gui/src/diagnostics.rs
@@ -25,7 +25,10 @@ pub(crate) struct DiagnosticsView {
 }
 
 impl DiagnosticsView {
-    pub(crate) fn new(on_intent: Rc<dyn Fn(DiagnosticsIntent)>) -> Self {
+    pub(crate) fn new(
+        on_intent: Rc<dyn Fn(DiagnosticsIntent)>,
+        return_focus: &gtk::Widget,
+    ) -> Self {
         let presented = Rc::new(Cell::new(false));
         let suppress_close = Rc::new(Cell::new(false));
 
@@ -149,10 +152,16 @@ impl DiagnosticsView {
             let on_intent = Rc::clone(&on_intent);
             let presented = Rc::clone(&presented);
             let suppress_close = Rc::clone(&suppress_close);
+            let return_focus = return_focus.downgrade();
             move |_| {
                 presented.set(false);
                 if !suppress_close.replace(false) {
                     on_intent(DiagnosticsIntent::Close);
+                }
+                // The menu item that opened the dialog no longer exists, and
+                // a native file chooser can also clear the parent's focus.
+                if let Some(return_focus) = return_focus.upgrade() {
+                    return_focus.grab_focus();
                 }
             }
         });
@@ -267,15 +276,20 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     }
 
     let intents = Rc::new(RefCell::new(Vec::new()));
-    let view = DiagnosticsView::new(Rc::new({
-        let intents = Rc::clone(&intents);
-        move |intent| intents.borrow_mut().push(intent)
-    }));
+    let origin = gtk::Button::with_label("Open diagnostics");
+    let view = DiagnosticsView::new(
+        Rc::new({
+            let intents = Rc::clone(&intents);
+            move |intent| intents.borrow_mut().push(intent)
+        }),
+        origin.upcast_ref(),
+    );
     let wide_window = adw::ApplicationWindow::builder()
         .application(application)
         .default_width(800)
         .default_height(600)
         .build();
+    wide_window.set_content(Some(&origin));
     wide_window.present();
 
     assert!(view.report().is_focusable());
@@ -352,6 +366,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     // Native dismissal emits Close. Feeding that intent back through the
     // application and rendering its transition must not emit a second Close.
     intents.borrow_mut().clear();
+    gtk::prelude::GtkWindowExt::set_focus(&wide_window, None::<&gtk::Widget>);
     view.dialog.close();
     pump_until(|| intents.borrow().contains(&DiagnosticsIntent::Close));
     assert_eq!(*intents.borrow(), vec![DiagnosticsIntent::Close]);
@@ -362,6 +377,11 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     view.render(&wide_window, closed.presentation());
     pump_until(|| !view.presented.get() && !view.suppress_close.get());
     assert!(intents.borrow().is_empty());
+    assert_eq!(
+        gtk::prelude::GtkWindowExt::focus(&wide_window).as_ref(),
+        Some(origin.upcast_ref()),
+        "closing diagnostics restores keyboard focus after a native chooser",
+    );
     wide_window.close();
 
     let narrow_window = adw::ApplicationWindow::builder()

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -2747,6 +2747,10 @@ pub(crate) mod controller_test_support {
             );
             ApplicationController::handle_intent(&controller, OverviewIntent::Cancel);
             assert!(controller.closed.get());
+            assert!(
+                !controller.window.window().is_visible(),
+                "application quit must close the window even when pairing has a dialog open",
+            );
             let _ = std::fs::remove_file(settings_path);
         }
     }

--- a/crates/lg-buddy-gui/src/window.rs
+++ b/crates/lg-buddy-gui/src/window.rs
@@ -70,7 +70,6 @@ impl ApplicationWindow {
         let tvs = crate::tvs::TvsView::new(Rc::clone(&on_tvs));
         let pairing = crate::pairing::PairingView::new(on_tvs);
         let settings = crate::settings::SettingsView::new(on_settings);
-        let diagnostics = crate::diagnostics::DiagnosticsView::new(on_diagnostics);
         let stack = adw::ViewStack::new();
         stack.set_hhomogeneous(false);
         stack.set_vhomogeneous(false);
@@ -115,6 +114,8 @@ impl ApplicationWindow {
             .menu_model(&menu)
             .build();
         menu_button.update_property(&[gtk::accessible::Property::Label("Main Menu")]);
+        let diagnostics =
+            crate::diagnostics::DiagnosticsView::new(on_diagnostics, menu_button.upcast_ref());
         header.pack_end(&menu_button);
         let switcher_bar = adw::ViewSwitcherBar::builder().stack(&stack).build();
         let toasts = adw::ToastOverlay::new();
@@ -246,7 +247,10 @@ impl ApplicationWindow {
     pub(crate) fn close(&self) {
         self.allow_close.set(true);
         if !self.close_requested.get() {
-            self.window.close();
+            // Application policy has already approved closing. AdwWindow's
+            // close() can dismiss only its visible dialog and leave the window
+            // alive after the application model has shut down.
+            self.window.destroy();
         }
     }
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -4,6 +4,10 @@ version = "1.6.0"
 edition = "2021"
 publish = false
 
+[features]
+# Only for the installed GUI smoke; forbidden in release builds.
+gui-test-fixtures = []
+
 [dependencies]
 dbus = { version = "0.9.11", features = ["vendored"] }
 dbus-crossroads = "0.5.3"

--- a/crates/lg-buddy/examples/gui_journey_tv.rs
+++ b/crates/lg-buddy/examples/gui_journey_tv.rs
@@ -1,0 +1,217 @@
+//! Native TV fixture for the installed GUI journey.
+//!
+//! Start it with one control directory argument. The fixture publishes one
+//! atomic `state.json` there and consumes atomically-written command files:
+//! `stateful`, `pairing-rejected`, `stall`, `interrupted`, or `stop`.
+
+use std::env;
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Read, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use serde_json::json;
+
+mod auth {
+    pub use lg_buddy::auth::SystemUser;
+}
+
+mod platform_access_token {
+    pub use lg_buddy::platform_access_token::{PlatformAccessToken, PlatformAccessTokenStore};
+}
+
+// Keep the process fixture on the same adapter and server used by Cucumber.
+#[allow(dead_code)]
+#[path = "../tests/cucumber_support/webos.rs"]
+mod web_os;
+
+use web_os::{MockWebOsTv, MockWebOsVersion};
+
+const MAX_COMMAND_BYTES: u64 = 1024;
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+static TEMP_FILE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy)]
+enum Scenario {
+    Stateful,
+    PairingRejected,
+    Stall,
+    Interrupted,
+}
+
+impl Scenario {
+    fn parse(value: &str) -> Result<Self, String> {
+        match value {
+            "stateful" => Ok(Self::Stateful),
+            "pairing-rejected" => Ok(Self::PairingRejected),
+            "stall" => Ok(Self::Stall),
+            "interrupted" => Ok(Self::Interrupted),
+            other => Err(format!(
+                "unsupported fixture command `{other}`; use stateful, pairing-rejected, stall, interrupted, or stop"
+            )),
+        }
+    }
+
+    fn name(self) -> &'static str {
+        match self {
+            Self::Stateful => "stateful",
+            Self::PairingRejected => "pairing-rejected",
+            Self::Stall => "stall",
+            Self::Interrupted => "interrupted",
+        }
+    }
+}
+
+struct Fixture {
+    tv: MockWebOsTv,
+}
+
+impl Fixture {
+    fn start(scenario: Scenario) -> Self {
+        let tv = MockWebOsTv::with_version(MockWebOsVersion::WebOs24Version92261, "HDMI_3");
+        match scenario {
+            Scenario::Stateful => {}
+            Scenario::PairingRejected => tv.reject_pairing(),
+            Scenario::Stall => tv.stall_first_tv_response(),
+            Scenario::Interrupted => tv.interrupt_restore_and_ack_input_without_unblanking(),
+        }
+        Self { tv }
+    }
+
+    fn restart(self, scenario: Scenario) -> Self {
+        drop(self);
+        Self::start(scenario)
+    }
+
+    fn state(&self, status: &str, scenario: Scenario) -> String {
+        let snapshot = self.tv.snapshot();
+        format!(
+            "{}\n",
+            json!({
+                "status": status,
+                "scenario": scenario.name(),
+                "endpoint": "wss://127.0.0.1:3001",
+                "power_on": snapshot.power_on,
+                "screen_on": snapshot.screen_on,
+                "input": snapshot.input,
+                "backlight": snapshot.backlight,
+                "volume": snapshot.volume,
+                "muted": snapshot.muted,
+                "connection_count": snapshot.connection_count,
+                "pairing_prompt_count": snapshot.pairing_prompt_count,
+                "registration_tokens": snapshot.registration_tokens,
+            })
+        )
+    }
+}
+
+enum Command {
+    Scenario(Scenario),
+    Stop,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args_os();
+    let _program = args.next();
+    let control_dir = args.next().ok_or("usage: gui_journey_tv <control-dir>")?;
+    if args.next().is_some() {
+        return Err("usage: gui_journey_tv <control-dir>".into());
+    }
+    let control_dir = PathBuf::from(control_dir);
+    fs::create_dir_all(&control_dir)?;
+    let command_path = control_dir.join("command");
+    let state_path = control_dir.join("state.json");
+    let _ = fs::remove_file(&command_path);
+    let _ = fs::remove_file(&state_path);
+
+    let mut scenario = Scenario::Stateful;
+    let mut fixture = Fixture::start(scenario);
+    atomic_write(&state_path, &fixture.state("ready", scenario))?;
+    let mut last_state = String::new();
+
+    loop {
+        if let Some(raw_command) = take_command(&command_path)? {
+            match parse_command(&raw_command)? {
+                Command::Scenario(next) => {
+                    scenario = next;
+                    fixture = fixture.restart(scenario);
+                    last_state.clear();
+                }
+                Command::Stop => {
+                    let stopped = fixture.state("stopped", scenario);
+                    drop(fixture);
+                    atomic_write(&state_path, &stopped)?;
+                    return Ok(());
+                }
+            }
+        }
+
+        let state = fixture.state("ready", scenario);
+        if state != last_state {
+            atomic_write(&state_path, &state)?;
+            last_state = state;
+        }
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn parse_command(raw: &str) -> Result<Command, String> {
+    match raw.trim() {
+        "stop" => Ok(Command::Stop),
+        value => Ok(Command::Scenario(Scenario::parse(value)?)),
+    }
+}
+
+fn take_command(path: &Path) -> io::Result<Option<String>> {
+    let processing = path.with_file_name(format!(
+        ".command.{}.processing",
+        TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed)
+    ));
+    match fs::rename(path, &processing) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    }
+    let result = (|| {
+        let mut file = File::open(&processing)?;
+        let mut bytes = Vec::new();
+        Read::by_ref(&mut file)
+            .take(MAX_COMMAND_BYTES + 1)
+            .read_to_end(&mut bytes)?;
+        if bytes.len() as u64 > MAX_COMMAND_BYTES {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "fixture command is too large",
+            ));
+        }
+        String::from_utf8(bytes).map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
+    })();
+    let _ = fs::remove_file(processing);
+    result.map(Some)
+}
+
+fn atomic_write(path: &Path, contents: &str) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let sequence = TEMP_FILE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("state");
+    let temporary = parent.join(format!(".{file_name}.{sequence}.tmp"));
+    let result = (|| {
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary)?;
+        file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
+    }
+    result
+}

--- a/crates/lg-buddy/src/gui_test_fixtures.rs
+++ b/crates/lg-buddy/src/gui_test_fixtures.rs
@@ -1,0 +1,83 @@
+//! Transport substitution for the installed GUI smoke's debug binaries.
+//! Release selection, verification, installation, and handoff remain unchanged.
+
+use std::{net::SocketAddr, time::Duration};
+
+pub(crate) fn request(request: ureq::Request) -> ureq::Request {
+    let Ok(address) = std::env::var("LG_BUDDY_TEST_GITHUB_ADDRESS") else {
+        return request;
+    };
+    request_to(request, address.parse().expect("fixture socket address"))
+}
+
+fn request_to(request: ureq::Request, address: SocketAddr) -> ureq::Request {
+    assert!(address.ip().is_loopback(), "fixture must be on loopback");
+    let original = url::Url::parse(request.url()).expect("original request URL");
+    let target = format!(
+        "http://{address}/{}{}{}",
+        original.host_str().expect("original request host"),
+        original.path(),
+        original
+            .query()
+            .map(|query| format!("?{query}"))
+            .unwrap_or_default(),
+    );
+    let agent = ureq::AgentBuilder::new()
+        .try_proxy_from_env(false)
+        .redirects(0)
+        .timeout(Duration::from_secs(10))
+        .build();
+    let mut replay = agent.request(request.method(), &target);
+    for header in request.header_names() {
+        if let Some(value) = request.header(&header) {
+            replay = replay.set(&header, value);
+        }
+    }
+    replay
+}
+
+#[cfg(test)]
+mod tests {
+    use super::request_to;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    #[test]
+    fn request_rewrites_host_and_preserves_path_query_and_headers() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback listener");
+        let address = listener.local_addr().expect("read listener address");
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept fixture request");
+            let mut bytes = Vec::new();
+            let mut chunk = [0_u8; 1024];
+            while !bytes.windows(4).any(|window| window == b"\r\n\r\n") {
+                let count = stream.read(&mut chunk).expect("read fixture request");
+                assert!(count > 0, "fixture request ended before headers");
+                bytes.extend_from_slice(&chunk[..count]);
+            }
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .expect("write fixture response");
+            String::from_utf8(bytes).expect("fixture request is UTF-8")
+        });
+
+        let agent = ureq::AgentBuilder::new().try_proxy_from_env(false).build();
+        let request = agent
+            .get("https://api.github.com/repos/Staphylococcus/LG_Buddy/releases?per_page=1")
+            .set("Accept", "application/vnd.github+json")
+            .set("X-Fixture-Test", "preserve-me");
+        let response = request_to(request, address)
+            .call()
+            .expect("fixture request succeeds");
+        assert_eq!(response.status(), 200);
+
+        let captured = server.join().expect("fixture server joins");
+        assert!(captured.starts_with(
+            "GET /api.github.com/repos/Staphylococcus/LG_Buddy/releases?per_page=1 HTTP/1.1"
+        ));
+        let captured = captured.to_ascii_lowercase();
+        assert!(captured.contains("accept: application/vnd.github+json\r\n"));
+        assert!(captured.contains("x-fixture-test: preserve-me\r\n"));
+    }
+}

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -1,5 +1,10 @@
 mod dev;
 
+#[cfg(all(feature = "gui-test-fixtures", not(debug_assertions)))]
+compile_error!("gui-test-fixtures must never be enabled in a release build");
+#[cfg(feature = "gui-test-fixtures")]
+mod gui_test_fixtures;
+
 pub mod application;
 pub mod audio;
 pub mod auth;

--- a/crates/lg-buddy/src/release_bundle.rs
+++ b/crates/lg-buddy/src/release_bundle.rs
@@ -676,7 +676,10 @@ impl UreqGitHubSource {
         &self,
         url: &str,
     ) -> Result<T, BundleAcquisitionError> {
-        let response = match github_request(&self.api_agent, url, GITHUB_JSON_ACCEPT).call() {
+        let request = github_request(&self.api_agent, url, GITHUB_JSON_ACCEPT);
+        #[cfg(feature = "gui-test-fixtures")]
+        let request = crate::gui_test_fixtures::request(request);
+        let response = match request.call() {
             Ok(response) => response,
             Err(ureq::Error::Status(status, response)) => {
                 let body = read_response_text(response, url, MAX_API_ERROR_BYTES)?;
@@ -719,10 +722,11 @@ impl UreqGitHubSource {
         );
         let budget = remaining_request_budget(deadline)?;
         let agent = github_agent(budget.connect, budget.request);
-        match github_request(&agent, &url, GITHUB_ASSET_ACCEPT)
-            .set("Accept-Encoding", "identity")
-            .call()
-        {
+        let request =
+            github_request(&agent, &url, GITHUB_ASSET_ACCEPT).set("Accept-Encoding", "identity");
+        #[cfg(feature = "gui-test-fixtures")]
+        let request = crate::gui_test_fixtures::request(request);
+        match request.call() {
             Ok(response) if response.status() == 200 => Ok((response, url)),
             Ok(response) if response.status() == 302 => {
                 self.follow_asset_redirect(&url, response, deadline)
@@ -763,16 +767,17 @@ impl UreqGitHubSource {
         let safe_redirected_url = redact_url(&redirected_url);
         let budget = remaining_request_budget(deadline)?;
         let agent = github_agent(budget.connect, budget.request);
-        match agent
+        let request = agent
             .get(&redirected_url)
             .set("Accept", GITHUB_ASSET_ACCEPT)
             .set("Accept-Encoding", "identity")
             .set(
                 "User-Agent",
                 concat!("lg-buddy/", env!("CARGO_PKG_VERSION")),
-            )
-            .call()
-        {
+            );
+        #[cfg(feature = "gui-test-fixtures")]
+        let request = crate::gui_test_fixtures::request(request);
+        match request.call() {
             Ok(response) if response.status() == 200 => Ok((response, safe_redirected_url)),
             Ok(response) => Err(BundleAcquisitionError::HttpStatus {
                 url: safe_redirected_url,

--- a/crates/lg-buddy/src/updates.rs
+++ b/crates/lg-buddy/src/updates.rs
@@ -995,6 +995,8 @@ impl GitHubReleasesClient for UreqGitHubReleasesClient {
             request = request.set("If-None-Match", etag);
         }
 
+        #[cfg(feature = "gui-test-fixtures")]
+        let request = crate::gui_test_fixtures::request(request);
         let result = request.call();
 
         match result {

--- a/docs/development.md
+++ b/docs/development.md
@@ -17,6 +17,7 @@ Compiling and testing the GTK frontend additionally requires:
 - `glib-compile-resources` (provided by the GLib development tools)
 - a graphical session or virtual display for renderer tests
 - `xdotool` for native pointer tests and the executable launch smoke test
+- `pgrep` (`procps` on Debian, `procps-ng` on Fedora/Arch) for installed GUI process checks
 - AT-SPI 2 and its Python bindings (`python3-pyatspi` on Debian/Fedora,
   `python-atspi` on Arch) for observable GUI behavior tests
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -207,6 +207,25 @@ lifecycle topology, and uninstall cleanup without mutating the host installation
 The supported Fedora and Arch lanes repeat the dependency flow with their native
 package-manager mappings.
 
+For the complete installed GUI journey, build the local TV fixture and pass it
+to the existing smoke:
+
+```bash
+cargo build --locked -p lg-buddy --example gui_journey_tv
+dbus-run-session -- xvfb-run -a bash scripts/test-installed-gui.sh \
+  target/debug/lg-buddy target/debug/lg-buddy-gui \
+  target/debug/examples/gui_journey_tv
+```
+
+The CI bundle lane additionally builds a `0.0.0` debug runtime and GUI with
+`--features gui-test-fixtures` and passes the newer canonical candidate archive
+as the fourth argument. This enables deterministic manual checks and real
+installation/handoff within the same smoke. The HTTP fixture is loopback-only,
+and this feature cannot be used in a release build. Run as a regular user with
+unprivileged user namespaces available; the test never targets the host's
+installation or live services. `LG_BUDDY_KEEP_GUI_SMOKE=1` retains failure
+evidence in the printed temporary directory.
+
 Run the cross-version smoke with explicit previous and candidate archives:
 
 ```bash

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -339,9 +339,25 @@ navigation, default behavior activation after pairing, declined or unavailable
 behaviors remaining off, Settings retries, and preserving existing settings.
 Storage and service-boundary tests verify that pairing publication remains valid
 when a behavior activation fails. Installer fixtures verify handoff to the
-installed executable and preservation of existing configuration. Complete
-assembled-journey verification remains tracked in
-[#201](https://github.com/Staphylococcus/LG_Buddy/issues/201).
+installed executable and preservation of existing configuration.
+
+With the `gui_journey_tv` example supplied, the same installed smoke drives
+native webOS pairing against the existing local TLS TV fixture. It covers
+rejection, cancellation, interrupted setup, successful default activation,
+declined activation followed by Settings retry, re-pairing with retained
+preferences, and relaunch with an offline saved TV. Diagnostics is opened
+before and after pairing and while offline; its visible report, clipboard,
+and saved file must agree and exclude credentials when an observation fails.
+
+The update variant supplies a candidate from `build-release-bundle.sh` and
+debug binaries built with `gui-test-fixtures`. Only their HTTP transport is
+redirected to local GitHub-shaped responses. Saved-channel selection, fresh
+release resolution, archive and identity verification, compatibility checks,
+the shipped installer, and executable handoff use the normal application path.
+The test checks manual results with automatic checks disabled, cancelled
+confirmation, corrupt downloads, declined authorization, and successful
+replacement and relaunch with unchanged settings and credentials. The feature
+is forbidden in release builds; published artifacts use the default features.
 
 Diagnostics tests cover on-demand collection before pairing, partial reports,
 service-state distinctions, bounded subprocess reads, and credential exclusion.
@@ -364,6 +380,15 @@ keyboard-only behavior, external AT-SPI role/name/value checks, visibly distinct
 light/dark rendering, and 1x/2x window-geometry coverage. The display-backed
 renderer suite separately asserts the same GTK semantics directly at the widget
 boundary.
+
+These are controlled installed tests: systemd observations and authorization
+decisions are fixtures, and elevated installer operations run in an isolated
+user namespace and installation root. The supported-distro lanes verify the
+actual payload, desktop dependencies, authorization command boundary, and
+handoff on those distributions. They do not prove a real desktop PolicyKit
+dialog, live service lifecycle, TV authorization, or sleep/wake on hardware;
+those still require supported-host verification. NixOS development runs are
+not evidence of official NixOS support.
 
 The Ubuntu bundle smoke and the Fedora and Arch installation lanes also exercise
 GUI runtime dependency handling. They prove that an unconfirmed install does not

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -11,10 +11,10 @@ up LG Buddy for the first time, start with the [installation instructions](../RE
 <a id="desktop-app"></a>
 ## Open LG Buddy
 
-Open **LG Buddy** from your application launcher, or run `lg-buddy` with no
-arguments. With a saved TV, both open **Overview**. Without one, the app opens
-directly to [Pair a TV](#pair-your-first-tv), with navigation hidden until
-pairing succeeds. For a keyboard shortcut straight to
+Open **LG Buddy** from your application launcher, or run `lg-buddy`. With a saved TV, it opens
+**Overview**. After a fresh release-bundle install, the app opens directly to
+[Pair a TV](#pair-your-first-tv): **TVs** is the only page and the other tabs
+are hidden until pairing succeeds. For a keyboard shortcut straight to
 brightness, bind `lg-buddy brightness` to your preferred key combination.
 
 LG Buddy manages one TV. Screenshots use sample TV data.
@@ -51,12 +51,14 @@ In the dialog:
 Cancel is available until saving starts; once saving starts, the dialog stays
 open until the operation finishes. When verification and saving finish, the
 dialog closes and normal navigation becomes available. A fresh setup attempts
-the default Idle Blanking and TV Sleep & Wake behaviors; approve the desktop
-authorization prompt when a system operation needs it. Pairing again reactivates
-previously enabled behaviors and keeps disabled choices off. If a behavior cannot
-be activated or authorization is declined, that behavior stays off and can be
-enabled in **Settings** to retry. A failed pairing shows an error you can correct
-and submit again; a cancelled attempt does not save a TV.
+the default Idle Blanking and TV Sleep & Wake behaviors. There is no separate
+confirmation for each service; approve the desktop authorization prompt when a
+system operation needs it. Pairing again reactivates previously enabled
+behaviors and keeps disabled choices off. If authorization is declined or a
+behavior cannot be activated, the paired TV remains saved while that behavior
+stays off. Enable it in **Settings** later to retry and activate the service. A
+failed pairing shows an error you can correct and submit again; a cancelled
+attempt does not save a TV.
 
 ![The Pair a TV dialog with setup guidance and address fields](screenshots/pairing.png)
 
@@ -87,11 +89,11 @@ After unpairing, use **Pair a TV** and approve native webOS pairing again.
 Cancelling the unpair confirmation keeps the connection. Cancelling or failing
 the new pairing leaves no TV configured.
 
-For a terminal-only repair or reconfiguration, run `./configure.sh` from the
-release archive. To select native control for an existing profile and verify it
-before saving, use `lg-buddy settings set tv.platform lg_webos`. The explicit
-`bscpylgtv` value remains available as a compatibility fallback when native
-control cannot be used.
+For installed GUI reconfiguration, use **TVs** to change the HDMI input or
+unpair and pair again, and use **Settings** for screen, sleep and wake, desktop
+integration, and update preferences. The command-line setup and compatibility
+fallback remain available in [headless commands](#common-commands) when the GUI
+cannot be used.
 
 <a id="settings"></a>
 <a id="automatic-screen-blanking"></a>
@@ -147,6 +149,11 @@ guide](gamepad-subsystem.md) for supported input paths and troubleshooting.
 <a id="common-commands"></a>
 <a id="configuration"></a>
 ## Use commands for shortcuts, scripts, or a headless setup
+
+For first-time setup without the GUI, run `./configure.sh` from the extracted
+release archive before `./install.sh`. To select native control for an existing
+profile and verify it before saving, use `lg-buddy settings set tv.platform
+lg_webos`. The explicit `bscpylgtv` value remains a compatibility fallback.
 
 These commands work without opening the GUI:
 
@@ -210,7 +217,9 @@ This flow requires a compatible mutable release-bundle installation. Use the
 package manager for externally managed installations. Graphical authorization
 requires `pkexec` and a desktop authorization agent.
 
-The terminal equivalent is:
+### Headless update commands
+
+The terminal alternatives are:
 
 ```bash
 lg-buddy updates check
@@ -265,15 +274,15 @@ services, or pair a TV.
 The report excludes credentials and raw logs, but includes local TV addresses
 and configuration details. Review it before sharing. When reporting a problem,
 include what you expected, what happened, and the report. These additional
-checks can help identify the next step:
+checks include command-line alternatives for headless use:
 
 | Problem | Check |
 | --- | --- |
 | The TV is disconnected | Check its power, network, saved address, and Wake-on-LAN setting. For rejected authorization, follow [Fix a pairing problem](#fix-pairing-problem). |
 | Idle blanking does not work | `lg-buddy settings describe screen.backend`<br>`systemctl --user status LG_Buddy_screen.service`<br>`journalctl --user -u LG_Buddy_screen.service --since today` |
-| A setting shows an error | Follow its message, then use **Retry apply** when offered. If the integration is missing or disabled, rerun `./configure.sh` from the release archive. Use `lg-buddy settings describe <KEY>` to inspect an invalid saved value. |
+| A setting shows an error | Follow its message, then use **Retry apply** when offered. If a behavior is off after a declined or unavailable activation, enable it again in **Settings** after fixing the reported service or authorization issue. |
 | System sleep/wake behavior is wrong | `systemctl status LG_Buddy_lifecycle.service`<br>`journalctl -u LG_Buddy_lifecycle.service --since today` |
-| An update cannot be installed | Keep the complete `updates install` output, confirm the saved channel, and report the installed version from `lg-buddy --version`. |
+| An update cannot be installed | In the GUI, use the update toast's **Copy details** action. For a headless update, keep the complete `updates install` output, confirm the saved channel, and report the installed version from `lg-buddy --version`. |
 
 For deeper behavior and integration details, see [Technical references](#technical-references).
 

--- a/scripts/test-installed-gui.sh
+++ b/scripts/test-installed-gui.sh
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPOSITORY_ROOT="$(dirname "$SCRIPT_DIR")"
 RUNTIME_BINARY="${1:-$REPOSITORY_ROOT/target/debug/lg-buddy}"
 GUI_BINARY="${2:-$REPOSITORY_ROOT/target/debug/lg-buddy-gui}"
+TV_FIXTURE="${3:-${LG_BUDDY_GUI_TV_FIXTURE:-}}"
+UPDATE_ARCHIVE="${4:-${LG_BUDDY_GUI_UPDATE_ARCHIVE:-}}"
 WORK_DIR="$(mktemp -d)"
 INSTALL_ROOT="$WORK_DIR/root"
 HOME_DIR="$WORK_DIR/home"
@@ -221,7 +223,7 @@ cmp -s "$REPOSITORY_ROOT/data/icons/hicolor/scalable/apps/io.github.staphylococc
 
 export LG_BUDDY_CONFIG="$CONFIG_FILE"
 bash "$SCRIPT_DIR/test-gui-launch.sh" "$INSTALLED_RUNTIME" "$INSTALLED_GUI"
-bash "$SCRIPT_DIR/test-release-gui-behavior.sh" "$INSTALLED_RUNTIME" "$CONFIG_FILE"
+bash "$SCRIPT_DIR/test-release-gui-behavior.sh" "$INSTALLED_RUNTIME" "$CONFIG_FILE" "$TV_FIXTURE" "$UPDATE_ARCHIVE"
 
 mkdir -p "$(dirname "$NATIVE_TOKEN")"
 printf '%s\n' '{"access_token":"installed-gui-smoke-token"}' >"$NATIVE_TOKEN"

--- a/scripts/test-installed-gui.sh
+++ b/scripts/test-installed-gui.sh
@@ -49,6 +49,7 @@ trap cleanup EXIT
 [ -x "$GUI_BINARY" ] || fail "GUI binary is not executable: $GUI_BINARY"
 [ -n "${DISPLAY:-}" ] || fail "DISPLAY is required for the installed GUI smoke test."
 [ -n "${DBUS_SESSION_BUS_ADDRESS:-}" ] || fail "A D-Bus session is required for the installed GUI smoke test."
+command -v pgrep >/dev/null || fail "pgrep is required for the installed GUI smoke test."
 
 RUNTIME_BINARY="$(realpath "$RUNTIME_BINARY")"
 GUI_BINARY="$(realpath "$GUI_BINARY")"

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -130,6 +130,10 @@ def parse_args() -> argparse.Namespace:
         help="also require this text in a visible accessible name or text value",
     )
     parser.add_argument(
+        "--expected-absent-text",
+        help="also wait until this text is absent from visible accessible names and text values",
+    )
+    parser.add_argument(
         "--expected-toggle",
         action="append",
         default=[],
@@ -676,11 +680,13 @@ def contains_visible_text(accessibles: list[object], expected_text: str) -> bool
     )
 
 
-def text_contract(expected_text: str):
+def text_contract(expected_text: str | None):
     accessibles = accessible_tree()
     if not any(name(item) == WINDOW_TITLE for item in accessibles):
         return None
-    return (accessibles, None) if contains_visible_text(accessibles, expected_text) else None
+    if expected_text is not None and not contains_visible_text(accessibles, expected_text):
+        return None
+    return accessibles, None
 
 
 def expected_toggles(args: argparse.Namespace) -> list[tuple[str, bool]]:
@@ -841,13 +847,16 @@ def main() -> int:
             or args.save_diagnostics
         ):
             contract = diagnostics_contract(args.expected_diagnostics_state or "report", args.expected_text)
-        elif args.expected_text:
+        elif args.expected_text or args.expected_absent_text:
             contract = text_contract(args.expected_text)
         else:
             contract = observed_contract(args.expected_state, args.expected_slider_value)
         expected_text_ok = (
             args.expected_text is None
             or contains_visible_text(contract[0], args.expected_text)
+        ) and (
+            args.expected_absent_text is None
+            or not contains_visible_text(contract[0], args.expected_absent_text)
         ) if contract is not None else False
         if contract is not None and expected_text_ok and (
             args.expected_settings_state
@@ -883,6 +892,8 @@ def main() -> int:
             except Exception:
                 continue
         expected = f" {args.expected_settings_state or args.expected_tvs_state or args.expected_diagnostics_state or args.expected_updater_state or args.expected_state} state"
+        if args.expected_absent_text is not None:
+            expected += f" without {args.expected_absent_text!r}"
         if args.expected_slider_value is not None:
             expected += f" at slider value {args.expected_slider_value:g}"
         raise SystemExit(

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -347,10 +347,15 @@ def is_checked(accessible: object) -> bool:
 
 
 def is_toggle_control(accessible: object) -> bool:
-    return role(accessible) in {
+    toggle_roles = {
         pyatspi.ROLE_CHECK_BOX,
         pyatspi.ROLE_TOGGLE_BUTTON,
     }
+    # Newer GTK/AT-SPI versions expose GtkSwitch with its own role.
+    switch_role = getattr(pyatspi, "ROLE_SWITCH", None)
+    if switch_role is not None:
+        toggle_roles.add(switch_role)
+    return role(accessible) in toggle_roles
 
 
 def wait_for_accessible(predicate, timeout: float, description: str):
@@ -394,9 +399,7 @@ def showing_named(name_value: str, roles=None, root: object | None = None):
 def activate_control(control_name: str, timeout: float) -> None:
     action_roles = {
         pyatspi.ROLE_PUSH_BUTTON,
-        pyatspi.ROLE_TOGGLE_BUTTON,
         pyatspi.ROLE_MENU_ITEM,
-        pyatspi.ROLE_CHECK_BOX,
     }
     for optional_role_name in ("ROLE_MENU_BUTTON",):
         optional_role = getattr(pyatspi, optional_role_name, None)
@@ -410,7 +413,7 @@ def activate_control(control_name: str, timeout: float) -> None:
             try:
                 if (
                     name(item) == control_name
-                    and role(item) in action_roles
+                    and (role(item) in action_roles or is_toggle_control(item))
                     and is_showing(item)
                     and is_sensitive(item)
                     and item.queryAction().doAction(0)

--- a/scripts/test-release-gui-accessibility.py
+++ b/scripts/test-release-gui-accessibility.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import math
+from pathlib import Path
 import subprocess
 import sys
 import time
@@ -100,11 +101,56 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--select-page", choices=("Overview", "TVs", "Settings"))
     parser.add_argument("--expected-settings-state", choices=("ready", "invalid"))
+    parser.add_argument(
+        "--expected-updater-state",
+        choices=(
+            "idle",
+            "checking",
+            "available",
+            "confirmation",
+            "downloading",
+        ),
+        help="also verify the compact update row or its installation dialog",
+    )
     parser.add_argument("--expected-settings-timeout")
     parser.add_argument("--edit-settings-timeout", help="type a timeout draft through native keyboard input")
     parser.add_argument("--expected-tvs-state", choices=("empty", "configured", "pairing", "pairing-invalid", "unpair"))
     parser.add_argument("--expected-tv-address")
     parser.add_argument("--expected-tv-name", default="Primary TV")
+    parser.add_argument("--edit-pairing-address", help="type a TV address into the pairing form")
+    parser.add_argument("--edit-pairing-mac", help="type a MAC address into the pairing form")
+    parser.add_argument(
+        "--expected-diagnostics-state",
+        choices=("collecting", "report", "error"),
+        help="also verify the visible Diagnostics dialog state",
+    )
+    parser.add_argument(
+        "--expected-text",
+        dest="expected_text",
+        help="also require this text in a visible accessible name or text value",
+    )
+    parser.add_argument(
+        "--expected-toggle",
+        action="append",
+        default=[],
+        metavar="NAME=on|off",
+        help="also require a named toggle to have the requested checked state (repeatable)",
+    )
+    parser.add_argument(
+        "--read-diagnostics",
+        metavar="PATH",
+        help="write the visible Diagnostic report text to PATH",
+    )
+    parser.add_argument(
+        "--copy-diagnostics",
+        metavar="PATH",
+        help="activate Copy and write the resulting clipboard text to PATH",
+    )
+    parser.add_argument(
+        "--save-diagnostics",
+        metavar="PATH",
+        help="activate Save and complete the native chooser with PATH",
+    )
     parser.add_argument("--focus-control", help="focus a control using native Tab navigation")
     parser.add_argument("--activate-control", help="activate an accessible button")
     parser.add_argument("--window-id", help="X window used for keyboard navigation")
@@ -113,6 +159,18 @@ def parse_args() -> argparse.Namespace:
         parser.error("--timeout must be greater than zero")
     if args.expected_state != "ready" and args.expected_slider_value is not None:
         parser.error("--expected-slider-value requires --expected-state ready")
+    if (args.edit_pairing_address is not None or args.edit_pairing_mac is not None) and not args.window_id:
+        parser.error("pairing edits need --window-id")
+    for expectation in args.expected_toggle:
+        toggle_name, separator, toggle_state = expectation.partition("=")
+        if not separator or not toggle_name.strip() or toggle_state.lower() not in ("on", "off", "true", "false"):
+            parser.error(f"invalid --expected-toggle {expectation!r}; use NAME=on|off")
+    if sum(value is not None for value in (
+        args.read_diagnostics,
+        args.copy_diagnostics,
+        args.save_diagnostics,
+    )) > 1:
+        parser.error("choose only one diagnostics export action")
     return args
 
 
@@ -196,6 +254,24 @@ def tvs_contract(expected_state: str, address: str | None, tv_name: str):
     if expected_state in ("pairing", "pairing-invalid"):
         if len(dialogs) != 1 or not {"TV address", "MAC address", "HDMI input", "Cancel", "Pair"} <= names:
             return None
+        pair = next(
+            (
+                item for item in visible
+                if name(item) == "Pair"
+                and role(item) == pyatspi.ROLE_PUSH_BUTTON
+            ),
+            None,
+        )
+        cancel = next(
+            (
+                item for item in visible
+                if name(item) == "Cancel"
+                and role(item) == pyatspi.ROLE_PUSH_BUTTON
+            ),
+            None,
+        )
+        if pair is None or cancel is None or not is_sensitive(cancel):
+            return None
         dialog_names = {normalized_name(item) for item in accessible_tree(dialogs[0])}
         if "Close" in dialog_names:
             raise SystemExit("Pairing exposed a close button alongside Cancel")
@@ -230,13 +306,185 @@ def text_value(accessible: object) -> str:
         return ""
 
 
+def is_showing(accessible: object) -> bool:
+    try:
+        return accessible.getState().contains(pyatspi.STATE_SHOWING)
+    except Exception:
+        return False
+
+
+def is_sensitive(accessible: object) -> bool:
+    try:
+        return accessible.getState().contains(pyatspi.STATE_SENSITIVE)
+    except Exception:
+        return False
+
+
+def is_focused(accessible: object) -> bool:
+    try:
+        return accessible.getState().contains(pyatspi.STATE_FOCUSED)
+    except Exception:
+        return False
+
+
+def is_text_control(accessible: object) -> bool:
+    text_roles = {pyatspi.ROLE_TEXT}
+    entry_role = getattr(pyatspi, "ROLE_ENTRY", None)
+    if entry_role is not None:
+        text_roles.add(entry_role)
+    return role(accessible) in text_roles
+
+
+def is_checked(accessible: object) -> bool:
+    try:
+        return accessible.getState().contains(pyatspi.STATE_CHECKED)
+    except Exception:
+        return False
+
+
+def is_toggle_control(accessible: object) -> bool:
+    return role(accessible) in {
+        pyatspi.ROLE_CHECK_BOX,
+        pyatspi.ROLE_TOGGLE_BUTTON,
+    }
+
+
+def wait_for_accessible(predicate, timeout: float, description: str):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for item in accessible_tree():
+            try:
+                if predicate(item):
+                    return item
+            except Exception:
+                continue
+        time.sleep(0.05)
+    raise SystemExit(f"could not observe {description} over AT-SPI")
+
+
+def visible_dialog():
+    return next(
+        (
+            item
+            for item in accessible_tree()
+            if role(item) == pyatspi.ROLE_DIALOG and is_showing(item)
+        ),
+        None,
+    )
+
+
+def showing_named(name_value: str, roles=None, root: object | None = None):
+    allowed_roles = set(roles) if roles is not None else None
+    return next(
+        (
+            item
+            for item in accessible_tree(root)
+            if name(item) == name_value
+            and is_showing(item)
+            and (allowed_roles is None or role(item) in allowed_roles)
+        ),
+        None,
+    )
+
+
+def activate_control(control_name: str, timeout: float) -> None:
+    action_roles = {
+        pyatspi.ROLE_PUSH_BUTTON,
+        pyatspi.ROLE_TOGGLE_BUTTON,
+        pyatspi.ROLE_MENU_ITEM,
+        pyatspi.ROLE_CHECK_BOX,
+    }
+    for optional_role_name in ("ROLE_MENU_BUTTON",):
+        optional_role = getattr(pyatspi, optional_role_name, None)
+        if optional_role is not None:
+            action_roles.add(optional_role)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        dialog = visible_dialog()
+        candidates = accessible_tree(dialog) if dialog is not None else accessible_tree()
+        for item in candidates:
+            try:
+                if (
+                    name(item) == control_name
+                    and role(item) in action_roles
+                    and is_showing(item)
+                    and is_sensitive(item)
+                    and item.queryAction().doAction(0)
+                ):
+                    return
+            except Exception:
+                continue
+        time.sleep(0.05)
+    for item in accessible_tree():
+        if name(item):
+            print(f"  {role_name(item)}: {name(item)!r} showing={is_showing(item)} sensitive={is_sensitive(item)}", file=sys.stderr)
+    raise SystemExit(f"could not activate {control_name}")
+
+
+def focus_control(control_name: str, window_id: str, timeout: float, roles=None) -> None:
+    subprocess.run(["xdotool", "windowfocus", "--sync", window_id], check=True)
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if any(
+            name(item) == control_name
+            and (roles is None or role(item) in roles)
+            and is_showing(item)
+            and is_focused(item)
+            for item in accessible_tree()
+        ):
+            return
+        subprocess.run(["xdotool", "key", "--window", window_id, "Tab"], check=True)
+        time.sleep(0.05)
+    raise SystemExit(f"could not focus {control_name} through Tab navigation")
+
+
+def edit_text_control(control_name: str, value: str, window_id: str, timeout: float) -> None:
+    text_roles = {pyatspi.ROLE_TEXT}
+    entry_role = getattr(pyatspi, "ROLE_ENTRY", None)
+    if entry_role is not None:
+        text_roles.add(entry_role)
+    focus_control(control_name, window_id, timeout, text_roles)
+    subprocess.run(["xdotool", "key", "--window", window_id, "ctrl+a"], check=True)
+    subprocess.run(
+        ["xdotool", "type", "--window", window_id, "--clearmodifiers", "--", value],
+        check=True,
+    )
+    wait_for_accessible(
+        lambda item: (
+            name(item) == control_name
+            and is_text_control(item)
+            and is_showing(item)
+            and text_value(item) == value
+        ),
+        timeout,
+        f"{control_name} containing the typed value",
+    )
+
+
 def settings_contract(args: argparse.Namespace):
     accessibles = accessible_tree()
     names = {name(item) for item in accessibles}
-    if not {"Screen", "Sleep & Wake", "Updates", "Desktop integration", "Idle blanking",
-            "Idle timeout", "Restore policy", "TV sleep & wake", "Automatic update checks",
-            "Update channel", "Check for updates", "Installed version"} <= names:
+    if not {"Screen", "Sleep & Wake", "Updates", "Idle blanking",
+            "TV sleep & wake", "Automatic update checks",
+            "Update channel"} <= names:
         return None
+    updater_titles = {"Installed version", "Update available", "Restart required"}
+    if not any(value in names for value in updater_titles):
+        return None
+    if args.expected_updater_state and not updater_contract(args.expected_updater_state, accessibles):
+        return None
+    for toggle_name, expected_checked in expected_toggles(args):
+        toggle = next(
+            (
+                item for item in accessibles
+                if name(item) == toggle_name
+                and is_toggle_control(item)
+                and is_showing(item)
+            ),
+            None,
+        )
+        if toggle is None or is_checked(toggle) != expected_checked:
+            return None
     if args.expected_settings_timeout:
         timeout_entry = next(
             (
@@ -266,87 +514,353 @@ def settings_contract(args: argparse.Namespace):
     return accessibles, None
 
 
+def updater_contract(expected_state: str, accessibles: list[object]) -> bool:
+    visible = [item for item in accessibles if is_showing(item)]
+    names = {name(item) for item in visible}
+    if expected_state == "idle":
+        return (
+            "Installed version" in names
+            and any(
+                name(item) == "Check for updates"
+                and role(item) == pyatspi.ROLE_PUSH_BUTTON
+                and is_sensitive(item)
+                for item in visible
+            )
+        )
+    if expected_state == "checking":
+        return (
+            "Installed version" in names
+            and any(
+                name(item) == "Checking…"
+                and role(item) == pyatspi.ROLE_PUSH_BUTTON
+                and not is_sensitive(item)
+                for item in visible
+            )
+        )
+    if expected_state == "available":
+        return (
+            "Update available" in names
+            and any(
+                name(item) == "Install update…"
+                and role(item) == pyatspi.ROLE_PUSH_BUTTON
+                and is_sensitive(item)
+                for item in visible
+            )
+            and not any(role(item) == pyatspi.ROLE_DIALOG and is_showing(item) for item in visible)
+        )
+    dialog = next(
+        (item for item in visible if role(item) == pyatspi.ROLE_DIALOG),
+        None,
+    )
+    if dialog is None:
+        return False
+    dialog_items = accessible_tree(dialog)
+    dialog_names = {name(item) for item in dialog_items}
+    # GTK status labels expose their content through the Text interface.
+    dialog_text = dialog_names | {text_value(item) for item in dialog_items}
+    if expected_state == "confirmation":
+        cancel = showing_named("Cancel", (pyatspi.ROLE_PUSH_BUTTON,), dialog)
+        install = showing_named("Install and restart", (pyatspi.ROLE_PUSH_BUTTON,), dialog)
+        return (
+            any(
+                value.startswith("Install LG Buddy ") and value.endswith("?")
+                for value in dialog_text
+            )
+            and "Install and restart" in dialog_names
+            and cancel is not None
+            and install is not None
+            and is_sensitive(cancel)
+            and is_sensitive(install)
+        )
+    if expected_state != "downloading":
+        return False
+    title = "Downloading and verifying update…"
+    cancel = showing_named("Cancel", (pyatspi.ROLE_PUSH_BUTTON,), dialog)
+    return (
+        title in dialog_text
+        and showing_named(title, (pyatspi.ROLE_PROGRESS_BAR,), dialog) is not None
+        and cancel is not None
+        and is_sensitive(cancel)
+    )
+
+
+def diagnostics_contract(expected_state: str, expected_text: str | None):
+    accessibles = accessible_tree()
+    dialog = next(
+        (
+            item
+            for item in accessibles
+            if role(item) == pyatspi.ROLE_DIALOG and is_showing(item)
+            and any(name(child) == "Diagnostic report" for child in accessible_tree(item))
+        ),
+        None,
+    )
+    if dialog is None:
+        return None
+    dialog_items = accessible_tree(dialog)
+    names = {name(item) for item in dialog_items}
+    if not {"Diagnostic report", "Close", "Refresh", "Copy", "Save…"} <= names:
+        return None
+    buttons = {
+        button_name: showing_named(button_name, (pyatspi.ROLE_PUSH_BUTTON,), dialog)
+        for button_name in ("Refresh", "Copy", "Save…")
+    }
+    if any(button is None for button in buttons.values()):
+        return None
+    if expected_state == "collecting":
+        if "Collecting diagnostics…" not in names:
+            return None
+        if any(is_sensitive(button) for button in buttons.values()):
+            return None
+    elif expected_state == "report":
+        if not any(
+            is_text_control(item)
+            and name(item) == "Diagnostic report"
+            and text_value(item).strip()
+            for item in dialog_items
+        ):
+            return None
+        if any(not is_sensitive(button) for button in buttons.values()):
+            return None
+    elif expected_state == "error":
+        if not any(role(item) == pyatspi.ROLE_ALERT and is_showing(item) for item in dialog_items):
+            return None
+        if not is_sensitive(buttons["Refresh"]):
+            return None
+    if expected_text is not None and not any(
+        expected_text in name(item) or expected_text in text_value(item)
+        for item in dialog_items
+    ):
+        return None
+    return accessibles, None
+
+
+def visible_dialogs(accessibles: list[object] | None = None) -> list[object]:
+    return [
+        item
+        for item in (accessible_tree() if accessibles is None else accessibles)
+        if role(item) == pyatspi.ROLE_DIALOG and is_showing(item)
+    ]
+
+
+def diagnostics_dialog(accessibles: list[object] | None = None):
+    candidates = accessible_tree() if accessibles is None else accessibles
+    return next(
+        (
+            item for item in candidates
+            if role(item) == pyatspi.ROLE_DIALOG
+            and is_showing(item)
+            and any(name(child) == "Diagnostic report" for child in accessible_tree(item))
+        ),
+        None,
+    )
+
+
+def diagnostics_report_text(accessibles: list[object] | None = None) -> str | None:
+    dialog = diagnostics_dialog(accessibles)
+    if dialog is None:
+        return None
+    for item in accessible_tree(dialog):
+        if name(item) == "Diagnostic report" and is_text_control(item):
+            report = text_value(item)
+            if report:
+                return report
+    return None
+
+
+def contains_visible_text(accessibles: list[object], expected_text: str) -> bool:
+    return any(
+        is_showing(item)
+        and (expected_text in name(item) or expected_text in text_value(item))
+        for item in accessibles
+    )
+
+
+def text_contract(expected_text: str):
+    accessibles = accessible_tree()
+    if not any(name(item) == WINDOW_TITLE for item in accessibles):
+        return None
+    return (accessibles, None) if contains_visible_text(accessibles, expected_text) else None
+
+
+def expected_toggles(args: argparse.Namespace) -> list[tuple[str, bool]]:
+    toggles = []
+    for expectation in args.expected_toggle:
+        toggle_name, _, toggle_state = expectation.partition("=")
+        toggles.append((toggle_name.strip(), toggle_state.lower() in ("on", "true")))
+    return toggles
+
+
+def read_clipboard() -> str | None:
+    # GTK owns the clipboard in the installed application. Keep this
+    # asynchronous so the clipboard owner can service the request normally.
+    gtk_reader = r'''
+import sys
+try:
+    import gi
+    gi.require_version("Gtk", "4.0")
+    from gi.repository import Gdk, GLib, Gtk
+    Gtk.init()
+    display = Gdk.Display.get_default()
+    if display is None:
+        raise RuntimeError("no default display")
+    result = []
+    loop = GLib.MainLoop()
+    def done(clipboard, operation, _user_data=None):
+        try:
+            result.append(clipboard.read_text_finish(operation) or "")
+        except Exception:
+            result.append("")
+        loop.quit()
+    display.get_clipboard().read_text_async(None, done)
+    GLib.timeout_add(1000, lambda: (loop.quit(), False)[1])
+    loop.run()
+    sys.stdout.write(result[0] if result else "")
+except Exception:
+    raise SystemExit(1)
+'''
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", gtk_reader],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout
+
+
+def visible_window_ids() -> set[str]:
+    try:
+        result = subprocess.run(
+            ["xdotool", "search", "--onlyvisible", "--name", ".*"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return set()
+    return set(result.stdout.split())
+
+
+def save_path_after_chooser(
+    path: str,
+    timeout: float,
+    initial_dialog_count: int,
+    initial_window_ids: set[str],
+    expected_text: str,
+) -> None:
+    destination = Path(path)
+    initial_stat = destination.stat() if destination.exists() else None
+    wait_for_accessible(
+        lambda _item: len(visible_dialogs()) > initial_dialog_count
+        or bool(visible_window_ids() - initial_window_ids),
+        timeout,
+        "the native diagnostics save chooser",
+    )
+    subprocess.run(["xdotool", "key", "ctrl+a"], check=True)
+    subprocess.run(["xdotool", "type", "--clearmodifiers", "--", path], check=True)
+    subprocess.run(["xdotool", "key", "Return"], check=True)
+
+    def saved() -> bool:
+        try:
+            current = destination.stat()
+        except FileNotFoundError:
+            return False
+        if current.st_size == 0:
+            return False
+        if initial_stat is not None and current.st_mtime_ns == initial_stat.st_mtime_ns:
+            return False
+        try:
+            return destination.read_text(encoding="utf-8") == expected_text
+        except (OSError, UnicodeDecodeError):
+            return False
+
+    wait_for_accessible(lambda _item: saved(), timeout, f"diagnostics saved at {path}")
+
+
 def main() -> int:
     args = parse_args()
     if args.select_page:
         deadline = time.monotonic() + args.timeout
-        # Native button activation may finish after the AT-SPI call returns.
         activated = False
         while time.monotonic() < deadline:
             for item in accessible_tree():
                 try:
-                    if (normalized_name(item) == args.select_page
-                            and role(item) == pyatspi.ROLE_PAGE_TAB
-                            and item.getState().contains(pyatspi.STATE_SHOWING)):
+                    if (
+                        normalized_name(item) == args.select_page
+                        and role(item) == pyatspi.ROLE_PAGE_TAB
+                        and is_showing(item)
+                    ):
                         if item.getState().contains(pyatspi.STATE_SELECTED):
                             return 0
                         if not activated:
                             activated = item.queryAction().doAction(0)
                 except Exception:
                     continue
-            time.sleep(0.1)
+            time.sleep(0.05)
         raise SystemExit(f"could not select the {args.select_page} tab")
     if args.edit_settings_timeout is not None:
         if not args.window_id:
             raise SystemExit("--edit-settings-timeout needs --window-id")
-        accessibles = accessible_tree()
-        entry = next((item for item in accessibles if name(item) == "Idle timeout"
-                      and role(item) == pyatspi.ROLE_TEXT
-                      and item.getState().contains(pyatspi.STATE_SHOWING)), None)
-        if entry is None:
-            deadline = time.monotonic() + args.timeout
-            while entry is None and time.monotonic() < deadline:
-                subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
-                entry = next((item for item in accessible_tree() if name(item) == "Idle timeout"
-                              and role(item) == pyatspi.ROLE_TEXT
-                              and item.getState().contains(pyatspi.STATE_SHOWING)), None)
-                time.sleep(0.05)
-        if entry is None:
-            raise SystemExit("could not find the Idle timeout editor")
-        for _ in range(40):
-            if any(name(item) == "Idle timeout" and role(item) == pyatspi.ROLE_TEXT
-                   and item.getState().contains(pyatspi.STATE_FOCUSED)
-                   for item in accessible_tree()):
-                break
-            subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
-            time.sleep(0.05)
-        else:
-            raise SystemExit("could not focus the Idle timeout editor through Tab navigation")
-        subprocess.run(["xdotool", "key", "--window", args.window_id, "ctrl+a"], check=True)
-        subprocess.run(["xdotool", "type", "--window", args.window_id, "--clearmodifiers", "--", args.edit_settings_timeout], check=True)
+        edit_text_control("Idle timeout", args.edit_settings_timeout, args.window_id, args.timeout)
+        return 0
+    if args.edit_pairing_address is not None:
+        edit_text_control("TV address", args.edit_pairing_address, args.window_id, args.timeout)
+    if args.edit_pairing_mac is not None:
+        edit_text_control("MAC address", args.edit_pairing_mac, args.window_id, args.timeout)
+    if args.edit_pairing_address is not None or args.edit_pairing_mac is not None:
         return 0
     if args.focus_control:
         if not args.window_id:
             raise SystemExit("--focus-control needs --window-id")
-        for _ in range(20):
-            if any(name(item) == args.focus_control and item.getState().contains(pyatspi.STATE_FOCUSED)
-                   for item in accessible_tree()):
-                return 0
-            subprocess.run(["xdotool", "key", "--window", args.window_id, "Tab"], check=True)
-            time.sleep(0.1)
-        raise SystemExit(f"could not focus {args.focus_control} through Tab navigation")
+        focus_control(args.focus_control, args.window_id, args.timeout)
+        return 0
     if args.activate_control:
-        accessibles = accessible_tree()
-        dialog = next((item for item in accessibles if role(item) == pyatspi.ROLE_DIALOG
-                       and item.getState().contains(pyatspi.STATE_SHOWING)), None)
-        for item in accessible_tree(dialog) if dialog is not None else accessibles:
-            if (name(item) == args.activate_control
-                    and role(item) in (pyatspi.ROLE_PUSH_BUTTON, pyatspi.ROLE_TOGGLE_BUTTON)
-                    and item.getState().contains(pyatspi.STATE_SHOWING)
-                    and item.getState().contains(pyatspi.STATE_SENSITIVE)):
-                if item.queryAction().doAction(0):
-                    return 0
-        raise SystemExit(f"could not activate {args.activate_control}")
+        activate_control(args.activate_control, args.timeout)
+        return 0
     deadline = time.monotonic() + args.timeout
     contract = None
     while time.monotonic() < deadline:
-        if args.expected_settings_state:
+        if (
+            args.expected_settings_state
+            or args.expected_settings_timeout
+            or args.expected_updater_state
+            or args.expected_toggle
+        ):
             contract = settings_contract(args)
         elif args.expected_tvs_state:
             contract = tvs_contract(args.expected_tvs_state, args.expected_tv_address, args.expected_tv_name)
+        elif (
+            args.expected_diagnostics_state
+            or args.read_diagnostics
+            or args.copy_diagnostics
+            or args.save_diagnostics
+        ):
+            contract = diagnostics_contract(args.expected_diagnostics_state or "report", args.expected_text)
+        elif args.expected_text:
+            contract = text_contract(args.expected_text)
         else:
             contract = observed_contract(args.expected_state, args.expected_slider_value)
-        if contract is not None and (args.expected_settings_state or args.expected_tvs_state or audio_contract(contract[0], args)):
+        expected_text_ok = (
+            args.expected_text is None
+            or contains_visible_text(contract[0], args.expected_text)
+        ) if contract is not None else False
+        if contract is not None and expected_text_ok and (
+            args.expected_settings_state
+            or args.expected_settings_timeout
+            or args.expected_updater_state
+            or args.expected_toggle
+            or args.expected_tvs_state
+            or args.expected_diagnostics_state
+            or args.read_diagnostics
+            or args.copy_diagnostics
+            or args.save_diagnostics
+            or audio_contract(contract[0], args)
+        ):
             break
         contract = None
         time.sleep(0.1)
@@ -368,7 +882,7 @@ def main() -> int:
                     print(f"    value: {item.queryValue().currentValue}", file=sys.stderr)
             except Exception:
                 continue
-        expected = f" {args.expected_settings_state or args.expected_tvs_state or args.expected_state} state"
+        expected = f" {args.expected_settings_state or args.expected_tvs_state or args.expected_diagnostics_state or args.expected_updater_state or args.expected_state} state"
         if args.expected_slider_value is not None:
             expected += f" at slider value {args.expected_slider_value:g}"
         raise SystemExit(
@@ -377,15 +891,44 @@ def main() -> int:
 
     accessibles, slider_value = contract
 
-    observed = sorted(
-        {(role_name(item), name(item)) for item in accessibles if name(item)}
-    )
+    if args.expected_text is not None and not contains_visible_text(accessibles, args.expected_text):
+        raise SystemExit(f"visible accessibility tree did not contain expected text {args.expected_text!r}")
+    if args.read_diagnostics or args.copy_diagnostics or args.save_diagnostics:
+        report = diagnostics_report_text(accessibles)
+        if not report:
+            raise SystemExit("Diagnostics did not expose a non-empty report")
+        if args.read_diagnostics:
+            Path(args.read_diagnostics).write_text(report, encoding="utf-8")
+        elif args.copy_diagnostics:
+            activate_control("Copy", args.timeout)
+            deadline = time.monotonic() + args.timeout
+            clipboard = None
+            while time.monotonic() < deadline:
+                clipboard = read_clipboard()
+                if clipboard == report:
+                    break
+                time.sleep(0.05)
+            if clipboard != report:
+                raise SystemExit("Copy did not place the diagnostic report on the clipboard")
+            Path(args.copy_diagnostics).write_text(clipboard, encoding="utf-8")
+        else:
+            initial_dialog_count = len(visible_dialogs(accessibles))
+            initial_window_ids = visible_window_ids()
+            activate_control("Save…", args.timeout)
+            save_path_after_chooser(
+                args.save_diagnostics,
+                args.timeout,
+                initial_dialog_count,
+                initial_window_ids,
+                report,
+            )
+            # Xvfb has no window manager to return focus from the native chooser.
+            subprocess.run(["xdotool", "windowfocus", "--sync", args.window_id], check=True)
+
     print("AT-SPI accessibility contract verified:")
-    print(f"  presentation state: {args.expected_settings_state or args.expected_tvs_state or args.expected_state}")
+    print(f"  presentation state: {args.expected_settings_state or args.expected_tvs_state or args.expected_diagnostics_state or args.expected_updater_state or args.expected_state}")
     if slider_value is not None:
         print(f"  slider value: {slider_value:g}")
-    for observed_role, accessible_name in observed:
-        print(f"  {observed_role}: {accessible_name}")
     return 0
 
 

--- a/scripts/test-release-gui-behavior.sh
+++ b/scripts/test-release-gui-behavior.sh
@@ -3,12 +3,14 @@
 set -euo pipefail
 
 usage() {
-    echo "Usage: $0 <installed-lg-buddy> <config-file>"
+    echo "Usage: $0 <installed-lg-buddy> <config-file> [tv-fixture] [update-archive]"
     exit 1
 }
 
 RUNTIME_BINARY="${1:-}"
 CONFIG_FILE="${2:-}"
+TV_FIXTURE="${3:-${LG_BUDDY_GUI_TV_FIXTURE:-}}"
+UPDATE_ARCHIVE="${4:-${LG_BUDDY_GUI_UPDATE_ARCHIVE:-}}"
 SCRIPT_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
 REPOSITORY_ROOT="$(dirname "$SCRIPT_DIR")"
 WORK_DIR="$(mktemp -d)"
@@ -20,6 +22,8 @@ WINDOW_ID=""
 ACCESSIBILITY_BUS_PID=""
 ACCESSIBILITY_REGISTRY_PID=""
 ACCESSIBILITY_PYTHON=""
+TV_FIXTURE_PID=""
+GITHUB_FIXTURE_PID=""
 
 fail() {
     echo "$1" >&2
@@ -35,6 +39,12 @@ cleanup() {
         kill "$GUI_PID"
         wait "$GUI_PID" 2>/dev/null || true
     fi
+    for fixture_pid in "$TV_FIXTURE_PID" "$GITHUB_FIXTURE_PID"; do
+        if [ -n "$fixture_pid" ] && kill -0 "$fixture_pid" 2>/dev/null; then
+            kill "$fixture_pid" 2>/dev/null || true
+            wait "$fixture_pid" 2>/dev/null || true
+        fi
+    done
     if [ -n "$ACCESSIBILITY_REGISTRY_PID" ] && kill -0 "$ACCESSIBILITY_REGISTRY_PID" 2>/dev/null; then
         kill "$ACCESSIBILITY_REGISTRY_PID"
         wait "$ACCESSIBILITY_REGISTRY_PID" 2>/dev/null || true
@@ -43,7 +53,11 @@ cleanup() {
         kill "$ACCESSIBILITY_BUS_PID"
         wait "$ACCESSIBILITY_BUS_PID" 2>/dev/null || true
     fi
-    rm -rf "$WORK_DIR"
+    if [ "${LG_BUDDY_KEEP_GUI_SMOKE:-0}" = 1 ]; then
+        echo "GUI smoke evidence: $WORK_DIR" >&2
+    else
+        rm -rf "$WORK_DIR"
+    fi
 }
 trap cleanup EXIT
 
@@ -105,7 +119,10 @@ start_gui() {
     GUI_PID=$!
     for ((attempt = 0; attempt < 300; attempt++)); do
         WINDOW_ID="$(xdotool search --onlyvisible --name "^${WINDOW_TITLE}$" 2>/dev/null | head -n1 || true)"
-        [ -z "$WINDOW_ID" ] || return 0
+        if [ -n "$WINDOW_ID" ]; then
+            xdotool windowfocus --sync "$WINDOW_ID"
+            return 0
+        fi
         kill -0 "$GUI_PID" 2>/dev/null || fail "GUI exited before presenting its window."
         sleep 0.1
     done
@@ -219,6 +236,13 @@ observe_gui_state() {
     "$ACCESSIBILITY_PYTHON" "$SCRIPT_DIR/test-release-gui-accessibility.py" \
         --timeout 30 "$@"
 }
+
+if [ "${LG_BUDDY_GUI_JOURNEY_ONLY:-0}" = 1 ]; then
+    start_accessibility_bus
+    source "$SCRIPT_DIR/test-release-gui-journey.sh"
+    run_installed_gui_journey
+    exit 0
+fi
 
 # A plain installed launch opens Overview. An explicit brightness activation
 # from TVs returns to the same window and focuses the slider after the read.
@@ -458,6 +482,11 @@ if path.exists():
     state = json.loads(path.read_text(encoding="utf-8"))
     assert not any(call.get("command") == "set_settings" for call in state.get("calls", [])), state
 PY
+
+if [ -n "$TV_FIXTURE" ]; then
+    source "$SCRIPT_DIR/test-release-gui-journey.sh"
+    run_installed_gui_journey
+fi
 
 if [ "${LG_BUDDY_TEST_PLATFORM_CONTRACT:-0}" = "1" ]; then
     command -v xwd >/dev/null || fail "xwd is required for theme verification."

--- a/scripts/test-release-gui-journey.sh
+++ b/scripts/test-release-gui-journey.sh
@@ -97,7 +97,8 @@ case "$action" in
         if [ "$unit" = LG_Buddy_screen.service ] && [ -e "$dir/screen-fails" ]; then
             echo 'screen service failed' >&2; exit 1
         fi
-        touch "$dir/active-$scope-$unit" ;;
+        touch "$dir/active-$scope-$unit"
+        printf '%s %s %s\n' "$scope" "$action" "$unit" >> "$dir/successful-calls" ;;
     enable)
         if [[ " $* " == *" --now "* ]]; then
             if [ "$unit" = LG_Buddy_screen.service ] && [ -e "$dir/screen-fails" ]; then
@@ -192,8 +193,15 @@ SH
     journey_setting screen.idle_timeout 720
     observe_gui_state --expected-text 'Retry apply'
     rm "$WORK_DIR/services/screen-fails"
+    # A saved value and the earlier activation do not prove this retry worked.
+    : > "$WORK_DIR/services/successful-calls"
     observe_gui_state --activate-control 'Retry apply Idle timeout'
-    observe_gui_state --expected-settings-state ready --expected-settings-timeout 720
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        grep -qx 'user restart LG_Buddy_screen.service' "$WORK_DIR/services/successful-calls" && break
+        sleep 0.1
+    done
+    grep -qx 'user restart LG_Buddy_screen.service' "$WORK_DIR/services/successful-calls" || fail "Retry apply did not successfully restart the screen service."
+    observe_gui_state --expected-settings-state ready --expected-settings-timeout 720 --expected-absent-text 'Retry apply'
     observe_gui_state --select-page TVs
     observe_gui_state --activate-control 'Unpair TV…'
     observe_gui_state --expected-tvs-state unpair

--- a/scripts/test-release-gui-journey.sh
+++ b/scripts/test-release-gui-journey.sh
@@ -1,0 +1,389 @@
+#!/bin/bash
+# Sourced by test-release-gui-behavior.sh; reuse its installed app, isolated
+# configuration, accessibility observer, and process lifecycle helpers.
+
+journey_setting() {
+    local key="$1" expected="$2"
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        [ "$("$RUNTIME_BINARY" settings get "$key" 2>/dev/null)" = "$expected" ] && return
+        sleep 0.1
+    done
+    fail "The installed GUI did not persist $key=$expected."
+}
+
+journey_tv_scenario() {
+    printf '%s\n' "$1" > "$WORK_DIR/native-tv/command.tmp"
+    mv "$WORK_DIR/native-tv/command.tmp" "$WORK_DIR/native-tv/command"
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        if python3 - "$WORK_DIR/native-tv/state.json" "$1" <<'PY'
+import json, sys
+from pathlib import Path
+path = Path(sys.argv[1])
+raise SystemExit(0 if path.exists() and json.loads(path.read_text()).get("scenario") == sys.argv[2] else 1)
+PY
+        then return; fi
+        sleep 0.1
+    done
+    fail "Native TV fixture did not enter $1."
+}
+
+journey_pair() {
+    observe_gui_state --activate-control "Pair a TV"
+    observe_gui_state --expected-tvs-state pairing
+    observe_gui_state --edit-pairing-address 127.0.0.1 --edit-pairing-mac 02:00:00:00:00:10 --window-id "$WINDOW_ID"
+    observe_gui_state --focus-control "HDMI input" --window-id "$WINDOW_ID"
+    xdotool key --window "$WINDOW_ID" --delay 60 space Home Down Down Return
+    observe_gui_state --activate-control Pair
+}
+
+journey_close() {
+    gapplication action io.github.staphylococcus.LGBuddy quit
+    finish_gui "$1"
+}
+
+journey_diagnostics() {
+    local label="$1"
+    observe_gui_state --focus-control "Main Menu" --window-id "$WINDOW_ID"
+    # Activate the first menu entry through normal keyboard navigation. GTK
+    # 4.14 does not expose Gio menu-item labels through AT-SPI.
+    xdotool key --window "$WINDOW_ID" Return
+    xdotool key Home Return
+    observe_gui_state --expected-diagnostics-state report
+    observe_gui_state --read-diagnostics "$WORK_DIR/$label-report.txt"
+    observe_gui_state --focus-control Copy --window-id "$WINDOW_ID"
+    observe_gui_state --copy-diagnostics "$WORK_DIR/$label-copy.txt"
+    observe_gui_state --save-diagnostics "$WORK_DIR/$label-save.txt" --window-id "$WINDOW_ID"
+    cmp "$WORK_DIR/$label-report.txt" "$WORK_DIR/$label-copy.txt" || fail "Diagnostics Copy differs from its visible report."
+    cmp "$WORK_DIR/$label-report.txt" "$WORK_DIR/$label-save.txt" || fail "Diagnostics Save differs from its visible report."
+    if grep -E 'webos-test-access-token|diagnostics-secret-canary' "$WORK_DIR/$label-report.txt"; then
+        fail "Diagnostics exported a credential or raw failure payload."
+    fi
+    grep -q 'no accessible entries' "$WORK_DIR/$label-report.txt" || fail "Diagnostics did not explain unavailable observations."
+    observe_gui_state --activate-control Refresh
+    observe_gui_state --expected-diagnostics-state report
+    observe_gui_state --activate-control Close
+}
+
+run_installed_gui_journey() {
+    [ -x "$TV_FIXTURE" ] || fail "Native TV fixture is not executable: $TV_FIXTURE"
+    [ -n "${LG_BUDDY_INSTALL_ROOT:-}" ] && [ "$LG_BUDDY_INSTALL_ROOT" != / ] || fail "GUI journey requires an isolated installation root."
+    local old_path="$PATH"
+    local old_skip="${LG_BUDDY_SKIP_SYSTEMD_ACTIONS:-0}"
+    local CONFIG_FILE LG_BUDDY_CONFIG
+    CONFIG_FILE="$(cat "$LG_BUDDY_INSTALL_ROOT/usr/lib/lg-buddy/config-path")"
+    LG_BUDDY_CONFIG="$CONFIG_FILE"
+    export LG_BUDDY_CONFIG
+    local token="$(dirname "$CONFIG_FILE")/tvs/primary/access-token.json"
+    if [ -f "$token" ]; then cp "$token" "$WORK_DIR/before-journey.token"; fi
+    cp "$CONFIG_FILE" "$WORK_DIR/before-journey.env"
+    mkdir -p "$WORK_DIR/journey-bin" "$WORK_DIR/services" "$WORK_DIR/native-tv"
+    export LG_BUDDY_GUI_SERVICE_FIXTURE="$WORK_DIR/services"
+    printf 'accept\n' > "$WORK_DIR/services/auth-mode"
+    cat > "$WORK_DIR/journey-bin/systemctl" <<'SH'
+#!/bin/bash
+set -eu
+dir="$LG_BUDDY_GUI_SERVICE_FIXTURE"
+scope=system
+if [ "${1:-}" = --user ]; then scope=user; shift; fi
+action="${1:-}"; shift || true
+unit="${*: -1}"
+printf '%s %s %s\n' "$scope" "$action" "$unit" >> "$dir/calls"
+case "$action" in
+    cat|show-environment|daemon-reload) exit 0 ;;
+    is-active)
+        [ "$unit" = graphical-session.target ] || [ -e "$dir/active-$scope-$unit" ] ;;
+    is-enabled) [ -e "$dir/enabled-$scope-$unit" ] ;;
+    start|restart)
+        if [ "$unit" = LG_Buddy_screen.service ] && [ -e "$dir/screen-fails" ]; then
+            echo 'screen service failed' >&2; exit 1
+        fi
+        touch "$dir/active-$scope-$unit" ;;
+    enable)
+        if [[ " $* " == *" --now "* ]]; then
+            if [ "$unit" = LG_Buddy_screen.service ] && [ -e "$dir/screen-fails" ]; then
+                echo 'screen service failed' >&2; exit 1
+            fi
+            touch "$dir/active-$scope-$unit"
+        fi
+        touch "$dir/enabled-$scope-$unit" ;;
+    disable) rm -f "$dir/enabled-$scope-$unit" "$dir/active-$scope-$unit" ;;
+    show)
+        active=inactive; enabled=disabled
+        [ ! -e "$dir/active-$scope-$unit" ] || active=active
+        [ ! -e "$dir/enabled-$scope-$unit" ] || enabled=enabled
+        printf 'LoadState=loaded\nActiveState=%s\nSubState=dead\nUnitFileState=%s\n' "$active" "$enabled" ;;
+    *) echo "Unexpected systemctl request: $action $*" >&2; exit 2 ;;
+esac
+SH
+    cat > "$WORK_DIR/journey-bin/pkexec" <<'SH'
+#!/bin/bash
+set -eu
+dir="$LG_BUDDY_GUI_SERVICE_FIXTURE"
+[ "${1:-}" = --disable-internal-agent ] || exit 2
+shift
+printf '%s\n' "$*" >> "$dir/authorizations"
+[ "$(cat "$dir/auth-mode")" != decline ] || exit 126
+if [ "${1:-}" = /usr/bin/systemctl ] && [ "${2:-}" = start ] && [ "${3:-}" = LG_Buddy_lifecycle.service ]; then
+    shift
+    exec "$LG_BUDDY_SYSTEMCTL" "$@"
+fi
+exec unshare -Ur "$@"
+SH
+    cat > "$WORK_DIR/journey-bin/journalctl" <<'SH'
+#!/bin/sh
+echo 'token=diagnostics-secret-canary' >&2
+exit 1
+SH
+    chmod 755 "$WORK_DIR/journey-bin/"*
+    export PATH="$WORK_DIR/journey-bin:$PATH"
+    export LG_BUDDY_SYSTEMCTL="$WORK_DIR/journey-bin/systemctl"
+    export LG_BUDDY_JOURNALCTL="$WORK_DIR/journey-bin/journalctl"
+    export LG_BUDDY_SKIP_SYSTEMD_ACTIONS=0
+    "$TV_FIXTURE" "$WORK_DIR/native-tv" > "$WORK_DIR/native-tv.output" 2>&1 &
+    TV_FIXTURE_PID=$!
+    journey_tv_scenario stateful
+
+    # An installed app with no TV offers pairing and diagnostics, without tabs.
+    : > "$CONFIG_FILE"
+    rm -f "$token"
+    start_gui enabled "" "" normal
+    observe_gui_state --expected-tvs-state empty
+    journey_diagnostics before-pairing
+    [ ! -s "$CONFIG_FILE" ] || fail "Diagnostics changed the fresh configuration."
+    observe_gui_state --activate-control "Pair a TV"
+    observe_gui_state --expected-tvs-state pairing
+    observe_gui_state --activate-control Cancel
+    observe_gui_state --expected-tvs-state empty
+
+    journey_tv_scenario pairing-rejected
+    journey_pair
+    observe_gui_state --expected-text "Connection declined on TV"
+    observe_gui_state --activate-control Cancel
+    observe_gui_state --expected-tvs-state empty
+    [ ! -s "$CONFIG_FILE" ] && [ ! -e "$token" ] || fail "Rejected pairing saved a profile or credential."
+
+    journey_tv_scenario stall
+    journey_pair
+    observe_gui_state --expected-text "Verifying TV Access"
+    journey_close "interrupted first-run pairing"
+    [ ! -s "$CONFIG_FILE" ] && [ ! -e "$token" ] || fail "Interrupted pairing saved incomplete state."
+    journey_tv_scenario stateful
+    start_gui enabled "" "" normal
+    observe_gui_state --expected-tvs-state empty
+    journey_pair
+    journey_setting tv.ip 127.0.0.1
+    journey_setting screen.idle_blank enabled
+    journey_setting system.sleep_wake_policy enabled
+    observe_gui_state --select-page Settings
+    observe_gui_state --expected-toggle 'Idle blanking=on' --expected-toggle 'TV sleep & wake=on'
+    "$LG_BUDDY_SYSTEMCTL" --user is-active LG_Buddy_screen.service || fail "Default idle blanking did not activate its service."
+    "$LG_BUDDY_SYSTEMCTL" is-active LG_Buddy_lifecycle.service || fail "Default sleep/wake did not activate its service."
+    cp "$CONFIG_FILE" "$WORK_DIR/paired-config.snapshot"
+    cp "$token" "$WORK_DIR/paired-token.snapshot"
+    journey_diagnostics paired
+    cmp "$CONFIG_FILE" "$WORK_DIR/paired-config.snapshot" || fail "Diagnostics changed configuration."
+    cmp "$token" "$WORK_DIR/paired-token.snapshot" || fail "Diagnostics changed credentials."
+
+    # Re-pairing preserves preferences; failed activation leaves honest toggles
+    # and can be retried from Settings without repeating TV pairing.
+    touch "$WORK_DIR/services/screen-fails"
+    observe_gui_state --edit-settings-timeout 720 --window-id "$WINDOW_ID"
+    xdotool key --window "$WINDOW_ID" Return
+    journey_setting screen.idle_timeout 720
+    observe_gui_state --expected-text 'Retry apply'
+    rm "$WORK_DIR/services/screen-fails"
+    observe_gui_state --activate-control 'Retry apply Idle timeout'
+    observe_gui_state --expected-settings-state ready --expected-settings-timeout 720
+    observe_gui_state --select-page TVs
+    observe_gui_state --activate-control 'Unpair TV…'
+    observe_gui_state --expected-tvs-state unpair
+    observe_gui_state --activate-control Unpair
+    observe_gui_state --expected-tvs-state empty
+    journey_setting screen.idle_timeout 720
+    rm -f "$WORK_DIR/services/active-system-LG_Buddy_lifecycle.service" "$WORK_DIR/services/active-user-LG_Buddy_screen.service"
+    touch "$WORK_DIR/services/screen-fails"
+    printf 'decline\n' > "$WORK_DIR/services/auth-mode"
+    journey_pair
+    journey_setting tv.ip 127.0.0.1
+    observe_gui_state --select-page Settings
+    observe_gui_state --expected-toggle 'Idle blanking=off' --expected-toggle 'TV sleep & wake=off'
+    journey_setting screen.idle_blank disabled
+    journey_setting system.sleep_wake_policy disabled
+    journey_close "paired TV with declined activation"
+    cp "$WORK_DIR/services/authorizations" "$WORK_DIR/authorizations.snapshot"
+    start_gui enabled "" "" normal
+    observe_gui_state --select-page Settings
+    observe_gui_state --expected-toggle 'Idle blanking=off' --expected-toggle 'TV sleep & wake=off'
+    cmp "$WORK_DIR/services/authorizations" "$WORK_DIR/authorizations.snapshot" || fail "Relaunch unexpectedly requested activation again."
+    rm "$WORK_DIR/services/screen-fails"
+    printf 'accept\n' > "$WORK_DIR/services/auth-mode"
+    observe_gui_state --activate-control 'Idle blanking'
+    journey_setting screen.idle_blank enabled
+    observe_gui_state --activate-control 'TV sleep & wake'
+    journey_setting system.sleep_wake_policy enabled
+    journey_setting screen.idle_timeout 720
+    observe_gui_state --expected-toggle 'Idle blanking=on' --expected-toggle 'TV sleep & wake=on'
+    "$LG_BUDDY_SYSTEMCTL" --user is-active LG_Buddy_screen.service || fail "Settings retry did not activate idle blanking."
+    "$LG_BUDDY_SYSTEMCTL" is-active LG_Buddy_lifecycle.service || fail "Settings retry did not activate sleep/wake."
+    journey_close "successful activation from Settings"
+
+    # An offline saved TV remains a configured application after relaunch.
+    kill "$TV_FIXTURE_PID"
+    wait "$TV_FIXTURE_PID" 2>/dev/null || true
+    TV_FIXTURE_PID=""
+    start_gui enabled prefer-dark 2 normal
+    observe_gui_state --select-page TVs
+    observe_gui_state --expected-tvs-state configured --expected-tv-address 127.0.0.1
+    journey_diagnostics offline
+    journey_close "offline configured TV"
+
+    if [ -n "$UPDATE_ARCHIVE" ]; then journey_updates; fi
+
+    cp "$WORK_DIR/before-journey.env" "$CONFIG_FILE"
+    if [ -f "$WORK_DIR/before-journey.token" ]; then
+        cp "$WORK_DIR/before-journey.token" "$token"
+    else
+        rm -f "$token"
+    fi
+    export PATH="$old_path" LG_BUDDY_SKIP_SYSTEMD_ACTIONS="$old_skip"
+    unset LG_BUDDY_SYSTEMCTL LG_BUDDY_JOURNALCTL LG_BUDDY_GUI_SERVICE_FIXTURE
+    echo "Installed GUI pairing, activation, and diagnostics journey passed."
+}
+
+journey_update_mode() {
+    printf '{"mode":"%s","delay_seconds":%s}\n' "$1" "${2:-0}" > "$WORK_DIR/github-state.tmp"
+    mv "$WORK_DIR/github-state.tmp" "$WORK_DIR/github-state.json"
+}
+
+journey_update_unchanged() {
+    cmp "$CONFIG_FILE" "$WORK_DIR/update-config.snapshot" || fail "Update changed user settings."
+    cmp "$update_token" "$WORK_DIR/update-token.snapshot" || fail "Update changed pairing credentials."
+    cmp "$RUNTIME_BINARY" "$WORK_DIR/update-runtime.snapshot" || fail "Unfinished update replaced the runtime."
+    cmp "$(dirname "$RUNTIME_BINARY")/lg-buddy-gui" "$WORK_DIR/update-gui.snapshot" || fail "Unfinished update replaced the GUI."
+}
+
+journey_update_confirmation() {
+    observe_gui_state --activate-control 'Install update…'
+    observe_gui_state --expected-updater-state confirmation
+    observe_gui_state --expected-text "Install LG Buddy $expected_update_version?"
+}
+
+journey_updates() {
+    [ -f "$UPDATE_ARCHIVE" ] || fail "Candidate update archive is missing: $UPDATE_ARCHIVE"
+    local installed_gui="$(dirname "$RUNTIME_BINARY")/lg-buddy-gui"
+    local update_token="$(dirname "$CONFIG_FILE")/tvs/primary/access-token.json"
+    local expected_update_version
+    expected_update_version="$(tar -xOf "$UPDATE_ARCHIVE" --wildcards '*/release-manifest.json' | python3 -c 'import json,sys; print(json.load(sys.stdin)["version"])')"
+    for binary in "$RUNTIME_BINARY" "$installed_gui"; do
+        LC_ALL=C grep -aq LG_BUDDY_TEST_GITHUB_ADDRESS "$binary" || fail "Update smoke requires debug binaries built with gui-test-fixtures."
+    done
+    journey_update_mode up-to-date 1
+    python3 "$REPOSITORY_ROOT/tools/mock_github_gui.py" \
+        --archive "$UPDATE_ARCHIVE" --state "$WORK_DIR/github-state.json" \
+        --ready "$WORK_DIR/github-ready.json" --requests "$WORK_DIR/github-requests.jsonl" \
+        --current-version 0.0.0 > "$WORK_DIR/github.output" 2>&1 &
+    GITHUB_FIXTURE_PID=$!
+    for ((attempt = 0; attempt < 100; attempt++)); do
+        [ ! -f "$WORK_DIR/github-ready.json" ] || break
+        kill -0 "$GITHUB_FIXTURE_PID" 2>/dev/null || fail "GitHub fixture exited before becoming ready."
+        sleep 0.1
+    done
+    export LG_BUDDY_TEST_GITHUB_ADDRESS
+    LG_BUDDY_TEST_GITHUB_ADDRESS="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["address"])' "$WORK_DIR/github-ready.json")"
+    export LG_BUDDY_SKIP_SYSTEMD_ACTIONS=1
+    start_gui enabled prefer-dark 2 normal
+    local update_gui_pid
+    update_gui_pid="$(pgrep -P "$GUI_PID" -f lg-buddy-gui)"
+    observe_gui_state --select-page Settings
+    observe_gui_state --activate-control 'Automatic update checks'
+    journey_setting updates.auto_check disabled
+    [ ! -s "$WORK_DIR/github-requests.jsonl" ] || fail "Opening Settings unexpectedly checked for updates."
+
+    observe_gui_state --activate-control 'Check for updates'
+    observe_gui_state --expected-updater-state checking
+    observe_gui_state --expected-updater-state idle --expected-text 'Already up to date'
+    journey_update_mode error
+    observe_gui_state --activate-control 'Check for updates'
+    observe_gui_state --expected-text 'Could not check for updates'
+    observe_gui_state --expected-text 'Copy details'
+
+    journey_update_mode available
+    : > "$WORK_DIR/github-requests.jsonl"
+    observe_gui_state --activate-control 'Check for updates'
+    observe_gui_state --expected-updater-state available
+    grep -q '/releases/latest' "$WORK_DIR/github-requests.jsonl" || fail "Stable check ignored the saved channel."
+    if grep -q '/releases/assets/' "$WORK_DIR/github-requests.jsonl"; then
+        fail "Checking for updates downloaded installation assets."
+    fi
+    observe_gui_state --focus-control 'Update channel' --window-id "$WINDOW_ID"
+    xdotool key --window "$WINDOW_ID" --delay 60 space Home Down Return
+    journey_setting updates.channel prerelease
+    observe_gui_state --expected-updater-state idle
+    observe_gui_state --activate-control 'Check for updates'
+    observe_gui_state --expected-updater-state available
+    grep -q '/releases?per_page=1' "$WORK_DIR/github-requests.jsonl" || fail "Prerelease check ignored the saved channel."
+
+    cp "$CONFIG_FILE" "$WORK_DIR/update-config.snapshot"
+    cp "$update_token" "$WORK_DIR/update-token.snapshot"
+    cp "$RUNTIME_BINARY" "$WORK_DIR/update-runtime.snapshot"
+    cp "$installed_gui" "$WORK_DIR/update-gui.snapshot"
+    cp "$WORK_DIR/services/authorizations" "$WORK_DIR/update-authorizations.snapshot"
+    local discovery_count
+    discovery_count="$(grep -c '/releases?per_page=1' "$WORK_DIR/github-requests.jsonl")"
+    journey_update_confirmation
+    [ "$(grep -c '/releases?per_page=1' "$WORK_DIR/github-requests.jsonl")" -gt "$discovery_count" ] || fail "Install dialog did not discover a fresh release."
+    observe_gui_state --activate-control Cancel
+    observe_gui_state --expected-updater-state available
+    journey_update_unchanged
+    cmp "$WORK_DIR/services/authorizations" "$WORK_DIR/update-authorizations.snapshot" || fail "Cancelled confirmation requested installation authorization."
+
+    journey_update_mode corrupt-archive
+    journey_update_confirmation
+    observe_gui_state --activate-control 'Install and restart'
+    observe_gui_state --expected-text 'Could not install update'
+    journey_update_unchanged
+    cmp "$WORK_DIR/services/authorizations" "$WORK_DIR/update-authorizations.snapshot" || fail "Corrupt download reached the installer."
+
+    journey_update_mode available
+    printf 'decline\n' > "$WORK_DIR/services/auth-mode"
+    journey_update_confirmation
+    observe_gui_state --activate-control 'Install and restart'
+    observe_gui_state --expected-text 'Could not install update'
+    journey_update_unchanged
+    if cmp -s "$WORK_DIR/services/authorizations" "$WORK_DIR/update-authorizations.snapshot"; then
+        fail "Authorization-decline scenario did not reach the installer."
+    fi
+
+    printf 'accept\n' > "$WORK_DIR/services/auth-mode"
+    journey_update_mode available 1
+    journey_update_confirmation
+    observe_gui_state --activate-control 'Install and restart'
+    observe_gui_state --expected-updater-state downloading
+    for ((attempt = 0; attempt < 600; attempt++)); do
+        if ! cmp -s "$installed_gui" "$WORK_DIR/update-gui.snapshot" && cmp -s "/proc/$update_gui_pid/exe" "$installed_gui"; then
+            break
+        fi
+        kill -0 "$GUI_PID" 2>/dev/null || fail "GUI exited instead of handing off to the installed update."
+        sleep 0.1
+    done
+    ! cmp -s "$installed_gui" "$WORK_DIR/update-gui.snapshot" || fail "GUI update did not replace installed executables."
+    cmp -s "/proc/$update_gui_pid/exe" "$installed_gui" || fail "GUI did not relaunch the verified installed executable."
+    mkdir "$WORK_DIR/update-candidate"
+    tar -xzf "$UPDATE_ARCHIVE" -C "$WORK_DIR/update-candidate" --strip-components=1
+    cmp "$RUNTIME_BINARY" "$WORK_DIR/update-candidate/lg-buddy" || fail "Installed runtime differs from the candidate."
+    local gui_target
+    gui_target="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["gui_target"])' "$WORK_DIR/update-candidate/release-manifest.json")"
+    cmp "$installed_gui" "$WORK_DIR/update-candidate/docs/lg-buddy-gui-$gui_target" || fail "Installed GUI differs from the candidate."
+    "$RUNTIME_BINARY" --version
+    "$installed_gui" --version
+    cmp "$CONFIG_FILE" "$WORK_DIR/update-config.snapshot" || fail "Successful update changed settings."
+    cmp "$update_token" "$WORK_DIR/update-token.snapshot" || fail "Successful update changed pairing credentials."
+    observe_gui_state --select-page TVs
+    observe_gui_state --expected-tvs-state configured --expected-tv-address 127.0.0.1
+    journey_close 'updated installed GUI'
+    kill "$GITHUB_FIXTURE_PID"
+    wait "$GITHUB_FIXTURE_PID" 2>/dev/null || true
+    GITHUB_FIXTURE_PID=""
+    unset LG_BUDDY_TEST_GITHUB_ADDRESS
+    echo 'Installed GUI update check, confirmation, failure, installation, and relaunch journey passed.'
+}

--- a/scripts/test_mock_github_gui.py
+++ b/scripts/test_mock_github_gui.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+"""Protocol tests for tools/mock_github_gui.py."""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import unittest
+import urllib.error
+import urllib.request
+from pathlib import Path
+from urllib.parse import urlsplit
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "tools" / "mock_github_gui.py"
+
+
+class NoRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
+        return None
+
+
+def write_candidate(path: Path) -> bytes:
+    manifest = {
+        "schema_version": 1,
+        "critical": ["release_tag", "version", "channel", "target", "commit"],
+        "release_tag": "v1.7.0-beta.1",
+        "version": "1.7.0-beta.1",
+        "channel": "prerelease",
+        "target": "x86_64-unknown-linux-musl",
+        "commit": "0123456789abcdef0123456789abcdef01234567",
+    }
+    content = (json.dumps(manifest) + "\n").encode("utf-8")
+    root = "lg-buddy-1.7.0-beta.1-x86_64-unknown-linux-musl"
+    with tarfile.open(path, mode="w:gz") as bundle:
+        info = tarfile.TarInfo(f"{root}/release-manifest.json")
+        info.mode = 0o644
+        info.size = len(content)
+        bundle.addfile(info, io.BytesIO(content))
+    return path.read_bytes()
+
+
+class MockGitHubGuiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory(prefix="lg-buddy-mock-github-")
+        root = Path(self.directory.name)
+        self.archive = root / "candidate.tar.gz"
+        self.state = root / "state.json"
+        self.ready = root / "ready.json"
+        self.requests = root / "requests.jsonl"
+        self.archive_bytes = write_candidate(self.archive)
+        self.state.write_text('{"mode":"available"}\n', encoding="utf-8")
+        self.process = subprocess.Popen(
+            [
+                sys.executable,
+                str(SERVER),
+                "--archive",
+                str(self.archive),
+                "--state",
+                str(self.state),
+                "--ready",
+                str(self.ready),
+                "--requests",
+                str(self.requests),
+            ],
+            cwd=ROOT,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(100):
+            if self.ready.exists():
+                break
+            if self.process.poll() is not None:
+                self.fail(self.process.stderr.read())
+            time.sleep(0.05)
+        self.assertTrue(self.ready.exists())
+        self.address = json.loads(self.ready.read_text(encoding="utf-8"))["address"]
+        self.no_redirect = urllib.request.build_opener(NoRedirect)
+
+    def tearDown(self) -> None:
+        if self.process.poll() is None:
+            self.process.terminate()
+            self.process.wait(timeout=5)
+        if self.process.stdout is not None:
+            self.process.stdout.close()
+        if self.process.stderr is not None:
+            self.process.stderr.close()
+        self.directory.cleanup()
+
+    def url(self, path: str) -> str:
+        return f"http://{self.address}{path}"
+
+    def get(self, path: str):  # type: ignore[no-untyped-def]
+        return urllib.request.urlopen(self.url(path), timeout=3)
+
+    def get_no_redirect(self, path: str):  # type: ignore[no-untyped-def]
+        try:
+            return self.no_redirect.open(self.url(path), timeout=3)
+        except urllib.error.HTTPError as error:
+            if 300 <= error.code < 400:
+                return error
+            raise
+
+    def test_prerelease_metadata_tag_peeling_and_asset_bytes(self) -> None:
+        with self.get(
+            "/api.github.com/repos/Staphylococcus/LG_Buddy/releases?per_page=1"
+        ) as response:
+            release = json.load(response)[0]
+        self.assertEqual(release["tag_name"], "v1.7.0-beta.1")
+        self.assertTrue(release["prerelease"])
+        archive_asset = next(
+            asset
+            for asset in release["assets"]
+            if asset["name"].endswith(".tar.gz")
+        )
+
+        with self.get(
+            "/api.github.com/repos/Staphylococcus/LG_Buddy/git/ref/tags/v1.7.0-beta.1"
+        ) as response:
+            reference = json.load(response)
+        self.assertEqual(reference["object"]["type"], "tag")
+        with self.get(
+            "/api.github.com/repos/Staphylococcus/LG_Buddy/git/tags/"
+            + reference["object"]["sha"]
+        ) as response:
+            tag_object = json.load(response)
+        self.assertEqual(tag_object["object"]["type"], "commit")
+        self.assertEqual(
+            tag_object["object"]["sha"],
+            "0123456789abcdef0123456789abcdef01234567",
+        )
+
+        with self.get_no_redirect(
+            "/api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/"
+            + str(archive_asset["id"])
+        ) as response:
+            self.assertEqual(response.status, 302)
+            location = response.headers["Location"]
+        # The Rust transport fixture rewrites this validated external host to
+        # the following local path before making the redirected request.
+        local_path = "/release-assets.githubusercontent.com" + urlsplit(location).path
+        with self.get(local_path) as response:
+            self.assertEqual(response.status, 200)
+            self.assertEqual(response.read(), self.archive_bytes)
+
+    def test_state_transitions_include_error_and_corrupt_asset(self) -> None:
+        stable = "/api.github.com/repos/Staphylococcus/LG_Buddy/releases/latest"
+        prerelease = "/api.github.com/repos/Staphylococcus/LG_Buddy/releases?per_page=1"
+        with self.get(stable) as response:
+            self.assertEqual(json.load(response)["tag_name"], "v1.7.0")
+        with self.get(prerelease) as response:
+            self.assertEqual(json.load(response)[0]["tag_name"], "v1.7.0-beta.1")
+
+        self.state.write_text('{"mode":"up-to-date"}\n', encoding="utf-8")
+        with self.get(stable) as response:
+            self.assertEqual(json.load(response)["tag_name"], "v0.0.0")
+
+        self.state.write_text('{"mode":"error","status":503}\n', encoding="utf-8")
+        with self.assertRaises(urllib.error.HTTPError) as error:
+            self.get(stable)
+        self.assertEqual(error.exception.code, 500)
+
+        self.state.write_text('{"mode":"corrupt-archive"}\n', encoding="utf-8")
+        with self.get_no_redirect(
+            "/api.github.com/repos/Staphylococcus/LG_Buddy/releases/assets/1200"
+        ) as response:
+            location = response.headers["Location"]
+        redirect_path = urlsplit(location).path
+        local_path = "/release-assets.githubusercontent.com" + redirect_path
+        with self.get(local_path) as response:
+            self.assertNotEqual(response.read(), self.archive_bytes)
+
+        records = [
+            json.loads(line)
+            for line in self.requests.read_text(encoding="utf-8").splitlines()
+        ]
+        self.assertTrue(any(record["path"].endswith("/releases?per_page=1") for record in records))
+        self.assertTrue(any("/releases/assets/1200" in record["path"] for record in records))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/mock_github_gui.py
+++ b/tools/mock_github_gui.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Deterministic local GitHub API/assets fixture for installed GUI tests."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import signal
+import sys
+import tarfile
+import tempfile
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path, PurePosixPath
+from urllib.parse import parse_qs, unquote, urlsplit
+
+
+OWNER = "Staphylococcus"
+REPO = "LG_Buddy"
+API = f"/api.github.com/repos/{OWNER}/{REPO}"
+ASSET_PREFIX = "/release-assets.githubusercontent.com/github-production-release-asset/"
+REDIRECT_PATH = "/github-production-release-asset/"
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def archive_facts(path: Path) -> dict[str, object]:
+    data = path.read_bytes()
+    with tarfile.open(path, "r:gz") as bundle:
+        matches = [
+            m for m in bundle.getmembers()
+            if (
+                m.isfile()
+                and len(PurePosixPath(m.name).parts) == 2
+                and PurePosixPath(m.name).parts[1] == "release-manifest.json"
+            )
+        ]
+        if len(matches) != 1:
+            raise ValueError("archive must contain one top-level release-manifest.json")
+        stream = bundle.extractfile(matches[0])
+        if stream is None:
+            raise ValueError("release-manifest.json is unreadable")
+        manifest = json.load(stream)
+    version = manifest["version"]
+    target = manifest["target"]
+    return {
+        "bytes": data,
+        "version": version,
+        "tag": manifest["release_tag"],
+        "channel": manifest["channel"],
+        "target": target,
+        "commit": manifest["commit"],
+        "sha": sha256(data),
+    }
+
+
+def make_release(
+    facts: dict[str, object], version: str, channel: str, asset_id: int
+) -> dict[str, object]:
+    name = f"lg-buddy-{version}-{facts['target']}.tar.gz"
+    checksums = f"{facts['sha']}  {name}\n".encode("ascii")
+    return {
+        "version": version,
+        "tag": facts["tag"] if version == facts["version"] else f"v{version}",
+        "channel": channel,
+        "commit": facts["commit"],
+        "name": name,
+        "archive_id": asset_id,
+        "checksum_id": asset_id + 1,
+        "archive": facts["bytes"],
+        "checksums": checksums,
+    }
+
+
+def release_json(item: dict[str, object]) -> dict[str, object]:
+    base = f"https://api.github.com/repos/{OWNER}/{REPO}"
+    tag, archive, checksums = item["tag"], item["archive"], item["checksums"]
+    return {
+        "tag_name": tag,
+        "html_url": f"https://github.com/{OWNER}/{REPO}/releases/tag/{tag}",
+        "draft": False,
+        "prerelease": item["channel"] == "prerelease",
+        "assets": [
+            {
+                "id": item["archive_id"],
+                "name": item["name"],
+                "state": "uploaded",
+                "size": len(archive),
+                "digest": f"sha256:{sha256(archive)}",
+                "url": f"{base}/releases/assets/{item['archive_id']}",
+                "browser_download_url": (
+                    f"https://github.com/{OWNER}/{REPO}/releases/download/"
+                    f"{tag}/{item['name']}"
+                ),
+            },
+            {
+                "id": item["checksum_id"],
+                "name": "sha256sums.txt",
+                "state": "uploaded",
+                "size": len(checksums),
+                "digest": f"sha256:{sha256(checksums)}",
+                "url": f"{base}/releases/assets/{item['checksum_id']}",
+                "browser_download_url": (
+                    f"https://github.com/{OWNER}/{REPO}/releases/download/"
+                    f"{tag}/sha256sums.txt"
+                ),
+            },
+        ],
+    }
+
+
+def body(value: object) -> bytes:
+    return json.dumps(value, separators=(",", ":")).encode() + b"\n"
+
+
+class Fixture:
+    def __init__(
+        self, archive: Path, state: Path, request_log: Path | None, current: str
+    ):
+        facts = archive_facts(archive)
+        self.state, self.request_log, self.lock = state, request_log, threading.Lock()
+        stable = str(facts["version"]).split("-", 1)[0]
+        self.current = make_release(
+            facts, current, "prerelease" if "-" in current else "stable", 1000
+        )
+        self.stable = make_release(facts, stable, "stable", 1100)
+        self.candidate = make_release(
+            facts, str(facts["version"]), str(facts["channel"]), 1200
+        )
+        self.releases = (self.current, self.stable, self.candidate)
+
+    def selected(self, channel: str, mode: str) -> dict[str, object]:
+        return (
+            self.current
+            if mode == "up-to-date"
+            else (self.stable if channel == "stable" else self.candidate)
+        )
+
+    def log(self, handler: BaseHTTPRequestHandler) -> None:
+        if self.request_log is None:
+            return
+        parsed = urlsplit(handler.path)
+        path = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+        record = {"path": path}
+        self.request_log.parent.mkdir(parents=True, exist_ok=True)
+        with self.lock, self.request_log.open("a", encoding="utf-8") as output:
+            output.write(
+                json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n"
+            )
+
+
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "LG-Buddy-GitHub-Fixture/1"
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        return
+
+    @property
+    def fixture(self) -> Fixture:
+        return self.server.fixture  # type: ignore[attr-defined]
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.fixture.log(self)
+        try:
+            mode, options = self.load_state()
+            if mode == "error":
+                return self.send(500, b'{"message":"mock GitHub error"}\n')
+            time.sleep(max(0, min(float(options.get("delay_seconds", 0)), 120)))
+            status, headers, data = self.route(mode)
+            self.send(status, data, headers)
+        except (ValueError, OSError) as error:
+            self.send(500, body({"message": str(error)}))
+
+    def load_state(self) -> tuple[str, dict[str, object]]:
+        raw = self.fixture.state.read_text(encoding="utf-8").strip()
+        value = json.loads(raw)
+        if not isinstance(value, dict):
+            raise ValueError("state must be a JSON object")
+        return str(value.get("mode", "available")), value
+
+    def route(self, mode: str) -> tuple[int, dict[str, str], bytes]:
+        parsed = urlsplit(self.path)
+        path = unquote(parsed.path)
+        query = parse_qs(parsed.query, keep_blank_values=True)
+        if path == f"{API}/releases/latest":
+            item = self.fixture.selected("stable", mode)
+            return 200, {"Content-Type": "application/json"}, body(release_json(item))
+        if path == f"{API}/releases" and query.get("per_page") == ["1"]:
+            item = self.fixture.selected("prerelease", mode)
+            return 200, {"Content-Type": "application/json"}, body([release_json(item)])
+        if path.startswith(f"{API}/releases/tags/"):
+            tag = path.rsplit("/", 1)[-1]
+            item = next((x for x in self.fixture.releases if x["tag"] == tag), None)
+            if item:
+                return 200, {"Content-Type": "application/json"}, body(
+                    release_json(item)
+                )
+            return 404, {}, body({"message": "unknown release tag"})
+        if path.startswith(f"{API}/git/ref/tags/"):
+            tag = path.rsplit("/", 1)[-1]
+            if not any(x["tag"] == tag for x in self.fixture.releases):
+                return 404, {}, body({"message": "unknown tag"})
+            tag_sha = sha256(f"annotated-tag:{tag}".encode())[:40]
+            return 200, {"Content-Type": "application/json"}, body(
+                {"object": {"type": "tag", "sha": tag_sha}}
+            )
+        if path.startswith(f"{API}/git/tags/"):
+            tag_sha = path.rsplit("/", 1)[-1]
+            item = next(
+                (
+                    x
+                    for x in self.fixture.releases
+                    if sha256(f"annotated-tag:{x['tag']}".encode())[:40] == tag_sha
+                ),
+                None,
+            )
+            if item:
+                return 200, {"Content-Type": "application/json"}, body(
+                    {"object": {"type": "commit", "sha": item["commit"]}}
+                )
+            return 404, {}, body({"message": "unknown tag object"})
+        if path.startswith(f"{API}/releases/assets/"):
+            asset = path.rsplit("/", 1)[-1]
+            if not asset.isdigit() or not any(
+                int(asset) in {x["archive_id"], x["checksum_id"]}
+                for x in self.fixture.releases
+            ):
+                return 404, {}, body({"message": "unknown asset"})
+            return (
+                302,
+                {
+                    "Location": (
+                        f"https://release-assets.githubusercontent.com"
+                        f"{REDIRECT_PATH}{asset}/file"
+                    )
+                },
+                b"",
+            )
+        if path.startswith(ASSET_PREFIX):
+            asset = path.rstrip("/").split("/")[-2]
+            if not asset.isdigit():
+                return 404, {}, body({"message": "unknown asset"})
+            item = next(
+                (
+                    x
+                    for x in self.fixture.releases
+                    if int(asset) in {x["archive_id"], x["checksum_id"]}
+                ),
+                None,
+            )
+            if item is None:
+                return 404, {}, body({"message": "unknown asset"})
+            data = (
+                item["archive"]
+                if int(asset) == item["archive_id"]
+                else item["checksums"]
+            )
+            if mode == "corrupt-archive" and int(asset) == item["archive_id"]:
+                data = bytes([data[0] ^ 1]) + data[1:]
+            return 200, {"Content-Type": "application/octet-stream"}, data
+        return 404, {}, body({"message": "unknown fixture path"})
+
+    def send(
+        self, status: int, data: bytes, headers: dict[str, str] | None = None
+    ) -> None:
+        self.send_response(status)
+        self.send_header("Content-Length", str(len(data)))
+        for name, value in (headers or {}).items():
+            self.send_header(name, value)
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def atomic_write(path: Path, data: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(fd, "wb") as output:
+            output.write(data)
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--state", type=Path, required=True)
+    parser.add_argument("--ready", type=Path, required=True)
+    parser.add_argument("--requests", type=Path)
+    parser.add_argument("--current-version", default="0.0.0")
+    args = parser.parse_args()
+    try:
+        fixture = Fixture(args.archive, args.state, args.requests, args.current_version)
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        server.fixture = fixture  # type: ignore[attr-defined]
+        host, port = server.server_address
+        atomic_write(
+            args.ready,
+            body({"address": f"{host}:{port}", "host": host, "port": port}),
+        )
+    except (ValueError, OSError) as error:
+        print(f"mock GitHub fixture: {error}", file=sys.stderr)
+        return 2
+
+    def stop(_signal: int, _frame: object) -> None:
+        threading.Thread(target=server.shutdown, daemon=True).start()
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+    try:
+        server.serve_forever(poll_interval=0.05)
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The individual setup, update, and diagnostics tests did not verify that their installed GUI flows work together. Extend the canonical installed/release-bundle smoke to drive native pairing, behavior activation and retry, reconfiguration, offline relaunch, Diagnostics copy/save, and a confirmed GUI update through the shipped installer and executable handoff. Update README and the user guide to follow that GUI journey while retaining headless alternatives.

The journey exposed two GTK integration defects, fixed here with regressions: quitting during pairing could leave a window alive after the model shut down, and closing Diagnostics after its native Save chooser could leave keyboard focus unset.

Use the existing native TV server and a loopback GitHub transport feature confined to debug fixture binaries. Candidate/published release artifacts retain their normal transport and default features. CI and release validation exercise the same canonical smoke; CI carries the fixtures separately into the Fedora and Arch lanes. The smoke accepts both older checkbox/toggle-button roles and the newer AT-SPI switch role, and explicitly requires the process tools used to track the installed GUI.

Validation:

- Core suite: 975 unit tests and 134 Cucumber scenarios passed; fixture-feature suite: 976 unit tests passed, one ignored.
- Display-backed GTK suite passed, including both new window/focus regressions; formatting and all-target/all-feature Clippy passed.
- Ubuntu 24.04 default release-bundle smoke and complete installed GUI update smoke passed. Covered declined activation, Retry apply, preserved preferences/credentials, clipboard/native Save exports, failed/cancelled updates, real installation/relaunch, keyboard access, and 1x/2x light/dark checks.
- 69 Python tests, shell syntax, workflow validation, and release-artifact fixture exclusion checks passed.
- Reproduced the Arch role mismatch with the exact CI artifacts. After the fix, the full installed GUI journey passed on Fedora 43 and Arch current; the native pairing/updater journey also passed on Ubuntu 24.04 with its older AT-SPI bindings. A missing-pgrep probe fails immediately with a clear prerequisite error.
- Retry recovery regression probes: the complete installed GUI smoke passes; skipping Retry apply or keeping the service failure active both fail at the new successful-restart assertion. The UI check also waits for the retry warning to disappear.

TV, systemd, and authorization decisions are controlled fixtures; installation runs in an isolated root and user namespace. These results do not claim real TV hardware, desktop PolicyKit-agent, or live sleep/wake verification. Official NixOS support remains outside this work.

Closes #201.
