### PR TITLE
Allow apps to prevent idle blanking when enabled

### DIFF
--- a/bin/LG_Buddy_Common
+++ b/bin/LG_Buddy_Common
@@ -11,6 +11,7 @@ LG_BUDDY_POINTER_FILE="${LG_BUDDY_INSTALL_DIR}/config-path"
 LG_BUDDY_DEFAULT_TV_PLATFORM="bscpylgtv"
 LG_BUDDY_DEFAULT_SCREEN_BACKEND="auto"
 LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK="enabled"
+LG_BUDDY_DEFAULT_SCREEN_HONOR_IDLE_INHIBITORS="disabled"
 LG_BUDDY_DEFAULT_IDLE_TIMEOUT=300
 LG_BUDDY_MAX_IDLE_TIMEOUT=86400
 LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY="conservative"
@@ -231,6 +232,7 @@ lg_buddy_load_config() {
     fi
     screen_backend="$(lg_buddy_config_get_valid "screen_backend" '^(auto|gnome|wayland|swayidle)$' "$LG_BUDDY_DEFAULT_SCREEN_BACKEND" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_blank="$(lg_buddy_config_get_valid "screen_idle_blank" '^(enabled|disabled)$' "$LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK" "$LG_BUDDY_CONFIG_FILE")"
+    screen_honor_idle_inhibitors="$(lg_buddy_config_get_valid "screen_honor_idle_inhibitors" '^(enabled|disabled)$' "$LG_BUDDY_DEFAULT_SCREEN_HONOR_IDLE_INHIBITORS" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_config_get_valid "screen_idle_timeout" '^[0-9]+$' "$LG_BUDDY_DEFAULT_IDLE_TIMEOUT" "$LG_BUDDY_CONFIG_FILE")"
     screen_idle_timeout="$(lg_buddy_normalize_idle_timeout "$screen_idle_timeout")"
     screen_restore_policy="$(lg_buddy_config_get_valid "screen_restore_policy" '^(marker_only|conservative|aggressive)$' "$LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY" "$LG_BUDDY_CONFIG_FILE")"

--- a/configure.sh
+++ b/configure.sh
@@ -64,6 +64,13 @@ validate_screen_idle_blank() {
     esac
 }
 
+validate_screen_honor_idle_inhibitors() {
+    case "$1" in
+        enabled|disabled) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 validate_restore_policy() {
     case "$1" in
         marker_only|conservative|aggressive) return 0 ;;
@@ -98,6 +105,7 @@ current_input="HDMI_1"
 current_tv_platform="lg_webos"
 current_screen_backend="$LG_BUDDY_DEFAULT_SCREEN_BACKEND"
 current_screen_idle_blank="$LG_BUDDY_DEFAULT_SCREEN_IDLE_BLANK"
+current_screen_honor_idle_inhibitors="$LG_BUDDY_DEFAULT_SCREEN_HONOR_IDLE_INHIBITORS"
 current_screen_idle_timeout="$LG_BUDDY_DEFAULT_IDLE_TIMEOUT"
 current_screen_restore_policy="$LG_BUDDY_DEFAULT_SCREEN_RESTORE_POLICY"
 current_system_sleep_wake_policy="$LG_BUDDY_DEFAULT_SYSTEM_SLEEP_WAKE_POLICY"
@@ -113,6 +121,7 @@ if lg_buddy_load_config >/dev/null 2>&1; then
     current_tv_platform="$tv_platform"
     current_screen_backend="$screen_backend"
     current_screen_idle_blank="$screen_idle_blank"
+    current_screen_honor_idle_inhibitors="$screen_honor_idle_inhibitors"
     current_screen_idle_timeout="$screen_idle_timeout"
     current_screen_restore_policy="$(normalize_restore_policy "$screen_restore_policy")"
     current_system_sleep_wake_policy="$system_sleep_wake_policy"
@@ -134,6 +143,7 @@ if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
     tv_platform="${LG_BUDDY_TV_PLATFORM:-$current_tv_platform}"
     screen_backend="${LG_BUDDY_SCREEN_BACKEND:-$current_screen_backend}"
     screen_idle_blank="$current_screen_idle_blank"
+    screen_honor_idle_inhibitors="${LG_BUDDY_SCREEN_HONOR_IDLE_INHIBITORS:-$current_screen_honor_idle_inhibitors}"
     screen_idle_timeout="${LG_BUDDY_SCREEN_IDLE_TIMEOUT:-$current_screen_idle_timeout}"
     screen_restore_policy="${LG_BUDDY_SCREEN_RESTORE_POLICY:-$current_screen_restore_policy}"
     system_sleep_wake_policy="${LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY:-$current_system_sleep_wake_policy}"
@@ -168,6 +178,10 @@ if [ "${LG_BUDDY_NONINTERACTIVE:-0}" = "1" ]; then
     }
     validate_screen_idle_blank "$screen_idle_blank" || {
         echo "screen_idle_blank must be one of enabled or disabled."
+        exit 1
+    }
+    validate_screen_honor_idle_inhibitors "$screen_honor_idle_inhibitors" || {
+        echo "LG_BUDDY_SCREEN_HONOR_IDLE_INHIBITORS must be one of enabled or disabled."
         exit 1
     }
     validate_restore_policy "$screen_restore_policy" || {
@@ -370,8 +384,28 @@ else
                 *) echo "  Please enter a number between 1 and 2." ;;
             esac
         done
+
+        if [ "$screen_backend" != "swayidle" ]; then
+            case "$current_screen_honor_idle_inhibitors" in
+                enabled) default_honor_idle_inhibitors_choice="Y" ;;
+                disabled) default_honor_idle_inhibitors_choice="n" ;;
+                *) default_honor_idle_inhibitors_choice="n" ;;
+            esac
+
+            while true; do
+                HONOR_IDLE_INHIBITORS_CHOICE="$(prompt_with_default "Allow apps to prevent idle blanking? (native desktop integrations only) (y/N)" "$default_honor_idle_inhibitors_choice")"
+                case "$HONOR_IDLE_INHIBITORS_CHOICE" in
+                    [Yy]*|1|true|TRUE|True|yes|YES|Yes) screen_honor_idle_inhibitors="enabled"; break ;;
+                    ""|[Nn]*|0|false|FALSE|False|no|NO|No) screen_honor_idle_inhibitors="disabled"; break ;;
+                    *) echo "  Please answer yes or no." ;;
+                esac
+            done
+        else
+            screen_honor_idle_inhibitors="$current_screen_honor_idle_inhibitors"
+        fi
     else
         screen_backend="$current_screen_backend"
+        screen_honor_idle_inhibitors="$current_screen_honor_idle_inhibitors"
         screen_idle_timeout="$current_screen_idle_timeout"
         screen_restore_policy="$current_screen_restore_policy"
     fi
@@ -388,6 +422,7 @@ echo "  TV MAC:              $tv_mac"
 echo "  PC Input:            $input"
 echo "  TV Platform:         $tv_platform"
 echo "  Screen Idle Blank:   $screen_idle_blank"
+echo "  Honor Idle Inhibitors: $screen_honor_idle_inhibitors"
 echo "  Screen Backend:      $screen_backend"
 echo "  Screen Idle Timeout: $screen_idle_timeout"
 echo "  Screen Restore:      $screen_restore_policy"
@@ -422,6 +457,7 @@ tvs_primary_mac=$tv_mac
 tvs_primary_input=$input
 tvs_primary_platform=bscpylgtv
 screen_idle_blank=$screen_idle_blank
+screen_honor_idle_inhibitors=$screen_honor_idle_inhibitors
 screen_backend=$screen_backend
 screen_idle_timeout=$screen_idle_timeout
 screen_restore_policy=$screen_restore_policy

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -816,7 +816,13 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     assert!(!rows.iter().any(|row| row.is::<adw::ExpanderRow>()));
     assert!(!view.updater.presented.get());
     assert_eq!(view.groups.borrow().len(), 3);
-    assert_eq!(rows.len(), 7);
+    assert_eq!(rows.len(), 8);
+    assert!(
+        descendants(rows[1].upcast_ref())
+            .iter()
+            .any(|widget| widget.accessible_role() == gtk::AccessibleRole::Switch),
+        "idle inhibitor row contains an accessible toggle"
+    );
     assert!(widgets
         .iter()
         .filter_map(|widget| widget.clone().downcast::<gtk::Label>().ok())
@@ -855,7 +861,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             .iter()
             .filter(|row| matches!(row.editor, NativeEditor::Toggle(_)))
             .count(),
-        3
+        4
     );
     assert_eq!(
         view.rows
@@ -900,7 +906,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     assert!(view.rows.borrow().iter().all(|row| row.row.is_sensitive()));
     // A new edit supersedes this refresh; its stale read must not replace the value.
     intents.borrow_mut().clear();
-    let entry = match &view.rows.borrow()[2].editor {
+    let entry = match &view.rows.borrow()[3].editor {
         NativeEditor::Number { entry, .. } => entry.clone(),
         _ => unreachable!(),
     };
@@ -929,7 +935,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         .is_none());
     view.render(writing.presentation());
     assert!(view.rows.borrow().iter().all(|row| row.row.is_sensitive()));
-    assert!(!view.rows.borrow()[2].feedback.is_visible());
+    assert!(!view.rows.borrow()[3].feedback.is_visible());
     assert_eq!(
         view.groups.borrow()[0]
             .measure(gtk::Orientation::Vertical, 600)
@@ -970,7 +976,7 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
         "failure restores the previous effective value"
     );
     assert!(entry.is_sensitive());
-    assert!(view.rows.borrow()[2].feedback.is_visible());
+    assert!(view.rows.borrow()[3].feedback.is_visible());
     assert!(intents.borrow().is_empty(), "restoration emits no write");
     match &view.rows.borrow()[0].editor {
         NativeEditor::Toggle(switch) => switch.set_active(false),
@@ -983,7 +989,18 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
             enabled: false,
         })
     );
-    match &view.rows.borrow()[6].editor {
+    match &view.rows.borrow()[1].editor {
+        NativeEditor::Toggle(switch) => switch.set_active(true),
+        _ => unreachable!(),
+    }
+    assert_eq!(
+        intents.borrow_mut().pop(),
+        Some(SettingsIntent::SetEnabled {
+            setting: BehaviorSetting::ScreenHonorIdleInhibitors,
+            enabled: true,
+        })
+    );
+    match &view.rows.borrow()[7].editor {
         NativeEditor::Choice(choice) => choice.set_selected(1),
         _ => unreachable!(),
     }
@@ -1038,6 +1055,26 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     // Keep its native widget/draft and hide its associated errors too.
     entry.grab_focus();
     intents.borrow_mut().clear();
+    let swayidle = SettingsPresentation::from_store(
+        &ConfigEnvReader::parse(
+            "/unused/config.env",
+            "screen_idle_blank=enabled\nscreen_backend=swayidle\n",
+        )
+        .into_store(),
+    );
+    view.render(&swayidle);
+    assert!(
+        !rows[1].is_visible(),
+        "native inhibitor setting is hidden for swayidle"
+    );
+    assert!(
+        rows[2].is_visible(),
+        "the selected swayidle backend remains visible"
+    );
+    assert!(
+        rows[3].is_visible(),
+        "idle timeout remains visible for swayidle"
+    );
     let disabled = SettingsPresentation::from_store(
         &ConfigEnvReader::parse(
             "/unused/config.env",
@@ -1048,11 +1085,12 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
     view.render(&disabled);
     pump_until(|| !entry.is_mapped());
     assert!(rows[0].is_visible(), "Idle blanking remains available");
-    assert!(!rows[1].is_visible(), "Desktop integration is hidden");
-    assert!(!rows[2].is_visible(), "Idle timeout is hidden");
-    assert!(rows[3].is_visible(), "Restore policy remains available");
-    assert!(!view.rows.borrow()[1].problem.is_visible());
-    assert!(!view.rows.borrow()[2].feedback.is_visible());
+    assert!(!rows[1].is_visible(), "Idle inhibitor preference is hidden");
+    assert!(!rows[2].is_visible(), "Desktop integration is hidden");
+    assert!(!rows[3].is_visible(), "Idle timeout is hidden");
+    assert!(rows[4].is_visible(), "Restore policy remains available");
+    assert!(!view.rows.borrow()[2].problem.is_visible());
+    assert!(!view.rows.borrow()[3].feedback.is_visible());
     assert!(
         intents.borrow().is_empty(),
         "hiding rows must not save a draft"
@@ -1062,9 +1100,9 @@ pub(crate) fn run_renderer_scenarios(application: &adw::Application) {
 
     view.render(failed.presentation());
     pump_until(|| entry.is_mapped());
-    assert!(rows[1].is_visible());
     assert!(rows[2].is_visible());
-    assert!(view.rows.borrow()[2].feedback.is_visible());
+    assert!(rows[3].is_visible());
+    assert!(view.rows.borrow()[3].feedback.is_visible());
     assert_eq!(entry.text(), "721", "hiding must preserve the editor draft");
     assert!(view
         .rows
@@ -1125,7 +1163,7 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
         .content(view.widget())
         .build();
     window.present();
-    let choice = match &view.rows.borrow()[1].editor {
+    let choice = match &view.rows.borrow()[2].editor {
         NativeEditor::Choice(choice) => choice.clone(),
         _ => unreachable!(),
     };
@@ -1179,7 +1217,7 @@ fn choice_row_click_opens_the_value_menu(application: &adw::Application) {
         .unwrap()
         .success());
     pump_until(|| !intents.borrow().is_empty());
-    let expected = ready.presentation().groups()[0].rows()[1]
+    let expected = ready.presentation().groups()[0].rows()[2]
         .editor()
         .choices()
         .unwrap()

--- a/crates/lg-buddy/src/backend.rs
+++ b/crates/lg-buddy/src/backend.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use crate::config::{load_config, resolve_config_path_from_env, ConfigPathError, ScreenBackend};
 use crate::session_bus::new_session_bus_client;
 use crate::sources::desktop::gnome::{
-    GNOME_IDLE_MONITOR_NAME, GNOME_REQUIRED_SERVICES_REASON, GNOME_SCREEN_SAVER_NAME,
-    GNOME_SHELL_NAME,
+    GNOME_IDLE_INHIBITORS_REQUIRED_REASON, GNOME_IDLE_MONITOR_NAME, GNOME_REQUIRED_SERVICES_REASON,
+    GNOME_SCREEN_SAVER_NAME, GNOME_SESSION_MANAGER_NAME, GNOME_SHELL_NAME,
 };
 use crate::sources::desktop::wayland::{
     connect_wayland, probe_wayland_capabilities_on, WaylandProviderCapabilities,
@@ -108,6 +108,9 @@ pub trait BackendProbe {
     fn gnome_shell_available(&self) -> bool;
     fn gnome_screen_saver_available(&self) -> bool;
     fn gnome_idle_monitor_available(&self) -> bool;
+    fn gnome_session_manager_available(&self) -> bool {
+        false
+    }
     fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
         Err("native Wayland capability probing is unavailable".to_string())
     }
@@ -166,6 +169,15 @@ impl BackendProbe for SystemBackendProbe {
         bus.name_has_owner(GNOME_IDLE_MONITOR_NAME).unwrap_or(false)
     }
 
+    fn gnome_session_manager_available(&self) -> bool {
+        let mut bus = match new_session_bus_client() {
+            Ok(bus) => bus,
+            Err(_) => return false,
+        };
+        bus.name_has_owner(GNOME_SESSION_MANAGER_NAME)
+            .unwrap_or(false)
+    }
+
     fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
         let connection = match self.wayland_connection.borrow().as_ref() {
             Some(connection) => connection.clone(),
@@ -222,6 +234,13 @@ pub fn configured_backend_from_sources(
     Ok(config_backend.unwrap_or(ScreenBackend::Auto))
 }
 
+pub(crate) fn honor_idle_inhibitors_from_config() -> bool {
+    resolve_config_path_from_env()
+        .ok()
+        .and_then(|path| load_config(&path).ok())
+        .is_some_and(|config| config.screen_honor_idle_inhibitors.is_enabled())
+}
+
 pub fn detect_backend_from_system(
     configured: ScreenBackend,
 ) -> Result<ScreenBackend, BackendDetectionError> {
@@ -231,34 +250,49 @@ pub fn detect_backend_from_system(
 pub fn resolve_backend_from_system(
     configured: ScreenBackend,
 ) -> Result<BackendResolution, BackendDetectionError> {
-    resolve_backend_with_probe(&SystemBackendProbe::default(), configured)
+    resolve_backend_with_probe(
+        &SystemBackendProbe::default(),
+        configured,
+        honor_idle_inhibitors_from_config(),
+    )
 }
 
 pub fn detect_backend_with_probe(
     probe: &impl BackendProbe,
     configured: ScreenBackend,
+    honor_idle_inhibitors: bool,
 ) -> Result<ScreenBackend, BackendDetectionError> {
-    resolve_backend_with_probe(probe, configured).map(|resolution| resolution.backend())
+    resolve_backend_with_probe(probe, configured, honor_idle_inhibitors)
+        .map(|resolution| resolution.backend())
 }
 
 pub fn resolve_backend_with_probe(
     probe: &impl BackendProbe,
     configured: ScreenBackend,
+    honor_idle_inhibitors: bool,
 ) -> Result<BackendResolution, BackendDetectionError> {
     match configured {
         ScreenBackend::Auto => {
             let gnome_shell_available = probe.gnome_shell_available();
-            if gnome_shell_available
-                && probe.gnome_screen_saver_available()
-                && probe.gnome_idle_monitor_available()
-            {
+            let gnome_screen_saver_available =
+                gnome_shell_available && probe.gnome_screen_saver_available();
+            let gnome_idle_monitor_available =
+                gnome_screen_saver_available && probe.gnome_idle_monitor_available();
+            let gnome_core_available = gnome_shell_available
+                && gnome_screen_saver_available
+                && gnome_idle_monitor_available;
+            let gnome_available = gnome_core_available
+                && (!honor_idle_inhibitors || probe.gnome_session_manager_available());
+            if gnome_available {
                 return Ok(BackendResolution::selected(ScreenBackend::Gnome, None));
             }
 
-            let gnome_reason = if gnome_shell_available {
+            let gnome_reason = if !gnome_shell_available {
+                "GNOME Shell is not available".to_string()
+            } else if !gnome_core_available {
                 GNOME_REQUIRED_SERVICES_REASON.to_string()
             } else {
-                "GNOME Shell is not available".to_string()
+                GNOME_IDLE_INHIBITORS_REQUIRED_REASON.to_string()
             };
 
             match probe.wayland_capabilities() {
@@ -282,15 +316,27 @@ pub fn resolve_backend_with_probe(
             }
         }
         ScreenBackend::Gnome => {
-            if probe.gnome_shell_available()
-                && probe.gnome_screen_saver_available()
-                && probe.gnome_idle_monitor_available()
-            {
+            let gnome_shell_available = probe.gnome_shell_available();
+            let gnome_screen_saver_available =
+                gnome_shell_available && probe.gnome_screen_saver_available();
+            let gnome_idle_monitor_available =
+                gnome_screen_saver_available && probe.gnome_idle_monitor_available();
+            let gnome_core_available = gnome_shell_available
+                && gnome_screen_saver_available
+                && gnome_idle_monitor_available;
+            let gnome_available = gnome_core_available
+                && (!honor_idle_inhibitors || probe.gnome_session_manager_available());
+            if gnome_available {
                 Ok(BackendResolution::selected(ScreenBackend::Gnome, None))
             } else {
+                let reason = if !gnome_core_available {
+                    GNOME_REQUIRED_SERVICES_REASON
+                } else {
+                    GNOME_IDLE_INHIBITORS_REQUIRED_REASON
+                };
                 Err(BackendDetectionError::UnavailableBackend {
                     backend: ScreenBackend::Gnome,
-                    reason: GNOME_REQUIRED_SERVICES_REASON.to_string(),
+                    reason: reason.to_string(),
                 })
             }
         }
@@ -340,6 +386,7 @@ mod tests {
         gnome_shell_available: bool,
         gnome_screen_saver_available: bool,
         gnome_idle_monitor_available: bool,
+        gnome_session_manager_available: bool,
         has_swayidle: bool,
         swayidle_fallback_reason: Option<&'static str>,
         wayland_capabilities: Result<WaylandProviderCapabilities, &'static str>,
@@ -351,6 +398,7 @@ mod tests {
                 gnome_shell_available: false,
                 gnome_screen_saver_available: false,
                 gnome_idle_monitor_available: false,
+                gnome_session_manager_available: false,
                 has_swayidle: false,
                 swayidle_fallback_reason: None,
                 wayland_capabilities: Err("no Wayland compositor is available"),
@@ -376,6 +424,10 @@ mod tests {
 
         fn gnome_idle_monitor_available(&self) -> bool {
             self.gnome_idle_monitor_available
+        }
+
+        fn gnome_session_manager_available(&self) -> bool {
+            self.gnome_session_manager_available
         }
 
         fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
@@ -473,14 +525,78 @@ mod tests {
             gnome_shell_available: true,
             gnome_screen_saver_available: true,
             gnome_idle_monitor_available: true,
+            gnome_session_manager_available: false,
             has_swayidle: true,
             ..FakeProbe::default()
         };
 
-        let backend =
-            detect_backend_with_probe(&probe, ScreenBackend::Auto).expect("detect gnome backend");
+        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
+            .expect("detect gnome backend");
 
         assert_eq!(backend, ScreenBackend::Gnome);
+    }
+
+    #[test]
+    fn auto_falls_back_when_honoring_inhibitors_but_session_manager_is_missing() {
+        let probe = FakeProbe {
+            gnome_shell_available: true,
+            gnome_screen_saver_available: true,
+            gnome_idle_monitor_available: true,
+            gnome_session_manager_available: false,
+            has_swayidle: true,
+            wayland_capabilities: Ok(native_wayland_capabilities()),
+            ..FakeProbe::default()
+        };
+
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, true)
+            .expect("fall back from GNOME without SessionManager");
+
+        assert_eq!(resolution.backend(), ScreenBackend::Wayland);
+        assert_eq!(
+            resolution.fallback_reason(),
+            Some(
+                "GNOME unavailable: GNOME SessionManager is required when idle inhibitor honoring is enabled"
+            )
+        );
+    }
+
+    #[test]
+    fn auto_selects_gnome_when_honoring_inhibitors_and_session_manager_is_available() {
+        let probe = FakeProbe {
+            gnome_shell_available: true,
+            gnome_screen_saver_available: true,
+            gnome_idle_monitor_available: true,
+            gnome_session_manager_available: true,
+            ..FakeProbe::default()
+        };
+
+        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto, true)
+            .expect("detect GNOME with SessionManager");
+
+        assert_eq!(backend, ScreenBackend::Gnome);
+    }
+
+    #[test]
+    fn forced_gnome_requires_session_manager_when_honoring_inhibitors() {
+        let probe = FakeProbe {
+            gnome_shell_available: true,
+            gnome_screen_saver_available: true,
+            gnome_idle_monitor_available: true,
+            gnome_session_manager_available: false,
+            ..FakeProbe::default()
+        };
+
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome, true)
+            .expect_err("honoring inhibitors requires SessionManager");
+
+        assert_eq!(
+            err,
+            BackendDetectionError::UnavailableBackend {
+                backend: ScreenBackend::Gnome,
+                reason: "GNOME SessionManager is required when idle inhibitor honoring is enabled"
+                    .to_string(),
+            }
+        );
     }
 
     #[test]
@@ -491,7 +607,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto)
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect("detect native Wayland backend");
 
         assert_eq!(resolution.backend(), ScreenBackend::Wayland);
@@ -512,7 +628,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto)
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect("fall back from incomplete GNOME to native Wayland");
 
         assert_eq!(resolution.backend(), ScreenBackend::Wayland);
@@ -532,7 +648,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto)
+        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect("detect swayidle backend");
 
         assert_eq!(backend, ScreenBackend::Swayidle);
@@ -548,7 +664,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect_err("missing backend should fail");
 
         assert_eq!(
@@ -571,7 +687,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome, false)
             .expect_err("forced gnome without a full GNOME session should fail");
 
         assert_eq!(
@@ -595,7 +711,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect_err("unsupported gnome surface should fail explicitly");
 
         assert_eq!(
@@ -620,7 +736,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect_err("unsafe automatic fallback should fail");
         assert_eq!(
             err,
@@ -632,7 +748,7 @@ mod tests {
             }
         );
 
-        let explicit = detect_backend_with_probe(&probe, ScreenBackend::Swayidle)
+        let explicit = detect_backend_with_probe(&probe, ScreenBackend::Swayidle, false)
             .expect("explicit swayidle should bypass native fallback safety");
         assert_eq!(explicit, ScreenBackend::Swayidle);
     }
@@ -647,7 +763,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto)
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, false)
             .expect("fallback to swayidle when GNOME is incomplete");
 
         assert_eq!(resolution.backend(), ScreenBackend::Swayidle);
@@ -666,7 +782,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome, false)
             .expect_err("forced gnome without idle monitor should fail");
 
         assert_eq!(
@@ -690,7 +806,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Swayidle)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Swayidle, false)
             .expect_err("forced swayidle without command should fail");
 
         assert_eq!(
@@ -709,6 +825,7 @@ mod tests {
                 "ext_idle_notifier_v1 version 1 is unsupported; version 2 or newer is required",
             )),
             ScreenBackend::Wayland,
+            false,
         )
         .expect_err("forced Wayland without protocol v2 should fail");
 
@@ -728,6 +845,7 @@ mod tests {
         let backend = detect_backend_with_probe(
             &WaylandProbe(Ok(native_wayland_capabilities())),
             ScreenBackend::Wayland,
+            false,
         )
         .expect("forced Wayland should be available");
 

--- a/crates/lg-buddy/src/brightness.rs
+++ b/crates/lg-buddy/src/brightness.rs
@@ -1177,6 +1177,7 @@ mod tests {
             screen_idle_timeout: 300,
             screen_restore_policy: ScreenRestorePolicy::MarkerOnly,
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
+            screen_honor_idle_inhibitors: crate::config::ScreenHonorIdleInhibitorsPolicy::Disabled,
             system_sleep_wake_policy: SystemSleepWakePolicy::Enabled,
         }
     }

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -2248,6 +2248,7 @@ mod tests {
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,
             screen_restore_policy,
+            screen_honor_idle_inhibitors: crate::config::ScreenHonorIdleInhibitorsPolicy::Disabled,
             system_sleep_wake_policy: SystemSleepWakePolicy::Enabled,
         }
     }

--- a/crates/lg-buddy/src/config.rs
+++ b/crates/lg-buddy/src/config.rs
@@ -122,6 +122,37 @@ pub enum ScreenIdleBlankPolicy {
     Disabled,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenHonorIdleInhibitorsPolicy {
+    Enabled,
+    Disabled,
+}
+
+impl ScreenHonorIdleInhibitorsPolicy {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Enabled => "enabled",
+            Self::Disabled => "disabled",
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        matches!(self, Self::Enabled)
+    }
+}
+
+impl FromStr for ScreenHonorIdleInhibitorsPolicy {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "enabled" => Ok(Self::Enabled),
+            "disabled" => Ok(Self::Disabled),
+            _ => Err(()),
+        }
+    }
+}
+
 impl ScreenIdleBlankPolicy {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -313,6 +344,7 @@ pub struct Config {
     pub screen_idle_timeout: u64,
     pub screen_restore_policy: ScreenRestorePolicy,
     pub screen_idle_blank: ScreenIdleBlankPolicy,
+    pub screen_honor_idle_inhibitors: ScreenHonorIdleInhibitorsPolicy,
     pub system_sleep_wake_policy: SystemSleepWakePolicy,
 }
 
@@ -520,6 +552,11 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
         .and_then(|value| value.parse::<ScreenIdleBlankPolicy>().ok())
         .unwrap_or(ScreenIdleBlankPolicy::Enabled);
 
+    let screen_honor_idle_inhibitors = entries
+        .get("screen_honor_idle_inhibitors")
+        .and_then(|value| value.parse::<ScreenHonorIdleInhibitorsPolicy>().ok())
+        .unwrap_or(ScreenHonorIdleInhibitorsPolicy::Disabled);
+
     let system_sleep_wake_policy = entries
         .get("system_sleep_wake_policy")
         .and_then(|value| value.parse::<SystemSleepWakePolicy>().ok())
@@ -534,6 +571,7 @@ pub fn parse_config(contents: &str) -> Result<Config, ConfigError> {
         screen_idle_timeout,
         screen_restore_policy,
         screen_idle_blank,
+        screen_honor_idle_inhibitors,
         system_sleep_wake_policy,
     })
 }
@@ -582,9 +620,9 @@ fn sanitize_config_value(value: &str) -> String {
 mod tests {
     use super::{
         parse_config, parse_home_from_passwd_entries, resolve_config_path, Config, ConfigError,
-        ConfigPathError, ConfigPathSources, HdmiInput, ScreenBackend, ScreenIdleBlankPolicy,
-        ScreenRestorePolicy, SystemSleepWakePolicy, TvPlatform, DEFAULT_IDLE_TIMEOUT,
-        MAX_IDLE_TIMEOUT,
+        ConfigPathError, ConfigPathSources, HdmiInput, ScreenBackend,
+        ScreenHonorIdleInhibitorsPolicy, ScreenIdleBlankPolicy, ScreenRestorePolicy,
+        SystemSleepWakePolicy, TvPlatform, DEFAULT_IDLE_TIMEOUT, MAX_IDLE_TIMEOUT,
     };
     use std::path::Path;
 
@@ -786,6 +824,7 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
                 screen_idle_timeout: DEFAULT_IDLE_TIMEOUT,
                 screen_restore_policy: ScreenRestorePolicy::MarkerOnly,
                 screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
+                screen_honor_idle_inhibitors: ScreenHonorIdleInhibitorsPolicy::Disabled,
                 system_sleep_wake_policy: SystemSleepWakePolicy::Enabled,
             }
         );
@@ -817,6 +856,10 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
             ScreenRestorePolicy::Aggressive
         );
         assert_eq!(config.screen_idle_blank, ScreenIdleBlankPolicy::Disabled);
+        assert_eq!(
+            config.screen_honor_idle_inhibitors,
+            ScreenHonorIdleInhibitorsPolicy::Disabled
+        );
         assert_eq!(
             config.system_sleep_wake_policy,
             SystemSleepWakePolicy::Disabled
@@ -864,6 +907,10 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
             ScreenRestorePolicy::MarkerOnly
         );
         assert_eq!(config.screen_idle_blank, ScreenIdleBlankPolicy::Enabled);
+        assert_eq!(
+            config.screen_honor_idle_inhibitors,
+            ScreenHonorIdleInhibitorsPolicy::Disabled
+        );
         assert_eq!(
             config.system_sleep_wake_policy,
             SystemSleepWakePolicy::Enabled
@@ -966,6 +1013,45 @@ vas:x:1000:1000:vas:/home/vas:/bin/bash\n";
         assert!(!disabled.screen_idle_blank.is_enabled());
         assert_eq!(ScreenIdleBlankPolicy::Enabled.as_str(), "enabled");
         assert_eq!(ScreenIdleBlankPolicy::Disabled.as_str(), "disabled");
+    }
+
+    #[test]
+    fn parse_accepts_screen_honor_idle_inhibitors_policy_values() {
+        let enabled = parse_config(
+            "\
+            tv_ip=192.168.1.42
+            tv_mac=aa:bb:cc:dd:ee:ff
+            input=HDMI_1
+            screen_honor_idle_inhibitors=enabled
+            ",
+        )
+        .expect("parse enabled idle inhibitor policy");
+
+        let disabled = parse_config(
+            "\
+            tv_ip=192.168.1.42
+            tv_mac=aa:bb:cc:dd:ee:ff
+            input=HDMI_1
+            screen_honor_idle_inhibitors=disabled
+            ",
+        )
+        .expect("parse disabled idle inhibitor policy");
+
+        assert_eq!(
+            enabled.screen_honor_idle_inhibitors,
+            ScreenHonorIdleInhibitorsPolicy::Enabled
+        );
+        assert!(enabled.screen_honor_idle_inhibitors.is_enabled());
+        assert_eq!(
+            disabled.screen_honor_idle_inhibitors,
+            ScreenHonorIdleInhibitorsPolicy::Disabled
+        );
+        assert!(!disabled.screen_honor_idle_inhibitors.is_enabled());
+        assert_eq!(ScreenHonorIdleInhibitorsPolicy::Enabled.as_str(), "enabled");
+        assert_eq!(
+            ScreenHonorIdleInhibitorsPolicy::Disabled.as_str(),
+            "disabled"
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/diagnostics.rs
+++ b/crates/lg-buddy/src/diagnostics.rs
@@ -318,6 +318,10 @@ fn gnome_interface_observation() -> String {
         ("GNOME Shell", "org.gnome.Shell"),
         ("GNOME ScreenSaver", "org.gnome.ScreenSaver"),
         ("GNOME IdleMonitor", "org.gnome.Mutter.IdleMonitor"),
+        (
+            "GNOME SessionManager (required for idle inhibitor honoring)",
+            "org.gnome.SessionManager",
+        ),
     ];
     let mut body = format!("using {command}: ");
     for (index, (label, name)) in names.iter().enumerate() {

--- a/crates/lg-buddy/src/lifecycle.rs
+++ b/crates/lg-buddy/src/lifecycle.rs
@@ -2998,6 +2998,7 @@ mod tests {
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,
             screen_restore_policy: ScreenRestorePolicy::MarkerOnly,
+            screen_honor_idle_inhibitors: crate::config::ScreenHonorIdleInhibitorsPolicy::Disabled,
             system_sleep_wake_policy: SystemSleepWakePolicy::Enabled,
         }
     }

--- a/crates/lg-buddy/src/presentation/settings.rs
+++ b/crates/lg-buddy/src/presentation/settings.rs
@@ -191,14 +191,35 @@ impl SettingsPresentation {
     /// Keep dependent settings intact while only presenting controls that apply.
     /// Missing or invalid blanking values retain the controls for diagnosis.
     pub fn row_visible(&self, setting: BehaviorSetting) -> bool {
-        !matches!(
+        if !matches!(
             setting,
-            BehaviorSetting::ScreenBackend | BehaviorSetting::ScreenIdleTimeout
-        ) || !matches!(
+            BehaviorSetting::ScreenBackend
+                | BehaviorSetting::ScreenHonorIdleInhibitors
+                | BehaviorSetting::ScreenIdleTimeout
+        ) {
+            return true;
+        }
+
+        if matches!(
             self.row(BehaviorSetting::ScreenIdleBlank)
                 .map(SettingsRow::editor),
             Some(SettingsEditor::Toggle { value: Some(false) })
-        )
+        ) {
+            return false;
+        }
+
+        if setting != BehaviorSetting::ScreenHonorIdleInhibitors {
+            return true;
+        }
+
+        let backend_is_swayidle = self
+            .row(BehaviorSetting::ScreenBackend)
+            .and_then(|row| {
+                let selected = row.editor().selected_choice()?;
+                row.editor().choices()?.get(selected)
+            })
+            .is_some_and(|choice| choice.value() == "swayidle");
+        !backend_is_swayidle
     }
 
     pub(crate) fn row(&self, setting: BehaviorSetting) -> Option<&SettingsRow> {
@@ -492,6 +513,7 @@ pub(crate) fn groups_from_store(store: &SettingsStore) -> Vec<SettingsGroup> {
             "Choose when LG Buddy blanks and restores your TV screen.",
             vec![
                 row_from_effective(setting("screen.idle_blank")),
+                row_from_effective(setting("screen.honor_idle_inhibitors")),
                 row_from_effective(setting("screen.backend")),
                 row_from_effective(setting("screen.idle_timeout")),
                 row_from_effective(setting("screen.restore_policy")),
@@ -573,6 +595,7 @@ fn editor_for(
 ) -> SettingsEditor {
     match setting {
         BehaviorSetting::ScreenIdleBlank
+        | BehaviorSetting::ScreenHonorIdleInhibitors
         | BehaviorSetting::SystemSleepWakePolicy
         | BehaviorSetting::UpdatesAutoCheck => SettingsEditor::Toggle {
             value: effective.value().and_then(|value| match value {
@@ -621,6 +644,7 @@ fn setting_title(key: &str) -> &'static str {
     match key {
         "screen.backend" => "Desktop integration",
         "screen.idle_blank" => "Idle blanking",
+        "screen.honor_idle_inhibitors" => "Allow apps to prevent idle blanking",
         "screen.idle_timeout" => "Idle timeout",
         "screen.restore_policy" => "Restore policy",
         "system.sleep_wake_policy" => "TV sleep & wake",

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -2280,6 +2280,7 @@ mod tests {
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,
             screen_restore_policy: ScreenRestorePolicy::MarkerOnly,
+            screen_honor_idle_inhibitors: crate::config::ScreenHonorIdleInhibitorsPolicy::Disabled,
             system_sleep_wake_policy: SystemSleepWakePolicy::Enabled,
         }
     }

--- a/crates/lg-buddy/src/session.rs
+++ b/crates/lg-buddy/src/session.rs
@@ -46,4 +46,11 @@ pub(crate) enum SessionObservation {
         source: EventSource,
         observed_at: Instant,
     },
+    /// Desktop permission for automatic blanking; never user activity or a
+    /// request to restore the screen.
+    IdleBlankingPermission {
+        allowed: bool,
+        source: EventSource,
+        observed_at: Instant,
+    },
 }

--- a/crates/lg-buddy/src/session.rs
+++ b/crates/lg-buddy/src/session.rs
@@ -53,4 +53,7 @@ pub(crate) enum SessionObservation {
         source: EventSource,
         observed_at: Instant,
     },
+    /// Suspend automatic blanking while the source refreshes permission.
+    /// This is not an inhibitor transition and must not renew the deadline.
+    IdleBlankingPermissionPending { source: EventSource },
 }

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -35,6 +35,7 @@ pub struct InactivityEngine {
     blank_after: Duration,
     blank_at: Option<Instant>,
     idle_blanking_allowed: bool,
+    idle_blanking_permission_pending: bool,
     provider_driven_blank: bool,
     power_off_after: Duration,
     power_off_at: Option<Instant>,
@@ -84,6 +85,7 @@ impl InactivityEngine {
             blank_after,
             blank_at: Some(started_at + blank_after),
             idle_blanking_allowed: true,
+            idle_blanking_permission_pending: false,
             provider_driven_blank: false,
             power_off_after,
             power_off_at: None,
@@ -113,6 +115,7 @@ impl InactivityEngine {
             blank_after,
             blank_at: Some(started_at + blank_after),
             idle_blanking_allowed: true,
+            idle_blanking_permission_pending: false,
             provider_driven_blank: false,
             power_off_after,
             power_off_at: Some(started_at + power_off_after),
@@ -127,7 +130,9 @@ impl InactivityEngine {
 
     pub fn time_until_action(&self, now: Instant) -> Option<Duration> {
         match self.phase {
-            InactivityPhase::Unknown | InactivityPhase::Active if self.idle_blanking_allowed => {
+            InactivityPhase::Unknown | InactivityPhase::Active
+                if self.can_blank_automatically() =>
+            {
                 self.blank_at
                     .map(|deadline| deadline.saturating_duration_since(now))
             }
@@ -146,9 +151,18 @@ impl InactivityEngine {
         self.phase == InactivityPhase::Blanked && self.power_off_at.is_some()
     }
 
+    fn can_blank_automatically(&self) -> bool {
+        self.idle_blanking_allowed && !self.idle_blanking_permission_pending
+    }
+
+    pub fn defer_idle_blanking(&mut self) {
+        self.idle_blanking_permission_pending = true;
+    }
+
     /// An inhibitor changes permission to blank, never activity or ownership.
     /// Start a full timeout when permission returns, including after startup.
     pub fn set_idle_blanking_allowed(&mut self, allowed: bool, observed_at: Instant) {
+        self.idle_blanking_permission_pending = false;
         if self.idle_blanking_allowed == allowed {
             return;
         }
@@ -169,7 +183,7 @@ impl InactivityEngine {
     }
 
     pub fn observe_provider_idle(&mut self) -> InactivityDecision {
-        if self.idle_blanking_allowed
+        if self.can_blank_automatically()
             && matches!(
                 self.phase,
                 InactivityPhase::Unknown | InactivityPhase::Active
@@ -287,7 +301,7 @@ impl InactivityEngine {
     pub fn observe_time(&mut self, observed_at: Instant) -> InactivityDecision {
         match self.phase {
             InactivityPhase::Unknown | InactivityPhase::Active
-                if self.idle_blanking_allowed
+                if self.can_blank_automatically()
                     && self
                         .blank_at
                         .is_some_and(|deadline| observed_at >= deadline) =>
@@ -356,6 +370,75 @@ mod tests {
 
     fn test_engine(started_at: Instant) -> InactivityEngine {
         InactivityEngine::new(Duration::from_secs(5), started_at)
+    }
+
+    #[test]
+    fn pending_permission_blocks_expiry_without_renewing_an_uninhibited_deadline() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        engine.defer_idle_blanking();
+        let after_deadline = start + Duration::from_secs(6);
+        assert_eq!(engine.time_until_action(after_deadline), None);
+        assert_eq!(
+            engine.observe_time(after_deadline),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(engine.observe_provider_idle(), InactivityDecision::NoOp);
+
+        // An unrelated inhibitor change must not give us another full timeout.
+        engine.set_idle_blanking_allowed(true, after_deadline);
+        assert_eq!(
+            engine.time_until_action(after_deadline),
+            Some(Duration::ZERO)
+        );
+        assert_eq!(
+            engine.observe_time(after_deadline),
+            InactivityDecision::BlankNow
+        );
+    }
+
+    #[test]
+    fn a_confirmed_inhibitor_keeps_a_pending_deadline_blocked_until_release() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        engine.defer_idle_blanking();
+        let reply_at = start + Duration::from_secs(6);
+        engine.set_idle_blanking_allowed(false, reply_at);
+        assert_eq!(engine.time_until_action(reply_at), None);
+        assert_eq!(engine.observe_time(reply_at), InactivityDecision::NoOp);
+
+        engine.defer_idle_blanking();
+        let released = start + Duration::from_secs(10);
+        engine.set_idle_blanking_allowed(true, released);
+        assert_eq!(
+            engine.time_until_action(released),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[test]
+    fn pending_permission_preserves_explicit_lock_power_off_and_real_input() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        engine.defer_idle_blanking();
+        assert_eq!(engine.observe_lock(start), InactivityDecision::BlankNow);
+        engine.complete_blank(true, start);
+        assert_eq!(
+            engine.time_until_action(start),
+            Some(InactivityEngine::DEFAULT_POWER_OFF_AFTER)
+        );
+        let mut power_off_engine = engine;
+        assert_eq!(
+            power_off_engine.observe_time(start + InactivityEngine::DEFAULT_POWER_OFF_AFTER),
+            InactivityDecision::TimedPowerOffNow,
+        );
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                start + Duration::from_secs(2),
+            ),
+            InactivityDecision::RestoreNow,
+        );
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -34,6 +34,7 @@ enum InactivityPhase {
 pub struct InactivityEngine {
     blank_after: Duration,
     blank_at: Option<Instant>,
+    idle_blanking_allowed: bool,
     provider_driven_blank: bool,
     power_off_after: Duration,
     power_off_at: Option<Instant>,
@@ -82,6 +83,7 @@ impl InactivityEngine {
         Self {
             blank_after,
             blank_at: Some(started_at + blank_after),
+            idle_blanking_allowed: true,
             provider_driven_blank: false,
             power_off_after,
             power_off_at: None,
@@ -110,6 +112,7 @@ impl InactivityEngine {
         Self {
             blank_after,
             blank_at: Some(started_at + blank_after),
+            idle_blanking_allowed: true,
             provider_driven_blank: false,
             power_off_after,
             power_off_at: Some(started_at + power_off_after),
@@ -124,13 +127,16 @@ impl InactivityEngine {
 
     pub fn time_until_action(&self, now: Instant) -> Option<Duration> {
         match self.phase {
-            InactivityPhase::Unknown | InactivityPhase::Active => self
-                .blank_at
-                .map(|deadline| deadline.saturating_duration_since(now)),
+            InactivityPhase::Unknown | InactivityPhase::Active if self.idle_blanking_allowed => {
+                self.blank_at
+                    .map(|deadline| deadline.saturating_duration_since(now))
+            }
             InactivityPhase::Blanked => self
                 .power_off_at
                 .map(|deadline| deadline.saturating_duration_since(now)),
-            InactivityPhase::BlankRequested
+            InactivityPhase::Unknown
+            | InactivityPhase::Active
+            | InactivityPhase::BlankRequested
             | InactivityPhase::InactiveWithoutEscalation
             | InactivityPhase::TimedPowerOffAttempted => None,
         }
@@ -140,11 +146,35 @@ impl InactivityEngine {
         self.phase == InactivityPhase::Blanked && self.power_off_at.is_some()
     }
 
+    /// An inhibitor changes permission to blank, never activity or ownership.
+    /// Start a full timeout when permission returns, including after startup.
+    pub fn set_idle_blanking_allowed(&mut self, allowed: bool, observed_at: Instant) {
+        if self.idle_blanking_allowed == allowed {
+            return;
+        }
+        self.idle_blanking_allowed = allowed;
+        if allowed
+            && !self.provider_driven_blank
+            && matches!(
+                self.phase,
+                InactivityPhase::Unknown | InactivityPhase::Active
+            )
+        {
+            self.blank_at = Some(
+                self.blank_at
+                    .unwrap_or(observed_at)
+                    .max(observed_at + self.blank_after),
+            );
+        }
+    }
+
     pub fn observe_provider_idle(&mut self) -> InactivityDecision {
-        if matches!(
-            self.phase,
-            InactivityPhase::Unknown | InactivityPhase::Active
-        ) {
+        if self.idle_blanking_allowed
+            && matches!(
+                self.phase,
+                InactivityPhase::Unknown | InactivityPhase::Active
+            )
+        {
             self.phase = InactivityPhase::BlankRequested;
             self.blank_at = None;
             return InactivityDecision::BlankNow;
@@ -257,9 +287,10 @@ impl InactivityEngine {
     pub fn observe_time(&mut self, observed_at: Instant) -> InactivityDecision {
         match self.phase {
             InactivityPhase::Unknown | InactivityPhase::Active
-                if self
-                    .blank_at
-                    .is_some_and(|deadline| observed_at >= deadline) =>
+                if self.idle_blanking_allowed
+                    && self
+                        .blank_at
+                        .is_some_and(|deadline| observed_at >= deadline) =>
             {
                 self.phase = InactivityPhase::BlankRequested;
                 self.lock_activity_floor = self.session_locked_since;
@@ -325,6 +356,129 @@ mod tests {
 
     fn test_engine(started_at: Instant) -> InactivityEngine {
         InactivityEngine::new(Duration::from_secs(5), started_at)
+    }
+
+    #[test]
+    fn inhibition_blocks_startup_until_permission_returns_with_a_fresh_timeout() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        engine.set_idle_blanking_allowed(false, start);
+        let released = start + Duration::from_secs(30);
+        assert_eq!(engine.observe_time(released), InactivityDecision::NoOp);
+        assert_eq!(engine.time_until_action(released), None);
+
+        engine.set_idle_blanking_allowed(true, released);
+        assert_eq!(
+            engine.time_until_action(released),
+            Some(Duration::from_secs(5))
+        );
+        // Repeated observations must not indefinitely extend the deadline.
+        engine.set_idle_blanking_allowed(true, released + Duration::from_secs(4));
+        assert_eq!(
+            engine.observe_time(released + Duration::from_secs(4)),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_time(released + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
+        );
+    }
+
+    #[test]
+    fn inhibition_replaces_an_almost_expired_deadline_after_the_last_release() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        engine.set_idle_blanking_allowed(false, start + Duration::from_secs(4));
+        assert_eq!(
+            engine.observe_time(start + Duration::from_secs(6)),
+            InactivityDecision::NoOp
+        );
+        engine.set_idle_blanking_allowed(true, start + Duration::from_secs(10));
+        assert_eq!(
+            engine.observe_time(start + Duration::from_secs(14)),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_time(start + Duration::from_secs(15)),
+            InactivityDecision::BlankNow
+        );
+    }
+
+    #[test]
+    fn inhibition_is_not_restore_activity_and_does_not_cancel_post_blank_power_off() {
+        let start = Instant::now();
+        let mut engine = InactivityEngine::new_with_power_off_after(
+            Duration::from_secs(5),
+            Duration::from_secs(10),
+            start,
+        );
+        assert_eq!(
+            engine.observe_time(start + Duration::from_secs(5)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, start + Duration::from_secs(5));
+        engine.set_idle_blanking_allowed(false, start + Duration::from_secs(6));
+        engine.set_idle_blanking_allowed(true, start + Duration::from_secs(8));
+        assert!(engine.timed_power_off_pending());
+        assert_eq!(
+            engine.observe_time(start + Duration::from_secs(15)),
+            InactivityDecision::TimedPowerOffNow
+        );
+    }
+
+    #[test]
+    fn real_input_restores_while_inhibited_and_still_resets_the_shared_deadline() {
+        for observation in [
+            InactivityObservation::DesktopActivityObserved,
+            InactivityObservation::UserActivityObserved,
+        ] {
+            let start = Instant::now();
+            let mut engine = test_engine(start);
+            assert_eq!(
+                engine.observe_time(start + Duration::from_secs(5)),
+                InactivityDecision::BlankNow
+            );
+            engine.complete_blank(true, start + Duration::from_secs(5));
+            engine.set_idle_blanking_allowed(false, start + Duration::from_secs(6));
+            assert_eq!(
+                engine.observe_activity(observation, start + Duration::from_secs(7)),
+                InactivityDecision::RestoreNow
+            );
+            assert!(!engine.timed_power_off_pending());
+            assert_eq!(
+                engine.observe_time(start + Duration::from_secs(20)),
+                InactivityDecision::NoOp
+            );
+            engine.set_idle_blanking_allowed(true, start + Duration::from_secs(21));
+            assert_eq!(
+                engine.observe_activity(observation, start + Duration::from_secs(24)),
+                InactivityDecision::NoOp
+            );
+            assert_eq!(
+                engine.observe_time(start + Duration::from_secs(28)),
+                InactivityDecision::NoOp
+            );
+            assert_eq!(
+                engine.observe_time(start + Duration::from_secs(29)),
+                InactivityDecision::BlankNow
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_lock_still_blanks_while_idle_blanking_is_inhibited() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        engine.set_idle_blanking_allowed(false, start);
+        assert_eq!(
+            engine.observe_lock(start + Duration::from_secs(1)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, start + Duration::from_secs(1));
+        engine.set_idle_blanking_allowed(true, start + Duration::from_secs(2));
+        assert!(engine.timed_power_off_pending());
+        engine.observe_unlock();
+        assert!(engine.timed_power_off_pending());
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -917,6 +917,11 @@ where
         };
 
         match message {
+            RunnerMessage::IdleBlankingPermissionPending { source } => {
+                if honor_idle_inhibitors && source == EventSource::DesktopSession {
+                    inactivity.defer_idle_blanking();
+                }
+            }
             RunnerMessage::IdleBlankingPermission {
                 allowed,
                 source,
@@ -1225,6 +1230,9 @@ fn send_source_observation(
     observation: SessionObservation,
 ) -> bool {
     let message = match observation {
+        SessionObservation::IdleBlankingPermissionPending { source } => {
+            RunnerMessage::IdleBlankingPermissionPending { source }
+        }
         SessionObservation::IdleBlankingPermission {
             allowed,
             source,
@@ -1434,6 +1442,9 @@ fn run_gamepad_activity_process(sender: mpsc::Sender<RunnerMessage>, stop: Arc<A
 }
 
 enum RunnerMessage {
+    IdleBlankingPermissionPending {
+        source: EventSource,
+    },
     IdleBlankingPermission {
         allowed: bool,
         source: EventSource,

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -14,8 +14,9 @@ use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use crate::backend::{
-    configured_backend_from_env_or_config, resolve_backend_with_probe, BackendDetectionError,
-    BackendResolution, BackendSelectionError, SystemBackendProbe, SWAYIDLE_DEPRECATION_NOTICE,
+    configured_backend_from_env_or_config, honor_idle_inhibitors_from_config,
+    resolve_backend_with_probe, BackendDetectionError, BackendResolution, BackendSelectionError,
+    SystemBackendProbe, SWAYIDLE_DEPRECATION_NOTICE,
 };
 use crate::commands::{run_sleep_pre_for_event, run_system_resume};
 use crate::config::{
@@ -565,7 +566,8 @@ fn prepare_monitor_backend(
     probe: &mut SystemBackendProbe,
     configured: ScreenBackend,
 ) -> Result<(BackendResolution, Option<wayland_client::Connection>), BackendDetectionError> {
-    let resolution = resolve_backend_with_probe(probe, configured)?;
+    let resolution =
+        resolve_backend_with_probe(probe, configured, honor_idle_inhibitors_from_config())?;
     let connection = probe.take_wayland_connection();
     Ok((resolution, connection))
 }
@@ -758,7 +760,8 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
 ) -> Result<(), SessionRunnerError> {
-    let source = GnomeSource::connect().map_err(map_gnome_source_error)?;
+    let honor_idle_inhibitors = honor_idle_inhibitors_from_config();
+    let source = GnomeSource::connect(honor_idle_inhibitors).map_err(map_gnome_source_error)?;
 
     writeln!(writer, "LG Buddy Monitor: Using GNOME backend.")?;
 
@@ -766,6 +769,7 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
         writer,
         dispatcher,
         ScreenBackend::Gnome,
+        honor_idle_inhibitors,
         move |sender, latest_observation| {
             spawn_gnome_monitor_thread(source, sender, latest_observation)
         },
@@ -778,13 +782,20 @@ fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
     connection: wayland_client::Connection,
 ) -> Result<(), SessionRunnerError> {
     writeln!(writer, "LG Buddy Monitor: Using native Wayland backend.")?;
+    let honor_idle_inhibitors = honor_idle_inhibitors_from_config();
 
     run_native_session_monitor(
         writer,
         dispatcher,
         ScreenBackend::Wayland,
+        honor_idle_inhibitors,
         move |sender, latest_observation| {
-            spawn_wayland_monitor_thread(connection, sender, latest_observation)
+            spawn_wayland_monitor_thread(
+                connection,
+                honor_idle_inhibitors,
+                sender,
+                latest_observation,
+            )
         },
     )
 }
@@ -793,6 +804,7 @@ fn run_native_session_monitor<W, E, S>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
+    honor_idle_inhibitors: bool,
     spawn_monitor: S,
 ) -> Result<(), SessionRunnerError>
 where
@@ -804,6 +816,7 @@ where
         writer,
         dispatcher,
         backend,
+        honor_idle_inhibitors,
         spawn_monitor,
         |sender| Some(spawn_logind_lock_monitor(sender)),
     )
@@ -813,6 +826,7 @@ fn run_native_session_monitor_with_lock_monitor<W, E, S, L>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
+    honor_idle_inhibitors: bool,
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
@@ -827,6 +841,7 @@ where
         dispatcher,
         backend,
         InitialBlankTrigger::Deadline,
+        honor_idle_inhibitors,
         spawn_monitor,
         spawn_lock_monitor,
     )
@@ -843,6 +858,7 @@ fn run_session_monitor_with_lock_monitor<W, E, S, L>(
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
     initial_blank_trigger: InitialBlankTrigger,
+    honor_idle_inhibitors: bool,
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
@@ -871,6 +887,12 @@ where
         InactivityEngine::new_with_power_off_after(blank_after, power_off_after, started_at)
     };
 
+    // No automatic blanking until an enabled native source has established
+    // permission, including when inhibition predates monitor startup.
+    if honor_idle_inhibitors {
+        inactivity.set_idle_blanking_allowed(false, started_at);
+    }
+
     let (sender, receiver) = mpsc::channel();
     let latest_inactivity = Arc::new(LatestInactivityObservation::default());
     let monitor_handle = spawn_monitor(sender.clone(), Arc::clone(&latest_inactivity));
@@ -895,6 +917,15 @@ where
         };
 
         match message {
+            RunnerMessage::IdleBlankingPermission {
+                allowed,
+                source,
+                observed_at,
+            } => {
+                if honor_idle_inhibitors && source == EventSource::DesktopSession {
+                    inactivity.set_idle_blanking_allowed(allowed, observed_at);
+                }
+            }
             RunnerMessage::InactivityObservationReady => {
                 if let Some(observation) = latest_inactivity.take() {
                     handle_inactivity_observation(
@@ -1027,6 +1058,7 @@ fn run_swayidle_monitor<W: Write, E: SessionActionExecutor>(
         dispatcher,
         ScreenBackend::Swayidle,
         InitialBlankTrigger::Provider,
+        false,
         move |sender, _latest_observation| {
             thread::spawn(move || {
                 let event_sender = sender.clone();
@@ -1133,11 +1165,12 @@ fn spawn_gnome_monitor_thread(
 
 fn spawn_wayland_monitor_thread(
     connection: wayland_client::Connection,
+    honor_idle_inhibitors: bool,
     sender: mpsc::Sender<RunnerMessage>,
     latest_observation: Arc<LatestInactivityObservation>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
-        let result = run_wayland_session_source(connection, {
+        let result = run_wayland_session_source(connection, honor_idle_inhibitors, {
             let sender = sender.clone();
             move |observation| {
                 publish_desktop_observation(&sender, &latest_observation, observation)
@@ -1192,6 +1225,15 @@ fn send_source_observation(
     observation: SessionObservation,
 ) -> bool {
     let message = match observation {
+        SessionObservation::IdleBlankingPermission {
+            allowed,
+            source,
+            observed_at,
+        } => RunnerMessage::IdleBlankingPermission {
+            allowed,
+            source,
+            observed_at,
+        },
         SessionObservation::Event {
             event,
             source,
@@ -1392,6 +1434,11 @@ fn run_gamepad_activity_process(sender: mpsc::Sender<RunnerMessage>, stop: Arc<A
 }
 
 enum RunnerMessage {
+    IdleBlankingPermission {
+        allowed: bool,
+        source: EventSource,
+        observed_at: Instant,
+    },
     SessionEvent {
         event: SessionEvent,
         source: EventSource,
@@ -2787,6 +2834,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
+            false,
             |sender, _latest_inactivity| {
                 thread::spawn(move || {
                     let result = activity_receiver
@@ -2839,6 +2887,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Wayland,
+            false,
             |sender, _latest_inactivity| {
                 thread::spawn(move || {
                     thread::sleep(Duration::from_millis(150));
@@ -2884,6 +2933,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
+            false,
             |sender, _latest_inactivity| {
                 thread::spawn(move || {
                     let locked_at = Instant::now();

--- a/crates/lg-buddy/src/settings.rs
+++ b/crates/lg-buddy/src/settings.rs
@@ -59,6 +59,7 @@ const SETTING_DEFINITIONS: &[SettingDefinition] = &[
     tv::PLATFORM,
     screen::BACKEND,
     screen::IDLE_BLANK,
+    screen::HONOR_IDLE_INHIBITORS,
     screen::IDLE_TIMEOUT,
     screen::RESTORE_POLICY,
     system::SLEEP_WAKE_POLICY,
@@ -264,6 +265,7 @@ mod tests {
                 "tv.platform",
                 "screen.backend",
                 "screen.idle_blank",
+                "screen.honor_idle_inhibitors",
                 "screen.idle_timeout",
                 "screen.restore_policy",
                 "system.sleep_wake_policy",
@@ -290,6 +292,10 @@ mod tests {
                 ("tv.platform", "tvs_primary_platform"),
                 ("screen.backend", "screen_backend"),
                 ("screen.idle_blank", "screen_idle_blank"),
+                (
+                    "screen.honor_idle_inhibitors",
+                    "screen_honor_idle_inhibitors",
+                ),
                 ("screen.idle_timeout", "screen_idle_timeout"),
                 ("screen.restore_policy", "screen_restore_policy"),
                 ("system.sleep_wake_policy", "system_sleep_wake_policy"),
@@ -314,8 +320,9 @@ mod tests {
                 "tv.mac | storage=tvs_primary_mac | fallbacks=tv_mac | type=mac-address | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=MAC address of the primary configured TV for Wake-on-LAN.",
                 "tv.input | storage=tvs_primary_input | fallbacks=input | type=enum values=HDMI_1,HDMI_2,HDMI_3,HDMI_4 aliases=(none) | default=required | mutability=read-write | ops=get,describe,set | apply=no-runtime-apply-required | description=HDMI input used by the primary configured TV.",
                 "tv.platform | storage=tvs_primary_platform | fallbacks=(none) | type=enum values=bscpylgtv,lg_webos aliases=(none) | default=bscpylgtv | mutability=read-write | ops=get,describe,set,unset | apply=no-runtime-apply-required | description=Control platform for the primary configured TV.",
-                "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,wayland,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration.",
+                "screen.backend | storage=screen_backend | fallbacks=(none) | type=enum values=auto,gnome,wayland,swayidle aliases=(none) | default=auto | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration. The idle-inhibitor preference applies only to native integrations; swayidle always honors keep-awake requests.",
                 "screen.idle_blank | storage=screen_idle_blank | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Blank the TV screen when the computer is idle or locked, and restore it when activity resumes.",
+                "screen.honor_idle_inhibitors | storage=screen_honor_idle_inhibitors | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=disabled | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Honor keep-awake requests from video players, presentations, and other apps.",
                 "screen.idle_timeout | storage=screen_idle_timeout | fallbacks=(none) | type=integer range=1..=86400 | default=300 | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Seconds of user inactivity before LG Buddy blanks the configured screen.",
                 "screen.restore_policy | storage=screen_restore_policy | fallbacks=(none) | type=enum values=conservative,aggressive aliases=marker_only->conservative | default=conservative | mutability=read-write | ops=get,describe,set,unset | apply=restart-user-screen-service | description=Conservative restores the TV only after LG Buddy blanked or powered it off. Aggressive also attempts to restore it without a prior LG Buddy action.",
                 "system.sleep_wake_policy | storage=system_sleep_wake_policy | fallbacks=(none) | type=enum values=enabled,disabled aliases=(none) | default=enabled | mutability=read-write | ops=get,describe,set,unset | apply=runtime-policy-only | description=Power off the TV before the computer sleeps and restore it after waking.",
@@ -407,6 +414,7 @@ tv.input=<missing> (missing, read-write, ops: get,describe,set)
 tv.platform=bscpylgtv (default, read-write, ops: get,describe,set,unset)
 screen.backend=gnome (config.env, read-write, ops: get,describe,set,unset)
 screen.idle_blank=enabled (default, read-write, ops: get,describe,set,unset)
+screen.honor_idle_inhibitors=disabled (default, read-write, ops: get,describe,set,unset)
 screen.idle_timeout=300 (default, read-write, ops: get,describe,set,unset)
 screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)
 system.sleep_wake_policy=disabled (config.env, read-write, ops: get,describe,set,unset)
@@ -503,7 +511,7 @@ screen.backend
   supported operations: get, describe, set, unset
   allowed values: auto, gnome, wayland, swayidle (deprecated compatibility backend)
   apply: restart-user-screen-service
-  description: Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration.
+  description: Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration. The idle-inhibitor preference applies only to native integrations; swayidle always honors keep-awake requests.
 
 screen.idle_blank
   storage key: screen_idle_blank
@@ -516,6 +524,18 @@ screen.idle_blank
   allowed values: enabled, disabled
   apply: restart-user-screen-service
   description: Blank the TV screen when the computer is idle or locked, and restore it when activity resumes.
+
+screen.honor_idle_inhibitors
+  storage key: screen_honor_idle_inhibitors
+  type: enum
+  current: disabled
+  source: default
+  default: disabled
+  mutability: read-write
+  supported operations: get, describe, set, unset
+  allowed values: enabled, disabled
+  apply: restart-user-screen-service
+  description: Honor keep-awake requests from video players, presentations, and other apps.
 
 screen.idle_timeout
   storage key: screen_idle_timeout
@@ -899,6 +919,7 @@ screen_restore_policy=aggressive
                 "tv.platform",
                 "screen.backend",
                 "screen.idle_blank",
+                "screen.honor_idle_inhibitors",
                 "screen.idle_timeout",
                 "screen.restore_policy",
                 "system.sleep_wake_policy",
@@ -915,6 +936,7 @@ screen_restore_policy=aggressive
                 "bscpylgtv",
                 "gnome",
                 "enabled",
+                "disabled",
                 "300",
                 "conservative",
                 "disabled",
@@ -933,6 +955,7 @@ screen_restore_policy=aggressive
                 SettingSource::Default,
                 SettingSource::Default,
                 SettingSource::Default,
+                SettingSource::Default,
                 SettingSource::ConfigEnv,
                 SettingSource::Default,
                 SettingSource::Default,
@@ -945,6 +968,7 @@ screen_restore_policy=aggressive
         for key in [
             "screen.backend",
             "screen.idle_blank",
+            "screen.honor_idle_inhibitors",
             "screen.idle_timeout",
             "screen.restore_policy",
             "system.sleep_wake_policy",

--- a/crates/lg-buddy/src/settings/formatter.rs
+++ b/crates/lg-buddy/src/settings/formatter.rs
@@ -152,6 +152,9 @@ impl SettingsFormatter {
             if let Some(notice) = screen::deprecation_notice(&configured) {
                 writeln!(writer, "  deprecation: {notice}.").map_err(output_error)?;
             }
+            if let Some(notice) = screen::swayidle_inhibitor_notice(&configured) {
+                writeln!(writer, "  compatibility: {notice}.").map_err(output_error)?;
+            }
         }
         writeln!(writer, "  source: {}", setting.source().as_str()).map_err(output_error)?;
         writeln!(writer, "  default: {}", definition.default_value_label())

--- a/crates/lg-buddy/src/settings/mutation.rs
+++ b/crates/lg-buddy/src/settings/mutation.rs
@@ -177,6 +177,10 @@ mod tests {
                 presentation.row_visible(BehaviorSetting::ScreenIdleTimeout),
                 enabled
             );
+            assert_eq!(
+                presentation.row_visible(BehaviorSetting::ScreenHonorIdleInhibitors),
+                enabled
+            );
             assert!(presentation.row_visible(BehaviorSetting::ScreenRestorePolicy));
             let toggle = presentation.groups()[0]
                 .rows()
@@ -196,6 +200,7 @@ mod tests {
         for (key, value, restarts, enables, disables) in [
             ("screen.backend", "gnome", 1, 0, 0),
             ("screen.idle_blank", "disabled", 1, 0, 0),
+            ("screen.honor_idle_inhibitors", "enabled", 1, 0, 0),
             ("screen.idle_timeout", "600", 1, 0, 0),
             ("screen.restore_policy", "aggressive", 1, 0, 0),
             ("system.sleep_wake_policy", "disabled", 0, 0, 0),

--- a/crates/lg-buddy/src/settings/screen.rs
+++ b/crates/lg-buddy/src/settings/screen.rs
@@ -11,6 +11,7 @@ use super::{
 const SERVICE_NAME: &str = "LG_Buddy_screen.service";
 const BACKEND_VALUES: &[&str] = &["auto", "gnome", "wayland", "swayidle"];
 const IDLE_BLANK_VALUES: &[&str] = &["enabled", "disabled"];
+const HONOR_IDLE_INHIBITORS_VALUES: &[&str] = &["enabled", "disabled"];
 const RESTORE_POLICY_VALUES: &[&str] = &["conservative", "aggressive"];
 const RESTORE_POLICY_ALIASES: &[SettingAlias] = &[SettingAlias {
     from: "marker_only",
@@ -29,7 +30,7 @@ pub(super) const BACKEND: SettingDefinition = SettingDefinition {
     mutability: SettingMutability::ReadWrite,
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RestartUserScreenService,
-    description: "Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration.",
+    description: "Choose how LG Buddy detects inactivity and activity in your desktop session. Automatic selects a compatible integration. The idle-inhibitor preference applies only to native integrations; swayidle always honors keep-awake requests.",
 };
 
 pub(super) const IDLE_BLANK: SettingDefinition = SettingDefinition {
@@ -45,6 +46,21 @@ pub(super) const IDLE_BLANK: SettingDefinition = SettingDefinition {
     operations: READ_WRITE_OPERATIONS,
     apply_strategy: ApplyStrategy::RestartUserScreenService,
     description: "Blank the TV screen when the computer is idle or locked, and restore it when activity resumes.",
+};
+
+pub(super) const HONOR_IDLE_INHIBITORS: SettingDefinition = SettingDefinition {
+    key: "screen.honor_idle_inhibitors",
+    storage_key: "screen_honor_idle_inhibitors",
+    fallback_storage_keys: EMPTY_STORAGE_KEYS,
+    value_type: SettingType::Enum(EnumSettingType {
+        values: HONOR_IDLE_INHIBITORS_VALUES,
+        aliases: EMPTY_ALIASES,
+    }),
+    default_value: Some(SettingValue::Enum("disabled")),
+    mutability: SettingMutability::ReadWrite,
+    operations: READ_WRITE_OPERATIONS,
+    apply_strategy: ApplyStrategy::RestartUserScreenService,
+    description: "Honor keep-awake requests from video players, presentations, and other apps.",
 };
 
 pub(super) const IDLE_TIMEOUT: SettingDefinition = SettingDefinition {
@@ -140,6 +156,12 @@ pub(super) fn resolution_details(
 
 pub(super) fn deprecation_notice(configured: &str) -> Option<&'static str> {
     (configured == ScreenBackend::Swayidle.as_str()).then_some(SWAYIDLE_DEPRECATION_NOTICE)
+}
+
+pub(super) fn swayidle_inhibitor_notice(configured: &str) -> Option<&'static str> {
+    (configured == ScreenBackend::Swayidle.as_str()).then_some(
+        "swayidle always honors keep-awake requests; this preference applies only to native backends",
+    )
 }
 
 pub(super) fn apply_service_restart<C: ServiceController>(
@@ -289,6 +311,7 @@ mod tests {
         assert!(output.contains("  resolved backend: swayidle\n"));
         assert!(output.contains("  fallback reason: none; explicit selection does not fall back\n"));
         assert!(output.contains("  deprecation: swayidle is a deprecated compatibility backend planned for removal in LG Buddy 2.0.0; use auto or wayland.\n"));
+        assert!(output.contains("  compatibility: swayidle always honors keep-awake requests; this preference applies only to native backends.\n"));
     }
 
     #[test]
@@ -495,6 +518,69 @@ screen_idle_timeout=300
             definition.parse_value("kde"),
             Err(SettingsError::InvalidValue { .. })
         ));
+    }
+
+    #[test]
+    fn screen_honor_idle_inhibitors_defaults_to_disabled_and_accepts_values() {
+        let definition = SETTINGS_REGISTRY
+            .get_by_name("screen.honor_idle_inhibitors")
+            .unwrap();
+        assert_eq!(
+            definition.default_value(),
+            Some(SettingValue::Enum("disabled"))
+        );
+        assert_eq!(
+            definition.parse_value("enabled"),
+            Ok(SettingValue::Enum("enabled"))
+        );
+        assert_eq!(
+            definition.parse_value("disabled"),
+            Ok(SettingValue::Enum("disabled"))
+        );
+        assert!(matches!(
+            definition.parse_value("maybe"),
+            Err(SettingsError::InvalidValue { .. })
+        ));
+    }
+
+    #[test]
+    fn settings_runner_sets_and_unsets_idle_inhibitor_preference() {
+        let path = unique_test_path("idle-inhibitors");
+        fs::write(&path, "screen_honor_idle_inhibitors=disabled\n").unwrap();
+        let fake_service = FakeServiceController::active_or_enabled();
+        let restarts = fake_service.restarts.clone();
+        let runner = SettingsCommandRunner::with_applier(
+            SettingsStore::load(&path).unwrap(),
+            SettingsApplier::new(fake_service),
+        );
+        runner
+            .run(
+                SettingsCommand::Set {
+                    key: "screen.honor_idle_inhibitors".into(),
+                    value: "enabled".into(),
+                },
+                &mut Vec::new(),
+            )
+            .unwrap();
+        assert_eq!(
+            fs::read_to_string(&path).unwrap(),
+            "screen_honor_idle_inhibitors=enabled\n"
+        );
+        assert_eq!(restarts.get(), 1);
+
+        let runner = SettingsCommandRunner::with_applier(
+            SettingsStore::load(&path).unwrap(),
+            SettingsApplier::new(FakeServiceController::active_or_enabled()),
+        );
+        runner
+            .run(
+                SettingsCommand::Unset("screen.honor_idle_inhibitors".into()),
+                &mut Vec::new(),
+            )
+            .unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "");
+
+        let _ = fs::remove_file(path);
     }
 
     #[test]

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -25,6 +25,7 @@ use crate::update_install::UpdateInstallStage;
 pub enum BehaviorSetting {
     ScreenBackend,
     ScreenIdleBlank,
+    ScreenHonorIdleInhibitors,
     ScreenIdleTimeout,
     ScreenRestorePolicy,
     SystemSleepWakePolicy,
@@ -37,6 +38,7 @@ impl BehaviorSetting {
         match self {
             Self::ScreenBackend => "screen.backend",
             Self::ScreenIdleBlank => "screen.idle_blank",
+            Self::ScreenHonorIdleInhibitors => "screen.honor_idle_inhibitors",
             Self::ScreenIdleTimeout => "screen.idle_timeout",
             Self::ScreenRestorePolicy => "screen.restore_policy",
             Self::SystemSleepWakePolicy => "system.sleep_wake_policy",
@@ -49,6 +51,7 @@ impl BehaviorSetting {
         Some(match key {
             "screen.backend" => Self::ScreenBackend,
             "screen.idle_blank" => Self::ScreenIdleBlank,
+            "screen.honor_idle_inhibitors" => Self::ScreenHonorIdleInhibitors,
             "screen.idle_timeout" => Self::ScreenIdleTimeout,
             "screen.restore_policy" => Self::ScreenRestorePolicy,
             "system.sleep_wake_policy" => Self::SystemSleepWakePolicy,
@@ -1088,7 +1091,7 @@ mod tests {
     fn default_settings_are_ready_and_grouped() {
         let groups = groups("");
         assert_eq!(groups.len(), 3);
-        assert_eq!(groups[0].rows().len(), 4);
+        assert_eq!(groups[0].rows().len(), 5);
         assert_eq!(groups[1].rows().len(), 1);
         assert_eq!(groups[2].rows().len(), 2);
 
@@ -1097,6 +1100,13 @@ mod tests {
         assert_eq!(backend.source_label(), "Default");
         assert_eq!(backend.default_label(), "Automatic");
         assert!(backend.problem().is_none());
+
+        let inhibitors = row(&groups, "Screen", "Allow apps to prevent idle blanking");
+        assert_eq!(
+            inhibitors.description(),
+            "Honor keep-awake requests from video players, presentations, and other apps."
+        );
+        assert_eq!(inhibitors.editor().as_toggle(), Some(Some(false)));
     }
 
     #[test]
@@ -1110,6 +1120,7 @@ mod tests {
             let presentation = SettingsPresentation::ready(groups(config));
             for setting in [
                 BehaviorSetting::ScreenBackend,
+                BehaviorSetting::ScreenHonorIdleInhibitors,
                 BehaviorSetting::ScreenIdleTimeout,
             ] {
                 assert_eq!(presentation.row_visible(setting), visible, "{config}");
@@ -1117,6 +1128,16 @@ mod tests {
             assert!(presentation.row_visible(BehaviorSetting::ScreenIdleBlank));
             assert!(presentation.row_visible(BehaviorSetting::ScreenRestorePolicy));
         }
+    }
+
+    #[test]
+    fn idle_inhibitor_preference_is_hidden_for_explicit_swayidle() {
+        let presentation = SettingsPresentation::ready(groups(
+            "screen_idle_blank=enabled\nscreen_backend=swayidle\n",
+        ));
+        assert!(presentation.row_visible(BehaviorSetting::ScreenBackend));
+        assert!(presentation.row_visible(BehaviorSetting::ScreenIdleTimeout));
+        assert!(!presentation.row_visible(BehaviorSetting::ScreenHonorIdleInhibitors));
     }
 
     fn update_report(channel: crate::updates::UpdateChannel) -> UpdateCheckReport {
@@ -1339,6 +1360,12 @@ screen_backend=wayland\n",
                 "screen.idle_blank",
                 "Idle blanking",
                 "Enabled",
+                "Enabled, Disabled",
+            ),
+            (
+                "screen.honor_idle_inhibitors",
+                "Allow apps to prevent idle blanking",
+                "Disabled",
                 "Enabled, Disabled",
             ),
             (

--- a/crates/lg-buddy/src/sources/desktop/gnome.rs
+++ b/crates/lg-buddy/src/sources/desktop/gnome.rs
@@ -50,6 +50,7 @@ pub(crate) struct GnomeSource {
     trusted_screen_saver_signals: TrustedScreenSaverSignals,
     trusted_session_manager_signals: Option<TrustedSessionManagerSignals>,
     initial_idle_blanking_allowed: Option<bool>,
+    activity_watch: Option<GnomeActivityWatch>,
 }
 
 #[derive(Debug)]
@@ -95,6 +96,9 @@ impl GnomeSource {
         }
 
         subscribe_to_gnome_signals(&mut bus, honor_idle_inhibitors)?;
+        let activity_watch = honor_idle_inhibitors
+            .then(|| GnomeActivityWatch::connect(&mut bus))
+            .transpose()?;
         let owner = resolve_screen_saver_owner(&mut bus).map_err(|err| {
             GnomeSourceError::Failed(format!("failed to resolve GNOME ScreenSaver owner: {err}"))
         })?;
@@ -123,6 +127,7 @@ impl GnomeSource {
             trusted_screen_saver_signals: TrustedScreenSaverSignals::new(Some(owner)),
             trusted_session_manager_signals,
             initial_idle_blanking_allowed,
+            activity_watch,
         })
     }
 
@@ -144,6 +149,7 @@ impl GnomeSource {
             &mut self.bus,
             &mut self.trusted_screen_saver_signals,
             self.trusted_session_manager_signals.as_mut(),
+            self.activity_watch.as_mut(),
             &mut publish,
         )
     }
@@ -258,6 +264,15 @@ fn subscribe_to_gnome_signals(
     if honor_idle_inhibitors {
         bus.add_signal_match(BusSignalMatch {
             sender: None,
+            path: Some(GNOME_IDLE_MONITOR_PATH),
+            interface: Some(GNOME_IDLE_MONITOR_INTERFACE),
+            member: Some("WatchFired"),
+        })
+        .map_err(|err| {
+            GnomeSourceError::Failed(format!("failed to subscribe to Mutter activity: {err}"))
+        })?;
+        bus.add_signal_match(BusSignalMatch {
+            sender: None,
             path: Some(GNOME_SESSION_MANAGER_PATH),
             interface: Some(GNOME_SESSION_MANAGER_INTERFACE),
             member: None,
@@ -362,10 +377,60 @@ fn gnome_session_manager_available_from_session_bus(bus: &mut impl SessionBusCli
         .unwrap_or(false)
 }
 
+/// Mutter resets GetIdletime when inhibition ends, without firing user-active
+/// watches. Use those watches to distinguish input from the counter reset.
+struct GnomeActivityWatch {
+    owner: String,
+    id: u32,
+}
+
+impl GnomeActivityWatch {
+    fn connect(bus: &mut impl SessionBusClient) -> Result<Self, GnomeSourceError> {
+        let owner = get_name_owner(bus, GNOME_IDLE_MONITOR_NAME).map_err(|err| {
+            GnomeSourceError::Failed(format!("failed to resolve Mutter IdleMonitor owner: {err}"))
+        })?;
+        let mut watch = Self { owner, id: 0 };
+        watch.arm(bus)?;
+        Ok(watch)
+    }
+
+    fn arm(&mut self, bus: &mut impl SessionBusClient) -> Result<(), GnomeSourceError> {
+        self.id = bus
+            .call_method(BusMethodCall::new(
+                &self.owner,
+                GNOME_IDLE_MONITOR_PATH,
+                GNOME_IDLE_MONITOR_INTERFACE,
+                "AddUserActiveWatch",
+            ))
+            .and_then(|reply| reply.single_u32())
+            .map_err(|err| {
+                GnomeSourceError::Failed(format!("failed to watch Mutter user activity: {err}"))
+            })?;
+        Ok(())
+    }
+
+    fn fired(&self, signal: &BusSignal) -> bool {
+        signal.sender.as_deref() == Some(self.owner.as_str())
+            && signal.path == GNOME_IDLE_MONITOR_PATH
+            && signal.interface == GNOME_IDLE_MONITOR_INTERFACE
+            && signal.member == "WatchFired"
+            && signal.body == [BusValue::U32(self.id)]
+    }
+
+    fn owner_changed(&self, signal: &BusSignal) -> bool {
+        signal.sender.as_deref() == Some(DBUS_SERVICE_NAME)
+            && parse_name_owner_changed_signal(signal).is_some_and(|change| {
+                change.name == GNOME_IDLE_MONITOR_NAME
+                    && change.new_owner.as_deref() != Some(self.owner.as_str())
+            })
+    }
+}
+
 fn run_gnome_monitor_process<F>(
     bus: &mut impl SessionBusClient,
     trusted_screen_saver_signals: &mut TrustedScreenSaverSignals,
     mut trusted_session_manager_signals: Option<&mut TrustedSessionManagerSignals>,
+    mut activity_watch: Option<&mut GnomeActivityWatch>,
     publish: &mut F,
 ) -> Result<(), GnomeSourceError>
 where
@@ -381,7 +446,7 @@ where
         }
 
         let now = Instant::now();
-        if now >= next_idle_poll {
+        if activity_watch.is_none() && now >= next_idle_poll {
             if !poll_idle_monitor_once(bus, publish) {
                 return Ok(());
             }
@@ -389,9 +454,13 @@ where
         }
 
         let now = Instant::now();
-        let mut process_timeout = next_idle_poll
-            .saturating_duration_since(now)
-            .min(GNOME_BUS_PROCESS_INTERVAL);
+        let mut process_timeout = if activity_watch.is_some() {
+            GNOME_BUS_PROCESS_INTERVAL
+        } else {
+            next_idle_poll
+                .saturating_duration_since(now)
+                .min(GNOME_BUS_PROCESS_INTERVAL)
+        };
         if let Some(timeout) = test_timeout {
             process_timeout = process_timeout.min(timeout.saturating_sub(started.elapsed()));
         }
@@ -402,6 +471,26 @@ where
         else {
             continue;
         };
+
+        if let Some(watch) = activity_watch.as_deref_mut() {
+            if watch.owner_changed(&signal) {
+                return Err(GnomeSourceError::Failed(
+                    "Mutter IdleMonitor owner changed while watching user activity".to_string(),
+                ));
+            }
+            if watch.fired(&signal) {
+                if !publish(SessionObservation::Inactivity {
+                    observation: InactivityObservation::DesktopActivityObserved,
+                    source: EventSource::DesktopSession,
+                    observed_at: Instant::now(),
+                }) {
+                    return Ok(());
+                }
+                // User-active watches are one-shot. Keep listening even while
+                // inhibition is active, so real input can always restore.
+                watch.arm(bus)?;
+            }
+        }
 
         if let Some(trusted_session_manager_signals) =
             trusted_session_manager_signals.as_deref_mut()
@@ -415,6 +504,13 @@ where
                 }
                 Some(SessionManagerSignal::OwnerChanged(Some(_)))
                 | Some(SessionManagerSignal::InhibitorChanged) => {
+                    // The runner's timer is independent of this blocking call.
+                    // Suspend it before querying, without inventing an inhibitor.
+                    if !publish(SessionObservation::IdleBlankingPermissionPending {
+                        source: EventSource::DesktopSession,
+                    }) {
+                        return Ok(());
+                    }
                     let allowed = current_idle_blanking_allowed(bus).map_err(|err| {
                         GnomeSourceError::Failed(format!(
                             "failed to read GNOME idle inhibitor state after a SessionManager change: {err}"
@@ -484,8 +580,8 @@ mod tests {
         gnome_service_status_from_session_bus, map_screen_saver_signal, map_session_manager_signal,
         monitor_test_timeout, poll_idle_monitor_once, resolve_screen_saver_owner,
         run_gnome_monitor_process, screen_saver_owner_changed, session_manager_owner_changed,
-        subscribe_to_gnome_signals, GnomeServiceStatus, GnomeSourceError, SessionManagerSignal,
-        TrustedScreenSaverSignals, TrustedSessionManagerSignals,
+        subscribe_to_gnome_signals, GnomeActivityWatch, GnomeServiceStatus, GnomeSourceError,
+        SessionManagerSignal, TrustedScreenSaverSignals, TrustedSessionManagerSignals,
         GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV,
     };
     use crate::events::EventSource;
@@ -496,7 +592,10 @@ mod tests {
         SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
     };
     use std::collections::VecDeque;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, Mutex, OnceLock,
+    };
     use std::time::{Duration, Instant};
 
     #[derive(Debug, Default)]
@@ -507,8 +606,11 @@ mod tests {
         idletime_ms: Option<u64>,
         screen_saver_owner: Option<String>,
         session_manager_owner: Option<String>,
+        idle_monitor_owner: Option<String>,
+        watch_ids: VecDeque<u32>,
         inhibited: Option<bool>,
         inhibited_plan: VecDeque<bool>,
+        permission_pending: Option<Arc<AtomicBool>>,
         method_calls: Vec<(String, String, String, String)>,
         method_bodies: Vec<Vec<BusValue>>,
         signal_matches: Vec<[Option<String>; 4]>,
@@ -554,6 +656,7 @@ mod tests {
                 let owner = match name.as_str() {
                     super::GNOME_SCREEN_SAVER_NAME => self.screen_saver_owner.as_deref(),
                     super::GNOME_SESSION_MANAGER_NAME => self.session_manager_owner.as_deref(),
+                    super::GNOME_IDLE_MONITOR_NAME => self.idle_monitor_owner.as_deref(),
                     _ => None,
                 };
                 return owner
@@ -565,6 +668,27 @@ mod tests {
                     .ok_or_else(|| {
                         SessionBusError::Transport("no queued GNOME owner reply".to_string())
                     });
+            }
+
+            if call.path == super::GNOME_IDLE_MONITOR_PATH
+                && call.interface == super::GNOME_IDLE_MONITOR_INTERFACE
+                && call.member == "AddUserActiveWatch"
+                && Some(call.destination) == self.idle_monitor_owner.as_deref()
+            {
+                assert!(call.body.is_empty());
+                return self
+                    .watch_ids
+                    .pop_front()
+                    .map(|id| BusReply::new(vec![BusValue::U32(id)]))
+                    .ok_or_else(|| SessionBusError::Transport("no queued watch id".to_string()));
+            }
+            if call.member == "IsInhibited" {
+                if let Some(pending) = &self.permission_pending {
+                    assert!(
+                        pending.load(Ordering::SeqCst),
+                        "permission must be suspended before querying"
+                    );
+                }
             }
 
             match (
@@ -828,7 +952,7 @@ mod tests {
         let mut bus = FakeSessionBus::default();
         subscribe_to_gnome_signals(&mut bus, true).expect("subscribe GNOME signals");
 
-        assert_eq!(bus.signal_matches.len(), 3);
+        assert_eq!(bus.signal_matches.len(), 4);
         assert!(bus.signal_matches.iter().any(|[_, path, interface, _]| {
             path.as_deref() == Some(super::GNOME_SESSION_MANAGER_PATH)
                 && interface.as_deref() == Some(super::GNOME_SESSION_MANAGER_INTERFACE)
@@ -837,6 +961,7 @@ mod tests {
 
     #[test]
     fn inhibitor_transition_publishes_permission_without_activity_or_restore() {
+        let pending = Arc::new(AtomicBool::new(false));
         let signal = BusSignal::new(
             super::GNOME_SESSION_MANAGER_PATH,
             super::GNOME_SESSION_MANAGER_INTERFACE,
@@ -847,6 +972,7 @@ mod tests {
             "/org/gnome/SessionManager/Inhibitor1".to_string(),
         )]);
         let mut bus = FakeSessionBus {
+            permission_pending: Some(Arc::clone(&pending)),
             inhibited_plan: [true].into_iter().collect(),
             process_results: [
                 Ok(Some(signal)),
@@ -865,7 +991,11 @@ mod tests {
                 &mut bus,
                 &mut screen_saver,
                 Some(&mut session_manager),
+                None,
                 &mut |observation| {
+                    if matches!(observation, SessionObservation::IdleBlankingPermissionPending { .. }) {
+                        pending.store(true, Ordering::SeqCst);
+                    }
                     observations.push(observation);
                     true
                 },
@@ -874,11 +1004,16 @@ mod tests {
         ));
         assert!(matches!(
             observations.as_slice(),
-            [SessionObservation::IdleBlankingPermission {
-                allowed: false,
-                source: EventSource::DesktopSession,
-                ..
-            }]
+            [
+                SessionObservation::IdleBlankingPermissionPending {
+                    source: EventSource::DesktopSession
+                },
+                SessionObservation::IdleBlankingPermission {
+                    allowed: false,
+                    source: EventSource::DesktopSession,
+                    ..
+                }
+            ]
         ));
     }
 
@@ -938,6 +1073,137 @@ mod tests {
                 "GetIdletime".to_string(),
             )]
         );
+    }
+
+    fn watch_fired(id: u32) -> BusSignal {
+        BusSignal::new(
+            super::GNOME_IDLE_MONITOR_PATH,
+            super::GNOME_IDLE_MONITOR_INTERFACE,
+            "WatchFired",
+        )
+        .with_sender(":1.42")
+        .with_body(vec![BusValue::U32(id)])
+    }
+
+    #[test]
+    fn activity_watch_requires_current_owner_id_and_signal_shape() {
+        let watch = GnomeActivityWatch {
+            owner: ":1.42".to_string(),
+            id: 7,
+        };
+        assert!(watch.fired(&watch_fired(7)));
+        assert!(!watch.fired(&watch_fired(8)));
+        assert!(!watch.fired(&watch_fired(7).with_sender(":1.99")));
+        assert!(!watch.fired(&watch_fired(7).with_body(vec![BusValue::U64(7)])));
+        let mut wrong_path = watch_fired(7);
+        wrong_path.path = "/untrusted".to_string();
+        assert!(!watch.fired(&wrong_path));
+    }
+
+    #[test]
+    fn activity_watch_rearms_after_input_without_polling_the_resettable_counter() {
+        let mut bus = FakeSessionBus {
+            idle_monitor_owner: Some(":1.42".to_string()),
+            watch_ids: [7, 8, 9].into_iter().collect(),
+            idletime_ms: Some(0),
+            process_results: [
+                Ok(Some(watch_fired(7).with_sender(":1.99"))),
+                Ok(Some(watch_fired(7))),
+                Ok(Some(watch_fired(7))), // One-shot watch has already expired.
+                Ok(Some(watch_fired(8))),
+                Err(SessionBusError::Transport("stop test loop".to_string())),
+            ]
+            .into_iter()
+            .collect(),
+            ..FakeSessionBus::default()
+        };
+        let mut watch = GnomeActivityWatch::connect(&mut bus).expect("register activity watch");
+        let mut screen_saver = TrustedScreenSaverSignals::new(Some(":1.42".to_string()));
+        let mut observations = Vec::new();
+        assert!(run_gnome_monitor_process(
+            &mut bus,
+            &mut screen_saver,
+            None,
+            Some(&mut watch),
+            &mut |observation| {
+                observations.push(observation);
+                true
+            },
+        )
+        .is_err());
+        assert_eq!(observations.len(), 2);
+        assert!(observations.iter().all(|observation| matches!(
+            observation,
+            SessionObservation::Inactivity {
+                observation: InactivityObservation::DesktopActivityObserved,
+                source: EventSource::DesktopSession,
+                ..
+            }
+        )));
+        assert_eq!(watch.id, 9);
+        assert!(!bus
+            .method_calls
+            .iter()
+            .any(|(_, _, _, member)| member == "GetIdletime"));
+    }
+
+    #[test]
+    fn activity_watch_owner_loss_is_an_error_instead_of_silent_input_loss() {
+        let change = BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
+            .with_sender(DBUS_SERVICE_NAME)
+            .with_body(vec![
+                BusValue::String(super::GNOME_IDLE_MONITOR_NAME.to_string()),
+                BusValue::String(":1.42".to_string()),
+                BusValue::String(String::new()),
+            ]);
+        let mut watch = GnomeActivityWatch {
+            owner: ":1.42".to_string(),
+            id: 7,
+        };
+        assert!(!watch.owner_changed(&change.clone().with_sender(":1.99")));
+        let mut bus = FakeSessionBus {
+            process_results: [Ok(Some(change))].into_iter().collect(),
+            ..FakeSessionBus::default()
+        };
+        let mut screen_saver = TrustedScreenSaverSignals::new(Some(":1.42".to_string()));
+        let result = run_gnome_monitor_process(
+            &mut bus,
+            &mut screen_saver,
+            None,
+            Some(&mut watch),
+            &mut |_| panic!("owner loss is not activity"),
+        );
+        assert!(
+            matches!(result, Err(GnomeSourceError::Failed(message)) if message.contains("owner changed"))
+        );
+    }
+
+    #[test]
+    fn activity_watch_rearm_failure_is_an_error_instead_of_polling_for_input() {
+        let mut bus = FakeSessionBus {
+            process_results: [Ok(Some(watch_fired(7)))].into_iter().collect(),
+            ..FakeSessionBus::default()
+        };
+        let mut watch = GnomeActivityWatch {
+            owner: ":1.42".to_string(),
+            id: 7,
+        };
+        let mut screen_saver = TrustedScreenSaverSignals::new(Some(":1.42".to_string()));
+        let mut observations = Vec::new();
+        let result = run_gnome_monitor_process(
+            &mut bus,
+            &mut screen_saver,
+            None,
+            Some(&mut watch),
+            &mut |observation| {
+                observations.push(observation);
+                true
+            },
+        );
+        assert!(
+            matches!(result, Err(GnomeSourceError::Failed(message)) if message.contains("failed to watch"))
+        );
+        assert_eq!(observations.len(), 1);
     }
 
     #[test]

--- a/crates/lg-buddy/src/sources/desktop/gnome.rs
+++ b/crates/lg-buddy/src/sources/desktop/gnome.rs
@@ -23,8 +23,14 @@ pub const GNOME_SCREEN_SAVER_INTERFACE: &str = "org.gnome.ScreenSaver";
 pub const GNOME_IDLE_MONITOR_NAME: &str = "org.gnome.Mutter.IdleMonitor";
 pub const GNOME_IDLE_MONITOR_PATH: &str = "/org/gnome/Mutter/IdleMonitor/Core";
 pub const GNOME_IDLE_MONITOR_INTERFACE: &str = "org.gnome.Mutter.IdleMonitor";
+pub const GNOME_SESSION_MANAGER_NAME: &str = "org.gnome.SessionManager";
+pub const GNOME_SESSION_MANAGER_PATH: &str = "/org/gnome/SessionManager";
+pub const GNOME_SESSION_MANAGER_INTERFACE: &str = "org.gnome.SessionManager";
+pub const GNOME_IDLE_INHIBITION_FLAG: u32 = 8;
 pub const GNOME_REQUIRED_SERVICES_REASON: &str =
     "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required";
+pub const GNOME_IDLE_INHIBITORS_REQUIRED_REASON: &str =
+    "GNOME SessionManager is required when idle inhibitor honoring is enabled";
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct GnomeServiceStatus {
@@ -42,6 +48,8 @@ impl GnomeServiceStatus {
 pub(crate) struct GnomeSource {
     bus: Box<dyn SessionBusClient + Send>,
     trusted_screen_saver_signals: TrustedScreenSaverSignals,
+    trusted_session_manager_signals: Option<TrustedSessionManagerSignals>,
+    initial_idle_blanking_allowed: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -62,7 +70,7 @@ impl fmt::Display for GnomeSourceError {
 impl std::error::Error for GnomeSourceError {}
 
 impl GnomeSource {
-    pub(crate) fn connect() -> Result<Self, GnomeSourceError> {
+    pub(crate) fn connect(honor_idle_inhibitors: bool) -> Result<Self, GnomeSourceError> {
         let mut bus = new_session_bus_client().map_err(|err| {
             GnomeSourceError::Failed(format!("failed to open GNOME session bus client: {err}"))
         })?;
@@ -80,14 +88,41 @@ impl GnomeSource {
             ));
         }
 
-        subscribe_to_gnome_signals(&mut bus)?;
+        if honor_idle_inhibitors && !gnome_session_manager_available_from_session_bus(&mut bus) {
+            return Err(GnomeSourceError::Unavailable(
+                GNOME_IDLE_INHIBITORS_REQUIRED_REASON,
+            ));
+        }
+
+        subscribe_to_gnome_signals(&mut bus, honor_idle_inhibitors)?;
         let owner = resolve_screen_saver_owner(&mut bus).map_err(|err| {
             GnomeSourceError::Failed(format!("failed to resolve GNOME ScreenSaver owner: {err}"))
         })?;
+        let (trusted_session_manager_signals, initial_idle_blanking_allowed) =
+            if honor_idle_inhibitors {
+                let owner = resolve_session_manager_owner(&mut bus).map_err(|err| {
+                    GnomeSourceError::Failed(format!(
+                        "failed to resolve GNOME SessionManager owner: {err}"
+                    ))
+                })?;
+                let allowed = current_idle_blanking_allowed(&mut bus).map_err(|err| {
+                    GnomeSourceError::Failed(format!(
+                        "failed to read GNOME idle inhibitor state: {err}"
+                    ))
+                })?;
+                (
+                    Some(TrustedSessionManagerSignals::new(Some(owner))),
+                    Some(allowed),
+                )
+            } else {
+                (None, None)
+            };
 
         Ok(Self {
             bus,
             trusted_screen_saver_signals: TrustedScreenSaverSignals::new(Some(owner)),
+            trusted_session_manager_signals,
+            initial_idle_blanking_allowed,
         })
     }
 
@@ -95,9 +130,20 @@ impl GnomeSource {
     where
         F: FnMut(SessionObservation) -> bool,
     {
+        if let Some(allowed) = self.initial_idle_blanking_allowed {
+            if !publish(SessionObservation::IdleBlankingPermission {
+                allowed,
+                source: EventSource::DesktopSession,
+                observed_at: Instant::now(),
+            }) {
+                return Ok(());
+            }
+        }
+
         run_gnome_monitor_process(
             &mut self.bus,
             &mut self.trusted_screen_saver_signals,
+            self.trusted_session_manager_signals.as_mut(),
             &mut publish,
         )
     }
@@ -122,9 +168,24 @@ pub fn resolve_screen_saver_owner(
     get_name_owner(bus, GNOME_SCREEN_SAVER_NAME)
 }
 
+pub fn resolve_session_manager_owner(
+    bus: &mut impl SessionBusClient,
+) -> Result<String, SessionBusError> {
+    get_name_owner(bus, GNOME_SESSION_MANAGER_NAME)
+}
+
 pub fn screen_saver_owner_changed(signal: &BusSignal) -> Option<Option<String>> {
     let owner_change = parse_name_owner_changed_signal(signal)?;
     if owner_change.name != GNOME_SCREEN_SAVER_NAME {
+        return None;
+    }
+
+    Some(owner_change.new_owner)
+}
+
+pub fn session_manager_owner_changed(signal: &BusSignal) -> Option<Option<String>> {
+    let owner_change = parse_name_owner_changed_signal(signal)?;
+    if owner_change.name != GNOME_SESSION_MANAGER_NAME {
         return None;
     }
 
@@ -143,6 +204,24 @@ pub fn current_idle_monitor_idletime_ms(
     .single_u64()
 }
 
+pub fn current_idle_blanking_allowed(
+    bus: &mut impl SessionBusClient,
+) -> Result<bool, SessionBusError> {
+    let inhibited = bus
+        .call_method(
+            BusMethodCall::new(
+                GNOME_SESSION_MANAGER_NAME,
+                GNOME_SESSION_MANAGER_PATH,
+                GNOME_SESSION_MANAGER_INTERFACE,
+                "IsInhibited",
+            )
+            .with_body(vec![BusValue::U32(GNOME_IDLE_INHIBITION_FLAG)]),
+        )?
+        .single_bool()?;
+
+    Ok(!inhibited)
+}
+
 fn gnome_service_status_from_session_bus(bus: &mut impl SessionBusClient) -> GnomeServiceStatus {
     GnomeServiceStatus {
         shell_available: bus.name_has_owner(GNOME_SHELL_NAME).unwrap_or(false),
@@ -151,7 +230,10 @@ fn gnome_service_status_from_session_bus(bus: &mut impl SessionBusClient) -> Gno
     }
 }
 
-fn subscribe_to_gnome_signals(bus: &mut impl SessionBusClient) -> Result<(), GnomeSourceError> {
+fn subscribe_to_gnome_signals(
+    bus: &mut impl SessionBusClient,
+    honor_idle_inhibitors: bool,
+) -> Result<(), GnomeSourceError> {
     bus.add_signal_match(BusSignalMatch {
         sender: None,
         path: Some(GNOME_SCREEN_SAVER_PATH),
@@ -171,7 +253,23 @@ fn subscribe_to_gnome_signals(bus: &mut impl SessionBusClient) -> Result<(), Gno
     })
     .map_err(|err| {
         GnomeSourceError::Failed(format!("failed to subscribe to D-Bus owner changes: {err}"))
-    })
+    })?;
+
+    if honor_idle_inhibitors {
+        bus.add_signal_match(BusSignalMatch {
+            sender: None,
+            path: Some(GNOME_SESSION_MANAGER_PATH),
+            interface: Some(GNOME_SESSION_MANAGER_INTERFACE),
+            member: None,
+        })
+        .map_err(|err| {
+            GnomeSourceError::Failed(format!(
+                "failed to subscribe to GNOME SessionManager signals: {err}"
+            ))
+        })?;
+    }
+
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -206,9 +304,68 @@ impl TrustedScreenSaverSignals {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SessionManagerSignal {
+    OwnerChanged(Option<String>),
+    InhibitorChanged,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TrustedSessionManagerSignals {
+    owner: Option<String>,
+}
+
+impl TrustedSessionManagerSignals {
+    fn new(owner: Option<String>) -> Self {
+        Self { owner }
+    }
+
+    fn observe(&mut self, signal: &BusSignal) -> Option<SessionManagerSignal> {
+        if signal.path == DBUS_OBJECT_PATH
+            && signal.interface == DBUS_INTERFACE
+            && signal.member == "NameOwnerChanged"
+        {
+            if signal.sender.as_deref() != Some(DBUS_SERVICE_NAME) {
+                return None;
+            }
+
+            if let Some(new_owner) = session_manager_owner_changed(signal) {
+                self.owner = new_owner.clone();
+                return Some(SessionManagerSignal::OwnerChanged(new_owner));
+            }
+            return None;
+        }
+
+        if signal.sender.as_deref() != self.owner.as_deref() {
+            return None;
+        }
+
+        map_session_manager_signal(signal).map(|_| SessionManagerSignal::InhibitorChanged)
+    }
+}
+
+fn map_session_manager_signal(signal: &BusSignal) -> Option<()> {
+    if signal.path != GNOME_SESSION_MANAGER_PATH
+        || signal.interface != GNOME_SESSION_MANAGER_INTERFACE
+    {
+        return None;
+    }
+
+    match (signal.member.as_str(), signal.body.as_slice()) {
+        ("InhibitorAdded" | "InhibitorRemoved", [BusValue::ObjectPath(_)]) => Some(()),
+        _ => None,
+    }
+}
+
+fn gnome_session_manager_available_from_session_bus(bus: &mut impl SessionBusClient) -> bool {
+    bus.name_has_owner(GNOME_SESSION_MANAGER_NAME)
+        .unwrap_or(false)
+}
+
 fn run_gnome_monitor_process<F>(
     bus: &mut impl SessionBusClient,
     trusted_screen_saver_signals: &mut TrustedScreenSaverSignals,
+    mut trusted_session_manager_signals: Option<&mut TrustedSessionManagerSignals>,
     publish: &mut F,
 ) -> Result<(), GnomeSourceError>
 where
@@ -245,6 +402,35 @@ where
         else {
             continue;
         };
+
+        if let Some(trusted_session_manager_signals) =
+            trusted_session_manager_signals.as_deref_mut()
+        {
+            match trusted_session_manager_signals.observe(&signal) {
+                Some(SessionManagerSignal::OwnerChanged(None)) => {
+                    return Err(GnomeSourceError::Failed(
+                        "GNOME SessionManager disappeared while idle inhibitor honoring was enabled"
+                            .to_string(),
+                    ));
+                }
+                Some(SessionManagerSignal::OwnerChanged(Some(_)))
+                | Some(SessionManagerSignal::InhibitorChanged) => {
+                    let allowed = current_idle_blanking_allowed(bus).map_err(|err| {
+                        GnomeSourceError::Failed(format!(
+                            "failed to read GNOME idle inhibitor state after a SessionManager change: {err}"
+                        ))
+                    })?;
+                    if !publish(SessionObservation::IdleBlankingPermission {
+                        allowed,
+                        source: EventSource::DesktopSession,
+                        observed_at: Instant::now(),
+                    }) {
+                        return Ok(());
+                    }
+                }
+                None => {}
+            }
+        }
 
         let Some(event) = trusted_screen_saver_signals.observe(&signal) else {
             continue;
@@ -294,10 +480,13 @@ pub(crate) fn monitor_test_timeout() -> Option<Duration> {
 #[cfg(test)]
 mod tests {
     use super::{
-        current_idle_monitor_idletime_ms, gnome_service_status_from_session_bus,
-        map_screen_saver_signal, monitor_test_timeout, poll_idle_monitor_once,
-        resolve_screen_saver_owner, screen_saver_owner_changed, GnomeServiceStatus,
-        TrustedScreenSaverSignals, GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV,
+        current_idle_blanking_allowed, current_idle_monitor_idletime_ms,
+        gnome_service_status_from_session_bus, map_screen_saver_signal, map_session_manager_signal,
+        monitor_test_timeout, poll_idle_monitor_once, resolve_screen_saver_owner,
+        run_gnome_monitor_process, screen_saver_owner_changed, session_manager_owner_changed,
+        subscribe_to_gnome_signals, GnomeServiceStatus, GnomeSourceError, SessionManagerSignal,
+        TrustedScreenSaverSignals, TrustedSessionManagerSignals,
+        GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV,
     };
     use crate::events::EventSource;
     use crate::session::inactivity::InactivityObservation;
@@ -306,6 +495,7 @@ mod tests {
         BusMethodCall, BusReply, BusSignal, BusSignalMatch, BusValue, SessionBusClient,
         SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
     };
+    use std::collections::VecDeque;
     use std::sync::{Mutex, OnceLock};
     use std::time::{Duration, Instant};
 
@@ -316,7 +506,13 @@ mod tests {
         idle_monitor_available: bool,
         idletime_ms: Option<u64>,
         screen_saver_owner: Option<String>,
+        session_manager_owner: Option<String>,
+        inhibited: Option<bool>,
+        inhibited_plan: VecDeque<bool>,
         method_calls: Vec<(String, String, String, String)>,
+        method_bodies: Vec<Vec<BusValue>>,
+        signal_matches: Vec<[Option<String>; 4]>,
+        process_results: VecDeque<Result<Option<BusSignal>, SessionBusError>>,
         failed_names: Vec<String>,
     }
 
@@ -332,6 +528,7 @@ mod tests {
                 super::GNOME_SHELL_NAME => Ok(self.shell_available),
                 super::GNOME_SCREEN_SAVER_NAME => Ok(self.screen_saver_available),
                 super::GNOME_IDLE_MONITOR_NAME => Ok(self.idle_monitor_available),
+                super::GNOME_SESSION_MANAGER_NAME => Ok(self.session_manager_owner.is_some()),
                 _ => Ok(false),
             }
         }
@@ -343,34 +540,61 @@ mod tests {
                 call.interface.to_string(),
                 call.member.to_string(),
             ));
+            self.method_bodies.push(call.body.clone());
+            if call.destination == DBUS_SERVICE_NAME
+                && call.path == DBUS_OBJECT_PATH
+                && call.interface == DBUS_INTERFACE
+                && call.member == "GetNameOwner"
+            {
+                let [BusValue::String(name)] = call.body.as_slice() else {
+                    return Err(SessionBusError::Transport(
+                        "missing GetNameOwner test name".to_string(),
+                    ));
+                };
+                let owner = match name.as_str() {
+                    super::GNOME_SCREEN_SAVER_NAME => self.screen_saver_owner.as_deref(),
+                    super::GNOME_SESSION_MANAGER_NAME => self.session_manager_owner.as_deref(),
+                    _ => None,
+                };
+                return owner
+                    .map(|value| {
+                        BusReply::new(vec![crate::session_bus::BusValue::String(
+                            value.to_string(),
+                        )])
+                    })
+                    .ok_or_else(|| {
+                        SessionBusError::Transport("no queued GNOME owner reply".to_string())
+                    });
+            }
+
             match (
                 call.destination,
                 call.path,
                 call.interface,
                 call.member,
-                self.screen_saver_owner.as_deref(),
                 self.idletime_ms,
             ) {
-                (
-                    DBUS_SERVICE_NAME,
-                    DBUS_OBJECT_PATH,
-                    DBUS_INTERFACE,
-                    "GetNameOwner",
-                    Some(value),
-                    _,
-                ) => Ok(BusReply::new(vec![crate::session_bus::BusValue::String(
-                    value.to_string(),
-                )])),
                 (
                     super::GNOME_IDLE_MONITOR_NAME,
                     super::GNOME_IDLE_MONITOR_PATH,
                     super::GNOME_IDLE_MONITOR_INTERFACE,
                     "GetIdletime",
-                    _,
                     Some(value),
-                ) => Ok(BusReply::new(vec![crate::session_bus::BusValue::U64(
-                    value,
-                )])),
+                ) => Ok(BusReply::new(vec![BusValue::U64(value)])),
+                (
+                    super::GNOME_SESSION_MANAGER_NAME,
+                    super::GNOME_SESSION_MANAGER_PATH,
+                    super::GNOME_SESSION_MANAGER_INTERFACE,
+                    "IsInhibited",
+                    _,
+                ) => self
+                    .inhibited_plan
+                    .pop_front()
+                    .or(self.inhibited)
+                    .map(|value| BusReply::new(vec![BusValue::Bool(value)]))
+                    .ok_or_else(|| {
+                        SessionBusError::Transport("no queued inhibition reply".to_string())
+                    }),
                 _ => Err(SessionBusError::Transport(
                     "no queued GNOME method reply".to_string(),
                 )),
@@ -378,13 +602,18 @@ mod tests {
         }
 
         fn add_signal_match(&mut self, rule: BusSignalMatch<'_>) -> Result<(), SessionBusError> {
-            let _ = rule;
-            unreachable!("not used in GNOME probing tests")
+            self.signal_matches.push([
+                rule.sender.map(str::to_owned),
+                rule.path.map(str::to_owned),
+                rule.interface.map(str::to_owned),
+                rule.member.map(str::to_owned),
+            ]);
+            Ok(())
         }
 
         fn process(&mut self, timeout: Duration) -> Result<Option<BusSignal>, SessionBusError> {
             let _ = timeout;
-            unreachable!("not used in GNOME probing tests")
+            self.process_results.pop_front().unwrap_or(Ok(None))
         }
     }
 
@@ -473,6 +702,184 @@ mod tests {
             ]);
 
         assert_eq!(screen_saver_owner_changed(&signal), None);
+    }
+
+    #[test]
+    fn session_manager_is_inhibited_flag_maps_to_blanking_permission() {
+        let mut bus = FakeSessionBus {
+            inhibited: Some(true),
+            ..FakeSessionBus::default()
+        };
+
+        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(false));
+        assert_eq!(
+            bus.method_bodies,
+            vec![vec![BusValue::U32(super::GNOME_IDLE_INHIBITION_FLAG)]]
+        );
+    }
+
+    #[test]
+    fn overlapping_inhibitors_keep_blanking_suppressed_until_last_release() {
+        let mut bus = FakeSessionBus {
+            inhibited_plan: [true, true, false].into_iter().collect(),
+            ..FakeSessionBus::default()
+        };
+
+        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(false));
+        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(false));
+        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(true));
+    }
+
+    #[test]
+    fn session_manager_signals_require_current_owner_and_valid_inhibitor_path() {
+        let mut trusted = TrustedSessionManagerSignals::new(Some(":1.42".to_string()));
+        let added = BusSignal::new(
+            super::GNOME_SESSION_MANAGER_PATH,
+            super::GNOME_SESSION_MANAGER_INTERFACE,
+            "InhibitorAdded",
+        )
+        .with_sender(":1.42")
+        .with_body(vec![BusValue::ObjectPath(
+            "/org/gnome/SessionManager/Inhibitor1".to_string(),
+        )]);
+        let spoofed = added.clone().with_sender(":1.99");
+        let malformed = added.clone().with_body(vec![BusValue::String(
+            "/org/gnome/SessionManager/Inhibitor1".to_string(),
+        )]);
+
+        assert_eq!(map_session_manager_signal(&added), Some(()));
+        assert_eq!(
+            trusted.observe(&added),
+            Some(SessionManagerSignal::InhibitorChanged)
+        );
+        assert_eq!(trusted.observe(&spoofed), None);
+        assert_eq!(trusted.observe(&malformed), None);
+    }
+
+    #[test]
+    fn session_manager_owner_changes_rebind_and_reject_old_sender() {
+        let mut trusted = TrustedSessionManagerSignals::new(Some(":1.42".to_string()));
+        let owner_change = BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
+            .with_sender(DBUS_SERVICE_NAME)
+            .with_body(vec![
+                BusValue::String(super::GNOME_SESSION_MANAGER_NAME.to_string()),
+                BusValue::String(":1.42".to_string()),
+                BusValue::String(":1.43".to_string()),
+            ]);
+
+        assert_eq!(
+            session_manager_owner_changed(&owner_change),
+            Some(Some(":1.43".to_string()))
+        );
+        assert_eq!(
+            trusted.observe(&owner_change),
+            Some(SessionManagerSignal::OwnerChanged(Some(
+                ":1.43".to_string()
+            )))
+        );
+
+        let signal = BusSignal::new(
+            super::GNOME_SESSION_MANAGER_PATH,
+            super::GNOME_SESSION_MANAGER_INTERFACE,
+            "InhibitorRemoved",
+        )
+        .with_body(vec![BusValue::ObjectPath(
+            "/org/gnome/SessionManager/Inhibitor1".to_string(),
+        )]);
+        assert_eq!(trusted.observe(&signal.clone().with_sender(":1.42")), None);
+        assert_eq!(
+            trusted.observe(&signal.with_sender(":1.43")),
+            Some(SessionManagerSignal::InhibitorChanged)
+        );
+
+        let owner_loss = BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
+            .with_sender(DBUS_SERVICE_NAME)
+            .with_body(vec![
+                BusValue::String(super::GNOME_SESSION_MANAGER_NAME.to_string()),
+                BusValue::String(":1.43".to_string()),
+                BusValue::String(String::new()),
+            ]);
+        assert_eq!(
+            trusted.observe(&owner_loss),
+            Some(SessionManagerSignal::OwnerChanged(None))
+        );
+    }
+
+    #[test]
+    fn idle_inhibitor_read_failures_are_errors_without_allowed_true() {
+        let mut bus = FakeSessionBus::default();
+        assert!(current_idle_blanking_allowed(&mut bus).is_err());
+    }
+
+    #[test]
+    fn disabled_idle_inhibitor_honoring_keeps_session_manager_out_of_signal_matches() {
+        let mut bus = FakeSessionBus::default();
+        subscribe_to_gnome_signals(&mut bus, false).expect("subscribe GNOME signals");
+
+        assert_eq!(bus.signal_matches.len(), 2);
+        assert!(!bus
+            .signal_matches
+            .iter()
+            .any(|[_, path, _, _]| { path.as_deref() == Some(super::GNOME_SESSION_MANAGER_PATH) }));
+    }
+
+    #[test]
+    fn enabled_idle_inhibitor_honoring_subscribes_to_session_manager_signals() {
+        let mut bus = FakeSessionBus::default();
+        subscribe_to_gnome_signals(&mut bus, true).expect("subscribe GNOME signals");
+
+        assert_eq!(bus.signal_matches.len(), 3);
+        assert!(bus.signal_matches.iter().any(|[_, path, interface, _]| {
+            path.as_deref() == Some(super::GNOME_SESSION_MANAGER_PATH)
+                && interface.as_deref() == Some(super::GNOME_SESSION_MANAGER_INTERFACE)
+        }));
+    }
+
+    #[test]
+    fn inhibitor_transition_publishes_permission_without_activity_or_restore() {
+        let signal = BusSignal::new(
+            super::GNOME_SESSION_MANAGER_PATH,
+            super::GNOME_SESSION_MANAGER_INTERFACE,
+            "InhibitorAdded",
+        )
+        .with_sender(":1.42")
+        .with_body(vec![BusValue::ObjectPath(
+            "/org/gnome/SessionManager/Inhibitor1".to_string(),
+        )]);
+        let mut bus = FakeSessionBus {
+            inhibited_plan: [true].into_iter().collect(),
+            process_results: [
+                Ok(Some(signal)),
+                Err(SessionBusError::Transport("stop test loop".to_string())),
+            ]
+            .into_iter()
+            .collect(),
+            ..FakeSessionBus::default()
+        };
+        let mut screen_saver = TrustedScreenSaverSignals::new(Some(":1.42".to_string()));
+        let mut session_manager = TrustedSessionManagerSignals::new(Some(":1.42".to_string()));
+        let mut observations = Vec::new();
+
+        assert!(matches!(
+            run_gnome_monitor_process(
+                &mut bus,
+                &mut screen_saver,
+                Some(&mut session_manager),
+                &mut |observation| {
+                    observations.push(observation);
+                    true
+                },
+            ),
+            Err(GnomeSourceError::Failed(message)) if message.contains("processing failed")
+        ));
+        assert!(matches!(
+            observations.as_slice(),
+            [SessionObservation::IdleBlankingPermission {
+                allowed: false,
+                source: EventSource::DesktopSession,
+                ..
+            }]
+        ));
     }
 
     #[test]

--- a/crates/lg-buddy/src/sources/desktop/wayland.rs
+++ b/crates/lg-buddy/src/sources/desktop/wayland.rs
@@ -126,7 +126,56 @@ impl RegistryFacts {
 
 struct SeatBinding {
     seat: wl_seat::WlSeat,
-    notification: Option<ext_idle_notification_v1::ExtIdleNotificationV1>,
+    input_notification: Option<ext_idle_notification_v1::ExtIdleNotificationV1>,
+    idle_notification: Option<ext_idle_notification_v1::ExtIdleNotificationV1>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotificationKind {
+    Input(u32),
+    IdlePermission(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NotificationMeaning {
+    InputActivity,
+    IdlePermission(bool),
+}
+
+#[derive(Debug, Default)]
+struct IdlePermissionTracker {
+    seats: HashMap<u32, bool>,
+    allowed: bool,
+}
+
+impl IdlePermissionTracker {
+    fn add_seat(&mut self, name: u32) -> Option<bool> {
+        self.seats.insert(name, false);
+        self.recompute()
+    }
+
+    fn remove_seat(&mut self, name: u32) -> Option<bool> {
+        self.seats.remove(&name)?;
+        self.recompute()
+    }
+
+    fn set_idle(&mut self, name: u32, idle: bool) -> Option<bool> {
+        let previous = self.seats.get_mut(&name)?;
+        if *previous == idle {
+            return None;
+        }
+        *previous = idle;
+        self.recompute()
+    }
+
+    fn recompute(&mut self) -> Option<bool> {
+        let allowed = !self.seats.is_empty() && self.seats.values().all(|idle| *idle);
+        if self.allowed == allowed {
+            return None;
+        }
+        self.allowed = allowed;
+        Some(allowed)
+    }
 }
 
 struct WaylandProviderState<F> {
@@ -134,27 +183,45 @@ struct WaylandProviderState<F> {
     registry_facts: RegistryFacts,
     idle_notifier: Option<(u32, ext_idle_notifier_v1::ExtIdleNotifierV1)>,
     seats: HashMap<u32, SeatBinding>,
+    idle_permission: IdlePermissionTracker,
+    honor_idle_inhibitors: bool,
     initialized: bool,
     running: bool,
     error: Option<WaylandProviderError>,
-    on_activity: F,
+    on_observation: F,
 }
 
 impl<F> WaylandProviderState<F>
 where
-    F: FnMut(Instant) -> bool + 'static,
+    F: FnMut(SessionObservation) -> bool + 'static,
 {
-    fn new(on_activity: F) -> Self {
+    fn new(on_observation: F, honor_idle_inhibitors: bool) -> Self {
         Self {
             registry: None,
             registry_facts: RegistryFacts::default(),
             idle_notifier: None,
             seats: HashMap::new(),
+            idle_permission: IdlePermissionTracker::default(),
+            honor_idle_inhibitors,
             initialized: false,
             running: true,
             error: None,
-            on_activity,
+            on_observation,
         }
+    }
+
+    fn publish(&mut self, observation: SessionObservation) {
+        if !(self.on_observation)(observation) {
+            self.running = false;
+        }
+    }
+
+    fn publish_idle_permission_change(&mut self, allowed: bool) {
+        self.publish(SessionObservation::IdleBlankingPermission {
+            allowed,
+            source: EventSource::DesktopSession,
+            observed_at: Instant::now(),
+        });
     }
 
     fn bind_idle_notifier(
@@ -195,9 +262,15 @@ where
             name,
             SeatBinding {
                 seat,
-                notification: None,
+                input_notification: None,
+                idle_notification: None,
             },
         );
+        if self.honor_idle_inhibitors {
+            if let Some(allowed) = self.idle_permission.add_seat(name) {
+                self.publish_idle_permission_change(allowed);
+            }
+        }
         self.attach_seat(name, queue_handle);
     }
 
@@ -215,12 +288,24 @@ where
         let Some(binding) = self.seats.get_mut(&name) else {
             return;
         };
-        if binding.notification.is_some() {
+        if binding.input_notification.is_some() {
             return;
         }
 
-        binding.notification =
-            Some(notifier.get_input_idle_notification(0, &binding.seat, queue_handle, name));
+        binding.input_notification = Some(notifier.get_input_idle_notification(
+            0,
+            &binding.seat,
+            queue_handle,
+            NotificationKind::Input(name),
+        ));
+        if self.honor_idle_inhibitors {
+            binding.idle_notification = Some(notifier.get_idle_notification(
+                0,
+                &binding.seat,
+                queue_handle,
+                NotificationKind::IdlePermission(name),
+            ));
+        }
     }
 
     fn remove_global(&mut self, name: u32) {
@@ -232,13 +317,22 @@ where
             .is_some_and(|(global_name, _)| *global_name == name);
 
         let removed_seat = if let Some(mut binding) = self.seats.remove(&name) {
-            if let Some(notification) = binding.notification.take() {
+            if let Some(notification) = binding.input_notification.take() {
+                notification.destroy();
+            }
+            if let Some(notification) = binding.idle_notification.take() {
                 notification.destroy();
             }
             true
         } else {
             false
         };
+
+        if removed_seat && self.honor_idle_inhibitors {
+            if let Some(allowed) = self.idle_permission.remove_seat(name) {
+                self.publish_idle_permission_change(allowed);
+            }
+        }
 
         if let Some(err) = global_removal_error(
             self.initialized,
@@ -275,9 +369,32 @@ fn notification_is_activity(event: &ext_idle_notification_v1::Event) -> bool {
     matches!(event, ext_idle_notification_v1::Event::Resumed)
 }
 
+fn idle_notification_permission(event: &ext_idle_notification_v1::Event) -> Option<bool> {
+    match event {
+        ext_idle_notification_v1::Event::Idled => Some(true),
+        ext_idle_notification_v1::Event::Resumed => Some(false),
+        _ => None,
+    }
+}
+
+fn notification_meaning(
+    kind: NotificationKind,
+    event: &ext_idle_notification_v1::Event,
+) -> Option<NotificationMeaning> {
+    match kind {
+        NotificationKind::Input(_) if notification_is_activity(event) => {
+            Some(NotificationMeaning::InputActivity)
+        }
+        NotificationKind::IdlePermission(_) => {
+            idle_notification_permission(event).map(NotificationMeaning::IdlePermission)
+        }
+        _ => None,
+    }
+}
+
 impl<F> Dispatch<wl_registry::WlRegistry, ()> for WaylandProviderState<F>
 where
-    F: FnMut(Instant) -> bool + 'static,
+    F: FnMut(SessionObservation) -> bool + 'static,
 {
     fn event(
         state: &mut Self,
@@ -334,7 +451,7 @@ impl Dispatch<wl_registry::WlRegistry, ()> for WaylandCapabilityProbeState {
 
 impl<F> Dispatch<wl_seat::WlSeat, u32> for WaylandProviderState<F>
 where
-    F: FnMut(Instant) -> bool + 'static,
+    F: FnMut(SessionObservation) -> bool + 'static,
 {
     fn event(
         _: &mut Self,
@@ -349,7 +466,7 @@ where
 
 impl<F> Dispatch<ext_idle_notifier_v1::ExtIdleNotifierV1, ()> for WaylandProviderState<F>
 where
-    F: FnMut(Instant) -> bool + 'static,
+    F: FnMut(SessionObservation) -> bool + 'static,
 {
     fn event(
         _: &mut Self,
@@ -362,20 +479,35 @@ where
     }
 }
 
-impl<F> Dispatch<ext_idle_notification_v1::ExtIdleNotificationV1, u32> for WaylandProviderState<F>
+impl<F> Dispatch<ext_idle_notification_v1::ExtIdleNotificationV1, NotificationKind>
+    for WaylandProviderState<F>
 where
-    F: FnMut(Instant) -> bool + 'static,
+    F: FnMut(SessionObservation) -> bool + 'static,
 {
     fn event(
         state: &mut Self,
         _: &ext_idle_notification_v1::ExtIdleNotificationV1,
         event: ext_idle_notification_v1::Event,
-        _: &u32,
+        kind: &NotificationKind,
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
-        if notification_is_activity(&event) && !(state.on_activity)(Instant::now()) {
-            state.running = false;
+        match notification_meaning(*kind, &event) {
+            Some(NotificationMeaning::InputActivity) => {
+                state.publish(SessionObservation::Inactivity {
+                    observation: InactivityObservation::DesktopActivityObserved,
+                    source: EventSource::DesktopSession,
+                    observed_at: Instant::now(),
+                });
+            }
+            Some(NotificationMeaning::IdlePermission(allowed)) => {
+                if let NotificationKind::IdlePermission(name) = *kind {
+                    if let Some(allowed) = state.idle_permission.set_idle(name, allowed) {
+                        state.publish_idle_permission_change(allowed);
+                    }
+                }
+            }
+            None => {}
         }
     }
 }
@@ -388,15 +520,16 @@ type InitializedWaylandProvider<F> = (
 
 fn initialize_provider<F>(
     connection: Connection,
-    on_activity: F,
+    honor_idle_inhibitors: bool,
+    on_observation: F,
 ) -> Result<InitializedWaylandProvider<F>, WaylandProviderError>
 where
-    F: FnMut(Instant) -> bool + 'static,
+    F: FnMut(SessionObservation) -> bool + 'static,
 {
     let display = connection.display();
     let mut event_queue = connection.new_event_queue();
     let queue_handle = event_queue.handle();
-    let mut state = WaylandProviderState::new(on_activity);
+    let mut state = WaylandProviderState::new(on_observation, honor_idle_inhibitors);
     state.registry = Some(display.get_registry(&queue_handle, ()));
 
     event_queue
@@ -436,19 +569,16 @@ pub(crate) fn probe_wayland_capabilities_on(
 
 pub(crate) fn run_session_source<F>(
     connection: Connection,
+    honor_idle_inhibitors: bool,
     mut publish: F,
 ) -> Result<(), WaylandProviderError>
 where
     F: FnMut(SessionObservation) -> bool + 'static,
 {
-    let on_activity = move |observed_at| {
-        publish(SessionObservation::Inactivity {
-            observation: InactivityObservation::DesktopActivityObserved,
-            source: EventSource::DesktopSession,
-            observed_at,
-        })
-    };
-    let (mut event_queue, mut state, _) = initialize_provider(connection, on_activity)?;
+    let (mut event_queue, mut state, _) =
+        initialize_provider(connection, honor_idle_inhibitors, move |observation| {
+            publish(observation)
+        })?;
 
     while state.running {
         event_queue
@@ -465,8 +595,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        ext_idle_notification_v1, global_removal_error, notification_is_activity, RegistryFacts,
-        WaylandProviderCapabilities, WaylandProviderError,
+        ext_idle_notification_v1, global_removal_error, idle_notification_permission,
+        notification_is_activity, notification_meaning, IdlePermissionTracker, NotificationKind,
+        NotificationMeaning, RegistryFacts, WaylandProviderCapabilities, WaylandProviderError,
     };
 
     const NOTIFIER: &str = "ext_idle_notifier_v1";
@@ -567,5 +698,59 @@ mod tests {
         assert!(notification_is_activity(
             &ext_idle_notification_v1::Event::Resumed
         ));
+    }
+
+    #[test]
+    fn idle_permission_stays_blocked_until_every_seat_reports_idle() {
+        let mut tracker = IdlePermissionTracker::default();
+
+        assert_eq!(tracker.add_seat(11), None);
+        assert_eq!(tracker.add_seat(12), None);
+        assert!(!tracker.allowed);
+        assert_eq!(tracker.set_idle(11, true), None);
+        assert_eq!(tracker.set_idle(12, true), Some(true));
+        assert_eq!(tracker.set_idle(12, true), None);
+        assert!(tracker.allowed);
+    }
+
+    #[test]
+    fn seat_addition_and_removal_recompute_permission_meaningfully() {
+        let mut tracker = IdlePermissionTracker::default();
+        tracker.add_seat(11);
+        tracker.set_idle(11, true);
+        assert!(tracker.allowed);
+
+        assert_eq!(tracker.add_seat(12), Some(false));
+        assert!(!tracker.allowed);
+        assert_eq!(tracker.remove_seat(12), Some(true));
+        assert!(tracker.allowed);
+        assert_eq!(tracker.remove_seat(11), Some(false));
+        assert!(!tracker.allowed);
+    }
+
+    #[test]
+    fn inhibitor_notification_resumed_changes_permission_without_becoming_activity() {
+        assert_eq!(
+            idle_notification_permission(&ext_idle_notification_v1::Event::Idled),
+            Some(true)
+        );
+        assert_eq!(
+            idle_notification_permission(&ext_idle_notification_v1::Event::Resumed),
+            Some(false)
+        );
+        assert_eq!(
+            notification_meaning(
+                NotificationKind::Input(11),
+                &ext_idle_notification_v1::Event::Resumed
+            ),
+            Some(NotificationMeaning::InputActivity)
+        );
+        assert_eq!(
+            notification_meaning(
+                NotificationKind::IdlePermission(11),
+                &ext_idle_notification_v1::Event::Resumed
+            ),
+            Some(NotificationMeaning::IdlePermission(false))
+        );
     }
 }

--- a/crates/lg-buddy/src/sources/linux/network_manager.rs
+++ b/crates/lg-buddy/src/sources/linux/network_manager.rs
@@ -597,6 +597,7 @@ mod tests {
             screen_idle_blank: ScreenIdleBlankPolicy::Enabled,
             screen_idle_timeout: 300,
             screen_restore_policy: ScreenRestorePolicy::MarkerOnly,
+            screen_honor_idle_inhibitors: crate::config::ScreenHonorIdleInhibitorsPolicy::Disabled,
             system_sleep_wake_policy,
         }
     }

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -36,6 +36,14 @@ fn scheduled_gnome_idle_inhibitors(world: &mut LgBuddyWorld, count: u32, seconds
     world.schedule_gnome_idle_inhibitors(count, seconds.parse().expect("inhibitor delay"));
 }
 
+#[given(regex = r#"GNOME delays the next inhibited query by ([0-9]+(?:\.[0-9]+)?) seconds"#)]
+fn gnome_delays_next_inhibited_query(world: &mut LgBuddyWorld, seconds: String) {
+    let seconds = seconds
+        .parse::<f64>()
+        .unwrap_or_else(|err| panic!("invalid GNOME inhibitor query delay `{seconds}`: {err}"));
+    world.delay_next_gnome_inhibited_query(seconds);
+}
+
 #[given(regex = r#"the idle timeout is (\d+) seconds"#)]
 fn idle_timeout_seconds(world: &mut LgBuddyWorld, seconds: u64) {
     world.set_idle_timeout_secs(seconds);
@@ -327,6 +335,14 @@ fn gnome_monitor_stays_open_for_seconds(world: &mut LgBuddyWorld, seconds: Strin
         .parse::<f64>()
         .unwrap_or_else(|err| panic!("invalid GNOME monitor sleep `{seconds}`: {err}"));
     world.gnome_monitor_stays_open_for_secs(seconds);
+}
+
+#[given(regex = r#"genuine desktop input occurs after ([0-9]+(?:\.[0-9]+)?) seconds"#)]
+fn genuine_desktop_input_occurs_after_seconds(world: &mut LgBuddyWorld, seconds: String) {
+    let seconds = seconds
+        .parse::<f64>()
+        .unwrap_or_else(|err| panic!("invalid GNOME desktop input delay `{seconds}`: {err}"));
+    world.gnome_real_input_occurs_after_secs(seconds);
 }
 
 #[given(regex = r#"gamepad activity is observed after ([0-9]+(?:\.[0-9]+)?) seconds"#)]

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -21,6 +21,21 @@ fn screen_idle_blanking(world: &mut LgBuddyWorld, policy: String) {
     world.set_screen_idle_blank(&policy);
 }
 
+#[given(regex = r#"honoring app keep-awake requests is "(enabled|disabled)""#)]
+fn honor_idle_inhibitors(world: &mut LgBuddyWorld, policy: String) {
+    world.set_honor_idle_inhibitors(&policy);
+}
+
+#[given(regex = r#"GNOME has (\d+) idle inhibitors"#)]
+fn gnome_idle_inhibitors(world: &mut LgBuddyWorld, count: u32) {
+    world.set_gnome_idle_inhibitors(count);
+}
+
+#[given(regex = r#"GNOME changes to (\d+) idle inhibitors after ([0-9]+(?:\.[0-9]+)?) seconds"#)]
+fn scheduled_gnome_idle_inhibitors(world: &mut LgBuddyWorld, count: u32, seconds: String) {
+    world.schedule_gnome_idle_inhibitors(count, seconds.parse().expect("inhibitor delay"));
+}
+
 #[given(regex = r#"the idle timeout is (\d+) seconds"#)]
 fn idle_timeout_seconds(world: &mut LgBuddyWorld, seconds: u64) {
     world.set_idle_timeout_secs(seconds);

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -93,6 +93,13 @@ impl LgBuddyWorld {
             .append_line(&format!("screen_idle_blank={policy}"));
     }
 
+    pub fn set_honor_idle_inhibitors(&self, policy: &str) {
+        self.config
+            .as_ref()
+            .expect("temporary config should be present")
+            .append_line(&format!("screen_honor_idle_inhibitors={policy}"));
+    }
+
     pub fn set_idle_timeout_secs(&mut self, seconds: u64) {
         self.ensure_env()
             .set("LG_BUDDY_IDLE_TIMEOUT", seconds.to_string());
@@ -553,6 +560,16 @@ exit 1\n",
     pub fn set_gnome_idle_monitor_available(&mut self, value: bool) {
         self.ensure_mock_session_bus_idle_monitor()
             .set_idle_monitor_available(value);
+    }
+
+    pub fn set_gnome_idle_inhibitors(&mut self, count: u32) {
+        self.ensure_mock_session_bus_idle_monitor()
+            .set_idle_inhibitor_count(count);
+    }
+
+    pub fn schedule_gnome_idle_inhibitors(&mut self, count: u32, after_secs: f64) {
+        self.ensure_mock_session_bus_idle_monitor()
+            .schedule_idle_inhibitor_count(std::time::Duration::from_secs_f64(after_secs), count);
     }
 
     pub fn gnome_monitor_emit_idle(&mut self) {

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -572,6 +572,11 @@ exit 1\n",
             .schedule_idle_inhibitor_count(std::time::Duration::from_secs_f64(after_secs), count);
     }
 
+    pub fn delay_next_gnome_inhibited_query(&mut self, delay_secs: f64) {
+        self.ensure_mock_session_bus_idle_monitor()
+            .delay_next_inhibited_query(std::time::Duration::from_secs_f64(delay_secs));
+    }
+
     pub fn gnome_monitor_emit_idle(&mut self) {
         self.ensure_mock_session_bus_idle_monitor()
             .emit_screen_saver_idle();
@@ -599,6 +604,11 @@ exit 1\n",
             idle_monitor.set_idle_monitor_idletime(last);
         }
         idle_monitor.set_idle_monitor_idletime_plan(values);
+    }
+
+    pub fn gnome_real_input_occurs_after_secs(&mut self, seconds: f64) {
+        self.ensure_mock_session_bus_idle_monitor()
+            .schedule_user_activity(std::time::Duration::from_secs_f64(seconds));
     }
 
     pub fn gnome_monitor_stays_open_for_secs(&mut self, seconds: f64) {

--- a/crates/lg-buddy/tests/features/detect_backend.feature
+++ b/crates/lg-buddy/tests/features/detect_backend.feature
@@ -27,6 +27,26 @@ Feature: Detect backend
     Then the command succeeds
     And stdout is "gnome"
 
+  Scenario: Automatic falls back when GNOME cannot honor keep-awake requests
+    Given a temporary LG Buddy config using input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And honoring app keep-awake requests is "enabled"
+    And swayidle is installed
+    When I run the command "detect-backend"
+    Then the command succeeds
+    And stdout is "swayidle"
+
+  Scenario: Explicit GNOME reports a missing keep-awake dependency
+    Given a temporary LG Buddy config using input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And honoring app keep-awake requests is "enabled"
+    And the backend override is "gnome"
+    When I run the command "detect-backend"
+    Then the command fails
+    And stderr contains "GNOME SessionManager is required"
+
   Scenario: Missing GNOME idle monitor is reported explicitly when no fallback exists
     Given a temporary LG Buddy config using input HDMI_2
     And the executable PATH is isolated

--- a/crates/lg-buddy/tests/features/idle_inhibition.feature
+++ b/crates/lg-buddy/tests/features/idle_inhibition.feature
@@ -1,0 +1,92 @@
+Feature: App keep-awake requests
+  Users can choose whether desktop keep-awake requests prevent automatic blanking.
+  Keep-awake requests are not user input and must not restore the TV.
+
+  Background:
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 1 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME emits no ScreenSaver signals
+    And GNOME idle monitor will report idletimes "1000"
+    And GNOME has 1 idle inhibitors
+
+  Scenario: Existing configurations keep blanking during playback
+    Given GNOME monitor stays open for 1.3 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV screen is blanked
+
+  Scenario: Enabled keep-awake support covers playback already active at startup
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME monitor stays open for 1.3 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+    And the TV client did not receive "turn_screen_on"
+    And the TV screen is visible
+
+  Scenario: Ending one of several keep-awake requests does not permit blanking
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 2 idle inhibitors
+    And GNOME changes to 1 idle inhibitors after 0.2 seconds
+    And GNOME monitor stays open for 1.5 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+    And the TV client did not receive "turn_screen_on"
+
+  Scenario Outline: Ending the last keep-awake request starts a fresh full timeout
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 2 idle inhibitors
+    And GNOME changes to 1 idle inhibitors after 0.2 seconds
+    And GNOME changes to 0 idle inhibitors after 1.5 seconds
+    And GNOME monitor stays open for <duration> seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_off" exactly <blanks> times
+    And the TV client did not receive "turn_screen_on"
+
+    Examples:
+      | duration | blanks |
+      | 2.2      | 0      |
+      | 2.9      | 1      |
+
+  Scenario: Releasing inhibition does not restore an already blanked screen
+    Given honoring app keep-awake requests is "enabled"
+    And the TV screen is blanked
+    And the session marker exists
+    And GNOME changes to 0 idle inhibitors after 0.2 seconds
+    And GNOME monitor stays open for 0.8 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_on"
+    And the TV screen is blanked
+    And the session marker exists
+
+  Scenario: Gamepad input still restores the screen during inhibition
+    Given honoring app keep-awake requests is "enabled"
+    And the TV screen is blanked
+    And the session marker exists
+    And gamepad activity is observed after 0.2 seconds
+    And GNOME monitor stays open for 1.6 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+    And the session marker is absent
+
+  Scenario: An explicit lock blanks the screen during inhibition
+    Given honoring app keep-awake requests is "enabled"
+    And mock system logind reports LockedHint=true
+    And GNOME monitor stays open for 0.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client did not receive "turn_screen_on"
+    And the TV screen is blanked

--- a/crates/lg-buddy/tests/features/idle_inhibition.feature
+++ b/crates/lg-buddy/tests/features/idle_inhibition.feature
@@ -30,6 +30,17 @@ Feature: App keep-awake requests
     And the TV client did not receive "turn_screen_on"
     And the TV screen is visible
 
+  Scenario: An inhibitor added before the blanking deadline survives a slow GNOME refresh
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 0 idle inhibitors
+    And GNOME changes to 1 idle inhibitors after 0.8 seconds
+    And GNOME delays the next inhibited query by 0.5 seconds
+    And GNOME monitor stays open for 1.6 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+
   Scenario: Ending one of several keep-awake requests does not permit blanking
     Given honoring app keep-awake requests is "enabled"
     And GNOME has 2 idle inhibitors
@@ -61,6 +72,7 @@ Feature: App keep-awake requests
     And the TV screen is blanked
     And the session marker exists
     And GNOME changes to 0 idle inhibitors after 0.2 seconds
+    And GNOME idle monitor will report idletimes "1000, 50, 300, 550"
     And GNOME monitor stays open for 0.8 seconds
     When I run the command "monitor"
     Then the command succeeds
@@ -73,6 +85,48 @@ Feature: App keep-awake requests
     And the TV screen is blanked
     And the session marker exists
     And gamepad activity is observed after 0.2 seconds
+    And GNOME monitor stays open for 1.6 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+    And the session marker is absent
+
+  Scenario: Genuine desktop input restores the screen during inhibition
+    Given honoring app keep-awake requests is "enabled"
+    And the TV screen is blanked
+    And the session marker exists
+    And genuine desktop input occurs after 0.2 seconds
+    And GNOME monitor stays open for 0.8 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+    And the session marker is absent
+
+  Scenario: Genuine desktop input immediately after release restores the screen
+    Given honoring app keep-awake requests is "enabled"
+    And the TV screen is blanked
+    And the session marker exists
+    And GNOME changes to 0 idle inhibitors after 0.2 seconds
+    And genuine desktop input occurs after 0.3 seconds
+    And GNOME monitor stays open for 0.9 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+    And the session marker is absent
+
+  Scenario: Repeated desktop input rearms the activity watch beyond the idle timeout
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 0 idle inhibitors
+    And the TV screen is blanked
+    And the session marker exists
+    And genuine desktop input occurs after 0.2 seconds
+    And genuine desktop input occurs after 1.0 seconds
     And GNOME monitor stays open for 1.6 seconds
     When I run the command "monitor"
     Then the command succeeds

--- a/crates/lg-buddy/tests/features/monitor_swayidle.feature
+++ b/crates/lg-buddy/tests/features/monitor_swayidle.feature
@@ -1,6 +1,22 @@
 Feature: swayidle monitor
   LG Buddy should consume swayidle idle and activity facts through the shared monitor policy.
 
+  Scenario: Automatic starts a fallback when GNOME cannot honor keep-awake requests
+    Given a temporary LG Buddy config using input HDMI_2
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And honoring app keep-awake requests is "enabled"
+    And swayidle is installed
+    And swayidle will emit an idle timeout
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "auto resolved to swayidle"
+    And stdout contains "GNOME SessionManager is required"
+    And the TV screen is blanked
+
   Scenario: swayidle timeout blanks the configured TV input
     Given a temporary LG Buddy config using input HDMI_2
     And LG Buddy session runtime is isolated

--- a/crates/lg-buddy/tests/features/settings.feature
+++ b/crates/lg-buddy/tests/features/settings.feature
@@ -11,6 +11,7 @@ Feature: Settings CLI
     And stdout contains "tv.platform=bscpylgtv (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.backend=auto (config.env, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.idle_blank=enabled (default, read-write, ops: get,describe,set,unset)"
+    And stdout contains "screen.honor_idle_inhibitors=disabled (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "screen.restore_policy=conservative (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "system.sleep_wake_policy=enabled (default, read-write, ops: get,describe,set,unset)"
     And stdout contains "updates.auto_check=enabled (default, read-write, ops: get,describe,set,unset)"
@@ -131,6 +132,15 @@ Feature: Settings CLI
     Then the command succeeds
     And stdout contains "screen.idle_blank"
     And stdout contains "storage key: screen_idle_blank"
+    And stdout contains "allowed values: enabled, disabled"
+    And stdout contains "apply: restart-user-screen-service"
+
+  Scenario: settings describe shows idle inhibitor policy operations
+    Given a temporary LG Buddy config using input HDMI_2
+    When I run the command "settings describe screen.honor_idle_inhibitors"
+    Then the command succeeds
+    And stdout contains "screen.honor_idle_inhibitors"
+    And stdout contains "storage key: screen_honor_idle_inhibitors"
     And stdout contains "allowed values: enabled, disabled"
     And stdout contains "apply: restart-user-screen-service"
 

--- a/crates/lg-buddy/tests/settings_operations.rs
+++ b/crates/lg-buddy/tests/settings_operations.rs
@@ -17,6 +17,7 @@ use support::{ExecutableScript, TestConfigFile, TestEnv};
 
 const BEHAVIOR_CONFIG: &str = "screen_backend=auto
 screen_idle_blank=enabled
+screen_honor_idle_inhibitors=disabled
 screen_idle_timeout=300
 screen_restore_policy=conservative
 system_sleep_wake_policy=enabled
@@ -92,7 +93,7 @@ fn environment_backend_edits_all_behavior_settings_without_a_tv_and_matches_cli(
             .iter()
             .map(|group| group.rows().len())
             .sum::<usize>(),
-        7,
+        8,
         "the Settings view is independent of TV availability"
     );
 
@@ -112,6 +113,14 @@ fn environment_backend_edits_all_behavior_settings_without_a_tv_and_matches_cli(
             },
             "screen.idle_blank",
             "disabled",
+        ),
+        (
+            SettingsIntent::SetEnabled {
+                setting: BehaviorSetting::ScreenHonorIdleInhibitors,
+                enabled: true,
+            },
+            "screen.honor_idle_inhibitors",
+            "enabled",
         ),
         (
             SettingsIntent::Commit {

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -1,6 +1,7 @@
 use dbus::arg::{PropMap, Variant as DbusVariant};
 use dbus::blocking::Connection as DbusConnection;
 use dbus::channel::{MatchingReceiver, Sender as DbusSender};
+use dbus::strings::BusName as DbusBusName;
 use dbus::Message as DbusMessage;
 use dbus::Path as DbusPath;
 use dbus_crossroads::{Crossroads, MethodErr};
@@ -365,8 +366,14 @@ struct MockSessionBusIdleMonitorState {
     idle_inhibitor_count: u32,
     inhibitor_plan: VecDeque<(Duration, u32)>,
     inhibitor_started_at: Option<Instant>,
+    next_inhibitor_query_delay: Option<Duration>,
     default_idletime: u64,
     idletime_plan: VecDeque<u64>,
+    idletime_reset_at: Option<Instant>,
+    next_user_active_watch_id: u32,
+    user_active_watches: VecDeque<(String, u32)>,
+    user_activity_plan: VecDeque<Duration>,
+    user_activity_started_at: Option<Instant>,
     screen_saver_signals: VecDeque<MockScreenSaverSignal>,
     client_ready: bool,
 }
@@ -384,6 +391,7 @@ impl MockSessionBusIdleMonitor {
         let (address, daemon_pid) = start_private_session_bus();
         let state = Arc::new(Mutex::new(MockSessionBusIdleMonitorState {
             default_idletime: 1500,
+            next_user_active_watch_id: 1,
             ..MockSessionBusIdleMonitorState::default()
         }));
         let stop = Arc::new(AtomicBool::new(false));
@@ -456,6 +464,10 @@ impl MockSessionBusIdleMonitor {
         self.patch_state(|state| state.inhibitor_plan.push_back((after, count)));
     }
 
+    pub fn delay_next_inhibited_query(&self, delay: Duration) {
+        self.patch_state(|state| state.next_inhibitor_query_delay = Some(delay));
+    }
+
     pub fn set_idle_monitor_idletime_plan(&self, values: &[u64]) {
         self.patch_state(|state| {
             state.idletime_plan = values.iter().copied().collect();
@@ -466,6 +478,10 @@ impl MockSessionBusIdleMonitor {
         self.patch_state(|state| {
             state.idletime_plan.push_back(value);
         });
+    }
+
+    pub fn schedule_user_activity(&self, after: Duration) {
+        self.patch_state(|state| state.user_activity_plan.push_back(after));
     }
 
     pub fn emit_screen_saver_idle(&self) {
@@ -693,26 +709,63 @@ fn spawn_mock_idle_monitor_service(
                     ("flags",),
                     ("inhibited",),
                     move |_, _, (flags,): (u32,)| {
-                        let mut state = inhibitor_state
-                            .lock()
-                            .expect("mock session manager state lock");
-                        state.inhibitor_started_at.get_or_insert_with(Instant::now);
-                        Ok((flags & 8 != 0 && state.idle_inhibitor_count > 0,))
+                        let (inhibited, delay) = {
+                            let mut state = inhibitor_state
+                                .lock()
+                                .expect("mock session manager state lock");
+                            state.inhibitor_started_at.get_or_insert_with(Instant::now);
+                            let inhibited = flags & 8 != 0 && state.idle_inhibitor_count > 0;
+                            let delay = if inhibited {
+                                state.next_inhibitor_query_delay.take()
+                            } else {
+                                None
+                            };
+                            (inhibited, delay)
+                        };
+                        if let Some(delay) = delay {
+                            thread::sleep(delay);
+                        }
+                        Ok((inhibited,))
                     },
                 );
             });
         let iface = crossroads.register("org.gnome.Mutter.IdleMonitor", move |builder| {
-            let state = Arc::clone(&idle_monitor_state);
+            let idletime_state = Arc::clone(&idle_monitor_state);
             builder.method("GetIdletime", (), ("idletime",), move |_, _, ()| {
-                let mut state = state
+                let mut state = idletime_state
                     .lock()
                     .expect("mock session-bus idle monitor state lock");
                 state.client_ready = true;
-                let value = state
-                    .idletime_plan
-                    .pop_front()
-                    .unwrap_or(state.default_idletime);
+                let value = state.idletime_plan.pop_front().unwrap_or_else(|| {
+                    state
+                        .idletime_reset_at
+                        .map(|reset_at| reset_at.elapsed().as_millis() as u64)
+                        .unwrap_or(state.default_idletime)
+                });
                 Ok((value,))
+            });
+
+            let watch_state = Arc::clone(&idle_monitor_state);
+            builder.method("AddUserActiveWatch", (), ("id",), move |ctx, _, ()| {
+                let mut state = watch_state
+                    .lock()
+                    .expect("mock session-bus idle monitor state lock");
+                let caller = ctx
+                    .message()
+                    .sender()
+                    .expect("mock AddUserActiveWatch caller unique name")
+                    .to_string();
+                state.client_ready = true;
+                state
+                    .user_activity_started_at
+                    .get_or_insert_with(Instant::now);
+                let id = state.next_user_active_watch_id;
+                state.next_user_active_watch_id = state
+                    .next_user_active_watch_id
+                    .checked_add(1)
+                    .expect("mock user-active watch id exhausted");
+                state.user_active_watches.push_back((caller, id));
+                Ok((id,))
             });
         });
         let notifications_iface =
@@ -781,6 +834,7 @@ fn spawn_mock_idle_monitor_service(
             let _ = connection.process(Duration::from_millis(50));
             sync_mock_bus_names(&connection, &state, &mut owned_names);
             emit_scheduled_mock_inhibitor_changes(&connection, &state);
+            emit_scheduled_mock_user_activity(&connection, &state);
             emit_queued_mock_screen_saver_signal(&connection, &state);
         }
     })
@@ -1069,6 +1123,12 @@ fn emit_scheduled_mock_inhibitor_changes(
             .expect("scheduled inhibitor change");
         let previous = state.idle_inhibitor_count;
         state.idle_inhibitor_count = count;
+        if previous > 0 && count == 0 {
+            // Mutter resets its monotonic idle counter when the final idle
+            // inhibitor is released. This is not user activity and does not
+            // fire a user-active watch.
+            state.idletime_reset_at = Some(Instant::now());
+        }
         let member = if count > previous {
             "InhibitorAdded"
         } else {
@@ -1087,6 +1147,45 @@ fn emit_scheduled_mock_inhibitor_changes(
             );
             let _ = connection.send(message);
         }
+    }
+}
+
+fn emit_scheduled_mock_user_activity(
+    connection: &DbusConnection,
+    state: &Arc<Mutex<MockSessionBusIdleMonitorState>>,
+) {
+    let watches = {
+        let mut state = state
+            .lock()
+            .expect("mock session-bus idle monitor state lock");
+        let Some(started_at) = state.user_activity_started_at else {
+            return;
+        };
+        let Some(after) = state.user_activity_plan.front().copied() else {
+            return;
+        };
+        if started_at.elapsed() < after {
+            return;
+        }
+
+        // Mutter user-active watches are one-shot. Input resets the idle
+        // counter, is consumed even if no watch is armed, and drains every
+        // watch armed for that input.
+        state.user_activity_plan.pop_front();
+        state.idletime_reset_at = Some(Instant::now());
+        state.user_active_watches.drain(..).collect::<Vec<_>>()
+    };
+
+    for (caller, watch_id) in watches {
+        let mut message = DbusMessage::new_signal(
+            "/org/gnome/Mutter/IdleMonitor/Core",
+            "org.gnome.Mutter.IdleMonitor",
+            "WatchFired",
+        )
+        .expect("create mock Mutter WatchFired signal")
+        .append1(watch_id);
+        message.set_destination(Some(DbusBusName::from(caller)));
+        let _ = connection.send(message);
     }
 }
 

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -16,7 +16,7 @@ use std::process::{self, Command as ProcessCommand};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{mpsc, Arc, Mutex, MutexGuard, OnceLock};
 use std::thread::{self, JoinHandle};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 #[allow(dead_code)]
 pub struct MockBscpylgtv {
@@ -361,6 +361,10 @@ struct MockSessionBusIdleMonitorState {
     screen_saver_available: bool,
     idle_monitor_available: bool,
     notifications_available: bool,
+    session_manager_available: bool,
+    idle_inhibitor_count: u32,
+    inhibitor_plan: VecDeque<(Duration, u32)>,
+    inhibitor_started_at: Option<Instant>,
     default_idletime: u64,
     idletime_plan: VecDeque<u64>,
     screen_saver_signals: VecDeque<MockScreenSaverSignal>,
@@ -438,6 +442,18 @@ impl MockSessionBusIdleMonitor {
 
     pub fn set_idle_monitor_idletime(&self, value: u64) {
         self.patch_state(|state| state.default_idletime = value);
+    }
+
+    pub fn set_idle_inhibitor_count(&self, count: u32) {
+        self.patch_state(|state| {
+            state.session_manager_available = true;
+            state.idle_inhibitor_count = count;
+        });
+        wait_for_mock_bus_name_sync();
+    }
+
+    pub fn schedule_idle_inhibitor_count(&self, after: Duration, count: u32) {
+        self.patch_state(|state| state.inhibitor_plan.push_back((after, count)));
     }
 
     pub fn set_idle_monitor_idletime_plan(&self, values: &[u64]) {
@@ -669,6 +685,22 @@ fn spawn_mock_idle_monitor_service(
 
         let mut crossroads = Crossroads::new();
         let idle_monitor_state = Arc::clone(&state);
+        let inhibitor_state = Arc::clone(&state);
+        let session_manager_iface =
+            crossroads.register("org.gnome.SessionManager", move |builder| {
+                builder.method(
+                    "IsInhibited",
+                    ("flags",),
+                    ("inhibited",),
+                    move |_, _, (flags,): (u32,)| {
+                        let mut state = inhibitor_state
+                            .lock()
+                            .expect("mock session manager state lock");
+                        state.inhibitor_started_at.get_or_insert_with(Instant::now);
+                        Ok((flags & 8 != 0 && state.idle_inhibitor_count > 0,))
+                    },
+                );
+            });
         let iface = crossroads.register("org.gnome.Mutter.IdleMonitor", move |builder| {
             let state = Arc::clone(&idle_monitor_state);
             builder.method("GetIdletime", (), ("idletime",), move |_, _, ()| {
@@ -726,6 +758,7 @@ fn spawn_mock_idle_monitor_service(
                 );
             });
         crossroads.insert("/org/gnome/Mutter/IdleMonitor/Core", &[iface], ());
+        crossroads.insert("/org/gnome/SessionManager", &[session_manager_iface], ());
         crossroads.insert("/org/freedesktop/Notifications", &[notifications_iface], ());
 
         let shared_crossroads = Arc::new(Mutex::new(crossroads));
@@ -747,6 +780,7 @@ fn spawn_mock_idle_monitor_service(
         while !stop.load(Ordering::SeqCst) {
             let _ = connection.process(Duration::from_millis(50));
             sync_mock_bus_names(&connection, &state, &mut owned_names);
+            emit_scheduled_mock_inhibitor_changes(&connection, &state);
             emit_queued_mock_screen_saver_signal(&connection, &state);
         }
     })
@@ -957,6 +991,7 @@ struct MockOwnedBusNames {
     screen_saver: bool,
     idle_monitor: bool,
     notifications: bool,
+    session_manager: bool,
 }
 
 fn sync_mock_bus_names(
@@ -964,7 +999,13 @@ fn sync_mock_bus_names(
     state: &Arc<Mutex<MockSessionBusIdleMonitorState>>,
     owned_names: &mut MockOwnedBusNames,
 ) {
-    let (want_shell, want_screen_saver, want_idle_monitor, want_notifications) = {
+    let (
+        want_shell,
+        want_screen_saver,
+        want_idle_monitor,
+        want_notifications,
+        want_session_manager,
+    ) = {
         let state = state
             .lock()
             .expect("mock session-bus idle monitor state lock");
@@ -973,6 +1014,7 @@ fn sync_mock_bus_names(
             state.screen_saver_available,
             state.idle_monitor_available,
             state.notifications_available,
+            state.session_manager_available,
         )
     };
 
@@ -1000,6 +1042,52 @@ fn sync_mock_bus_names(
         want_notifications,
         &mut owned_names.notifications,
     );
+    sync_mock_bus_name(
+        connection,
+        "org.gnome.SessionManager",
+        want_session_manager,
+        &mut owned_names.session_manager,
+    );
+}
+
+fn emit_scheduled_mock_inhibitor_changes(
+    connection: &DbusConnection,
+    state: &Arc<Mutex<MockSessionBusIdleMonitorState>>,
+) {
+    let mut state = state.lock().expect("mock session manager state lock");
+    let Some(started_at) = state.inhibitor_started_at else {
+        return;
+    };
+    while state
+        .inhibitor_plan
+        .front()
+        .is_some_and(|(after, _)| started_at.elapsed() >= *after)
+    {
+        let (_, count) = state
+            .inhibitor_plan
+            .pop_front()
+            .expect("scheduled inhibitor change");
+        let previous = state.idle_inhibitor_count;
+        state.idle_inhibitor_count = count;
+        let member = if count > previous {
+            "InhibitorAdded"
+        } else {
+            "InhibitorRemoved"
+        };
+        for id in count.min(previous)..count.max(previous) {
+            let message = DbusMessage::new_signal(
+                "/org/gnome/SessionManager",
+                "org.gnome.SessionManager",
+                member,
+            )
+            .expect("inhibitor signal")
+            .append1(
+                DbusPath::new(format!("/org/gnome/SessionManager/Inhibitor{id}"))
+                    .expect("inhibitor path"),
+            );
+            let _ = connection.send(message);
+        }
+    }
 }
 
 fn sync_mock_bus_name(connection: &DbusConnection, name: &str, wanted: bool, owned: &mut bool) {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -948,7 +948,8 @@ The detailed session model is documented in `docs/session-backend-model.md`.
 
 - the GNOME session-bus connection and subscriptions
 - ScreenSaver sender ownership validation and signal mapping
-- Mutter idletime polling and normalized activity observations
+- Mutter user-active watches when honoring inhibitors, legacy idletime polling
+  otherwise, and normalized activity observations
 
 `sources/desktop/wayland.rs` is the native non-GNOME adapter. It owns the
 Wayland connection, registry, every advertised seat, and zero-timeout idle

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,6 +39,7 @@ For GNOME end-to-end work, the running session also needs the full GNOME contrac
 - GNOME Shell
 - `org.gnome.ScreenSaver`
 - `org.gnome.Mutter.IdleMonitor`
+- `org.gnome.SessionManager` when testing **Allow apps to prevent idle blanking**
 
 The C toolchain is required because `cargo build` now compiles vendored
 `libdbus` as part of the dependency graph. On common Linux distributions that

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -126,7 +126,7 @@ Current shared-runtime inputs:
 | `org.gnome.ScreenSaver.ActiveChanged(true)` | Non-authoritative idle observation | GNOME source -> shared runner; does not change the LG Buddy deadline |
 | `org.gnome.ScreenSaver.ActiveChanged(false)` | `ProviderActive` | `InactivityEngine` |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | `InactivityEngine` |
-| Recent activity reported by `org.gnome.Mutter.IdleMonitor.GetIdletime` | `DesktopActivityObserved` | `InactivityEngine` |
+| Recent Mutter `GetIdletime` activity (honoring disabled) or a trusted user-active `WatchFired` (honoring enabled) | `DesktopActivityObserved` | `InactivityEngine` |
 | Linux gamepad activity | `UserActivityObserved` from `AuxiliaryInput` | Shared session runtime -> `InactivityEngine` |
 | Initial or changed logind `LockedHint=true` | `SessionEvent::Lock` from `LinuxLogind` | Shared session runtime -> `InactivityEngine` |
 | Changed logind `LockedHint=false` after lock | `SessionEvent::Unlock` from `LinuxLogind` | Clear the observed lock state without requesting screen restore |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -71,10 +71,11 @@ These are the semantic events the runtime should reason about.
 
 ## Runtime Contract
 
-Native sources publish `SessionObservation` values. Each observation carries a
-canonical session event, inactivity fact, or idle-blanking permission, an `EventSource`, and the time it
-was observed. Source modules do not decide whether to blank or restore the
-screen.
+Native sources publish `SessionObservation` values: canonical session events,
+inactivity facts, or idle-blanking permission updates, with an `EventSource` and
+observation time. A pending permission refresh suspends automatic blanking
+without changing the last confirmed permission or renewing the deadline.
+Source modules do not decide whether to blank or restore the screen.
 
 GNOME and native Wayland feed activity facts to the shared runner, which owns
 their configured inactivity deadline. `swayidle` owns its initial timeout but
@@ -112,7 +113,8 @@ Current mapping:
 | `org.gnome.ScreenSaver.ActiveChanged (true,)` | Idle observation that cannot bypass LG Buddy's timeout | Implemented |
 | `org.gnome.ScreenSaver.ActiveChanged (false,)` | `Active` | Implemented |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | Implemented |
-| Recent activity from `org.gnome.Mutter.IdleMonitor.GetIdletime` | `UserActivity` | Implemented |
+| Recent activity from `org.gnome.Mutter.IdleMonitor.GetIdletime` (honoring disabled) | `UserActivity` | Implemented |
+| Mutter `WatchFired` for the current `AddUserActiveWatch` (honoring enabled) | `UserActivity` | Implemented |
 | `org.gnome.SessionManager.IsInhibited(8)` | Idle-blanking permission when honoring is enabled | Implemented |
 
 Notes:
@@ -121,6 +123,10 @@ Notes:
 - Enabling inhibitor honoring additionally requires `org.gnome.SessionManager`.
   The source reads its current aggregate idle-inhibition state at startup and
   after trusted `InhibitorAdded`, `InhibitorRemoved`, or owner-change signals.
+  Automatic blanking pauses while each refresh is pending; an unchanged result
+  preserves the existing deadline. User input comes from Mutter's one-shot
+  user-active watches, rearmed after each signal. Unlike `GetIdletime`, these
+  do not treat the idle-counter reset on inhibitor release as activity.
   Other inhibition flags do not block blanking. Losing the service or failing
   to read its state ends the source with a diagnostic error rather than assuming
   blanking is allowed. With the setting disabled, this extra dependency is not
@@ -128,8 +134,8 @@ Notes:
 - LG Buddy owns the configured timeout value for this backend.
 - LG Buddy owns one inactivity deadline. Desktop, auxiliary, active, and wake
   activity reports reset it; expiry after `screen_idle_timeout` triggers blanking.
-- Mutter idletime is used only to detect recent desktop activity. Its absolute
-  value does not trigger blanking.
+- With honoring disabled, Mutter idletime is used only to detect recent desktop
+  activity. Its absolute value does not trigger blanking.
 - ScreenSaver idle cannot trigger blanking by itself. ScreenSaver active and
   wake signals reset the same LG Buddy deadline and remain restore observations
   evaluated by screen policy.

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -72,7 +72,7 @@ These are the semantic events the runtime should reason about.
 ## Runtime Contract
 
 Native sources publish `SessionObservation` values. Each observation carries a
-canonical session event or inactivity fact, an `EventSource`, and the time it
+canonical session event, inactivity fact, or idle-blanking permission, an `EventSource`, and the time it
 was observed. Source modules do not decide whether to blank or restore the
 screen.
 
@@ -81,6 +81,15 @@ their configured inactivity deadline. `swayidle` owns its initial timeout but
 publishes `Idle` and independent desktop-activity observations back to the same
 runner. All three backends therefore share blank, restore, and post-blank
 power-off policy.
+
+`screen.honor_idle_inhibitors` defaults to `disabled`. When enabled, native
+sources also publish `IdleBlankingPermission`. The runner initially withholds
+automatic blanking until the source establishes permission, including when an
+inhibitor predates startup. Restoring permission starts a fresh full timeout;
+duplicate observations do not extend it. Permission changes are never activity
+or restore requests. Real desktop and gamepad input still share the inactivity
+deadline. Explicit lock behavior and an already pending post-blank power-off
+deadline are unaffected.
 
 ## Provider Map
 
@@ -104,10 +113,18 @@ Current mapping:
 | `org.gnome.ScreenSaver.ActiveChanged (false,)` | `Active` | Implemented |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | Implemented |
 | Recent activity from `org.gnome.Mutter.IdleMonitor.GetIdletime` | `UserActivity` | Implemented |
+| `org.gnome.SessionManager.IsInhibited(8)` | Idle-blanking permission when honoring is enabled | Implemented |
 
 Notes:
 
 - GNOME requires GNOME Shell, `org.gnome.ScreenSaver`, and `org.gnome.Mutter.IdleMonitor`.
+- Enabling inhibitor honoring additionally requires `org.gnome.SessionManager`.
+  The source reads its current aggregate idle-inhibition state at startup and
+  after trusted `InhibitorAdded`, `InhibitorRemoved`, or owner-change signals.
+  Other inhibition flags do not block blanking. Losing the service or failing
+  to read its state ends the source with a diagnostic error rather than assuming
+  blanking is allowed. With the setting disabled, this extra dependency is not
+  queried or subscribed to.
 - LG Buddy owns the configured timeout value for this backend.
 - LG Buddy owns one inactivity deadline. Desktop, auxiliary, active, and wake
   activity reports reset it; expiry after `screen_idle_timeout` triggers blanking.
@@ -183,8 +200,15 @@ selection requirement.
 The native `wayland` backend requires `ext_idle_notifier_v1` version 2 or newer
 and at least one advertised `wl_seat`. It monitors every seat, including
 seats that currently advertise no input capabilities, using zero-timeout idle
-notifications. `resumed` maps to desktop activity; `idled` remains
-observational, so only LG Buddy's inactivity deadline can trigger blanking.
+notifications from `get_input_idle_notification`. Its `resumed` maps to desktop
+activity; `idled` remains observational, so only LG Buddy's inactivity deadline
+can trigger blanking.
+
+When inhibitor honoring is enabled, a separate zero-timeout
+`get_idle_notification` observes permission on each seat. Blanking is allowed
+only once every seat reports idle. Its inhibitor-aware `resumed` withdraws
+permission without reporting input or restoring the TV. New seats initially
+withhold permission, and removing a seat recomputes the aggregate state.
 
 Seats are added and removed dynamically. Connection or dispatch loss, removal
 of the bound notifier, or removal of the last seat is fatal to the provider and
@@ -207,6 +231,10 @@ Notes:
   and is planned for removal in 2.0.0 after the native provider remains
   field-validated across supported compositors and the 1.x migration window.
 - `swayidle` does not provide a clear equivalent of GNOME's `WakeRequested`.
+- Its source-owned timeout always honors compositor inhibition, independently
+  of `screen.honor_idle_inhibitors`, including when `auto` falls back to it.
+  The preference is hidden for explicit `swayidle` selections; this compatibility
+  backend does not offer the native default-off behavior.
 - `swayidle` does not provide a Mutter-style early activity surface.
 - LG Buddy owns the configured timeout value for this backend.
 - The shared runner owns lock observation, screen policy, and the post-blank

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -107,10 +107,13 @@ Mock the API surface we consume, not the whole system behind it.
 Examples:
 
 - the TV mock reproduces `bscpylgtvcommand` command line, exit status, stdout, and stderr behavior that LG Buddy cares about
-- GNOME monitor/runtime tests should use the private session-bus harness for ScreenSaver signals and Mutter idletime
+- GNOME monitor/runtime tests should use the private session-bus harness for
+  ScreenSaver signals, Mutter idletime, and SessionManager idle-inhibition
+  snapshots and signals
 - native Wayland provider tests should model registry discovery, protocol-version
-  rejection, every advertised seat, resumed-only activity, and fatal provider
-  loss without requiring a compositor
+  rejection, every advertised seat, input-notification resumed activity, separate
+  inhibitor-aware permission notifications, and fatal provider loss without
+  requiring a compositor
 - logind lifecycle/runtime tests should use the private system-bus harness for
   `PreparingForSleep` and `PrepareForSleep` behavior
 
@@ -252,6 +255,8 @@ Examples:
 - native Wayland protocol-version and seat discovery
 - native Wayland resumed-notification and registry-removal mapping
 - gamepad activity integration with the LG Buddy inactivity deadline
+- opt-in idle inhibition at startup, overlapping inhibitors, a fresh timeout
+  after the last release, and release never acting as restore activity
 - screen runtime-phase eligibility over the private logind system-bus seam
 - logind lock state entering the shared blanked state without making unlock a
   restore trigger, while observation-time tests cover pre-lock, post-lock grace,
@@ -271,6 +276,9 @@ cases report a precise fallback reason, and `auto` retains the
 GNOME-then-native-Wayland-then-`swayidle` order. Release-facing changes must
 keep the static x86_64 musl build and release-bundle smoke test green, including
 preservation and deprecation reporting for an existing `swayidle` config.
+For inhibitor changes, start real video playback before the monitor: disabled
+must still blank, enabled must remain visible past the timeout, and stopping
+playback must leave the screen visible for a fresh full timeout before blanking.
 
 ### Gamepad activity
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -250,8 +250,10 @@ Secondary concern:
 Examples:
 
 - GNOME signal mapping
-- GNOME monitor setup, sender ownership, and idletime polling over the
-  session-bus seam
+- GNOME monitor setup, sender ownership, idletime polling, and one-shot
+  user-active watches over the session-bus seam
+- delayed inhibitor replies crossing the blanking deadline, and inhibitor
+  release resetting Mutter's idle counter without reporting user input
 - native Wayland protocol-version and seat discovery
 - native Wayland resumed-notification and registry-removal mapping
 - gamepad activity integration with the LG Buddy inactivity deadline

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -104,6 +104,11 @@ Open **Settings** to adapt the TV to your routine:
 - To wait longer before blanking, increase **Screen → Idle timeout**. The value
   is in seconds: `600` gives you ten minutes. The default is five minutes.
 - To keep the panel on while you are away, turn off **Idle blanking**.
+- To keep the panel on during video playback or presentations, turn on
+  **Allow apps to prevent idle blanking**. It is off by default. Apps must
+  request that the desktop stay awake; when the last request ends, LG Buddy
+  starts a fresh idle timeout. A request does not restore an already blanked
+  TV or prevent blanking when you lock the session.
 - To stop the TV following PC sleep and wake, turn off
   **Sleep & Wake → TV sleep & wake**. Enable it to power the TV off before
   sleep and restore it after wake.
@@ -129,7 +134,12 @@ Leave **Desktop integration** at **Automatic** unless you need to select a
 particular compatible desktop. See the [session backend model](session-backend-model.md)
 for compatibility details, including the deprecated `swayidle` option.
 
-Turning off **Idle blanking** hides **Desktop integration** and **Idle timeout**
+This preference applies to the native GNOME and Wayland integrations. The
+deprecated `swayidle` integration always honors app inhibition, including when
+**Automatic** falls back to it. Selecting `swayidle` hides this preference.
+
+Turning off **Idle blanking** hides **Allow apps to prevent idle blanking**,
+**Desktop integration**, and **Idle timeout**
 while keeping their saved values for when you turn it back on. **Restore policy**
 stays available because it also controls restoration after system sleep and
 explicit screen-on requests.

--- a/scripts/test-release-bundle.sh
+++ b/scripts/test-release-bundle.sh
@@ -505,7 +505,7 @@ mkdir -p "$FRESH_CONFIG_HOME"
     export LG_BUDDY_NATIVE_PAIRING_MARKER="$FRESH_NATIVE_PAIRING_MARKER"
     export LG_BUDDY_SKIP_SYSTEMD_ACTIONS="1"
     printf '%s\n' \
-        '192.0.2.10' 'aa:bb:cc:dd:ee:ff' '2' '' 'Y' '1' '300' '1' 'Y' \
+        '192.0.2.10' 'aa:bb:cc:dd:ee:ff' '2' '' 'Y' '1' '300' '1' 'n' 'Y' \
         | bash "$BUNDLE_DIR/configure.sh" >"$FRESH_CONFIG_OUTPUT" 2>&1
 )
 grep -F -q 'TV Platform:         lg_webos' "$FRESH_CONFIG_OUTPUT"
@@ -521,6 +521,7 @@ if grep -F -q 'swayidle' "$FRESH_CONFIG_OUTPUT"; then
     exit 1
 fi
 grep -q '^screen_backend=auto$' "$FRESH_CONFIG_HOME/.config/lg-buddy/config.env"
+grep -q '^screen_honor_idle_inhibitors=disabled$' "$FRESH_CONFIG_HOME/.config/lg-buddy/config.env"
 
 export HOME="$HOME_DIR"
 export XDG_CONFIG_HOME="$XDG_CONFIG_HOME"
@@ -548,6 +549,7 @@ tvs_primary_mac=aa:bb:cc:dd:ee:ff
 tvs_primary_input=HDMI_2
 tvs_primary_platform=bscpylgtv
 screen_idle_blank=enabled
+screen_honor_idle_inhibitors=disabled
 screen_backend=auto
 screen_idle_timeout=300
 screen_restore_policy=conservative
@@ -622,6 +624,7 @@ grep -q '^tvs_primary_mac=aa:bb:cc:dd:ee:ff$' "$CONFIG_FILE"
 grep -q '^tvs_primary_input=HDMI_2$' "$CONFIG_FILE"
 grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 grep -q '^screen_idle_blank=enabled$' "$CONFIG_FILE"
+grep -q '^screen_honor_idle_inhibitors=disabled$' "$CONFIG_FILE"
 grep -q '^screen_backend=auto$' "$CONFIG_FILE"
 grep -q '^system_sleep_wake_policy=enabled$' "$CONFIG_FILE"
 grep -q "$CONFIG_FILE" "$INSTALLED_POINTER"
@@ -672,6 +675,7 @@ printf '%s\n' "$NATIVE_PLATFORM_OUTPUT" | grep -F -q 'No stored native TV creden
 grep -q '^tvs_primary_platform=bscpylgtv$' "$CONFIG_FILE"
 
 "$INSTALLED_BINARY" settings set screen.backend swayidle
+"$INSTALLED_BINARY" settings set screen.honor_idle_inhibitors enabled
 "$INSTALLED_BINARY" settings set screen.idle_timeout 900
 "$INSTALLED_BINARY" settings set screen.idle_timeout 90000
 grep -q '^screen_idle_timeout=86400$' "$CONFIG_FILE"
@@ -687,6 +691,7 @@ grep -q '^screen_idle_timeout=86400$' "$CONFIG_FILE"
 BACKGROUND_UPDATE_OUTPUT="$("$INSTALLED_BINARY" updates background-check)"
 printf '%s\n' "$BACKGROUND_UPDATE_OUTPUT" | grep -F -q 'background: skipped (automatic update checks disabled)'
 grep -q '^screen_backend=swayidle$' "$CONFIG_FILE"
+grep -q '^screen_honor_idle_inhibitors=enabled$' "$CONFIG_FILE"
 grep -q '^screen_idle_blank=disabled$' "$CONFIG_FILE"
 grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
 grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"
@@ -708,6 +713,7 @@ LEGACY_CONFIGURE_OUTPUT="$WORK_DIR/legacy-configure.output"
     unset LG_BUDDY_SCREEN_BACKEND
     unset LG_BUDDY_SCREEN_IDLE_TIMEOUT
     unset LG_BUDDY_SCREEN_RESTORE_POLICY
+    unset LG_BUDDY_SCREEN_HONOR_IDLE_INHIBITORS
     unset LG_BUDDY_SYSTEM_SLEEP_WAKE_POLICY
     export LG_BUDDY_TV_IP="192.168.1.11"
     export LG_BUDDY_TV_MAC="11:22:33:44:55:66"
@@ -723,6 +729,7 @@ grep -q '^tvs_primary_mac=11:22:33:44:55:66$' "$CONFIG_FILE"
 grep -q '^tvs_primary_input=HDMI_3$' "$CONFIG_FILE"
 grep -q '^tvs_primary_platform=lg_webos$' "$CONFIG_FILE"
 grep -q '^screen_backend=swayidle$' "$CONFIG_FILE"
+grep -q '^screen_honor_idle_inhibitors=enabled$' "$CONFIG_FILE"
 grep -q '^screen_idle_blank=disabled$' "$CONFIG_FILE"
 grep -q '^screen_idle_timeout=900$' "$CONFIG_FILE"
 grep -q '^screen_restore_policy=aggressive$' "$CONFIG_FILE"


### PR DESCRIPTION
Video players and presentations can now prevent automatic idle blanking when **Allow apps to prevent idle blanking** is enabled. The option defaults off, preserving existing native-backend behavior. Ending the last keep-awake request starts a fresh configured timeout.

GNOME reads SessionManager's aggregate idle-inhibition state and pauses automatic blanking while refreshing it. When honoring inhibitors, it uses Mutter user-active watches so an idle-counter reset when playback ends cannot restore the TV. Native Wayland uses separate inhibitor-aware notifications alongside the existing input notifications. Gamepad input, explicit locking, Restore policy, and post-blank power-off retain their behavior. Automatic backend selection accounts for the additional GNOME dependency when the option is enabled.

The preference uses the existing settings registry, GTK controls, CLI, configuration, and service-apply paths. It is hidden when Idle Blanking is off or explicit `swayidle` is selected. The deprecated `swayidle` backend continues always honoring inhibitors, including automatic fallback; the UI and documentation explain this exception.

Validation:

- Full core Rust suite (1,005 unit tests, 150 Cucumber scenarios), display-backed GTK suite, and all-target/all-feature Clippy pass.
- Regression controls reproduce blanking during a delayed GNOME inhibitor query and restoration after Mutter's idle-counter reset with the pre-fix source. Both pass with the fixes. The private D-Bus harness also covers startup, overlapping inhibitors, release timing, genuine desktop input during and immediately after inhibition, repeated activity-watch rearming, independent gamepad input, explicit locking, and backend fallback.
- Installed GUI and first-run installer smoke passed for `66db0a97c1dbe752884c7228ae7f52dc179c8805`, before the GNOME follow-up fixes.
- Static musl runtime and GTK release builds, manifest/linkage checks, and the canonical release-bundle smoke passed for `66db0a97c1dbe752884c7228ae7f52dc179c8805`.
- Real KWin 6.7.4 and Sway 1.11 sessions with mpv 0.40 native Wayland playback were verified with that packaged runtime: disabled blanks during playback; enabled covers playback already active at startup; stopping playback starts a fresh timeout. Explicit and Automatic backend selection were verified. These used a virtual display and the native webOS TV fixture, not a physical TV.

Closes #196. Related report: #195.
