### PR TITLE
Remove Zenity brightness fallback and dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
           sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
-          sudo apt-get install -y at-spi2-core dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev pkexec python3-pyatspi xdotool xvfb zenity
+          sudo apt-get install -y at-spi2-core dbus-x11 libadwaita-1-dev libglib2.0-bin libgtk-4-dev pkexec python3-pyatspi xdotool xvfb
 
       - name: Run display-backed GTK test suite
         run: |
@@ -110,7 +110,9 @@ jobs:
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
           sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
-          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools pkexec python3-pyatspi strace xdotool xvfb zenity
+          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools pkexec python3-pyatspi strace xdotool xvfb
+          # Prove current installation and GUI behavior without the retired dialog tool.
+          sudo apt-get purge -y zenity
 
       - name: Build headless runtime and GTK GUI
         env:
@@ -150,6 +152,10 @@ jobs:
 
       - name: Smoke test release bundle
         run: |
+          if command -v zenity; then
+            echo "Release-bundle smoke requires a host without Zenity." >&2
+            exit 1
+          fi
           dbus-run-session -- xvfb-run -a env ADW_DISABLE_PORTAL=1 GDK_BACKEND=x11 GDK_DEBUG=no-portals NO_AT_BRIDGE=1 \
               LG_BUDDY_GUI_TV_FIXTURE="$PWD/target/gui-journey-fixtures/gui_journey_tv" \
               ./scripts/test-release-bundle.sh \
@@ -239,11 +245,11 @@ jobs:
           - name: Fedora 43
             image: fedora:43
             package_manager: dnf
-            setup: dnf install -y at-spi2-core binutils curl dbus-x11 findutils glib2 gobject-introspection gsettings-desktop-schemas gtk4 gzip libadwaita libglvnd-gles polkit procps-ng python3 python3-pyatspi shadow-utils strace tar util-linux which xdotool xorg-x11-server-Xvfb xorg-x11-xauth xwd zenity
+            setup: dnf install -y at-spi2-core binutils curl dbus-x11 findutils glib2 gobject-introspection gsettings-desktop-schemas gtk4 gzip libadwaita libglvnd-gles polkit procps-ng python3 python3-pyatspi shadow-utils strace tar util-linux which xdotool xorg-x11-server-Xvfb xorg-x11-xauth xwd
           - name: Arch current
             image: archlinux:latest
             package_manager: pacman
-            setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita polkit procps-ng python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd zenity
+            setup: pacman -Syu --noconfirm at-spi2-core binutils curl dbus diffutils glib2 gtk4 gzip libadwaita polkit procps-ng python python-atspi shadow strace tar util-linux which xdotool xorg-server-xvfb xorg-xauth xorg-xwd
     container:
       image: ${{ matrix.image }}
       options: --security-opt seccomp=unconfined

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
           sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
-          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools pkexec python3-pyatspi strace xdotool xvfb zenity
+          sudo apt-get install -y at-spi2-core binutils dbus-x11 libadwaita-1-dev libgtk-4-dev musl-tools pkexec python3-pyatspi strace xdotool xvfb
 
       - name: Build headless runtime and GTK GUI
         env:
@@ -428,7 +428,7 @@ jobs:
           # Chrome is unused; its third-party index must not block Ubuntu dependencies.
           sudo rm -fv /etc/apt/sources.list.d/google-chrome.list /etc/apt/sources.list.d/google-chrome.sources
           sudo apt-get update
-          sudo apt-get install -y libadwaita-1-0 libgtk-4-1 python3-venv util-linux zenity
+          sudo apt-get install -y libadwaita-1-0 libgtk-4-1 python3-venv util-linux
 
       - name: Download pinned updater-capable baseline
         run: |

--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ LG Buddy manages one TV. Connect it to the same network as your PC and enable
 are strongly recommended so the saved address stays valid and the TV remains
 ready to respond.
 
-Official bundles contain prebuilt binaries. They require GTK 4.14,
-libadwaita 1.5, and glibc 2.39 or newer—the Ubuntu 24.04 runtime baseline.
+Official bundles include the GTK desktop app and CLI together. The installer
+checks for GTK 4.14 and libadwaita 1.5 or newer, offers to install missing
+packages on Debian/Ubuntu, Fedora, and Arch with your confirmation, and verifies
+the requirements before proceeding. The prebuilt binaries require glibc 2.39
+or newer—the Ubuntu 24.04 runtime baseline.
 The release installer also needs Python 3 with `venv`/`pip` support
 for its compatibility tools. TV Sleep & Wake activation requires `pkexec` and
-a desktop authorization agent. Install the prerequisites for your distribution:
+a desktop authorization agent. You can also install the prerequisites manually:
 
 <details>
 <summary>Dependency commands for Debian/Ubuntu, Fedora, and Arch</summary>
@@ -75,9 +78,8 @@ sudo pacman -S python python-pip python-virtualenv gtk4 libadwaita polkit
 
 </details>
 
-The installer can also offer to install missing GTK/libadwaita packages on
-these distributions, with your confirmation. Older desktops that need the
-deprecated `swayidle` integration must install `swayidle` separately.
+Older desktops that need the deprecated `swayidle` integration must install
+`swayidle` separately.
 
 The shell installer supports conventional Linux installations with writable
 system locations. Official NixOS support is planned for 3.0.0; see

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ ready to respond.
 
 Official bundles contain prebuilt binaries. They require GTK 4.14,
 libadwaita 1.5, and glibc 2.39 or newer—the Ubuntu 24.04 runtime baseline.
-The release installer also needs Python 3 with `venv`/`pip` support and Zenity
+The release installer also needs Python 3 with `venv`/`pip` support
 for its compatibility tools. TV Sleep & Wake activation requires `pkexec` and
 a desktop authorization agent. Install the prerequisites for your distribution:
 
@@ -58,19 +58,19 @@ a desktop authorization agent. Install the prerequisites for your distribution:
 ### Debian, Ubuntu, and Pop!_OS
 
 ```bash
-sudo apt install python3-venv python3-pip zenity libgtk-4-1 libadwaita-1-0 pkexec
+sudo apt install python3-venv python3-pip libgtk-4-1 libadwaita-1-0 pkexec
 ```
 
 ### Fedora
 
 ```bash
-sudo dnf install python3 python3-pip python3-virtualenv zenity gtk4 libadwaita polkit
+sudo dnf install python3 python3-pip python3-virtualenv gtk4 libadwaita polkit
 ```
 
 ### Arch Linux
 
 ```bash
-sudo pacman -S python python-pip python-virtualenv zenity gtk4 libadwaita polkit
+sudo pacman -S python python-pip python-virtualenv gtk4 libadwaita polkit
 ```
 
 </details>

--- a/crates/lg-buddy/src/commands.rs
+++ b/crates/lg-buddy/src/commands.rs
@@ -1,21 +1,17 @@
 use std::env;
 use std::fs;
 use std::io::{self, Write};
-use std::net::Ipv4Addr;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::{Path, PathBuf};
 use std::process::Command as ProcessCommand;
 use std::process::Output;
 
 use crate::audio::{apply_audio_operation_with, read_audio_status_with, AudioOperation};
-use crate::brightness::{
-    notify_brightness_success_with, read_current_brightness_with, write_brightness_with,
-};
+use crate::brightness::{read_current_brightness_with, write_brightness_with};
 use crate::config::{load_config, resolve_config_path_from_env, Config};
 use crate::events::{EventSource, RuntimeEvent, RuntimeEventKind};
 use crate::lifecycle::ThreadSleeper;
 use crate::lifecycle::{self, JournalctlSleepDetector, NmOnlineNetworkWaiter};
-use crate::notifications::{FreedesktopNotifier, Notification, NotificationError, Notifier};
 use crate::session::actions::{RuntimeActionExecutor, SYSTEM_PRE_SLEEP_TV_COMMAND_TIMEOUT};
 use crate::state::{ScreenOwnershipMarker, StateScope, SystemSleepAttemptState};
 use crate::tv::{
@@ -28,33 +24,7 @@ use crate::{BrightnessCommand, MuteCommand, RunError, StartupMode, VolumeCommand
 const GUI_ENV: &str = "LG_BUDDY_GUI";
 const GUI_EXECUTABLE: &str = "lg-buddy-gui";
 
-trait ReachabilityChecker {
-    fn is_reachable(&self, tv_ip: Ipv4Addr) -> io::Result<bool>;
-}
-
-trait BrightnessUi {
-    fn prompt_brightness(&self, initial: OledBrightness) -> io::Result<Option<OledBrightness>>;
-    fn show_error(&self, title: &str, message: &str) -> io::Result<()>;
-}
-
-trait BrightnessCli {
-    fn get_brightness(&self) -> Result<OledBrightness, RunError>;
-    fn set_brightness(&self, brightness: OledBrightness) -> Result<String, RunError>;
-}
-
 struct SystemctlRebootDetector {
-    command_path: PathBuf,
-}
-
-struct PingReachabilityChecker {
-    command_path: PathBuf,
-}
-
-struct ZenityBrightnessUi {
-    command_path: PathBuf,
-}
-
-struct CurrentExeBrightnessCli {
     command_path: PathBuf,
 }
 
@@ -63,32 +33,7 @@ struct InstalledGui {
     command_path: PathBuf,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum GuiLaunchOutcome {
-    Launched,
-    Missing,
-}
-
-struct BrightnessDialogDeps<'a, R, U, B, N> {
-    reachability: &'a R,
-    ui: &'a U,
-    brightness_cli: &'a B,
-    notifier: &'a N,
-}
-
 impl Default for SystemctlRebootDetector {
-    fn default() -> Self {
-        Self::from_env()
-    }
-}
-
-impl Default for PingReachabilityChecker {
-    fn default() -> Self {
-        Self::from_env()
-    }
-}
-
-impl Default for ZenityBrightnessUi {
     fn default() -> Self {
         Self::from_env()
     }
@@ -101,41 +46,6 @@ impl SystemctlRebootDetector {
                 .map(PathBuf::from)
                 .unwrap_or_else(|| PathBuf::from("systemctl")),
         }
-    }
-}
-
-impl PingReachabilityChecker {
-    fn from_env() -> Self {
-        Self {
-            command_path: env::var_os("LG_BUDDY_PING")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| PathBuf::from("ping")),
-        }
-    }
-}
-
-impl ZenityBrightnessUi {
-    fn from_env() -> Self {
-        Self {
-            command_path: env::var_os("LG_BUDDY_ZENITY")
-                .map(PathBuf::from)
-                .unwrap_or_else(|| PathBuf::from("zenity")),
-        }
-    }
-}
-
-impl CurrentExeBrightnessCli {
-    fn from_current_exe() -> Result<Self, RunError> {
-        Ok(Self {
-            command_path: env::current_exe()?,
-        })
-    }
-
-    fn run(&self, args: &[&str]) -> Result<Output, RunError> {
-        ProcessCommand::new(&self.command_path)
-            .args(args)
-            .output()
-            .map_err(RunError::Io)
     }
 }
 
@@ -164,11 +74,14 @@ impl InstalledGui {
         }
     }
 
-    fn launch(&self, arguments: &[&str]) -> Result<GuiLaunchOutcome, RunError> {
+    fn launch(&self, arguments: &[&str]) -> Result<(), RunError> {
         match fs::symlink_metadata(&self.command_path) {
             Ok(_) => {}
             Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                return Ok(GuiLaunchOutcome::Missing);
+                return Err(RunError::Policy(format!(
+                    "LG Buddy GUI is not installed at `{}`; install the matching lg-buddy-gui executable",
+                    self.command_path.display()
+                )));
             }
             Err(error) => {
                 return Err(RunError::Policy(format!(
@@ -215,7 +128,7 @@ impl InstalledGui {
             })?;
 
         if output.status.success() {
-            Ok(GuiLaunchOutcome::Launched)
+            Ok(())
         } else {
             Err(RunError::Policy(format!(
                 "installed LG Buddy GUI at `{}` failed: {}",
@@ -257,30 +170,6 @@ fn gui_output_message(output: &Output) -> String {
     )
 }
 
-impl BrightnessCli for CurrentExeBrightnessCli {
-    fn get_brightness(&self) -> Result<OledBrightness, RunError> {
-        let output = self.run(&["brightness", "get"])?;
-
-        if !output.status.success() {
-            return Err(RunError::Policy(command_output_message(&output)));
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        OledBrightness::parse(stdout.trim())
-            .map_err(|err| RunError::Policy(format!("invalid output from `brightness get`: {err}")))
-    }
-
-    fn set_brightness(&self, brightness: OledBrightness) -> Result<String, RunError> {
-        let output = self.run(&["brightness", "set", &brightness.to_string()])?;
-
-        if output.status.success() {
-            Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-        } else {
-            Err(RunError::Policy(command_output_message(&output)))
-        }
-    }
-}
-
 impl lifecycle::RebootDetector for SystemctlRebootDetector {
     fn is_reboot_pending(&self) -> io::Result<bool> {
         let output = ProcessCommand::new(&self.command_path)
@@ -296,82 +185,6 @@ impl lifecycle::RebootDetector for SystemctlRebootDetector {
             .lines()
             .any(|line| line.contains("reboot.target") && line.contains("start")))
     }
-}
-
-impl ReachabilityChecker for PingReachabilityChecker {
-    fn is_reachable(&self, tv_ip: Ipv4Addr) -> io::Result<bool> {
-        let output = ProcessCommand::new(&self.command_path)
-            .args(["-c", "1", "-W", "2"])
-            .arg(tv_ip.to_string())
-            .output()?;
-
-        Ok(output.status.success())
-    }
-}
-
-impl BrightnessUi for ZenityBrightnessUi {
-    fn prompt_brightness(&self, initial: OledBrightness) -> io::Result<Option<OledBrightness>> {
-        let output = ProcessCommand::new(&self.command_path)
-            .args([
-                "--scale",
-                "--title=LG TV Brightness",
-                "--text=Set OLED Pixel Brightness:",
-                "--min-value=0",
-                "--max-value=100",
-                &format!("--value={initial}"),
-                "--step=5",
-            ])
-            .output()?;
-
-        if !output.status.success() {
-            return Ok(None);
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let value = OledBrightness::parse(stdout.trim()).map_err(|err| {
-            io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!("invalid zenity brightness value: {err}"),
-            )
-        })?;
-
-        Ok(Some(value))
-    }
-
-    fn show_error(&self, title: &str, message: &str) -> io::Result<()> {
-        let _ = ProcessCommand::new(&self.command_path)
-            .arg("--error")
-            .arg(format!("--title={title}"))
-            .arg(format!("--text={message}"))
-            .output()?;
-
-        Ok(())
-    }
-}
-
-fn command_output_message(output: &Output) -> String {
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-    if !stderr.is_empty() {
-        return strip_lg_buddy_prefix(&stderr).to_string();
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if !stdout.is_empty() {
-        return strip_lg_buddy_prefix(&stdout).to_string();
-    }
-
-    format!(
-        "brightness command failed with status {}",
-        output
-            .status
-            .code()
-            .map(|code| code.to_string())
-            .unwrap_or_else(|| "terminated by signal".to_string())
-    )
-}
-
-fn strip_lg_buddy_prefix(value: &str) -> &str {
-    value.strip_prefix("LG Buddy: ").unwrap_or(value)
 }
 
 pub fn run_screen_off<W: Write>(writer: &mut W) -> Result<(), RunError> {
@@ -450,14 +263,7 @@ pub fn run_nm_pre_down<W: Write>(writer: &mut W) -> Result<(), RunError> {
 }
 
 pub fn run_overview() -> Result<(), RunError> {
-    let gui = InstalledGui::from_env()?;
-    match gui.launch(&[])? {
-        GuiLaunchOutcome::Launched => Ok(()),
-        GuiLaunchOutcome::Missing => Err(RunError::Policy(format!(
-            "LG Buddy GUI is not installed at `{}`; install the matching lg-buddy-gui executable",
-            gui.command_path.display()
-        ))),
-    }
+    InstalledGui::from_env()?.launch(&[])
 }
 
 pub fn run_brightness<W: Write>(
@@ -465,28 +271,7 @@ pub fn run_brightness<W: Write>(
     command: BrightnessCommand,
 ) -> Result<(), RunError> {
     match command {
-        BrightnessCommand::Prompt => {
-            let gui = InstalledGui::from_env()?;
-            match gui.launch(&["brightness"])? {
-                GuiLaunchOutcome::Launched => return Ok(()),
-                GuiLaunchOutcome::Missing => {}
-            }
-
-            let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
-            let config = load_config(&config_path).map_err(RunError::Config)?;
-            let reachability = PingReachabilityChecker::default();
-            let ui = ZenityBrightnessUi::default();
-            let brightness_cli = CurrentExeBrightnessCli::from_current_exe()?;
-            let notifier = FreedesktopNotifier;
-            let deps = BrightnessDialogDeps {
-                reachability: &reachability,
-                ui: &ui,
-                brightness_cli: &brightness_cli,
-                notifier: &notifier,
-            };
-
-            run_brightness_prompt_with(writer, &config, deps)
-        }
+        BrightnessCommand::Prompt => InstalledGui::from_env()?.launch(&["brightness"]),
         BrightnessCommand::Get | BrightnessCommand::Set(_) => {
             let config_path = resolve_config_path_from_env().map_err(RunError::ConfigPath)?;
             let config = load_config(&config_path).map_err(RunError::Config)?;
@@ -713,75 +498,6 @@ fn set_muted<C: TvClient>(config: &Config, tv_client: &C, muted: bool) -> Result
         .map_err(|err| RunError::Policy(err.to_string()))
 }
 
-fn run_brightness_prompt_with<
-    W: Write,
-    R: ReachabilityChecker,
-    U: BrightnessUi,
-    B: BrightnessCli,
-    N: Notifier,
->(
-    writer: &mut W,
-    config: &Config,
-    deps: BrightnessDialogDeps<'_, R, U, B, N>,
-) -> Result<(), RunError> {
-    match deps.reachability.is_reachable(config.tv_ip) {
-        Ok(true) => {}
-        Ok(false) => {
-            let message = format!("TV is not reachable at {}.", config.tv_ip);
-            let _ = deps.ui.show_error("LG Buddy", &message);
-            return Err(RunError::Policy(message));
-        }
-        Err(err) => {
-            let message = format!("Could not check TV reachability at {}. {err}", config.tv_ip);
-            let _ = deps.ui.show_error("LG Buddy", &message);
-            return Err(RunError::Policy(message));
-        }
-    }
-
-    let initial_brightness = deps
-        .brightness_cli
-        .get_brightness()
-        .unwrap_or(OledBrightness::DEFAULT);
-
-    let Some(brightness) = deps.ui.prompt_brightness(initial_brightness)? else {
-        return Ok(());
-    };
-
-    match deps.brightness_cli.set_brightness(brightness) {
-        Ok(stdout) => {
-            write!(writer, "{stdout}")?;
-            notify_brightness_success(deps.notifier, brightness)?;
-            Ok(())
-        }
-        Err(err) => Err(notify_brightness_failure(deps.notifier, err)),
-    }
-}
-
-fn notify_brightness_success<N: Notifier>(
-    notifier: &N,
-    brightness: OledBrightness,
-) -> Result<(), RunError> {
-    notify_brightness_success_with(notifier, brightness).map_err(|err| {
-        RunError::Policy(format!(
-            "brightness was set to {brightness}%, but desktop notification failed: {err}"
-        ))
-    })
-}
-
-fn notify_brightness_failure<N: Notifier>(notifier: &N, primary: RunError) -> RunError {
-    match notifier.notify(&Notification::new("LG TV", "Failed to set brightness")) {
-        Ok(_) => primary,
-        Err(notification_err) => append_notification_failure(primary, notification_err),
-    }
-}
-
-fn append_notification_failure(primary: RunError, notification_err: NotificationError) -> RunError {
-    RunError::NotificationAfterPrimary {
-        primary: Box::new(primary),
-        notification: notification_err,
-    }
-}
-
 fn set_oled_brightness<C: TvClient>(
     config: &Config,
     tv_client: &C,
@@ -797,10 +513,7 @@ mod tests {
         include!(concat!(env!("CARGO_MANIFEST_DIR"), "/tests/support/mod.rs"));
     }
 
-    use super::{
-        run_brightness_command_with, run_brightness_prompt_with, BrightnessCli,
-        BrightnessDialogDeps, BrightnessUi, GuiLaunchOutcome, InstalledGui, ReachabilityChecker,
-    };
+    use super::{run_brightness_command_with, InstalledGui};
     use crate::config::{
         Config, HdmiInput, MacAddress, ScreenBackend, ScreenIdleBlankPolicy, ScreenRestorePolicy,
         SystemSleepWakePolicy,
@@ -809,13 +522,12 @@ mod tests {
         run_shutdown_with, run_startup_with, NetworkWaiter, RebootDetector, SleepRequestDetector,
         Sleeper, StartupDeps,
     };
-    use crate::notifications::{Notification, NotificationError, NotificationId, Notifier};
     use crate::screen::{run_screen_off_with, run_screen_on_with};
     use crate::state::ScreenOwnershipMarker;
     use crate::state::SystemSleepAttemptState;
     use crate::tv::{BscpylgtvCommandClient, OledBrightness};
     use crate::wol::{WakeOnLanError, WakeOnLanSender};
-    use crate::{BrightnessCommand, RunError, StartupMode};
+    use crate::{BrightnessCommand, StartupMode};
     use std::cell::RefCell;
     use std::env;
     use std::ffi::CString;
@@ -1564,53 +1276,19 @@ mod tests {
     }
 
     #[test]
-    fn brightness_dialog_uses_cli_get_and_set_then_notifies() {
-        let reachability = FakeReachabilityChecker::reachable();
-        let ui = FakeBrightnessUi::selected(65);
-        let brightness_cli = FakeBrightnessCli::success(72)
-            .with_set_stdout("LG Buddy Brightness: Set OLED pixel brightness to 65%.\n");
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect("brightness should succeed");
-
-        assert_eq!(ui.initial_values(), vec![72]);
-        assert!(ui.error_messages().is_empty());
-        assert_eq!(
-            notifier.messages(),
-            vec![("LG TV".to_string(), "Brightness set to 65%".to_string())]
-        );
-        assert_eq!(
-            brightness_cli.calls(),
-            vec![FakeBrightnessCliCall::Get, FakeBrightnessCliCall::Set(65),]
-        );
-        assert!(rendered(&output).contains("Set OLED pixel brightness to 65%."));
-    }
-
-    #[test]
     fn installed_brightness_gui_launches_only_the_brightness_command() {
         let launcher = InstalledGui::new(
             env::current_exe().expect("current executable"),
             find_command_in_path("test").expect("test executable"),
         );
 
-        assert_eq!(
-            launcher
-                .launch(&["brightness"])
-                .expect("GUI launch should succeed"),
-            GuiLaunchOutcome::Launched
-        );
+        launcher
+            .launch(&["brightness"])
+            .expect("GUI launch should succeed");
     }
 
     #[test]
-    fn missing_installed_brightness_gui_allows_compatibility_fallback() {
+    fn missing_installed_brightness_gui_reports_installation_remedy() {
         let anchor =
             ExecutableScript::new("brightness-gui-missing", "anchor", "#!/bin/sh\nexit 0\n");
         let launcher = InstalledGui::new(
@@ -1618,16 +1296,24 @@ mod tests {
             anchor.path().with_file_name("missing-lg-buddy-gui"),
         );
 
-        assert_eq!(
-            launcher
-                .launch(&["brightness"])
-                .expect("missing GUI should be recognized"),
-            GuiLaunchOutcome::Missing
+        let error = launcher
+            .launch(&["brightness"])
+            .expect_err("missing GUI must fail with installation guidance")
+            .to_string();
+
+        assert!(error.contains("LG Buddy GUI is not installed"), "{error}");
+        assert!(
+            error.contains(&launcher.command_path.display().to_string()),
+            "{error}"
+        );
+        assert!(
+            error.contains("install the matching lg-buddy-gui executable"),
+            "{error}"
         );
     }
 
     #[test]
-    fn failed_installed_brightness_gui_is_reported_without_fallback() {
+    fn failed_installed_brightness_gui_is_reported() {
         let launcher = InstalledGui::new(
             env::current_exe().expect("current executable"),
             python3_path(),
@@ -1635,7 +1321,7 @@ mod tests {
 
         let error = launcher
             .launch(&["brightness"])
-            .expect_err("failed GUI must not become a missing-GUI fallback");
+            .expect_err("failed GUI must report the launch error");
 
         let error = error.to_string();
         assert!(error.contains("brightness"), "{error}");
@@ -1672,7 +1358,7 @@ mod tests {
 
         let error = launcher
             .launch(&["brightness"])
-            .expect_err("dangling GUI installation must not use compatibility fallback");
+            .expect_err("dangling GUI installation must be reported");
 
         assert!(error
             .to_string()
@@ -1692,38 +1378,6 @@ mod tests {
         assert!(error
             .to_string()
             .contains("would recursively relaunch itself"));
-    }
-
-    #[test]
-    fn brightness_fails_after_success_when_notification_delivery_fails() {
-        let reachability = FakeReachabilityChecker::reachable();
-        let ui = FakeBrightnessUi::selected(65);
-        let brightness_cli = FakeBrightnessCli::success(72)
-            .with_set_stdout("LG Buddy Brightness: Set OLED pixel brightness to 65%.\n");
-        let notifier = RecordingNotifier::failing("bus unavailable");
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        let err = run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect_err("notification failure after success should fail");
-
-        assert_eq!(
-            notifier.messages(),
-            vec![("LG TV".to_string(), "Brightness set to 65%".to_string())]
-        );
-        assert_eq!(
-            brightness_cli.calls(),
-            vec![FakeBrightnessCliCall::Get, FakeBrightnessCliCall::Set(65),]
-        );
-        assert!(rendered(&output).contains("Set OLED pixel brightness to 65%."));
-        assert!(err
-            .to_string()
-            .contains("brightness was set to 65%, but desktop notification failed"));
     }
 
     #[test]
@@ -1761,139 +1415,6 @@ mod tests {
         assert_eq!(mock.state_snapshot().backlight, 61);
         assert_call_commands(&mock, &["set_settings"]);
         assert!(rendered(&output).contains("Set OLED pixel brightness to 61%."));
-    }
-
-    #[test]
-    fn brightness_returns_ok_when_dialog_is_cancelled() {
-        let reachability = FakeReachabilityChecker::reachable();
-        let ui = FakeBrightnessUi::cancelled();
-        let brightness_cli = FakeBrightnessCli::success(50);
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect("cancel should exit cleanly");
-
-        assert_eq!(ui.initial_values(), vec![50]);
-        assert_eq!(brightness_cli.calls(), vec![FakeBrightnessCliCall::Get]);
-        assert!(notifier.messages().is_empty());
-        assert!(rendered(&output).is_empty());
-    }
-
-    #[test]
-    fn brightness_shows_error_and_fails_when_tv_is_unreachable() {
-        let reachability = FakeReachabilityChecker::unreachable();
-        let ui = FakeBrightnessUi::selected(50);
-        let brightness_cli = FakeBrightnessCli::success(50);
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        let err = run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect_err("unreachable tv should fail");
-
-        assert!(matches!(err, crate::RunError::Policy(_)));
-        assert!(brightness_cli.calls().is_empty());
-        assert!(notifier.messages().is_empty());
-        assert_eq!(
-            ui.error_messages(),
-            vec![(
-                "LG Buddy".to_string(),
-                "TV is not reachable at 192.0.2.42.".to_string(),
-            )]
-        );
-    }
-
-    #[test]
-    fn brightness_defaults_to_fifty_when_current_brightness_query_fails() {
-        let reachability = FakeReachabilityChecker::reachable();
-        let ui = FakeBrightnessUi::cancelled();
-        let brightness_cli = FakeBrightnessCli::get_error("offline");
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect("fallback to default brightness should still allow cancellation");
-
-        assert_eq!(ui.initial_values(), vec![50]);
-        assert_eq!(brightness_cli.calls(), vec![FakeBrightnessCliCall::Get]);
-        assert!(notifier.messages().is_empty());
-        assert!(rendered(&output).is_empty());
-    }
-
-    #[test]
-    fn brightness_notifies_and_fails_when_tv_update_fails() {
-        let reachability = FakeReachabilityChecker::reachable();
-        let ui = FakeBrightnessUi::selected(30);
-        let brightness_cli = FakeBrightnessCli::success(50).with_set_error("offline");
-        let notifier = RecordingNotifier::default();
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        let err = run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect_err("tv command failure should fail");
-
-        assert!(matches!(err, crate::RunError::Policy(_)));
-        assert_eq!(ui.initial_values(), vec![50]);
-        assert_eq!(
-            notifier.messages(),
-            vec![("LG TV".to_string(), "Failed to set brightness".to_string())]
-        );
-        assert_eq!(
-            brightness_cli.calls(),
-            vec![FakeBrightnessCliCall::Get, FakeBrightnessCliCall::Set(30),]
-        );
-        assert!(rendered(&output).is_empty());
-    }
-
-    #[test]
-    fn brightness_preserves_tv_failure_when_failure_notification_fails() {
-        let reachability = FakeReachabilityChecker::reachable();
-        let ui = FakeBrightnessUi::selected(30);
-        let brightness_cli = FakeBrightnessCli::success(50).with_set_error("offline");
-        let notifier = RecordingNotifier::failing("bus unavailable");
-        let deps = BrightnessDialogDeps {
-            reachability: &reachability,
-            ui: &ui,
-            brightness_cli: &brightness_cli,
-            notifier: &notifier,
-        };
-
-        let mut output = Vec::new();
-        let err = run_brightness_prompt_with(&mut output, &sample_config(HdmiInput::Hdmi2), deps)
-            .expect_err("tv and notification failure should fail");
-
-        assert_eq!(
-            notifier.messages(),
-            vec![("LG TV".to_string(), "Failed to set brightness".to_string())]
-        );
-        assert_eq!(
-            err.to_string(),
-            "offline; additionally, desktop notification failed: desktop notification service error: bus unavailable"
-        );
-        assert!(rendered(&output).is_empty());
     }
 
     #[test]
@@ -2270,192 +1791,6 @@ mod tests {
                 Ok(()) => Ok(()),
                 Err(err) => Err(io::Error::new(err.kind(), err.to_string())),
             }
-        }
-    }
-
-    struct FakeReachabilityChecker {
-        reachable: io::Result<bool>,
-    }
-
-    impl FakeReachabilityChecker {
-        fn reachable() -> Self {
-            Self {
-                reachable: Ok(true),
-            }
-        }
-
-        fn unreachable() -> Self {
-            Self {
-                reachable: Ok(false),
-            }
-        }
-    }
-
-    impl ReachabilityChecker for FakeReachabilityChecker {
-        fn is_reachable(&self, _tv_ip: Ipv4Addr) -> io::Result<bool> {
-            match &self.reachable {
-                Ok(value) => Ok(*value),
-                Err(err) => Err(io::Error::new(err.kind(), err.to_string())),
-            }
-        }
-    }
-
-    #[derive(Debug, Clone, PartialEq, Eq)]
-    enum FakeBrightnessCliCall {
-        Get,
-        Set(u8),
-    }
-
-    struct FakeBrightnessCli {
-        get_result: Result<OledBrightness, String>,
-        set_result: Result<String, String>,
-        calls: RefCell<Vec<FakeBrightnessCliCall>>,
-    }
-
-    impl FakeBrightnessCli {
-        fn success(current: u8) -> Self {
-            Self {
-                get_result: Ok(
-                    OledBrightness::new(current).expect("fake brightness value should be valid")
-                ),
-                set_result: Ok(String::new()),
-                calls: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn get_error(message: &str) -> Self {
-            Self {
-                get_result: Err(message.to_string()),
-                set_result: Ok(String::new()),
-                calls: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn with_set_error(mut self, message: &str) -> Self {
-            self.set_result = Err(message.to_string());
-            self
-        }
-
-        fn with_set_stdout(mut self, stdout: &str) -> Self {
-            self.set_result = Ok(stdout.to_string());
-            self
-        }
-
-        fn calls(&self) -> Vec<FakeBrightnessCliCall> {
-            self.calls.borrow().clone()
-        }
-    }
-
-    impl BrightnessCli for FakeBrightnessCli {
-        fn get_brightness(&self) -> Result<OledBrightness, RunError> {
-            self.calls.borrow_mut().push(FakeBrightnessCliCall::Get);
-            self.get_result
-                .as_ref()
-                .copied()
-                .map_err(|message| RunError::Policy(message.clone()))
-        }
-
-        fn set_brightness(&self, brightness: OledBrightness) -> Result<String, RunError> {
-            self.calls
-                .borrow_mut()
-                .push(FakeBrightnessCliCall::Set(brightness.as_percent()));
-            self.set_result
-                .as_ref()
-                .cloned()
-                .map_err(|message| RunError::Policy(message.clone()))
-        }
-    }
-
-    struct FakeBrightnessUi {
-        selection: io::Result<Option<OledBrightness>>,
-        initial_values: RefCell<Vec<u8>>,
-        error_messages: RefCell<Vec<(String, String)>>,
-    }
-
-    impl FakeBrightnessUi {
-        fn selected(value: u8) -> Self {
-            Self {
-                selection: Ok(Some(
-                    OledBrightness::new(value).expect("fake brightness value should be valid"),
-                )),
-                initial_values: RefCell::new(Vec::new()),
-                error_messages: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn cancelled() -> Self {
-            Self {
-                selection: Ok(None),
-                initial_values: RefCell::new(Vec::new()),
-                error_messages: RefCell::new(Vec::new()),
-            }
-        }
-
-        fn initial_values(&self) -> Vec<u8> {
-            self.initial_values.borrow().clone()
-        }
-
-        fn error_messages(&self) -> Vec<(String, String)> {
-            self.error_messages.borrow().clone()
-        }
-    }
-
-    impl BrightnessUi for FakeBrightnessUi {
-        fn prompt_brightness(&self, initial: OledBrightness) -> io::Result<Option<OledBrightness>> {
-            self.initial_values.borrow_mut().push(initial.as_percent());
-            match &self.selection {
-                Ok(value) => Ok(*value),
-                Err(err) => Err(io::Error::new(err.kind(), err.to_string())),
-            }
-        }
-
-        fn show_error(&self, title: &str, message: &str) -> io::Result<()> {
-            self.error_messages
-                .borrow_mut()
-                .push((title.to_string(), message.to_string()));
-            Ok(())
-        }
-    }
-
-    struct RecordingNotifier {
-        messages: RefCell<Vec<(String, String)>>,
-        result: Result<NotificationId, NotificationError>,
-    }
-
-    impl RecordingNotifier {
-        fn failing(message: &str) -> Self {
-            Self {
-                messages: RefCell::new(Vec::new()),
-                result: Err(NotificationError::Transport(message.to_string())),
-            }
-        }
-
-        fn messages(&self) -> Vec<(String, String)> {
-            self.messages.borrow().clone()
-        }
-    }
-
-    impl Default for RecordingNotifier {
-        fn default() -> Self {
-            Self {
-                messages: RefCell::new(Vec::new()),
-                result: Ok(NotificationId(1)),
-            }
-        }
-    }
-
-    impl Notifier for RecordingNotifier {
-        fn capabilities(
-            &self,
-        ) -> Result<crate::notifications::NotificationCapabilities, NotificationError> {
-            Ok(crate::notifications::NotificationCapabilities { actions: true })
-        }
-
-        fn notify(&self, notification: &Notification) -> Result<NotificationId, NotificationError> {
-            self.messages
-                .borrow_mut()
-                .push((notification.summary.clone(), notification.body.clone()));
-            self.result.clone()
         }
     }
 

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -154,16 +154,6 @@ fn inherited_user_environment_is_cleared(world: &mut LgBuddyWorld) {
     world.clear_inherited_user_env();
 }
 
-#[given("the TV is reachable over ping")]
-fn tv_is_reachable_over_ping(world: &mut LgBuddyWorld) {
-    world.install_ping_stub(true);
-}
-
-#[given("the TV is unreachable over ping")]
-fn tv_is_unreachable_over_ping(world: &mut LgBuddyWorld) {
-    world.install_ping_stub(false);
-}
-
 #[given(regex = r#"the TV is on input (HDMI_[1-4])"#)]
 fn tv_on_input(world: &mut LgBuddyWorld, input: String) {
     world.tv_mut().set_input(&input);
@@ -189,11 +179,6 @@ fn tv_mute_state(world: &mut LgBuddyWorld, state: String) {
     world.set_tv_muted(state == "muted");
 }
 
-#[given(regex = r#"the brightness dialog returns (\d+)"#)]
-fn brightness_dialog_returns(world: &mut LgBuddyWorld, value: u8) {
-    world.install_brightness_ui_stub(Some(value));
-}
-
 #[given("the GTK brightness GUI is unavailable")]
 fn gtk_brightness_gui_is_unavailable(world: &mut LgBuddyWorld) {
     world.make_brightness_gui_unavailable();
@@ -209,16 +194,6 @@ fn failing_gtk_brightness_gui(world: &mut LgBuddyWorld, status: i32) {
     world.install_brightness_gui_stub(status);
 }
 
-#[given("the brightness dialog is cancelled")]
-fn brightness_dialog_is_cancelled(world: &mut LgBuddyWorld) {
-    world.install_brightness_ui_stub(None);
-}
-
-#[given("the brightness error dialog is available")]
-fn brightness_error_dialog_is_available(world: &mut LgBuddyWorld) {
-    world.install_brightness_ui_stub(None);
-}
-
 #[then(regex = r#"the GTK brightness GUI received "([^"]+)""#)]
 fn gtk_brightness_gui_received(world: &mut LgBuddyWorld, arguments: String) {
     world.assert_brightness_gui_received(&arguments);
@@ -227,11 +202,6 @@ fn gtk_brightness_gui_received(world: &mut LgBuddyWorld, arguments: String) {
 #[then("the GTK brightness GUI was not launched")]
 fn gtk_brightness_gui_not_launched(world: &mut LgBuddyWorld) {
     world.assert_brightness_gui_not_launched();
-}
-
-#[then("the brightness compatibility dialog was not opened")]
-fn brightness_compatibility_dialog_not_opened(world: &mut LgBuddyWorld) {
-    world.assert_brightness_ui_not_opened();
 }
 
 #[given("the TV screen is blanked")]

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -24,7 +24,6 @@ pub struct LgBuddyWorld {
     swayidle: Option<MockSwayidle>,
     path_scripts: Vec<ExecutableScript>,
     brightness_gui_calls_path: Option<PathBuf>,
-    brightness_ui_calls_path: Option<PathBuf>,
     config_snapshot: Option<String>,
     systemctl_log_path: Option<PathBuf>,
     command_result: Option<CommandExecution>,
@@ -55,7 +54,6 @@ impl fmt::Debug for LgBuddyWorld {
             .field("swayidle", &self.swayidle.is_some())
             .field("path_scripts", &self.path_scripts.len())
             .field("brightness_gui_calls_path", &self.brightness_gui_calls_path)
-            .field("brightness_ui_calls_path", &self.brightness_ui_calls_path)
             .field("config_snapshot", &self.config_snapshot.is_some())
             .field("systemctl_log_path", &self.systemctl_log_path)
             .field("command_result", &self.command_result)
@@ -457,37 +455,6 @@ exit 1\n",
             .set("LG_BUDDY_SLEEP_RETRY_DELAY_SECS", "0");
     }
 
-    pub fn install_ping_stub(&mut self, reachable: bool) {
-        let status = if reachable { 0 } else { 1 };
-        let body = format!("#!/bin/sh\nexit {status}\n");
-        let script = ExecutableScript::new("cucumber-ping", "mock-ping", &body);
-        self.ensure_env().set("LG_BUDDY_PING", script.path());
-        self.path_scripts.push(script);
-    }
-
-    pub fn install_brightness_ui_stub(&mut self, selection: Option<u8>) {
-        self.ensure_mock_session_bus_idle_monitor()
-            .set_notifications_available(true);
-        let log_owner =
-            ExecutableScript::new("cucumber-zenity-log", "log-owner", "#!/bin/sh\nexit 0\n");
-        let calls_path = log_owner.path().with_extension("calls");
-        let body = match selection {
-            Some(value) => format!(
-                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"--scale\" ]; then\n  printf '%s\\n' '{value}'\n  exit 0\nfi\nif [ \"$1\" = \"--error\" ]; then\n  exit 0\nfi\nexit 1\n",
-                calls_path.display()
-            ),
-            None => format!(
-                "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nif [ \"$1\" = \"--scale\" ]; then\n  exit 1\nfi\nif [ \"$1\" = \"--error\" ]; then\n  exit 0\nfi\nexit 1\n",
-                calls_path.display()
-            ),
-        };
-        let script = ExecutableScript::new("cucumber-zenity", "mock-zenity", &body);
-        self.ensure_env().set("LG_BUDDY_ZENITY", script.path());
-        self.brightness_ui_calls_path = Some(calls_path);
-        self.path_scripts.push(log_owner);
-        self.path_scripts.push(script);
-    }
-
     pub fn make_brightness_gui_unavailable(&mut self) {
         let anchor = ExecutableScript::new(
             "cucumber-missing-brightness-gui",
@@ -536,17 +503,6 @@ exit 1\n",
         assert!(
             !calls_path.exists(),
             "brightness GUI was unexpectedly launched"
-        );
-    }
-
-    pub fn assert_brightness_ui_not_opened(&self) {
-        let calls_path = self
-            .brightness_ui_calls_path
-            .as_ref()
-            .expect("brightness compatibility UI stub should be installed");
-        assert!(
-            !calls_path.exists(),
-            "brightness compatibility dialog was unexpectedly opened"
         );
     }
 

--- a/crates/lg-buddy/tests/features/brightness.feature
+++ b/crates/lg-buddy/tests/features/brightness.feature
@@ -7,7 +7,7 @@ Feature: Brightness
     Then the command succeeds
     And the GTK brightness GUI received "brightness"
 
-  Scenario: A failed GTK launch reports the installation failure
+  Scenario: A failed GTK launch reports its exit status
     Given the GTK brightness GUI exits with status 23
     When I run the command "brightness"
     Then the command fails
@@ -16,7 +16,7 @@ Feature: Brightness
     And stderr contains "exited with status 23"
     And the GTK brightness GUI received "brightness"
 
-  Scenario: Missing GTK GUI reports how to repair the installation without contacting the TV
+  Scenario: An incomplete installation reports the missing GUI executable
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client
     And the GTK brightness GUI is unavailable

--- a/crates/lg-buddy/tests/features/brightness.feature
+++ b/crates/lg-buddy/tests/features/brightness.feature
@@ -3,49 +3,42 @@ Feature: Brightness
 
   Scenario: Brightness launches the GTK window through the stable command
     Given a working GTK brightness GUI
-    And the brightness error dialog is available
     When I run the command "brightness"
     Then the command succeeds
     And the GTK brightness GUI received "brightness"
-    And the brightness compatibility dialog was not opened
 
-  Scenario: A failed GTK launch does not open the compatibility dialog
+  Scenario: A failed GTK launch reports the installation failure
     Given the GTK brightness GUI exits with status 23
-    And the brightness error dialog is available
     When I run the command "brightness"
     Then the command fails
     And the command exits with status 1
     And stderr contains "installed LG Buddy GUI"
     And stderr contains "exited with status 23"
     And the GTK brightness GUI received "brightness"
-    And the brightness compatibility dialog was not opened
 
-  Scenario: Missing GTK GUI falls back to the brightness compatibility dialog
+  Scenario: Missing GTK GUI reports how to repair the installation without contacting the TV
     Given a temporary LG Buddy config using input HDMI_2
     And a mock TV client
-    And the TV backlight is 72
-    And the TV is reachable over ping
     And the GTK brightness GUI is unavailable
-    And the brightness dialog returns 65
     When I run the command "brightness"
-    Then the command succeeds
-    And stdout contains "Set OLED pixel brightness to 65%."
-    And the TV client received "get_picture_settings"
-    And the TV client received "set_settings"
-    And the TV brightness is 65
-
-  Scenario: Brightness exits cleanly when the dialog is cancelled
-    Given a temporary LG Buddy config using input HDMI_2
-    And a mock TV client
-    And the TV backlight is 44
-    And the TV is reachable over ping
-    And the GTK brightness GUI is unavailable
-    And the brightness dialog is cancelled
-    When I run the command "brightness"
-    Then the command succeeds
-    And the TV client received "get_picture_settings"
+    Then the command fails
+    And the command exits with status 1
+    And stderr contains "LG Buddy GUI is not installed"
+    And stderr contains "install the matching lg-buddy-gui executable"
+    And the TV client did not receive "get_picture_settings"
     And the TV client did not receive "set_settings"
-    And the TV brightness is 44
+
+  Scenario: Headless brightness remains usable without the GTK GUI
+    Given a temporary LG Buddy config using input HDMI_2
+    And a mock TV client
+    And the TV backlight is 58
+    And the GTK brightness GUI is unavailable
+    When I run the command "brightness get"
+    Then the command succeeds
+    And stdout is "58"
+    When I run the command "brightness set 66"
+    Then the command succeeds
+    And the TV brightness is 66
 
   Scenario: Brightness get prints the current OLED brightness
     Given a temporary LG Buddy config using input HDMI_2
@@ -83,18 +76,6 @@ Feature: Brightness
     And the TV client did not receive "get_picture_settings"
     And the TV client did not receive "set_settings"
     And the TV brightness is 44
-
-  Scenario: Brightness fails when the TV is unreachable
-    Given a temporary LG Buddy config using input HDMI_2
-    And a mock TV client
-    And the TV is unreachable over ping
-    And the GTK brightness GUI is unavailable
-    And the brightness error dialog is available
-    When I run the command "brightness"
-    Then the command fails
-    And the command exits with status 1
-    And stderr contains "TV is not reachable"
-    And the TV client did not receive "set_settings"
 
   Scenario: Brightness help describes the public commands
     When I run the command "brightness --help"

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -515,18 +515,18 @@ owns an operational cache under the user cache directory for GitHub ETag,
 latest release metadata, and last-notified release state used by the observable
 update notification policy; that cache is not user configuration and is not
 part of the settings API.
-The no-argument `lg-buddy` command locates `lg-buddy-gui` beside the running CLI
-and launches its no-argument entrypoint for normal Overview. A missing GUI is an
-error on this path. The `brightness` command locates the same executable and
-launches its `brightness` entrypoint, which selects the brightness control even
-when another view is already open. Both graphical launch paths require the
-matching GUI executable and report installation guidance when it is missing.
-An invalid installation or failed GUI process is reported directly. The
-`brightness get` and `brightness set` commands never enter either launcher and
-use the TV picture abstraction in `tv.rs` for typed OLED brightness validation
-and live TV read/write operations. The GTK
-entrypoint opens one Overview alongside the primary TV summary, volume, and
-mute. Two icon-and-slider rows submit changes as the sliders move; the sound
+
+The installer supplies the matching runtime and GTK executable together, checks
+GTK/libadwaita versions, and offers to install missing runtime packages before
+proceeding. The no-argument `lg-buddy` command locates `lg-buddy-gui` beside the
+running CLI and launches its no-argument entrypoint for normal Overview.
+The `brightness` command locates the same executable and launches its
+`brightness` entrypoint, which selects the brightness control even when another
+view is already open. The `brightness get` and `brightness set` commands never
+enter either launcher and use the TV picture abstraction in `tv.rs` for typed
+OLED brightness validation and live TV read/write operations. The GTK entrypoint
+opens one Overview alongside the primary TV summary, volume, and mute.
+Two icon-and-slider rows submit changes as the sliders move; the sound
 icon toggles mute. The core Overview application owns its declarations and semantic
 intents; GTK renders them without adding TV or configuration policy. Workers
 keep blocking operations off the GTK main loop. Capability state is independent,

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -99,7 +99,7 @@ The main runtime consumers are:
 - the installed `lg-buddy` launcher with no arguments, which opens normal
   Overview through the matching GTK executable
 - the `lg-buddy brightness` launcher, which opens the matching GTK executable
-  focused on brightness and uses Zenity only when that executable is absent
+  focused on brightness
 - the `lg-buddy-gui` GTK window, which renders Overview, TVs, pairing, and
   Settings from typed application state and sends semantic user intents through
   the in-process Rust API
@@ -125,7 +125,6 @@ flowchart LR
     end
 
     subgraph Frontend["Frontend"]
-        ZENITY["zenity brightness dialog<br/>interactive prompt"]
         GTK["lg-buddy-gui<br/>Overview / TVs / Settings / dialogs"]
     end
 
@@ -199,8 +198,6 @@ flowchart LR
     NM --> MAIN
     TERMINAL --> MAIN
     MAIN -->|"normal / brightness launcher"| GTK
-    MAIN -.->|"brightness only; GUI absent"| ZENITY
-    ZENITY --> MAIN
     GTK -->|"semantic intents / worker completions"| APPLICATION
     APPLICATION --> VIEWS
     VIEWS --> PRESENTATION
@@ -522,13 +519,12 @@ The no-argument `lg-buddy` command locates `lg-buddy-gui` beside the running CLI
 and launches its no-argument entrypoint for normal Overview. A missing GUI is an
 error on this path. The `brightness` command locates the same executable and
 launches its `brightness` entrypoint, which selects the brightness control even
-when another view is already open. Only an absent GUI on this focused path
-selects the temporary Zenity compatibility flow; an invalid installation or
-failed GUI process is returned directly without a second prompt. The
+when another view is already open. Both graphical launch paths require the
+matching GUI executable and report installation guidance when it is missing.
+An invalid installation or failed GUI process is reported directly. The
 `brightness get` and `brightness set` commands never enter either launcher and
 use the TV picture abstraction in `tv.rs` for typed OLED brightness validation
-and live TV read/write operations. The interactive Zenity brightness dialog
-delegates its TV operations back through those direct CLI commands. The GTK
+and live TV read/write operations. The GTK
 entrypoint opens one Overview alongside the primary TV summary, volume, and
 mute. Two icon-and-slider rows submit changes as the sliders move; the sound
 icon toggles mute. The core Overview application owns its declarations and semantic

--- a/docs/development.md
+++ b/docs/development.md
@@ -79,12 +79,13 @@ exercised with `cargo run -p lg-buddy`; it resolves `lg-buddy-gui` beside the
 running CLI executable and launches its normal Overview entrypoint.
 `cargo run -p lg-buddy -- brightness` remains the brightness-focused deep link.
 `LG_BUDDY_GUI` overrides that companion path for relocation and subprocess
-tests. Both graphical launch paths require the matching GUI executable and
-report installation guidance when it is missing. Headless brightness get/set
-commands remain available without the GUI.
+tests. Both graphical launch paths use this GTK executable. Headless brightness
+get/set commands operate directly through the runtime.
 
 The local installer accepts the GUI and runtime as separate build artifacts.
-Official release bundles ship and verify both.
+Official release bundles ship and verify both. Fresh installs and upgrades
+check GTK/libadwaita versions and offer to install missing packages through the
+distribution's package manager before validating and installing the binary pair.
 
 The fresh release-bundle installer installs the payload and launches the installed
 GUI for pairing. Pairing then attempts the default Idle Blanking and TV Sleep &

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,7 +26,6 @@ testing release bundles also requires:
 
 - `python3-venv`
 - `python3-pip`
-- `zenity`
 
 Backend-specific tools used in development and local testing:
 
@@ -80,8 +79,9 @@ exercised with `cargo run -p lg-buddy`; it resolves `lg-buddy-gui` beside the
 running CLI executable and launches its normal Overview entrypoint.
 `cargo run -p lg-buddy -- brightness` remains the brightness-focused deep link.
 `LG_BUDDY_GUI` overrides that companion path for relocation and subprocess
-tests. Only the brightness path selects the temporary Zenity compatibility flow
-when the GUI path is missing; the no-argument launcher requires the GUI.
+tests. Both graphical launch paths require the matching GUI executable and
+report installation guidance when it is missing. Headless brightness get/set
+commands remain available without the GUI.
 
 The local installer accepts the GUI and runtime as separate build artifacts.
 Official release bundles ship and verify both.

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -88,9 +88,9 @@ activation keeps one window.
 
 `lg-buddy brightness get` and `lg-buddy brightness set <0-100>` are direct
 headless TV operations. The bare `lg-buddy brightness` command is the
-brightness-focused GUI entrypoint. Both graphical launch paths require the
-matching GUI executable and report installation guidance when it is absent.
-A present but invalid GUI, or a GUI that starts and fails, is reported directly.
+brightness-focused GUI entrypoint. The release bundle ships the matching GTK
+executable for both graphical launch paths. Installation owns providing that
+executable and satisfying its GTK/libadwaita runtime requirements.
 
 Other supported headless user commands remain independent of GTK:
 

--- a/docs/gui-target-architecture.md
+++ b/docs/gui-target-architecture.md
@@ -88,10 +88,9 @@ activation keeps one window.
 
 `lg-buddy brightness get` and `lg-buddy brightness set <0-100>` are direct
 headless TV operations. The bare `lg-buddy brightness` command is the
-brightness-focused GUI entrypoint; only this path uses the retained Zenity
-compatibility flow when the GUI executable is absent. A present but invalid
-GUI, or a GUI that starts and fails, is reported directly. The no-argument
-application launch requires the GUI.
+brightness-focused GUI entrypoint. Both graphical launch paths require the
+matching GUI executable and report installation guidance when it is absent.
+A present but invalid GUI, or a GUI that starts and fails, is reported directly.
 
 Other supported headless user commands remain independent of GTK:
 
@@ -405,5 +404,3 @@ service paths GTK-free.
 
 The frontend grew from the brightness MVP tracked in [issue #127](https://github.com/Staphylococcus/LG_Buddy/issues/127), but the current
 architecture is the shared Overview/application coordinator described here.
-The retained Zenity path is a compatibility fallback only; it is not the GTK
-frontend contract.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -343,14 +343,16 @@ credentials byte-for-byte, conditionally preserves or repairs the Python
 environment, replaces the owned bundle assets, checks service action order, and
 verifies the installed runtime against the candidate bytes and identity.
 
-The installed GUI smoke also verifies the desktop entry's no-argument
-`lg-buddy` launch opens the existing pairing prompt without navigation for an
-unconfigured installation, and normal Overview for a saved TV. `lg-buddy brightness` selects the
-brightness control even when another view is already open. A missing GUI fails
-both graphical launch paths with installation guidance, while headless
-brightness get/set remains available. The application presentation/intent tests
-cover brightness read, apply, cancellation, and failures; GTK tests cover rendering
-and intent routing.
+The installer dependency smoke uses package-manager fixtures to verify that
+missing GTK/libadwaita packages are installed and their versions checked before
+the candidate GUI executes. The installed GUI smoke then verifies the desktop
+entry's no-argument `lg-buddy` launch opens the existing pairing prompt without
+navigation for an unconfigured installation, and normal Overview for a saved TV.
+`lg-buddy brightness` selects the brightness control even when another view is
+already open. The application presentation/intent tests cover brightness read,
+apply, cancellation, and failures; GTK tests cover rendering and intent routing.
+Launcher tests separately cover a damaged installation with a missing GUI
+executable and direct headless brightness get/set operations.
 Parser coverage keeps bare launch separate from `--help` and `help`, which
 remain global CLI help. Existing headless CLI, service, and update paths remain
 covered by their current tests. First-run application tests cover saved-profile

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -347,7 +347,10 @@ The installed GUI smoke also verifies the desktop entry's no-argument
 `lg-buddy` launch opens the existing pairing prompt without navigation for an
 unconfigured installation, and normal Overview for a saved TV. `lg-buddy brightness` selects the
 brightness control even when another view is already open. A missing GUI fails
-the plain launcher; only the brightness path retains the Zenity fallback.
+both graphical launch paths with installation guidance, while headless
+brightness get/set remains available. The application presentation/intent tests
+cover brightness read, apply, cancellation, and failures; GTK tests cover rendering
+and intent routing.
 Parser coverage keeps bare launch separate from `--help` and `help`, which
 remain global CLI help. Existing headless CLI, service, and update paths remain
 covered by their current tests. First-run application tests cover saved-profile

--- a/install.sh
+++ b/install.sh
@@ -792,7 +792,6 @@ check_install_prerequisites() {
     check_gui_runtime_prerequisites
     if [ "$UPGRADE_MODE" -eq 0 ]; then
         check_dep "python3-venv" "python3-venv" "check_python3_venv"
-        check_dep "zenity" "zenity" "command -v zenity"
         if [ "$FRESH_SETUP_MODE" -eq 1 ]; then
             check_dep "pkexec (required for TV Sleep & Wake)" "$(pkexec_package)" "pkexec_available"
         fi

--- a/scripts/test-cross-version-upgrade.sh
+++ b/scripts/test-cross-version-upgrade.sh
@@ -229,6 +229,14 @@ export PIP_DISABLE_PIP_VERSION_CHECK="1"
 export PIP_NO_PYTHON_VERSION_WARNING="1"
 
 (
+    # The historical installer checks for Zenity but this noninteractive setup
+    # never opens a dialog. Satisfy only that old availability check; any actual
+    # invocation fails. The candidate runs outside this subshell without it.
+    zenity() {
+        echo "Historical setup unexpectedly invoked Zenity." >&2
+        exit 1
+    }
+    export -f zenity
     cd "$PREVIOUS_BUNDLE"
     bash ./install.sh
 )

--- a/scripts/test-installer-first-run.sh
+++ b/scripts/test-installer-first-run.sh
@@ -134,10 +134,6 @@ fi
 
 exit 1
 EOF
-cat >"$STUB_DIR/zenity" <<'EOF'
-#!/bin/sh
-exit 0
-EOF
 cat >"$STUB_DIR/gui-runtime-probe" <<'EOF'
 #!/bin/sh
 exit 0
@@ -155,7 +151,7 @@ cat >"$STUB_DIR/pkexec" <<'EOF'
 #!/bin/sh
 exit 0
 EOF
-chmod 755 "$STUB_DIR/python3" "$STUB_DIR/zenity" "$STUB_DIR/gui-runtime-probe" \
+chmod 755 "$STUB_DIR/python3" "$STUB_DIR/gui-runtime-probe" \
     "$STUB_DIR/systemd-tmpfiles" "$STUB_DIR/systemctl" "$STUB_DIR/pkexec"
 
 run_install() {
@@ -192,7 +188,7 @@ run_install() {
             path_index=$((path_index + 1))
         done < <(printf '%s\n' "$PATH" | tr ':' '\n')
         command_path="$scenario_stub_dir:$filtered_path"
-        for command in python3 zenity gui-runtime-probe systemd-tmpfiles systemctl; do
+        for command in python3 gui-runtime-probe systemd-tmpfiles systemctl; do
             ln -s "$STUB_DIR/$command" "$scenario_stub_dir/$command"
         done
     fi


### PR DESCRIPTION
LG Buddy uses its GTK app for graphical brightness control. Official bundles ship the GUI and CLI together; fresh installs and upgrades use the existing dependency checks to offer missing GTK/libadwaita packages through the distribution's package manager, verify the requirements, and install the matching binaries. Fresh setup opens the installed GTK app for pairing.

Remove the Zenity fallback, its private CLI/ping/dialog scaffolding and mocks, and all current installer, CI/release prerequisite, and documentation references. Headless `brightness get` and `brightness set` continue to operate directly through the runtime. Documentation makes supplying GTK part of the installation contract.

The Ubuntu bundle lane explicitly removes Zenity before testing. The pinned v1.4 installer retains only a setup-scoped availability shim that fails if invoked; the candidate upgrade runs without it. GTK rendering and application-owned brightness policy are unchanged.

Closes #130.

Validation:
- Installer dependency smoke passed: missing GTK/libadwaita packages are requested and requirements verified before executing the GUI candidate.
- GTK renderer tests, direct/CLI GUI launch, and installed pairing/activation/diagnostics journey passed on Ubuntu 24.04 without Zenity.
- Runtime unit/integration tests and all 149 Cucumber scenarios passed (`RUST_TEST_THREADS=4`).
- First-run installer smoke, formatting, Clippy, shell syntax, and actionlint passed.
- Static musl runtime and GTK bundle built; complete release-bundle smoke and the pinned v1.4.0-beta.2 upgrade passed without Zenity. These checks used implementation commit `80d1383b92fb73a43951e3b3fb4e8c23cc6edb90`; the follow-up changes only documentation and scenario names and passes `git diff --check`.

A default-concurrency runtime run hit a diagnostics fixture process-launch failure; the four-thread rerun passed. No diagnostics code or tests were changed.
