### PR TITLE
Fix updater cancellation and privileged activation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
           sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
-          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools python3-pyatspi strace xdotool xvfb zenity
+          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools pkexec python3-pyatspi strace xdotool xvfb zenity
 
       - name: Build headless runtime and GTK GUI
         env:

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -2041,7 +2041,7 @@ pub(crate) mod controller_test_support {
                 progress: &mut dyn FnMut(UpdateInstallStage),
             ) -> Result<UpdateInstallOutcome, UpdateInstallFailure> {
                 match operation.task() {
-                    UpdateInstallTask::Prepare => {
+                    UpdateInstallTask::Prepare { .. } => {
                         if self.preparations.fetch_add(1, Ordering::SeqCst) == 0 {
                             Ok(UpdateInstallOutcome::UpToDate)
                         } else {

--- a/crates/lg-buddy-gui/src/lib.rs
+++ b/crates/lg-buddy-gui/src/lib.rs
@@ -2205,11 +2205,16 @@ pub(crate) mod controller_test_support {
                     .is_none()
             });
             pump_until(|| button(native.upcast_ref(), "Copy details").is_some());
-            assert!(button(native.upcast_ref(), "Install update…").is_some());
+            let expected_retry = if success {
+                "Retry restart"
+            } else {
+                "Install update…"
+            };
+            assert!(button(native.upcast_ref(), expected_retry).is_some());
         }
         assert_eq!(updater.installs.load(Ordering::SeqCst), 2);
         assert_eq!(updater.handoffs.load(Ordering::SeqCst), 1);
-        button(native.upcast_ref(), "Install update…")
+        button(native.upcast_ref(), "Retry restart")
             .unwrap()
             .emit_clicked();
         assert_eq!(updater.handoffs.load(Ordering::SeqCst), 2);

--- a/crates/lg-buddy-gui/src/settings.rs
+++ b/crates/lg-buddy-gui/src/settings.rs
@@ -157,6 +157,7 @@ struct UpdaterView {
     release: gtk::LinkButton,
     presented: Cell<bool>,
     close_pending: Rc<Cell<bool>>,
+    focus_after_close: Rc<Cell<bool>>,
     pulse: RefCell<Option<gtk::glib::SourceId>>,
     notice: RefCell<Option<adw::Toast>>,
 }
@@ -241,12 +242,25 @@ impl UpdaterView {
             // non-cancellable boundary before the next progress event arrives.
             .can_close(false)
             .build();
+        let focus_after_close = Rc::new(Cell::new(false));
         dialog.connect_close_attempt({
             let cancel_intent = Rc::clone(&cancel_intent);
             move |_| {
                 let intent = cancel_intent.borrow().clone();
                 if let Some(intent) = intent {
                     on_intent(intent);
+                }
+            }
+        });
+        dialog.connect_closed({
+            let action = action.downgrade();
+            let focus_after_close = Rc::clone(&focus_after_close);
+            move |_| {
+                if let Some(action) = action.upgrade() {
+                    if action.is_sensitive() {
+                        focus_after_close.set(false);
+                        action.grab_focus();
+                    }
                 }
             }
         });
@@ -293,6 +307,7 @@ impl UpdaterView {
             release,
             presented: Cell::new(false),
             close_pending,
+            focus_after_close,
             pulse: RefCell::new(None),
             notice: RefCell::new(None),
         }
@@ -334,12 +349,25 @@ impl UpdaterView {
         }
         if !active {
             if self.presented.replace(false) {
+                self.focus_after_close.set(true);
                 if self.dialog.child().is_some_and(|child| child.is_mapped()) {
                     self.dialog.force_close();
-                    self.action.grab_focus();
+                    let action = self.action.downgrade();
+                    gtk::glib::idle_add_local_once(move || {
+                        if let Some(action) = action.upgrade() {
+                            action.grab_focus();
+                        }
+                    });
                 } else {
                     self.close_pending.set(true);
                 }
+            }
+            if self.focus_after_close.get()
+                && self.action.is_sensitive()
+                && self.dialog.parent().is_none()
+            {
+                self.focus_after_close.set(false);
+                self.action.grab_focus();
             }
             return;
         }
@@ -1418,6 +1446,7 @@ fn updater_renderer_scenarios(application: &adw::Application) {
     let preparation = model
         .handle_intent(SettingsIntent::PrepareUpdateInstall)
         .unwrap();
+    let preparation_operation = preparation.update_install_operation().unwrap().clone();
     view.render(preparation.presentation());
     pump_until(|| {
         window.visible_dialog().as_ref() == Some(&view.updater.dialog)
@@ -1441,6 +1470,19 @@ fn updater_renderer_scenarios(application: &adw::Application) {
     view.render(model.presentation());
     pump_until(|| window.visible_dialog().is_none() && view.updater.dialog.parent().is_none());
     assert!(view.updater.pulse.borrow().is_none());
+
+    // Cancellation closes the modal immediately, but the worker remains
+    // active until its cleanup completes; focus returns when the action is
+    // available again.
+    assert!(!action.is_sensitive());
+    model
+        .complete_update_install(
+            &preparation_operation,
+            Err(UpdateInstallError::Cancelled.into()),
+        )
+        .unwrap();
+    view.render(model.presentation());
+    pump_until(|| action.is_sensitive());
     assert!(action.has_focus());
 
     let preparation = model

--- a/crates/lg-buddy/src/presentation/updater.rs
+++ b/crates/lg-buddy/src/presentation/updater.rs
@@ -26,11 +26,7 @@ impl UpdaterPresentation {
                 return Self {
                     title: "Restart required".into(),
                     description: "The update is installed. Restart LG Buddy to finish.".into(),
-                    action: SettingsAction::new(
-                        "Install update…",
-                        action.enabled(),
-                        action.intent(),
-                    ),
+                    action: SettingsAction::new("Retry restart", action.enabled(), action.intent()),
                 };
             }
         }

--- a/crates/lg-buddy/src/settings/service.rs
+++ b/crates/lg-buddy/src/settings/service.rs
@@ -215,7 +215,10 @@ impl ServiceController for SystemdUserServiceController {
     fn start_system_lifecycle(&self) -> Result<(), SettingsError> {
         let output = ProcessCommand::new("pkexec")
             .arg("--disable-internal-agent")
-            .arg("/usr/bin/systemctl")
+            // Keep the test/diagnostic command override out of the privileged
+            // executable selection. pkexec resolves this fixed command name
+            // through its sanitized system PATH.
+            .arg("systemctl")
             .arg("start")
             .arg("LG_Buddy_lifecycle.service")
             .output()

--- a/crates/lg-buddy/src/settings_view.rs
+++ b/crates/lg-buddy/src/settings_view.rs
@@ -766,7 +766,7 @@ impl SettingsApplication {
             return None;
         }
         let up_to_date = matches!(result, Ok(UpdateInstallOutcome::UpToDate))
-            && matches!(operation.task(), UpdateInstallTask::Prepare);
+            && matches!(operation.task(), UpdateInstallTask::Prepare { .. });
         let (next, diagnostic) = self.update_install.complete(operation, result)?;
         let notice = if up_to_date {
             self.presentation.update_check_mut().clear_result();

--- a/crates/lg-buddy/src/update_flow.rs
+++ b/crates/lg-buddy/src/update_flow.rs
@@ -284,6 +284,9 @@ impl UpdateInstallApplication {
                 Some(Some(operation))
             }
             SettingsIntent::CancelUpdateInstall if self.active() && !self.cancelling => {
+                let preparing = self.pending.as_ref().is_some_and(|operation| {
+                    matches!(operation.task, UpdateInstallTask::Prepare { .. })
+                });
                 if let Some(cancellation) =
                     self.pending
                         .as_ref()
@@ -297,9 +300,15 @@ impl UpdateInstallApplication {
                         return None;
                     }
                     self.cancelling = true;
-                    self.presentation.title = Some("Cancelling update…".into());
-                    self.presentation.description = "Waiting for the current preparation step to finish. No installation will start.".into();
-                    self.presentation.cancel_action = None;
+                    if preparing {
+                        // Close the modal immediately while the worker drains;
+                        // the pending operation still blocks a new update.
+                        self.clear_presentation();
+                    } else {
+                        self.presentation.title = Some("Cancelling update…".into());
+                        self.presentation.description = "Waiting for the current preparation step to finish. No installation will start.".into();
+                        self.presentation.cancel_action = None;
+                    }
                 } else {
                     self.pending = None;
                     self.prepared = None;

--- a/crates/lg-buddy/src/update_flow.rs
+++ b/crates/lg-buddy/src/update_flow.rs
@@ -9,14 +9,16 @@ use crate::presentation::update_check::UpdateCheckReport;
 use crate::presentation::update_install::UpdateInstallPresentation;
 use crate::settings_view::SettingsIntent;
 use crate::update_install::{
-    install_gui_update, prepare_gui_update, InstalledUpdate, PreparedUpdateInstall,
-    UpdateInstallCancellation, UpdateInstallError, UpdateInstallStage,
+    install_gui_update, prepare_gui_update_with_cancellation, InstalledUpdate,
+    PreparedUpdateInstall, UpdateInstallCancellation, UpdateInstallError, UpdateInstallStage,
 };
 use crate::updates::UpdateChannel;
 
 #[derive(Debug, Clone)]
 pub enum UpdateInstallTask {
-    Prepare,
+    Prepare {
+        cancellation: UpdateInstallCancellation,
+    },
     Install {
         prepared: PreparedUpdateInstall,
         cancellation: UpdateInstallCancellation,
@@ -125,14 +127,16 @@ impl UpdateInstallBackend for EnvironmentUpdateInstallBackend {
         progress: &mut dyn FnMut(UpdateInstallStage),
     ) -> Result<UpdateInstallOutcome, UpdateInstallFailure> {
         match operation.task() {
-            UpdateInstallTask::Prepare => prepare_gui_update()
-                .map(|prepared| {
-                    prepared.map_or(
-                        UpdateInstallOutcome::UpToDate,
-                        UpdateInstallOutcome::Prepared,
-                    )
-                })
-                .map_err(Into::into),
+            UpdateInstallTask::Prepare { cancellation } => {
+                prepare_gui_update_with_cancellation(cancellation)
+                    .map(|prepared| {
+                        prepared.map_or(
+                            UpdateInstallOutcome::UpToDate,
+                            UpdateInstallOutcome::Prepared,
+                        )
+                    })
+                    .map_err(Into::into)
+            }
             UpdateInstallTask::Install {
                 prepared,
                 cancellation,
@@ -259,7 +263,9 @@ impl UpdateInstallApplication {
                         .as_ref()
                         .is_some_and(SettingsAction::enabled) =>
             {
-                let operation = self.start(UpdateInstallTask::Prepare);
+                let operation = self.start(UpdateInstallTask::Prepare {
+                    cancellation: UpdateInstallCancellation::default(),
+                });
                 self.presentation.title = Some("Preparing update…".into());
                 self.presentation.description =
                     "Finding the latest update for your saved channel.".into();
@@ -278,10 +284,14 @@ impl UpdateInstallApplication {
                 Some(Some(operation))
             }
             SettingsIntent::CancelUpdateInstall if self.active() && !self.cancelling => {
-                if let Some(UpdateInstallOperation {
-                    task: UpdateInstallTask::Install { cancellation, .. },
-                    ..
-                }) = &self.pending
+                if let Some(cancellation) =
+                    self.pending
+                        .as_ref()
+                        .and_then(|operation| match &operation.task {
+                            UpdateInstallTask::Prepare { cancellation }
+                            | UpdateInstallTask::Install { cancellation, .. } => Some(cancellation),
+                            UpdateInstallTask::Relaunch(_) => None,
+                        })
                 {
                     if !cancellation.cancel() {
                         return None;
@@ -336,12 +346,19 @@ impl UpdateInstallApplication {
         if self.pending.as_ref() != Some(operation) {
             return None;
         }
+        let cancelled_prepare =
+            self.cancelling && matches!(operation.task(), UpdateInstallTask::Prepare { .. });
         self.pending = None;
         self.presentation.busy = false;
         self.presentation.cancel_action = None;
+        if cancelled_prepare {
+            self.cancelling = false;
+            self.clear_presentation();
+            return Some((None, None));
+        }
         match result {
             Ok(UpdateInstallOutcome::Prepared(prepared))
-                if matches!(operation.task, UpdateInstallTask::Prepare) =>
+                if matches!(operation.task(), UpdateInstallTask::Prepare { .. }) =>
             {
                 self.presentation.title = Some(format!(
                     "Install LG Buddy {}?",
@@ -358,7 +375,7 @@ impl UpdateInstallApplication {
                 self.presentation.cancel_action = Some(cancel_action());
             }
             Ok(UpdateInstallOutcome::UpToDate)
-                if matches!(operation.task, UpdateInstallTask::Prepare) =>
+                if matches!(operation.task(), UpdateInstallTask::Prepare { .. }) =>
             {
                 self.clear_presentation();
             }
@@ -531,7 +548,10 @@ mod tests {
     fn modal_selects_a_fresh_release_and_pins_only_the_confirmed_target() {
         let mut app = offered();
         let operation = prepare(&mut app);
-        assert!(matches!(operation.task(), UpdateInstallTask::Prepare));
+        assert!(matches!(
+            operation.task(),
+            UpdateInstallTask::Prepare { .. }
+        ));
         let latest = PreparedUpdateInstall::from_parts(
             VersionInfo::current(),
             "1.7.1".parse().unwrap(),
@@ -628,6 +648,11 @@ mod tests {
             })
             .is_none());
         app.handle_intent(SettingsIntent::CancelUpdateInstall)
+            .unwrap();
+        assert!(app
+            .handle_intent(SettingsIntent::PrepareUpdateInstall)
+            .is_none());
+        app.complete_update_install(&old, Err(UpdateInstallError::Cancelled.into()))
             .unwrap();
         let current = prepare(&mut app);
         assert!(app
@@ -756,6 +781,10 @@ mod tests {
                 .unwrap()
                 .intent(),
             SettingsIntent::RelaunchUpdatedApplication
+        );
+        assert_eq!(
+            failed.presentation().updater().action().label(),
+            "Retry restart"
         );
         assert!(app
             .handle_intent(SettingsIntent::ConfirmUpdateInstall)

--- a/crates/lg-buddy/src/update_install.rs
+++ b/crates/lg-buddy/src/update_install.rs
@@ -678,9 +678,15 @@ impl UpdateInstallRuntime for SystemUpdateInstallRuntime {
 /// latest qualifying release at the time it opens.
 pub fn prepare_gui_update() -> Result<Option<PreparedUpdateInstall>, UpdateInstallError> {
     let cancellation = UpdateInstallCancellation::new();
+    prepare_gui_update_with_cancellation(&cancellation)
+}
+
+pub fn prepare_gui_update_with_cancellation(
+    cancellation: &UpdateInstallCancellation,
+) -> Result<Option<PreparedUpdateInstall>, UpdateInstallError> {
     let mut runtime = SystemUpdateInstallRuntime { require_gui: true };
     let current = runtime.current_version();
-    prepare_gui_update_with(&mut runtime, &cancellation, current)
+    prepare_gui_update_with(&mut runtime, cancellation, current)
 }
 
 /// Install a previously prepared and explicitly confirmed GUI update.

--- a/crates/lg-buddy/tests/settings_operations.rs
+++ b/crates/lg-buddy/tests/settings_operations.rs
@@ -476,8 +476,7 @@ exit "$LG_BUDDY_TEST_AUTH_EXIT"
         .unwrap()
         .contains("system_sleep_wake_policy=enabled"));
     let calls = fs::read_to_string(&log).unwrap();
-    let expected_call =
-        "--disable-internal-agent\nsystemctl\nstart\nLG_Buddy_lifecycle.service\n";
+    let expected_call = "--disable-internal-agent\nsystemctl\nstart\nLG_Buddy_lifecycle.service\n";
     assert_eq!(calls, expected_call.repeat(3));
 
     run_mutation(

--- a/crates/lg-buddy/tests/settings_operations.rs
+++ b/crates/lg-buddy/tests/settings_operations.rs
@@ -476,11 +476,9 @@ exit "$LG_BUDDY_TEST_AUTH_EXIT"
         .unwrap()
         .contains("system_sleep_wake_policy=enabled"));
     let calls = fs::read_to_string(&log).unwrap();
-    assert_eq!(
-        calls,
-        "--disable-internal-agent\n/usr/bin/systemctl\nstart\nLG_Buddy_lifecycle.service\n"
-            .repeat(3)
-    );
+    let expected_call =
+        "--disable-internal-agent\nsystemctl\nstart\nLG_Buddy_lifecycle.service\n";
+    assert_eq!(calls, expected_call.repeat(3));
 
     run_mutation(
         &mut app,

--- a/scripts/test-release-gui-journey.sh
+++ b/scripts/test-release-gui-journey.sh
@@ -124,7 +124,8 @@ dir="$LG_BUDDY_GUI_SERVICE_FIXTURE"
 shift
 printf '%s\n' "$*" >> "$dir/authorizations"
 [ "$(cat "$dir/auth-mode")" != decline ] || exit 126
-if [ "${1:-}" = /usr/bin/systemctl ] && [ "${2:-}" = start ] && [ "${3:-}" = LG_Buddy_lifecycle.service ]; then
+if { [ "${1:-}" = systemctl ] || [ "${1:-}" = /usr/bin/systemctl ]; } &&
+    [ "${2:-}" = start ] && [ "${3:-}" = LG_Buddy_lifecycle.service ]; then
     shift
     exec "$LG_BUDDY_SYSTEMCTL" "$@"
 fi


### PR DESCRIPTION
## Summary
- keep test systemctl overrides out of privileged pkexec execution
- make update preparation cancellation propagate to the worker
- correct restart recovery labeling
- include pkexec in the release GUI smoke environment

## Validation
- cargo check -p lg-buddy --lib --all-targets
- cargo check -p lg-buddy-gui --all-targets
- cargo test -p lg-buddy --lib -- --test-threads=1 (1011 passed, 1 ignored)
- cargo test -p lg-buddy --test settings_operations -- --test-threads=1
- bash -n scripts/test-release-gui-journey.sh
- git diff --check