### PR TITLE
refactor: let runtime actions own native TV sessions

### DIFF
--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -6,20 +6,18 @@ use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::process::Output;
-use std::time::Duration;
 
 use crate::audio::{apply_audio_operation_with, read_audio_status_with, AudioOperation};
 use crate::brightness::{
     notify_brightness_success_with, read_current_brightness_with, write_brightness_with,
 };
 use crate::config::{load_config, resolve_config_path_from_env, Config};
-use crate::events::RuntimeEvent;
+use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
 use crate::lifecycle::ThreadSleeper;
 use crate::lifecycle::{self, JournalctlSleepDetector, NmOnlineNetworkWaiter};
 use crate::notifications::{FreedesktopNotifier, Notification, NotificationError, Notifier};
-use crate::state::{
-    ScreenOwnershipMarker, StateScope, SystemSleepAttemptState, SystemSleepCycleState,
-};
+use crate::session::actions::{RuntimeActionExecutor, SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT};
+use crate::state::{ScreenOwnershipMarker, StateScope, SystemSleepAttemptState};
 use crate::tv::{
     build_tv_client, AudioStatus, OledBrightness, TvClient, TvClientBuildOptions, TvDevice,
     VolumeLevel,
@@ -27,7 +25,6 @@ use crate::tv::{
 use crate::wol::UdpWakeOnLanSender;
 use crate::{BrightnessCommand, MuteCommand, RunError, StartupMode, VolumeCommand};
 
-const SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
 const GUI_ENV: &str = "LG_BUDDY_GUI";
 const GUI_EXECUTABLE: &str = "lg-buddy-gui";
 
@@ -378,7 +375,12 @@ fn strip_lg_buddy_prefix(value: &str) -> &str {
 }
 
 pub fn run_screen_off<W: Write>(writer: &mut W) -> Result<(), RunError> {
-    crate::screen::run_screen_off_from_env(writer)
+    RuntimeActionExecutor::default()
+        .run_screen_off(
+            writer,
+            RuntimeEvent::new(EventSource::CliApi, RuntimeEventKind::ScreenBlankRequested),
+        )
+        .map(|_| ())
 }
 
 pub fn run_sleep_pre<W: Write>(writer: &mut W) -> Result<(), RunError> {
@@ -393,30 +395,7 @@ pub fn run_sleep_pre_for_event<W: Write>(
     writer: &mut W,
     event: RuntimeEvent,
 ) -> Result<(), RunError> {
-    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-    let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let cycle_state =
-        SystemSleepCycleState::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(
-        &config_path,
-        config.tv_ip,
-        config.tv_platform,
-        TvClientBuildOptions::production()
-            .stored_token_only()
-            .with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
-    )?;
-    let sleeper = ThreadSleeper;
-
-    lifecycle::handle_system_suspend_with(
-        writer,
-        &config,
-        &marker,
-        &cycle_state,
-        &tv_client,
-        &sleeper,
-        event,
-    )
+    RuntimeActionExecutor::default().run_sleep_pre(writer, event)
 }
 
 pub fn run_sleep<W: Write>(writer: &mut W) -> Result<(), RunError> {
@@ -567,74 +546,7 @@ pub fn run_startup<W: Write>(writer: &mut W, mode: StartupMode) -> Result<(), Ru
 }
 
 pub fn run_system_resume<W: Write>(writer: &mut W) -> Result<(), RunError> {
-    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-    let marker = ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let attempt_state =
-        SystemSleepAttemptState::from_env(StateScope::System).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(
-        &config_path,
-        config.tv_ip,
-        config.tv_platform,
-        TvClientBuildOptions::production().stored_token_only(),
-    )?;
-    let wol_sender = UdpWakeOnLanSender::default();
-    let sleeper = ThreadSleeper;
-    let network_waiter = NmOnlineNetworkWaiter::default();
-
-    let result = (|| -> Result<(), RunError> {
-        match tv_client.can_authenticate_unattended() {
-            Ok(true) => lifecycle::restore_after_system_sleep_with(
-                writer,
-                &config,
-                &marker,
-                &tv_client,
-                &wol_sender,
-                &sleeper,
-                &network_waiter,
-            ),
-            Ok(false) => {
-                marker.clear()?;
-                writeln!(
-                    writer,
-                    "LG Buddy System Resume: No stored native TV credential; skipping unattended TV control."
-                )?;
-                Ok(())
-            }
-            Err(err) => {
-                marker.clear()?;
-                Err(err.into())
-            }
-        }
-    })();
-
-    let mut cleanup_error = None;
-
-    if let Err(err) = attempt_state.clear() {
-        writeln!(
-            writer,
-            "LG Buddy System Resume: could not clear system sleep attempt marker after resume. {err}"
-        )?;
-        cleanup_error = Some(err);
-    }
-
-    if let Err(err) = attempt_state.clear_outcome() {
-        writeln!(
-            writer,
-            "LG Buddy System Resume: could not clear system sleep cycle state after resume. {err}"
-        )?;
-        if cleanup_error.is_none() {
-            cleanup_error = Some(err);
-        }
-    }
-
-    if result.is_ok() {
-        if let Some(err) = cleanup_error {
-            return Err(RunError::Io(err));
-        }
-    }
-
-    result
+    RuntimeActionExecutor::default().run_system_resume(writer)
 }
 
 fn fail_open_nm_pre_down_after_system_bus_error<W: Write, E: std::fmt::Display>(
@@ -678,7 +590,13 @@ pub fn run_shutdown<W: Write>(writer: &mut W) -> Result<(), RunError> {
 }
 
 pub fn run_screen_on<W: Write>(writer: &mut W) -> Result<(), RunError> {
-    crate::screen::run_screen_on_from_env(writer)
+    RuntimeActionExecutor::default().run_screen_on(
+        writer,
+        RuntimeEvent::new(
+            EventSource::CliApi,
+            RuntimeEventKind::ScreenRestoreRequested,
+        ),
+    )
 }
 
 fn run_brightness_command_with<W: Write, C: TvClient>(

--- a/crates/lg-buddy/src/screen.rs
+++ b/crates/lg-buddy/src/screen.rs
@@ -3,20 +3,20 @@ use std::io::{self, Write};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::config::{
-    load_config, resolve_config_path_from_env, Config, HdmiInput, MacAddress, ScreenRestorePolicy,
-};
-use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
+use crate::config::{Config, HdmiInput, MacAddress, ScreenRestorePolicy};
+#[cfg(test)]
+use crate::events::RuntimeEventKind;
+use crate::events::{EventSource, RuntimeEvent};
 use crate::policy::{
     ActionKind, DecisionReason, DecisionReasonCode, Diagnostic, PolicyOutcome, StateMarker,
     StateTransition, TransitionReason, TransitionReasonCode,
 };
 #[cfg(test)]
 use crate::runtime_phase::NoopRuntimePhaseProvider;
-use crate::runtime_phase::{LogindRuntimePhaseProvider, RuntimePhaseProvider, RuntimePhaseRead};
+use crate::runtime_phase::{RuntimePhaseProvider, RuntimePhaseRead};
 use crate::state::{ScreenOwnershipMarker, StateScope};
-use crate::tv::{build_tv_client, CurrentInput, TvClient, TvClientBuildOptions, TvDevice, TvError};
-use crate::wol::{UdpWakeOnLanSender, WakeOnLanSender};
+use crate::tv::{CurrentInput, TvClient, TvDevice, TvError};
+use crate::wol::WakeOnLanSender;
 use crate::RunError;
 
 const SCREEN_ON_INITIAL_WAKE_DELAY: Duration = Duration::from_secs(6);
@@ -45,7 +45,7 @@ pub(crate) struct SystemMarkerLifecycleStatusProvider {
 }
 
 impl SystemMarkerLifecycleStatusProvider {
-    fn from_env() -> Result<Self, crate::state::StateDirError> {
+    pub(crate) fn from_env() -> Result<Self, crate::state::StateDirError> {
         Ok(Self {
             marker: ScreenOwnershipMarker::from_env(StateScope::System)?,
         })
@@ -227,146 +227,6 @@ impl ScreenRestoreTrace {
     }
 }
 
-pub(crate) fn run_screen_off_from_env<W: Write>(writer: &mut W) -> Result<(), RunError> {
-    run_screen_off_from_env_for_event(
-        writer,
-        RuntimeEvent::new(EventSource::CliApi, RuntimeEventKind::ScreenBlankRequested),
-    )
-}
-
-pub(crate) fn run_screen_off_from_env_for_event<W: Write>(
-    writer: &mut W,
-    event: RuntimeEvent,
-) -> Result<(), RunError> {
-    run_screen_off_from_env_for_event_with_result(writer, event).map(|_| ())
-}
-
-#[derive(Debug)]
-pub(crate) struct ScreenOffActionResult {
-    pub(crate) blank_succeeded: bool,
-}
-
-pub(crate) fn run_screen_off_from_env_for_event_with_result<W: Write>(
-    writer: &mut W,
-    event: RuntimeEvent,
-) -> Result<ScreenOffActionResult, RunError> {
-    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-    let marker =
-        ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(
-        &config_path,
-        config.tv_ip,
-        config.tv_platform,
-        TvClientBuildOptions::production(),
-    )?;
-    let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
-    let lifecycle_status =
-        SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
-
-    run_screen_off_with_result_for_event(
-        writer,
-        &config,
-        &marker,
-        &tv_client,
-        event,
-        &mut phase_provider,
-        &lifecycle_status,
-    )
-    .map(|result| ScreenOffActionResult {
-        blank_succeeded: result.blank_succeeded,
-    })
-}
-
-pub(crate) fn run_timed_power_off_from_env_for_event<W: Write>(
-    writer: &mut W,
-    event: RuntimeEvent,
-) -> Result<(), RunError> {
-    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-    let marker =
-        ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
-    if !config.screen_idle_blank.is_enabled() {
-        writeln!(
-            writer,
-            "LG Buddy Timed Power Off: Screen idle blanking is disabled; skipping power-off."
-        )?;
-        return Ok(());
-    }
-    if !marker.exists() {
-        writeln!(
-            writer,
-            "LG Buddy Timed Power Off: Screen ownership marker is absent; skipping power-off."
-        )?;
-        return Ok(());
-    }
-    let tv_client = build_tv_client(
-        &config_path,
-        config.tv_ip,
-        config.tv_platform,
-        TvClientBuildOptions::production(),
-    )?;
-    let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
-    let lifecycle_status =
-        SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
-
-    run_timed_power_off_with_event(
-        writer,
-        &config,
-        &marker,
-        &tv_client,
-        event,
-        &mut phase_provider,
-        &lifecycle_status,
-    )
-    .map(|_| ())
-}
-
-pub(crate) fn run_screen_on_from_env<W: Write>(writer: &mut W) -> Result<(), RunError> {
-    run_screen_on_from_env_for_event(
-        writer,
-        RuntimeEvent::new(
-            EventSource::CliApi,
-            RuntimeEventKind::ScreenRestoreRequested,
-        ),
-    )
-}
-
-pub(crate) fn run_screen_on_from_env_for_event<W: Write>(
-    writer: &mut W,
-    event: RuntimeEvent,
-) -> Result<(), RunError> {
-    let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    let config = load_config(&config_path).map_err(RunError::Config)?;
-    let marker =
-        ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
-    let tv_client = build_tv_client(
-        &config_path,
-        config.tv_ip,
-        config.tv_platform,
-        TvClientBuildOptions::production(),
-    )?;
-    let wol_sender = UdpWakeOnLanSender::default();
-    let sleeper = ThreadSleeper;
-    let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
-    let lifecycle_status =
-        SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
-
-    run_screen_on_with_event(
-        writer,
-        &config,
-        &marker,
-        ScreenOnDeps {
-            tv_client: &tv_client,
-            wol_sender: &wol_sender,
-            sleeper: &sleeper,
-            phase_provider: &mut phase_provider,
-            lifecycle_status: &lifecycle_status,
-        },
-        event,
-    )
-}
-
 #[cfg(test)]
 pub(crate) fn run_screen_off_with<W: Write>(
     writer: &mut W,
@@ -461,13 +321,13 @@ pub(crate) fn run_screen_off_with_outcome_for_event<
     .map(|result| result.outcome)
 }
 
-struct ScreenOffExecutionResult {
+pub(crate) struct ScreenOffExecutionResult {
     #[cfg(test)]
     outcome: PolicyOutcome,
-    blank_succeeded: bool,
+    pub(crate) blank_succeeded: bool,
 }
 
-fn run_screen_off_with_result_for_event<
+pub(crate) fn run_screen_off_with_result_for_event<
     W: Write,
     C: TvClient,
     P: RuntimePhaseProvider,

--- a/crates/lg-buddy/src/session.rs
+++ b/crates/lg-buddy/src/session.rs
@@ -1,6 +1,13 @@
+pub(crate) mod actions;
 pub mod gamepad;
 pub mod inactivity;
 pub mod runner;
+
+#[cfg(test)]
+pub(crate) fn test_env_lock() -> &'static std::sync::Mutex<()> {
+    static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+    LOCK.get_or_init(|| std::sync::Mutex::new(()))
+}
 
 use std::time::Instant;
 

--- a/crates/lg-buddy/src/session/actions.rs
+++ b/crates/lg-buddy/src/session/actions.rs
@@ -1,0 +1,282 @@
+//! Runtime ownership and environment setup for screen and lifecycle actions.
+//! Policy handlers borrow the owner's client; one-shot commands use a fresh owner.
+
+use std::io::Write;
+use std::net::Ipv4Addr;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::config::{load_config, resolve_config_path_from_env, Config, MacAddress, TvPlatform};
+use crate::events::RuntimeEvent;
+use crate::lifecycle::{self, NmOnlineNetworkWaiter};
+use crate::runtime_phase::LogindRuntimePhaseProvider;
+use crate::screen::{self, ScreenOnDeps, SystemMarkerLifecycleStatusProvider};
+use crate::state::{
+    ScreenOwnershipMarker, StateScope, SystemSleepAttemptState, SystemSleepCycleState,
+};
+use crate::tv::{build_tv_client, SelectedTvClient, TvClientBuildOptions};
+use crate::wol::UdpWakeOnLanSender;
+use crate::RunError;
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) const SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(PartialEq, Eq)]
+struct TvClientBinding {
+    config_path: PathBuf,
+    tv_ip: Ipv4Addr,
+    tv_mac: MacAddress,
+    platform: TvPlatform,
+    options: TvClientBuildOptions,
+}
+
+/// A monitor retains this owner across events. The adapter continues to own
+/// authentication, connection invalidation, and the no-ambiguous-write-replay rule.
+#[derive(Default)]
+pub struct RuntimeActionExecutor {
+    tv_client: Option<(TvClientBinding, SelectedTvClient)>,
+}
+
+impl RuntimeActionExecutor {
+    fn load_config(&mut self) -> Result<(PathBuf, Config), RunError> {
+        let result = (|| {
+            let path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
+            let config = load_config(&path).map_err(RunError::Config)?;
+            Ok((path, config))
+        })();
+        // An unpaired or unreadable profile must not leave an old TV connection
+        // available for reuse if configuration later becomes valid again.
+        if result.is_err() {
+            self.tv_client = None;
+        }
+        result
+    }
+
+    fn tv_client(
+        &mut self,
+        config_path: &Path,
+        config: &Config,
+        options: TvClientBuildOptions,
+    ) -> Result<&SelectedTvClient, RunError> {
+        let binding = TvClientBinding {
+            config_path: config_path.to_owned(),
+            tv_ip: config.tv_ip,
+            tv_mac: config.tv_mac,
+            platform: config.tv_platform,
+            options,
+        };
+        // Legacy commands retain their per-action environment/auth resolution.
+        // Native clients can be reused only for the same target and policy:
+        // a foreground timeout or pairing prompt must never leak into suspend.
+        if config.tv_platform == TvPlatform::Bscpylgtv
+            || self
+                .tv_client
+                .as_ref()
+                .is_none_or(|(current, _)| *current != binding)
+        {
+            self.tv_client = None;
+            let client = build_tv_client(config_path, config.tv_ip, config.tv_platform, options)?;
+            self.tv_client = Some((binding, client));
+        }
+        Ok(&self.tv_client.as_ref().expect("TV client initialized").1)
+    }
+
+    pub(crate) fn run_screen_off<W: Write>(
+        &mut self,
+        writer: &mut W,
+        event: RuntimeEvent,
+    ) -> Result<bool, RunError> {
+        let (config_path, config) = self.load_config()?;
+        let marker =
+            ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
+        let tv_client =
+            self.tv_client(&config_path, &config, TvClientBuildOptions::production())?;
+        let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
+        let lifecycle_status =
+            SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
+
+        screen::run_screen_off_with_result_for_event(
+            writer,
+            &config,
+            &marker,
+            tv_client,
+            event,
+            &mut phase_provider,
+            &lifecycle_status,
+        )
+        .map(|result| result.blank_succeeded)
+    }
+
+    pub(crate) fn run_timed_power_off<W: Write>(
+        &mut self,
+        writer: &mut W,
+        event: RuntimeEvent,
+    ) -> Result<(), RunError> {
+        let (config_path, config) = self.load_config()?;
+        let marker =
+            ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
+        if !config.screen_idle_blank.is_enabled() {
+            writeln!(
+                writer,
+                "LG Buddy Timed Power Off: Screen idle blanking is disabled; skipping power-off."
+            )?;
+            return Ok(());
+        }
+        if !marker.exists() {
+            writeln!(
+                writer,
+                "LG Buddy Timed Power Off: Screen ownership marker is absent; skipping power-off."
+            )?;
+            return Ok(());
+        }
+        let tv_client =
+            self.tv_client(&config_path, &config, TvClientBuildOptions::production())?;
+        let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
+        let lifecycle_status =
+            SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
+
+        screen::run_timed_power_off_with_event(
+            writer,
+            &config,
+            &marker,
+            tv_client,
+            event,
+            &mut phase_provider,
+            &lifecycle_status,
+        )
+        .map(|_| ())
+    }
+
+    pub(crate) fn run_screen_on<W: Write>(
+        &mut self,
+        writer: &mut W,
+        event: RuntimeEvent,
+    ) -> Result<(), RunError> {
+        let (config_path, config) = self.load_config()?;
+        let marker =
+            ScreenOwnershipMarker::from_env(StateScope::Session).map_err(RunError::StateDir)?;
+        let tv_client =
+            self.tv_client(&config_path, &config, TvClientBuildOptions::production())?;
+        let wol_sender = UdpWakeOnLanSender::default();
+        let sleeper = screen::ThreadSleeper;
+        let mut phase_provider = LogindRuntimePhaseProvider::from_system_bus();
+        let lifecycle_status =
+            SystemMarkerLifecycleStatusProvider::from_env().map_err(RunError::StateDir)?;
+
+        screen::run_screen_on_with_event(
+            writer,
+            &config,
+            &marker,
+            ScreenOnDeps {
+                tv_client,
+                wol_sender: &wol_sender,
+                sleeper: &sleeper,
+                phase_provider: &mut phase_provider,
+                lifecycle_status: &lifecycle_status,
+            },
+            event,
+        )
+    }
+
+    pub(crate) fn run_sleep_pre<W: Write>(
+        &mut self,
+        writer: &mut W,
+        event: RuntimeEvent,
+    ) -> Result<(), RunError> {
+        let (config_path, config) = self.load_config()?;
+        let marker =
+            ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
+        let cycle_state =
+            SystemSleepCycleState::from_env(StateScope::System).map_err(RunError::StateDir)?;
+        let tv_client = self.tv_client(
+            &config_path,
+            &config,
+            TvClientBuildOptions::production()
+                .stored_token_only()
+                .with_command_timeout(SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT),
+        )?;
+        let sleeper = lifecycle::ThreadSleeper;
+
+        lifecycle::handle_system_suspend_with(
+            writer,
+            &config,
+            &marker,
+            &cycle_state,
+            tv_client,
+            &sleeper,
+            event,
+        )
+    }
+
+    pub(crate) fn run_system_resume<W: Write>(&mut self, writer: &mut W) -> Result<(), RunError> {
+        let (config_path, config) = self.load_config()?;
+        let marker =
+            ScreenOwnershipMarker::from_env(StateScope::System).map_err(RunError::StateDir)?;
+        let attempt_state =
+            SystemSleepAttemptState::from_env(StateScope::System).map_err(RunError::StateDir)?;
+        let tv_client = self.tv_client(
+            &config_path,
+            &config,
+            TvClientBuildOptions::production().stored_token_only(),
+        )?;
+        let wol_sender = UdpWakeOnLanSender::default();
+        let sleeper = lifecycle::ThreadSleeper;
+        let network_waiter = NmOnlineNetworkWaiter::default();
+
+        let result = (|| -> Result<(), RunError> {
+            match tv_client.can_authenticate_unattended() {
+                Ok(true) => lifecycle::restore_after_system_sleep_with(
+                    writer,
+                    &config,
+                    &marker,
+                    tv_client,
+                    &wol_sender,
+                    &sleeper,
+                    &network_waiter,
+                ),
+                Ok(false) => {
+                    marker.clear()?;
+                    writeln!(
+                        writer,
+                        "LG Buddy System Resume: No stored native TV credential; skipping unattended TV control."
+                    )?;
+                    Ok(())
+                }
+                Err(err) => {
+                    marker.clear()?;
+                    Err(err.into())
+                }
+            }
+        })();
+
+        let mut cleanup_error = None;
+
+        if let Err(err) = attempt_state.clear() {
+            writeln!(
+                writer,
+                "LG Buddy System Resume: could not clear system sleep attempt marker after resume. {err}"
+            )?;
+            cleanup_error = Some(err);
+        }
+
+        if let Err(err) = attempt_state.clear_outcome() {
+            writeln!(
+                writer,
+                "LG Buddy System Resume: could not clear system sleep cycle state after resume. {err}"
+            )?;
+            if cleanup_error.is_none() {
+                cleanup_error = Some(err);
+            }
+        }
+
+        if result.is_ok() {
+            if let Some(err) = cleanup_error {
+                return Err(RunError::Io(err));
+            }
+        }
+
+        result
+    }
+}

--- a/crates/lg-buddy/src/session/actions/tests.rs
+++ b/crates/lg-buddy/src/session/actions/tests.rs
@@ -216,6 +216,53 @@ fn runtime_owner_lazily_reuses_native_session_across_screen_events() {
 }
 
 #[test]
+fn closed_session_recovers_input_before_next_idle_decision() {
+    use crate::web_os::WebOsPowerState;
+
+    let _lock = test_lock().lock().expect("runtime action test lock");
+    for (address, input, expected_state) in [
+        (8, WebOsTestInput::Hdmi2, WebOsPowerState::Active),
+        (9, WebOsTestInput::Hdmi3, WebOsPowerState::ScreenOff),
+    ] {
+        let server = server_at(address);
+        let fixture = Fixture::new(Ipv4Addr::new(127, 0, 0, address));
+        let _env = EnvGuard::for_fixture(&fixture);
+        let mut dispatcher = SessionEventDispatcher::new(RuntimeActionExecutor::default());
+        let mut output = Vec::new();
+        dispatcher
+            .dispatch_event(&mut output, SessionEvent::Idle)
+            .unwrap();
+        dispatcher
+            .dispatch_event(&mut output, SessionEvent::Active)
+            .unwrap();
+        assert_eq!(server.snapshot().connection_count, 1);
+
+        // Model switching inputs on the TV while the monitor's socket closes.
+        server.set_input(input);
+        server.close_active_connection();
+        output.clear();
+        dispatcher
+            .dispatch_event(&mut output, SessionEvent::Idle)
+            .unwrap();
+
+        let snapshot = server.snapshot();
+        assert_eq!(snapshot.power_state, expected_state);
+        assert_eq!(snapshot.input, input);
+        assert_eq!(snapshot.connection_count, 2);
+        assert_eq!(
+            snapshot.registration_tokens,
+            vec![Some(VALID_ACCESS_TOKEN.to_string()); 2]
+        );
+        assert!(!snapshot
+            .request_uris
+            .iter()
+            .any(|uri| uri == "ssap://system/turnOff"));
+        assert!(!String::from_utf8_lossy(&output).contains("Falling back to power_off"));
+        server.finish();
+    }
+}
+
+#[test]
 fn runtime_owner_reconnects_after_a_server_closed_session() {
     let _lock = test_lock().lock().expect("runtime action test lock");
     let ip = Ipv4Addr::new(127, 0, 0, 3);

--- a/crates/lg-buddy/src/session/actions/tests.rs
+++ b/crates/lg-buddy/src/session/actions/tests.rs
@@ -1,0 +1,341 @@
+use super::RuntimeActionExecutor;
+use crate::config::{load_config, HdmiInput, TvPlatform};
+use crate::session::runner::SessionEventDispatcher;
+use crate::session::SessionEvent;
+use crate::tv::{CurrentInput, SelectedTvClient, TvClient, TvClientBuildOptions, TvErrorKind};
+use crate::web_os::test_support::{
+    WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
+};
+use std::env;
+use std::fs;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
+
+const VALID_ACCESS_TOKEN: &str = "webos-test-access-token";
+
+fn test_lock() -> &'static Mutex<()> {
+    crate::session::test_env_lock()
+}
+
+struct EnvGuard {
+    previous: Vec<(&'static str, Option<std::ffi::OsString>)>,
+}
+
+impl EnvGuard {
+    fn for_fixture(fixture: &Fixture) -> Self {
+        let mut guard = Self {
+            previous: Vec::new(),
+        };
+        guard.set("LG_BUDDY_CONFIG", fixture.config_path.as_os_str());
+        guard.set(
+            "LG_BUDDY_SESSION_RUNTIME_DIR",
+            fixture.session_dir.as_os_str(),
+        );
+        guard.set(
+            "LG_BUDDY_SYSTEM_RUNTIME_DIR",
+            fixture.system_dir.as_os_str(),
+        );
+        guard
+    }
+
+    fn set(&mut self, key: &'static str, value: &std::ffi::OsStr) {
+        self.previous.push((key, env::var_os(key)));
+        env::set_var(key, value);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.previous.drain(..).rev() {
+            match value {
+                Some(value) => env::set_var(key, value),
+                None => env::remove_var(key),
+            }
+        }
+    }
+}
+
+struct Fixture {
+    root: PathBuf,
+    config_path: PathBuf,
+    session_dir: PathBuf,
+    system_dir: PathBuf,
+}
+
+impl Fixture {
+    fn new(ip: Ipv4Addr) -> Self {
+        static SEQUENCE: AtomicU64 = AtomicU64::new(0);
+        let sequence = SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let root = env::temp_dir().join(format!(
+            "lg-buddy-runtime-actions-{}-{sequence}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&root).expect("create runtime action fixture");
+        let fixture = Self {
+            config_path: root.join("config.env"),
+            session_dir: root.join("session"),
+            system_dir: root.join("system"),
+            root,
+        };
+        fixture.write_config(ip, "aa:bb:cc:dd:ee:ff", TvPlatform::LgWebOs);
+        let token_path = fixture
+            .config_path
+            .parent()
+            .expect("fixture config parent")
+            .join("tvs/primary/access-token.json");
+        fs::create_dir_all(token_path.parent().expect("fixture token parent"))
+            .expect("create fixture token directory");
+        fs::write(
+            token_path,
+            format!("{{\n  \"access_token\": \"{VALID_ACCESS_TOKEN}\"\n}}\n"),
+        )
+        .expect("write fixture token");
+        fixture
+    }
+
+    fn write_config(&self, ip: Ipv4Addr, mac: &str, platform: TvPlatform) {
+        fs::write(
+            &self.config_path,
+            format!(
+                "tvs_primary_ip={ip}\n\
+tvs_primary_mac={mac}\n\
+tvs_primary_input=HDMI_3\n\
+tvs_primary_platform={}\n\
+screen_backend=auto\n\
+screen_idle_timeout=300\n\
+system_sleep_wake_policy=disabled\n",
+                platform.as_str()
+            ),
+        )
+        .expect("write fixture config");
+    }
+
+    fn set_value(&self, key: &str, value: &str) {
+        let contents = fs::read_to_string(&self.config_path).expect("read fixture config");
+        let prefix = format!("{key}=");
+        let mut found = false;
+        let mut updated = contents
+            .lines()
+            .map(|line| {
+                if line.starts_with(&prefix) {
+                    found = true;
+                    format!("{key}={value}")
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>();
+        if !found {
+            updated.push(format!("{key}={value}"));
+        }
+        fs::write(&self.config_path, format!("{}\n", updated.join("\n")))
+            .expect("update fixture config");
+    }
+
+    fn config(&self) -> crate::config::Config {
+        load_config(&self.config_path).expect("load fixture config")
+    }
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn server_at(last_octet: u8) -> WebOsTestServer {
+    WebOsTestServer::active_tls_at(
+        WebOsTestVersion::WebOs24Version92261,
+        WebOsTestInput::Hdmi3,
+        SocketAddr::from(([127, 0, 0, last_octet], 3001)),
+    )
+}
+
+fn read_input(
+    owner: &mut RuntimeActionExecutor,
+    config_path: &Path,
+    config: &crate::config::Config,
+    options: TvClientBuildOptions,
+) -> CurrentInput {
+    owner
+        .tv_client(config_path, config, options)
+        .expect("build runtime TV client")
+        .current_input()
+        .expect("read fixture input")
+}
+
+#[test]
+fn runtime_owner_lazily_reuses_native_session_across_screen_events() {
+    let _lock = test_lock().lock().expect("runtime action test lock");
+    let ip = Ipv4Addr::new(127, 0, 0, 2);
+    let server = server_at(2);
+    let fixture = Fixture::new(ip);
+    let _env = EnvGuard::for_fixture(&fixture);
+    let mut dispatcher = SessionEventDispatcher::new(RuntimeActionExecutor::default());
+
+    assert_eq!(server.snapshot().connection_count, 0);
+
+    let mut output = Vec::new();
+    dispatcher
+        .dispatch_event(&mut output, SessionEvent::Idle)
+        .expect("screen blank dispatch should succeed");
+    let snapshot = server.snapshot();
+    assert_eq!(snapshot.connection_count, 1);
+    assert_eq!(
+        snapshot.registration_tokens,
+        vec![Some(VALID_ACCESS_TOKEN.to_string())]
+    );
+    assert!(
+        crate::state::ScreenOwnershipMarker::from_env(crate::state::StateScope::Session)
+            .expect("session marker")
+            .exists()
+    );
+
+    fixture.set_value("screen_idle_timeout", "600");
+    let mut output = Vec::new();
+    dispatcher
+        .dispatch_event(&mut output, SessionEvent::Active)
+        .expect("screen restore should succeed");
+    let snapshot = server.snapshot();
+    assert_eq!(snapshot.connection_count, 1);
+    assert_eq!(
+        snapshot.registration_tokens,
+        vec![Some(VALID_ACCESS_TOKEN.to_string())]
+    );
+    assert_eq!(snapshot.power_state, crate::web_os::WebOsPowerState::Active);
+    assert!(
+        !crate::state::ScreenOwnershipMarker::from_env(crate::state::StateScope::Session)
+            .expect("session marker")
+            .exists()
+    );
+
+    server.finish();
+}
+
+#[test]
+fn runtime_owner_reconnects_after_a_server_closed_session() {
+    let _lock = test_lock().lock().expect("runtime action test lock");
+    let ip = Ipv4Addr::new(127, 0, 0, 3);
+    let server = server_at(3);
+    server.set_scenario(WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff);
+    let fixture = Fixture::new(ip);
+    let _env = EnvGuard::for_fixture(&fixture);
+    let mut owner = RuntimeActionExecutor::default();
+    let config = fixture.config();
+
+    let error = owner
+        .tv_client(
+            &fixture.config_path,
+            &config,
+            TvClientBuildOptions::production(),
+        )
+        .expect("build runtime TV client")
+        .current_input()
+        .expect_err("closed session must report a transport failure");
+    assert_eq!(error.kind(), TvErrorKind::Transport);
+    assert_eq!(server.snapshot().connection_count, 1);
+
+    server.set_scenario(WebOsTestScenario::StatefulTv);
+    let config = fixture.config();
+    assert_eq!(
+        read_input(
+            &mut owner,
+            &fixture.config_path,
+            &config,
+            TvClientBuildOptions::production(),
+        ),
+        CurrentInput::Hdmi(HdmiInput::Hdmi3)
+    );
+    let snapshot = server.snapshot();
+    assert_eq!(snapshot.connection_count, 2);
+    assert_eq!(
+        snapshot.registration_tokens,
+        vec![Some(VALID_ACCESS_TOKEN.to_string()); 2]
+    );
+
+    server.finish();
+}
+
+#[test]
+fn runtime_owner_rebinds_when_profile_identity_or_build_options_change() {
+    let _lock = test_lock().lock().expect("runtime action test lock");
+    let first_server = server_at(5);
+    let second_server = server_at(6);
+    let first_fixture = Fixture::new(Ipv4Addr::new(127, 0, 0, 5));
+    let second_fixture = Fixture::new(Ipv4Addr::new(127, 0, 0, 6));
+    let mut owner = RuntimeActionExecutor::default();
+    let options = TvClientBuildOptions::production();
+
+    let assert_input = |owner: &mut RuntimeActionExecutor, fixture: &Fixture, options| {
+        assert_eq!(
+            read_input(owner, &fixture.config_path, &fixture.config(), options),
+            CurrentInput::Hdmi(HdmiInput::Hdmi3)
+        );
+    };
+    assert_input(&mut owner, &first_fixture, options);
+    assert_eq!(first_server.snapshot().connection_count, 1);
+
+    first_fixture.set_value("tvs_primary_mac", "aa:bb:cc:dd:ee:66");
+    assert_input(&mut owner, &first_fixture, options);
+    assert_eq!(first_server.snapshot().connection_count, 2);
+
+    first_fixture.set_value("tvs_primary_ip", "127.0.0.6");
+    assert_input(&mut owner, &first_fixture, options);
+    assert_eq!(second_server.snapshot().connection_count, 1);
+
+    first_fixture.set_value("tvs_primary_platform", TvPlatform::Bscpylgtv.as_str());
+    assert!(matches!(
+        owner
+            .tv_client(&first_fixture.config_path, &first_fixture.config(), options)
+            .expect("build legacy client"),
+        SelectedTvClient::Bscpylgtv(_)
+    ));
+    first_fixture.set_value("tvs_primary_platform", TvPlatform::LgWebOs.as_str());
+    assert_input(&mut owner, &first_fixture, options);
+    assert_eq!(second_server.snapshot().connection_count, 2);
+
+    for (changed_options, expected_connections) in [
+        (options.with_command_timeout(Duration::from_secs(1)), 3),
+        (options, 4),
+        (options.stored_token_only(), 5),
+        (options, 6),
+    ] {
+        assert_input(&mut owner, &first_fixture, changed_options);
+        assert_eq!(
+            second_server.snapshot().connection_count,
+            expected_connections
+        );
+    }
+
+    // Change only the profile path, keeping TV identity and options identical.
+    second_fixture.set_value("tvs_primary_mac", "aa:bb:cc:dd:ee:66");
+    assert_input(&mut owner, &second_fixture, options);
+    assert_eq!(second_server.snapshot().connection_count, 7);
+
+    first_server.finish();
+    second_server.finish();
+}
+
+#[test]
+fn runtime_owner_discards_client_when_profile_cannot_be_loaded() {
+    let _lock = test_lock().lock().expect("runtime action test lock");
+    let server = server_at(7);
+    let fixture = Fixture::new(Ipv4Addr::new(127, 0, 0, 7));
+    let _env = EnvGuard::for_fixture(&fixture);
+    let mut owner = RuntimeActionExecutor::default();
+    let config = fixture.config();
+    let options = TvClientBuildOptions::production();
+    read_input(&mut owner, &fixture.config_path, &config, options);
+    assert_eq!(server.snapshot().connection_count, 1);
+
+    let contents = fs::read(&fixture.config_path).expect("read fixture config");
+    fs::remove_file(&fixture.config_path).expect("remove profile");
+    assert!(owner.load_config().is_err());
+    fs::write(&fixture.config_path, contents).expect("restore profile");
+    read_input(&mut owner, &fixture.config_path, &config, options);
+    assert_eq!(server.snapshot().connection_count, 2);
+    server.finish();
+}

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -18,7 +18,6 @@ use crate::backend::{
     resolve_backend_with_probe, BackendDetectionError, BackendResolution, BackendSelectionError,
     SystemBackendProbe, SWAYIDLE_DEPRECATION_NOTICE,
 };
-use crate::commands::{run_sleep_pre_for_event, run_system_resume};
 use crate::config::{
     load_config, normalize_idle_timeout_secs, parse_config_entries, parse_idle_timeout_secs,
     resolve_config_path_from_env, ConfigPathError, ScreenBackend, ScreenIdleBlankPolicy,
@@ -83,34 +82,32 @@ pub trait SessionActionExecutor {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-pub struct RuntimeActionExecutor;
+pub use super::actions::RuntimeActionExecutor;
 
 impl SessionActionExecutor for RuntimeActionExecutor {
     fn screen_off(&mut self, event: RuntimeEvent) -> Result<ScreenOffResult, RunError> {
         let mut output = Vec::new();
-        let result =
-            crate::screen::run_screen_off_from_env_for_event_with_result(&mut output, event)?;
+        let blank_succeeded = self.run_screen_off(&mut output, event)?;
         Ok(ScreenOffResult {
             output: String::from_utf8_lossy(&output).into_owned(),
-            blank_succeeded: result.blank_succeeded,
+            blank_succeeded,
         })
     }
 
     fn timed_power_off(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
-        run_action(|writer| crate::screen::run_timed_power_off_from_env_for_event(writer, event))
+        run_action(|writer| self.run_timed_power_off(writer, event))
     }
 
     fn screen_on(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
-        run_action(|writer| crate::screen::run_screen_on_from_env_for_event(writer, event))
+        run_action(|writer| self.run_screen_on(writer, event))
     }
 
     fn before_sleep(&mut self, event: RuntimeEvent) -> Result<String, RunError> {
-        run_action(|writer| run_sleep_pre_for_event(writer, event))
+        run_action(|writer| self.run_sleep_pre(writer, event))
     }
 
     fn after_resume(&mut self, _event: RuntimeEvent) -> Result<String, RunError> {
-        run_action(run_system_resume)
+        run_action(|writer| self.run_system_resume(writer))
     }
 
     fn after_resume_streaming<W: Write>(
@@ -118,7 +115,7 @@ impl SessionActionExecutor for RuntimeActionExecutor {
         writer: &mut W,
         _event: RuntimeEvent,
     ) -> Result<(), RunError> {
-        run_system_resume(writer)
+        self.run_system_resume(writer)
     }
 }
 
@@ -362,7 +359,7 @@ impl<E: SessionActionExecutor> SessionEventDispatcher<E> {
 }
 
 pub fn run_monitor<W: Write>(writer: &mut W) -> Result<(), RunError> {
-    run_monitor_with_executor(writer, RuntimeActionExecutor).map_err(|err| match err {
+    run_monitor_with_executor(writer, RuntimeActionExecutor::default()).map_err(|err| match err {
         SessionRunnerError::BackendSelection(err) => RunError::BackendSelection(err),
         SessionRunnerError::BackendDetection(err) => RunError::BackendDetection(err),
         other => RunError::Policy(other.to_string()),
@@ -371,13 +368,12 @@ pub fn run_monitor<W: Write>(writer: &mut W) -> Result<(), RunError> {
 
 pub fn run_lifecycle_monitor<W: Write>(writer: &mut W) -> Result<(), RunError> {
     let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-    run_lifecycle_monitor_with_executor(writer, RuntimeActionExecutor, &config_path).map_err(
-        |err| match err {
+    run_lifecycle_monitor_with_executor(writer, RuntimeActionExecutor::default(), &config_path)
+        .map_err(|err| match err {
             SessionRunnerError::BackendSelection(err) => RunError::BackendSelection(err),
             SessionRunnerError::BackendDetection(err) => RunError::BackendDetection(err),
             other => RunError::Policy(other.to_string()),
-        },
-    )
+        })
 }
 
 fn run_lifecycle_monitor_with_executor<W: Write, E: SessionActionExecutor>(
@@ -1830,13 +1826,12 @@ mod tests {
     use std::fs;
     use std::io;
     use std::path::{Path, PathBuf};
-    use std::sync::{mpsc, Mutex, OnceLock};
+    use std::sync::{mpsc, Mutex};
     use std::thread;
     use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     fn env_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
+        crate::session::test_env_lock()
     }
 
     #[derive(Debug, Default)]

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -64,7 +64,16 @@ impl WebOsTvClient {
         action: impl FnOnce(&mut WebOsClient) -> Result<T, WebOsAdapterFailure>,
     ) -> Result<T, TvError> {
         let mut session = self.lock_session(operation)?;
-        self.ensure_session(operation, &mut session)?;
+        self.run_on_session(&mut session, operation, action)
+    }
+
+    fn run_on_session<T>(
+        &self,
+        session: &mut Option<WebOsClient>,
+        operation: TvOperation,
+        action: impl FnOnce(&mut WebOsClient) -> Result<T, WebOsAdapterFailure>,
+    ) -> Result<T, TvError> {
+        self.ensure_session(operation, session)?;
 
         let result = action(
             session
@@ -266,12 +275,24 @@ impl TvClient for WebOsTvClient {
     }
 
     fn current_input(&self) -> Result<CurrentInput, TvError> {
-        self.with_session(TvOperation::ReadInput, |client| {
+        let operation = TvOperation::ReadInput;
+        let mut session = self.lock_session(operation)?;
+        let reused_session = session.is_some();
+        let read = |client: &mut WebOsClient| {
             client
                 .foreground_app()
                 .map(|app| CurrentInput::from_raw(app.app_id().to_string()))
                 .map_err(foreground_app_failure)
-        })
+        };
+        let result = self.run_on_session(&mut session, operation, read);
+        // A socket closed between events must not turn an input check into
+        // policy's power-off fallback. Retry only this read, once, when it
+        // invalidated a reused session; failures on a fresh session still return.
+        if reused_session && result.is_err() && session.is_none() {
+            self.run_on_session(&mut session, operation, read)
+        } else {
+            result
+        }
     }
 
     fn oled_brightness(&self) -> Result<OledBrightness, TvError> {
@@ -961,6 +982,25 @@ mod tests {
                 .expect("verified session remains reusable"),
             CurrentInput::Hdmi(HdmiInput::Hdmi2)
         );
+        assert_eq!(server.snapshot().connection_count, 2);
+        server.finish();
+    }
+
+    #[test]
+    fn input_read_reconnects_only_once_after_a_cached_session_fails() {
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
+        let token_fixture = TestAccessTokenStore::new();
+        let client = client_for_server(&server, &token_fixture);
+        client.current_input().expect("establish initial session");
+        server.close_active_connection();
+        server.set_scenario(WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff);
+
+        let error = client
+            .current_input()
+            .expect_err("fresh connection also fails");
+
+        assert_eq!(error.kind(), TvErrorKind::Transport);
         assert_eq!(server.snapshot().connection_count, 2);
         server.finish();
     }

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -945,6 +945,15 @@ mod tests {
             after_write.connection_count, 2,
             "verification reconnects without replaying the effectful operation"
         );
+        assert_eq!(
+            after_write
+                .request_uris
+                .iter()
+                .filter(|uri| uri.as_str() == "ssap://tv/switchInput")
+                .count(),
+            1,
+            "the ambiguous input write must be sent exactly once"
+        );
 
         assert_eq!(
             client

--- a/crates/lg-buddy/src/web_os/test_support.rs
+++ b/crates/lg-buddy/src/web_os/test_support.rs
@@ -1,4 +1,6 @@
 mod test_server;
 
-pub(super) use test_server::{TestAccessTokenStore, WebOsTestInput};
-pub(crate) use test_server::{WebOsTestScenario, WebOsTestServer, WebOsTestVersion};
+pub(super) use test_server::TestAccessTokenStore;
+pub(crate) use test_server::{
+    WebOsTestInput, WebOsTestScenario, WebOsTestServer, WebOsTestVersion,
+};

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -759,6 +759,41 @@ impl WebOsTestServer {
     }
 
     #[allow(dead_code)]
+    pub(crate) fn set_input(&self, input: WebOsTestInput) {
+        self.runtime
+            .lock()
+            .expect("webOS test server state")
+            .tv
+            .input = input;
+    }
+
+    /// Close an established connection between operations, leaving the TV
+    /// available for the next connection.
+    #[allow(dead_code)]
+    pub(crate) fn close_active_connection(&self) {
+        self.active_connection
+            .lock()
+            .expect("webOS test active connection")
+            .as_ref()
+            .expect("an established webOS connection")
+            .shutdown(Shutdown::Both)
+            .expect("close webOS test connection");
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while self
+            .active_connection
+            .lock()
+            .expect("webOS test active connection")
+            .is_some()
+        {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "connection did not close"
+            );
+            thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[allow(dead_code)]
     pub(in crate::web_os) fn set_volume(&self, volume: i16) {
         assert!(volume == -1 || (0..=100).contains(&volume));
         self.runtime

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -127,15 +127,16 @@ impl WebOsTestInput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(in crate::web_os) struct WebOsTestTvSnapshot {
-    pub(in crate::web_os) power_state: WebOsPowerState,
-    pub(in crate::web_os) input: WebOsTestInput,
-    pub(in crate::web_os) backlight: Value,
-    pub(in crate::web_os) volume: i16,
-    pub(in crate::web_os) muted: bool,
-    pub(in crate::web_os) connection_count: u64,
-    pub(in crate::web_os) pairing_prompt_count: u64,
-    pub(in crate::web_os) registration_tokens: Vec<Option<String>>,
+pub(crate) struct WebOsTestTvSnapshot {
+    pub(crate) power_state: WebOsPowerState,
+    pub(crate) input: WebOsTestInput,
+    pub(crate) backlight: Value,
+    pub(crate) volume: i16,
+    pub(crate) muted: bool,
+    pub(crate) connection_count: u64,
+    pub(crate) pairing_prompt_count: u64,
+    pub(crate) registration_tokens: Vec<Option<String>>,
+    pub(crate) request_uris: Vec<String>,
 }
 
 struct WebOsTestTv {
@@ -565,6 +566,7 @@ struct WebOsTestRuntime {
     connection_count: u64,
     pairing_prompt_count: u64,
     registration_tokens: Vec<Option<String>>,
+    request_uris: Vec<String>,
     ambiguous_input_write_injected: bool,
     stalled_request_injected: bool,
     restore_session_interruption_injected: bool,
@@ -624,7 +626,7 @@ impl WebOsTestServer {
     }
 
     #[allow(dead_code)]
-    pub(in crate::web_os) fn active_tls_at(
+    pub(crate) fn active_tls_at(
         version: WebOsTestVersion,
         input: WebOsTestInput,
         address: std::net::SocketAddr,
@@ -680,6 +682,7 @@ impl WebOsTestServer {
             connection_count: 0,
             pairing_prompt_count: 0,
             registration_tokens: Vec::new(),
+            request_uris: Vec::new(),
             ambiguous_input_write_injected: false,
             stalled_request_injected: false,
             restore_session_interruption_injected: false,
@@ -743,12 +746,12 @@ impl WebOsTestServer {
         self.endpoint
     }
 
-    pub(in crate::web_os) fn access_token(&self) -> PlatformAccessToken {
+    pub(crate) fn access_token(&self) -> PlatformAccessToken {
         PlatformAccessToken::new(TEST_ACCESS_TOKEN).expect("webOS test access token")
     }
 
     #[allow(dead_code)]
-    pub(in crate::web_os) fn set_scenario(&self, scenario: WebOsTestScenario) {
+    pub(crate) fn set_scenario(&self, scenario: WebOsTestScenario) {
         self.runtime
             .lock()
             .expect("webOS test server state")
@@ -782,7 +785,7 @@ impl WebOsTestServer {
         );
     }
 
-    pub(in crate::web_os) fn snapshot(&self) -> WebOsTestTvSnapshot {
+    pub(crate) fn snapshot(&self) -> WebOsTestTvSnapshot {
         let runtime = self.runtime.lock().expect("webOS test TV state");
         WebOsTestTvSnapshot {
             power_state: runtime.tv.power_state.clone(),
@@ -793,6 +796,7 @@ impl WebOsTestServer {
             connection_count: runtime.connection_count,
             pairing_prompt_count: runtime.pairing_prompt_count,
             registration_tokens: runtime.registration_tokens.clone(),
+            request_uris: runtime.request_uris.clone(),
         }
     }
 
@@ -870,6 +874,17 @@ fn serve_connection<S>(
             }
             continue;
         }
+
+        runtime
+            .lock()
+            .expect("webOS test server state")
+            .request_uris
+            .push(
+                request["uri"]
+                    .as_str()
+                    .expect("webOS test request URI")
+                    .to_string(),
+            );
 
         let scenario = runtime.lock().expect("webOS test server state").scenario;
         if scenario == WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff {

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -223,7 +223,8 @@ Feature: Native webOS TV platform
     And stdout contains "Using GNOME backend."
     And the session marker is absent
     And the TV screen is visible
-    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV connection count is 1
+    And the native TV registration tokens are "webos-test-access-token"
     And the native TV pairing prompt count is 0
 
   Scenario: Native GNOME inactivity powers off an owned blank screen after the grace period
@@ -244,7 +245,8 @@ Feature: Native webOS TV platform
     And stdout contains "Timed power-off deadline reached"
     And the session marker exists
     And the TV is powered off
-    And the native TV registration tokens are "webos-test-access-token,webos-test-access-token"
+    And the native TV connection count is 1
+    And the native TV registration tokens are "webos-test-access-token"
     And the native TV pairing prompt count is 0
 
   Scenario: Native power on restoration is followed by native power off

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -620,7 +620,7 @@ fn session_dispatcher_skips_screen_action_while_logind_reports_sleep_pending() {
     env.set("LG_BUDDY_SESSION_RUNTIME_DIR", runtime.session_dir());
 
     let mut output = Vec::new();
-    let mut dispatcher = SessionEventDispatcher::new(RuntimeActionExecutor);
+    let mut dispatcher = SessionEventDispatcher::new(RuntimeActionExecutor::default());
     dispatcher
         .dispatch_event(&mut output, SessionEvent::Idle)
         .expect("session idle dispatch should succeed");
@@ -663,7 +663,7 @@ fn session_dispatcher_skips_screen_restore_while_system_resume_restore_is_pendin
     env.set("LG_BUDDY_SYSTEM_RUNTIME_DIR", runtime.system_dir());
 
     let mut output = Vec::new();
-    let mut dispatcher = SessionEventDispatcher::new(RuntimeActionExecutor);
+    let mut dispatcher = SessionEventDispatcher::new(RuntimeActionExecutor::default());
     dispatcher
         .dispatch_event(&mut output, SessionEvent::Active)
         .expect("session active dispatch should succeed");

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -131,7 +131,8 @@ flowchart LR
 
     subgraph Rust["Rust Runtime"]
         MAIN["main.rs / lib.rs<br/>CLI + command dispatch"]
-        COMMANDS["commands.rs<br/>CLI/API dependency assembly"]
+        COMMANDS["commands.rs<br/>CLI/API entrypoints"]
+        ACTIONS["session::actions<br/>action dependencies + TV client owner"]
         EVENTS["events.rs<br/>canonical runtime events"]
         POLICY["policy.rs<br/>action / no-action / state trail"]
         NOTIFICATIONS["notifications.rs<br/>native desktop notifications"]
@@ -218,7 +219,11 @@ flowchart LR
     COMMANDS --> NMGATE
     COMMANDS --> NOTIFICATIONS
     COMMANDS --> SESSIONNOTIFY
-    COMMANDS --> SCREEN
+    COMMANDS -->|"screen / sleep"| ACTIONS
+    RUNNER -->|"retains"| ACTIONS
+    ACTIONS -->|"screen events"| SCREEN
+    ACTIONS -->|"sleep / resume"| LIFECYCLE
+    ACTIONS --> TV
     COMMANDS --> LIFECYCLE
     SCREEN --> POLICY
     LIFECYCLE --> POLICY
@@ -237,8 +242,6 @@ flowchart LR
     RUNNER --> SESSIONNOTIFY
     SESSIONMODEL --> RUNNER
 
-    RUNNER -->|"Idle / Active / WakeRequested /<br/>UserActivity / Lock / TimedPowerOff"| SCREEN
-    RUNNER -->|"AfterResume"| LIFECYCLE
     COMMANDS --> CONFIG
     COMMANDS --> STATE
     BRIGHTNESS --> CONFIG
@@ -264,7 +267,8 @@ The current split is:
   - shared error types
 - `commands.rs`
   - CLI/API command entrypoints
-  - config, state, and dependency loading for command execution
+  - delegates screen and sleep actions to a short-lived runtime action owner
+  - config, state, and dependency loading for other command execution
   - command output handoff
 - `application.rs`
   - toolkit-neutral coordination between Overview, TVs, and Settings
@@ -386,6 +390,11 @@ The current split is:
   - combines backend observations with the inactivity engine
   - dispatches semantic session events into screen and lifecycle policy
   - starts source workers and multiplexes their normalized observations
+- `session/actions.rs`
+  - shared dependency assembly for screen and sleep actions
+  - retains the native TV client across compatible events in each monitor
+  - reloads configuration and replaces clients when their target or operation
+    policy changes
 - `sources/linux/logind.rs`
   - Linux system lifecycle and current-session lock-state adapter
   - maps `org.freedesktop.login1` resume signals into canonical lifecycle
@@ -484,8 +493,10 @@ public-surface migration:
 
 `lib.rs` parses the command line into a typed command enum and dispatches into
 the runtime command handlers in `commands.rs` and `session/runner.rs`.
-`commands.rs` then delegates screen and lifecycle decisions to their domain
-modules and delegates platform ingestion to `sources/`. The on-demand
+Screen and sleep actions share dependency assembly in `session/actions.rs`:
+monitors retain one action owner, while one-shot commands create a fresh owner.
+The owner delegates decisions to the screen and lifecycle domain modules;
+platform ingestion belongs to `sources/`. The on-demand
 `updates check` command reads the saved `updates.channel` policy and consumes
 the GitHub Releases API without entering the screen, lifecycle, or scheduling
 paths. `updates install` adds the user-confirmed upgrade orchestration: initial
@@ -851,6 +862,17 @@ may reconnect for safe read-only verification, but it never replays the
 effectful operation. The legacy adapter performs its equivalent power-state
 readback through `bscpylgtvcommand`; neither implementation exposes webOS power
 states to policy code.
+
+Each monitor's `RuntimeActionExecutor` retains this adapter across compatible
+events. Client construction and connection remain lazy: starting a monitor
+does not contact the TV. The owner reloads configuration for every action and
+replaces its client when the profile path, TV address, MAC, platform, or client
+options change. Unrelated settings changes preserve the connection. Client
+options keep foreground pairing and timeouts separate from unattended suspend
+and resume operations. Legacy clients are rebuilt per action, and one-shot
+commands drop their owner on completion. A consumed or invalidated native
+session reconnects only when a later operation needs it; there is no background
+connection maintenance.
 
 Native picture settings have two known service-invocation paths. A direct SSAP
 write sends `ssap://settings/setSystemSettings` on the websocket. The Luna path

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -871,8 +871,13 @@ options change. Unrelated settings changes preserve the connection. Client
 options keep foreground pairing and timeouts separate from unattended suspend
 and resume operations. Legacy clients are rebuilt per action, and one-shot
 commands drop their owner on completion. A consumed or invalidated native
-session reconnects only when a later operation needs it; there is no background
-connection maintenance.
+session reconnects on demand; there is no background connection maintenance.
+
+If an input query invalidates a reused session, the adapter retries that read
+once on a fresh connection before returning a failure to policy. This prevents
+a socket closed between events from triggering the screen-off fallback without
+checking the TV's current input. Fresh-session failures return normally, and
+effectful operations are never replayed by this recovery path.
 
 Native picture settings have two known service-invocation paths. A direct SSAP
 write sends `ssap://settings/setSystemSettings` on the websocket. The Luna path

--- a/docs/runtime-event-handler-map.md
+++ b/docs/runtime-event-handler-map.md
@@ -30,6 +30,12 @@ resets or cancels the applicable deadline; each expiry is edge-triggered.
 
 GNOME, native Wayland, and `swayidle` feed the shared session path.
 
+Screen and sleep actions pass through `session::actions` for configuration and
+dependency assembly before reaching their policy handlers. Each monitor retains
+one `RuntimeActionExecutor`, which lazily owns and reuses a native TV client for
+compatible events. One-shot commands use a fresh instance of the same owner.
+The handler map below omits this common assembly step.
+
 ## Current Top-Level Handlers
 
 | External event source | Runtime entrypoint | Primary handler | Current action |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -257,6 +257,9 @@ The code split is:
 - `crates/lg-buddy/src/session/runner.rs`
   - source selection, worker lifetime, observation multiplexing, shared
     inactivity state, and policy dispatch
+- `crates/lg-buddy/src/session/actions.rs`
+  - action dependency assembly and native TV client ownership across compatible
+    events; one-shot commands use the same assembly with a finite lifetime
 - `crates/lg-buddy/src/session/gamepad/`
   - desktop-independent auxiliary input discovery and activity observations
 - `crates/lg-buddy/src/sources/desktop/gnome.rs`

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -215,6 +215,12 @@ The native webOS client tests use one stateful server for complete webOS frames,
 device state, and protocol-fault scenarios. Characterization tests keep its TV
 behavior aligned with observed hardware evidence.
 
+`session/actions/tests.rs` uses this same server through the production client
+builder to verify runtime ownership across events: lazy connection, authenticated
+session reuse, later reconnection after closure, and replacement after profile
+or operation-policy changes. These tests use isolated loopback addresses on
+the standard webOS TLS port and share the session tests' environment lock.
+
 Cucumber adds the process-level product boundary. It runs the real `lg-buddy`
 binary against the same stateful server over TLS on the standard webOS port.
 The scenarios exercise the production unsigned registration manifest and


### PR DESCRIPTION
Screen and lifecycle monitors rebuilt their TV client for every action, limiting session reuse to a single helper call. Move shared screen and sleep action setup into `RuntimeActionExecutor`: monitors retain one lazy native client across compatible events, and one-shot commands use the same owner with a finite lifetime.

Configuration is reloaded for each action. Changes to the TV identity, profile path, platform, or pairing/timeout policy replace the client. The native adapter continues to own connection recovery and effect verification; legacy clients retain their per-action construction. If an input check invalidates a reused connection, it retries that read once on a fresh connection before policy handles the failure. Effectful operations are never replayed by this recovery path.

Scripted-server coverage proves event-to-event connection and registration reuse, correct idle decisions after closure on either the configured or another HDMI input, bounded reconnect recovery, profile invalidation, and no replay of an ambiguous input write. Updated the existing GNOME process scenarios to require one registration for blank/restore and blank/power-off.

Validation: complete core suite (1,011 unit tests, all 150 Cucumber scenarios, and integration tests), display-backed GTK tests, formatting, and workspace Clippy with all targets/features and warnings denied.

Closes #123.
