### PR TITLE
Prepare v1.7.0 release metadata and docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1206,7 +1206,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "lg-buddy"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "base64",
  "cucumber",
@@ -1231,7 +1231,7 @@ dependencies = [
 
 [[package]]
 name = "lg-buddy-gui"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "gtk4",
  "lg-buddy",

--- a/crates/lg-buddy-gui/Cargo.toml
+++ b/crates/lg-buddy-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy-gui"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 publish = false
 

--- a/crates/lg-buddy/Cargo.toml
+++ b/crates/lg-buddy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lg-buddy"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 publish = false
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1097,15 +1097,15 @@ What is still not implemented:
 - an immutable-distribution install layout that avoids conventional `/usr`
   writes
 
-The no-argument launcher opens the installed application but does not replace
-the shell setup surface. v1.6 exposes TV connection/capability status and
-actionable control, pairing, and settings errors. A resolved screen backend
-display is not a GUI requirement; the existing CLI diagnostics remain available.
-
-The complete GUI first-run, service, and update journey, including runtime/service
-state and update state, belongs to v1.7.0 under
-[issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129). The contents of
-runtime/service state remain to be defined. The current architecture is a
-Rust-owned runtime and application with a thin GTK renderer and shell setup
-surface. See [Frontend architecture](gui-target-architecture.md) for the current
-view and renderer boundaries.
+The no-argument launcher opens the installed application, while the shell layer
+remains the explicit setup, installation, and uninstallation surface for
+headless use. v1.7.0 extends the GUI with the complete first-run, service
+activation, update, and troubleshooting journey under
+[issue #129](https://github.com/Staphylococcus/LG_Buddy/issues/129). The
+application owns typed runtime/service and update state, including on-demand
+diagnostics; the GUI renders those states without inferring policy. A resolved
+screen backend display is not a GUI requirement, and the existing CLI paths
+remain available. The current architecture is a Rust-owned runtime and
+application with a thin GTK renderer and shell setup surface. See
+[Frontend architecture](gui-target-architecture.md) for the current view and
+renderer boundaries.

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -4,12 +4,12 @@ This document describes the current first-party Linux frontend in the
 development tree. The application and GUI are a single Rust workspace, with
 the application owning state and the GTK crate rendering it.
 
-> The `v1.6.0` frontend covers Overview, TVs, Settings, first-TV pairing, and
-> About. The development tree also provides manual update checks and
-> user-confirmed release-bundle installation in Settings, and first-run pairing
-> with default behavior activation. Unavailable or declined behaviors remain off
-> and can be retried in Settings. The app menu provides on-demand diagnostics
-> with report viewing, refresh, copying, and saving.
+> The `v1.7.0` frontend covers Overview, TVs, Settings, first-TV pairing,
+> About, manual update checks, user-confirmed release-bundle installation in
+> Settings, and first-run pairing with default behavior activation. Unavailable
+> or declined behaviors remain off and can be retried in Settings. The app menu
+> provides on-demand diagnostics with report viewing, refresh, copying, and
+> saving.
 
 ## Boundary
 


### PR DESCRIPTION
## Summary

- Bump `lg-buddy` and `lg-buddy-gui` to `1.7.0` in Cargo metadata and the lockfile.
- Update architecture status notes to describe the completed v1.7.0 GUI journey.
- Keep the historical screenshot provenance unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo metadata --locked --no-deps`
- `cargo test -p lg-buddy --lib -- --test-threads=1` (1,011 passed, 1 ignored)
- All tracked relative Markdown links resolve.
- Full Hearth NixOS system derivation build passed against the current pinned `dev` source.

This is the version-preparation PR only. The protected `dev -> main` promotion and release publication remain separate steps.
