### PR TITLE
Compose native activity sources and remove coupled inhibition

### DIFF
--- a/crates/lg-buddy/src/backend.rs
+++ b/crates/lg-buddy/src/backend.rs
@@ -11,9 +11,7 @@ use crate::sources::desktop::gnome::{
     GNOME_IDLE_MONITOR_NAME, GNOME_REQUIRED_SERVICES_REASON, GNOME_SCREEN_SAVER_NAME,
     GNOME_SHELL_NAME,
 };
-use crate::sources::desktop::wayland::{
-    connect_wayland, probe_wayland_capabilities_on, WaylandProviderCapabilities,
-};
+use crate::sources::desktop::wayland::{WaylandProviderCapabilities, WaylandSource};
 
 pub const SWAYIDLE_DEPRECATION_NOTICE: &str =
     "swayidle is a deprecated compatibility backend planned for removal in LG Buddy 2.0.0; use auto or wayland";
@@ -122,13 +120,13 @@ pub trait BackendProbe {
 
 #[derive(Default)]
 pub struct SystemBackendProbe {
-    wayland_connection: RefCell<Option<wayland_client::Connection>>,
+    wayland_source: RefCell<Option<WaylandSource>>,
     inherited_wayland_socket_consumed: Cell<bool>,
 }
 
 impl SystemBackendProbe {
-    pub fn take_wayland_connection(&mut self) -> Option<wayland_client::Connection> {
-        self.wayland_connection.get_mut().take()
+    pub(crate) fn take_wayland_source(&mut self) -> Option<WaylandSource> {
+        self.wayland_source.get_mut().take()
     }
 }
 
@@ -167,22 +165,17 @@ impl BackendProbe for SystemBackendProbe {
     }
 
     fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
-        let connection = match self.wayland_connection.borrow().as_ref() {
-            Some(connection) => connection.clone(),
-            None => {
-                let inherited_socket_without_display = env::var_os("WAYLAND_SOCKET").is_some()
-                    && env::var_os("WAYLAND_DISPLAY").is_none();
-                let result = connect_wayland().map_err(|err| err.to_string());
-                if inherited_socket_without_display && env::var_os("WAYLAND_SOCKET").is_none() {
-                    self.inherited_wayland_socket_consumed.set(true);
-                }
-                result?
-            }
-        };
-        let capabilities =
-            probe_wayland_capabilities_on(connection.clone()).map_err(|err| err.to_string())?;
-        *self.wayland_connection.borrow_mut() = Some(connection);
-        Ok(capabilities)
+        let inherited_socket_without_display =
+            env::var_os("WAYLAND_SOCKET").is_some() && env::var_os("WAYLAND_DISPLAY").is_none();
+        let result = self
+            .wayland_source
+            .borrow_mut()
+            .get_or_insert_with(WaylandSource::default)
+            .probe_capabilities();
+        if inherited_socket_without_display && env::var_os("WAYLAND_SOCKET").is_none() {
+            self.inherited_wayland_socket_consumed.set(true);
+        }
+        result.map_err(|err| err.to_string())
     }
 
     fn swayidle_fallback_available(&self) -> Result<(), String> {

--- a/crates/lg-buddy/src/backend.rs
+++ b/crates/lg-buddy/src/backend.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use crate::config::{load_config, resolve_config_path_from_env, ConfigPathError, ScreenBackend};
 use crate::session_bus::new_session_bus_client;
 use crate::sources::desktop::gnome::{
-    GNOME_IDLE_INHIBITORS_REQUIRED_REASON, GNOME_IDLE_MONITOR_NAME, GNOME_REQUIRED_SERVICES_REASON,
-    GNOME_SCREEN_SAVER_NAME, GNOME_SESSION_MANAGER_NAME, GNOME_SHELL_NAME,
+    GNOME_IDLE_MONITOR_NAME, GNOME_REQUIRED_SERVICES_REASON, GNOME_SCREEN_SAVER_NAME,
+    GNOME_SHELL_NAME,
 };
 use crate::sources::desktop::wayland::{
     connect_wayland, probe_wayland_capabilities_on, WaylandProviderCapabilities,
@@ -108,9 +108,6 @@ pub trait BackendProbe {
     fn gnome_shell_available(&self) -> bool;
     fn gnome_screen_saver_available(&self) -> bool;
     fn gnome_idle_monitor_available(&self) -> bool;
-    fn gnome_session_manager_available(&self) -> bool {
-        false
-    }
     fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
         Err("native Wayland capability probing is unavailable".to_string())
     }
@@ -169,15 +166,6 @@ impl BackendProbe for SystemBackendProbe {
         bus.name_has_owner(GNOME_IDLE_MONITOR_NAME).unwrap_or(false)
     }
 
-    fn gnome_session_manager_available(&self) -> bool {
-        let mut bus = match new_session_bus_client() {
-            Ok(bus) => bus,
-            Err(_) => return false,
-        };
-        bus.name_has_owner(GNOME_SESSION_MANAGER_NAME)
-            .unwrap_or(false)
-    }
-
     fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
         let connection = match self.wayland_connection.borrow().as_ref() {
             Some(connection) => connection.clone(),
@@ -234,13 +222,6 @@ pub fn configured_backend_from_sources(
     Ok(config_backend.unwrap_or(ScreenBackend::Auto))
 }
 
-pub(crate) fn honor_idle_inhibitors_from_config() -> bool {
-    resolve_config_path_from_env()
-        .ok()
-        .and_then(|path| load_config(&path).ok())
-        .is_some_and(|config| config.screen_honor_idle_inhibitors.is_enabled())
-}
-
 pub fn detect_backend_from_system(
     configured: ScreenBackend,
 ) -> Result<ScreenBackend, BackendDetectionError> {
@@ -250,26 +231,19 @@ pub fn detect_backend_from_system(
 pub fn resolve_backend_from_system(
     configured: ScreenBackend,
 ) -> Result<BackendResolution, BackendDetectionError> {
-    resolve_backend_with_probe(
-        &SystemBackendProbe::default(),
-        configured,
-        honor_idle_inhibitors_from_config(),
-    )
+    resolve_backend_with_probe(&SystemBackendProbe::default(), configured)
 }
 
 pub fn detect_backend_with_probe(
     probe: &impl BackendProbe,
     configured: ScreenBackend,
-    honor_idle_inhibitors: bool,
 ) -> Result<ScreenBackend, BackendDetectionError> {
-    resolve_backend_with_probe(probe, configured, honor_idle_inhibitors)
-        .map(|resolution| resolution.backend())
+    resolve_backend_with_probe(probe, configured).map(|resolution| resolution.backend())
 }
 
 pub fn resolve_backend_with_probe(
     probe: &impl BackendProbe,
     configured: ScreenBackend,
-    honor_idle_inhibitors: bool,
 ) -> Result<BackendResolution, BackendDetectionError> {
     match configured {
         ScreenBackend::Auto => {
@@ -281,18 +255,14 @@ pub fn resolve_backend_with_probe(
             let gnome_core_available = gnome_shell_available
                 && gnome_screen_saver_available
                 && gnome_idle_monitor_available;
-            let gnome_available = gnome_core_available
-                && (!honor_idle_inhibitors || probe.gnome_session_manager_available());
-            if gnome_available {
+            if gnome_core_available {
                 return Ok(BackendResolution::selected(ScreenBackend::Gnome, None));
             }
 
             let gnome_reason = if !gnome_shell_available {
                 "GNOME Shell is not available".to_string()
-            } else if !gnome_core_available {
-                GNOME_REQUIRED_SERVICES_REASON.to_string()
             } else {
-                GNOME_IDLE_INHIBITORS_REQUIRED_REASON.to_string()
+                GNOME_REQUIRED_SERVICES_REASON.to_string()
             };
 
             match probe.wayland_capabilities() {
@@ -324,16 +294,10 @@ pub fn resolve_backend_with_probe(
             let gnome_core_available = gnome_shell_available
                 && gnome_screen_saver_available
                 && gnome_idle_monitor_available;
-            let gnome_available = gnome_core_available
-                && (!honor_idle_inhibitors || probe.gnome_session_manager_available());
-            if gnome_available {
+            if gnome_core_available {
                 Ok(BackendResolution::selected(ScreenBackend::Gnome, None))
             } else {
-                let reason = if !gnome_core_available {
-                    GNOME_REQUIRED_SERVICES_REASON
-                } else {
-                    GNOME_IDLE_INHIBITORS_REQUIRED_REASON
-                };
+                let reason = GNOME_REQUIRED_SERVICES_REASON;
                 Err(BackendDetectionError::UnavailableBackend {
                     backend: ScreenBackend::Gnome,
                     reason: reason.to_string(),
@@ -386,7 +350,7 @@ mod tests {
         gnome_shell_available: bool,
         gnome_screen_saver_available: bool,
         gnome_idle_monitor_available: bool,
-        gnome_session_manager_available: bool,
+
         has_swayidle: bool,
         swayidle_fallback_reason: Option<&'static str>,
         wayland_capabilities: Result<WaylandProviderCapabilities, &'static str>,
@@ -398,7 +362,7 @@ mod tests {
                 gnome_shell_available: false,
                 gnome_screen_saver_available: false,
                 gnome_idle_monitor_available: false,
-                gnome_session_manager_available: false,
+
                 has_swayidle: false,
                 swayidle_fallback_reason: None,
                 wayland_capabilities: Err("no Wayland compositor is available"),
@@ -424,10 +388,6 @@ mod tests {
 
         fn gnome_idle_monitor_available(&self) -> bool {
             self.gnome_idle_monitor_available
-        }
-
-        fn gnome_session_manager_available(&self) -> bool {
-            self.gnome_session_manager_available
         }
 
         fn wayland_capabilities(&self) -> Result<WaylandProviderCapabilities, String> {
@@ -525,77 +485,28 @@ mod tests {
             gnome_shell_available: true,
             gnome_screen_saver_available: true,
             gnome_idle_monitor_available: true,
-            gnome_session_manager_available: false,
+
             has_swayidle: true,
             ..FakeProbe::default()
         };
 
-        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
-            .expect("detect gnome backend");
+        let backend =
+            detect_backend_with_probe(&probe, ScreenBackend::Auto).expect("detect gnome backend");
 
         assert_eq!(backend, ScreenBackend::Gnome);
     }
 
     #[test]
-    fn auto_falls_back_when_honoring_inhibitors_but_session_manager_is_missing() {
+    fn forced_gnome_activity_does_not_require_session_manager() {
         let probe = FakeProbe {
             gnome_shell_available: true,
             gnome_screen_saver_available: true,
             gnome_idle_monitor_available: true,
-            gnome_session_manager_available: false,
-            has_swayidle: true,
-            wayland_capabilities: Ok(native_wayland_capabilities()),
             ..FakeProbe::default()
         };
-
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, true)
-            .expect("fall back from GNOME without SessionManager");
-
-        assert_eq!(resolution.backend(), ScreenBackend::Wayland);
         assert_eq!(
-            resolution.fallback_reason(),
-            Some(
-                "GNOME unavailable: GNOME SessionManager is required when idle inhibitor honoring is enabled"
-            )
-        );
-    }
-
-    #[test]
-    fn auto_selects_gnome_when_honoring_inhibitors_and_session_manager_is_available() {
-        let probe = FakeProbe {
-            gnome_shell_available: true,
-            gnome_screen_saver_available: true,
-            gnome_idle_monitor_available: true,
-            gnome_session_manager_available: true,
-            ..FakeProbe::default()
-        };
-
-        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto, true)
-            .expect("detect GNOME with SessionManager");
-
-        assert_eq!(backend, ScreenBackend::Gnome);
-    }
-
-    #[test]
-    fn forced_gnome_requires_session_manager_when_honoring_inhibitors() {
-        let probe = FakeProbe {
-            gnome_shell_available: true,
-            gnome_screen_saver_available: true,
-            gnome_idle_monitor_available: true,
-            gnome_session_manager_available: false,
-            ..FakeProbe::default()
-        };
-
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome, true)
-            .expect_err("honoring inhibitors requires SessionManager");
-
-        assert_eq!(
-            err,
-            BackendDetectionError::UnavailableBackend {
-                backend: ScreenBackend::Gnome,
-                reason: "GNOME SessionManager is required when idle inhibitor honoring is enabled"
-                    .to_string(),
-            }
+            detect_backend_with_probe(&probe, ScreenBackend::Gnome),
+            Ok(ScreenBackend::Gnome)
         );
     }
 
@@ -607,7 +518,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect("detect native Wayland backend");
 
         assert_eq!(resolution.backend(), ScreenBackend::Wayland);
@@ -628,7 +539,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect("fall back from incomplete GNOME to native Wayland");
 
         assert_eq!(resolution.backend(), ScreenBackend::Wayland);
@@ -648,7 +559,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let backend = detect_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect("detect swayidle backend");
 
         assert_eq!(backend, ScreenBackend::Swayidle);
@@ -664,7 +575,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect_err("missing backend should fail");
 
         assert_eq!(
@@ -687,7 +598,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome, false)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome)
             .expect_err("forced gnome without a full GNOME session should fail");
 
         assert_eq!(
@@ -711,7 +622,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect_err("unsupported gnome surface should fail explicitly");
 
         assert_eq!(
@@ -736,7 +647,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect_err("unsafe automatic fallback should fail");
         assert_eq!(
             err,
@@ -748,7 +659,7 @@ mod tests {
             }
         );
 
-        let explicit = detect_backend_with_probe(&probe, ScreenBackend::Swayidle, false)
+        let explicit = detect_backend_with_probe(&probe, ScreenBackend::Swayidle)
             .expect("explicit swayidle should bypass native fallback safety");
         assert_eq!(explicit, ScreenBackend::Swayidle);
     }
@@ -763,7 +674,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto, false)
+        let resolution = resolve_backend_with_probe(&probe, ScreenBackend::Auto)
             .expect("fallback to swayidle when GNOME is incomplete");
 
         assert_eq!(resolution.backend(), ScreenBackend::Swayidle);
@@ -782,7 +693,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome, false)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Gnome)
             .expect_err("forced gnome without idle monitor should fail");
 
         assert_eq!(
@@ -806,7 +717,7 @@ mod tests {
             ..FakeProbe::default()
         };
 
-        let err = detect_backend_with_probe(&probe, ScreenBackend::Swayidle, false)
+        let err = detect_backend_with_probe(&probe, ScreenBackend::Swayidle)
             .expect_err("forced swayidle without command should fail");
 
         assert_eq!(
@@ -825,7 +736,6 @@ mod tests {
                 "ext_idle_notifier_v1 version 1 is unsupported; version 2 or newer is required",
             )),
             ScreenBackend::Wayland,
-            false,
         )
         .expect_err("forced Wayland without protocol v2 should fail");
 
@@ -845,7 +755,6 @@ mod tests {
         let backend = detect_backend_with_probe(
             &WaylandProbe(Ok(native_wayland_capabilities())),
             ScreenBackend::Wayland,
-            false,
         )
         .expect("forced Wayland should be available");
 

--- a/crates/lg-buddy/src/session.rs
+++ b/crates/lg-buddy/src/session.rs
@@ -1,4 +1,5 @@
 pub(crate) mod actions;
+mod activity;
 pub mod gamepad;
 pub mod inactivity;
 pub mod runner;
@@ -53,14 +54,4 @@ pub(crate) enum SessionObservation {
         source: EventSource,
         observed_at: Instant,
     },
-    /// Desktop permission for automatic blanking; never user activity or a
-    /// request to restore the screen.
-    IdleBlankingPermission {
-        allowed: bool,
-        source: EventSource,
-        observed_at: Instant,
-    },
-    /// Suspend automatic blanking while the source refreshes permission.
-    /// This is not an inhibitor transition and must not renew the deadline.
-    IdleBlankingPermissionPending { source: EventSource },
 }

--- a/crates/lg-buddy/src/session/activity.rs
+++ b/crates/lg-buddy/src/session/activity.rs
@@ -1,4 +1,4 @@
-//! Bounded activity contributions from independently connected native sources.
+//! Bounded, timestamped observations from application-lifetime activity adapters.
 use std::collections::BTreeMap;
 use std::sync::Mutex;
 use std::time::Instant;
@@ -21,79 +21,19 @@ impl ActivitySource {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) struct SourceInstance {
-    source: ActivitySource,
-    generation: u64,
-}
-
 #[derive(Debug, Default)]
 struct Contribution {
-    generation: u64,
-    connected: bool,
     latest: [Option<Instant>; 3],
     pending: [Option<(InactivityObservation, Instant)>; 3],
-    diagnostic: Option<String>,
 }
 
 #[derive(Debug, Default)]
 pub(crate) struct ActivityContributions {
     sources: Mutex<BTreeMap<ActivitySource, Contribution>>,
-    last_delivered: Mutex<Option<Instant>>,
-}
-
-#[derive(Debug)]
-pub(crate) struct ActivitySnapshot {
-    pub source: ActivitySource,
-    pub generation: u64,
-    pub connected: bool,
-    pub latest_activity: Option<Instant>,
-    pub diagnostic: Option<String>,
 }
 
 impl ActivityContributions {
-    pub(crate) fn begin(&self, source: ActivitySource) -> SourceInstance {
-        let mut sources = self.sources.lock().expect("activity sources");
-        let state = sources.entry(source).or_default();
-        state.generation += 1;
-        state.connected = false;
-        state.pending = [None; 3];
-        state.latest = [None; 3];
-        SourceInstance {
-            source,
-            generation: state.generation,
-        }
-    }
-
-    pub(crate) fn connected(&self, instance: SourceInstance) {
-        self.update(instance, |state| {
-            state.connected = true;
-            state.diagnostic = None;
-        });
-    }
-
-    pub(crate) fn unavailable(&self, instance: SourceInstance, reason: &str) {
-        self.update(instance, |state| {
-            state.connected = false;
-            state.pending = [None; 3];
-            state.diagnostic = Some(reason.chars().take(512).collect());
-        });
-    }
-
-    fn update(&self, instance: SourceInstance, update: impl FnOnce(&mut Contribution)) {
-        if let Some(state) = self
-            .sources
-            .lock()
-            .expect("activity sources")
-            .get_mut(&instance.source)
-        {
-            if state.generation == instance.generation {
-                update(state);
-            }
-        }
-    }
-
-    pub(crate) fn publish(&self, instance: SourceInstance, observation: SessionObservation) {
+    pub(crate) fn publish(&self, source: ActivitySource, observation: SessionObservation) {
         let (kind, at) = match observation {
             SessionObservation::Inactivity {
                 observation,
@@ -116,27 +56,20 @@ impl ActivityContributions {
             InactivityObservation::ProviderActive => 1,
             InactivityObservation::WakeRequested => 2,
         };
-        self.update(instance, |state| {
-            if state.connected && state.latest[index].is_none_or(|latest| at > latest) {
-                state.latest[index] = Some(at);
-                state.pending[index] = Some((kind, at));
-            }
-        });
+        let mut sources = self.sources.lock().expect("activity sources");
+        let state = sources.entry(source).or_default();
+        if state.latest[index].is_none_or(|latest| at > latest) {
+            state.latest[index] = Some(at);
+            state.pending[index] = Some((kind, at));
+        }
     }
 
-    pub(crate) fn drain(&self) -> Vec<(SourceInstance, InactivityObservation, Instant)> {
+    pub(crate) fn drain(&self) -> Vec<(ActivitySource, InactivityObservation, Instant)> {
         let mut observations = Vec::new();
         for (&source, state) in self.sources.lock().expect("activity sources").iter_mut() {
             for slot in &mut state.pending {
                 if let Some((observation, at)) = slot.take() {
-                    observations.push((
-                        SourceInstance {
-                            source,
-                            generation: state.generation,
-                        },
-                        observation,
-                        at,
-                    ));
+                    observations.push((source, observation, at));
                 }
             }
         }
@@ -144,47 +77,12 @@ impl ActivityContributions {
         observations
     }
 
-    /// Recheck the instance immediately before delivery: a previous TV action
-    /// may have blocked while this source disconnected or was replaced.
-    pub(crate) fn accept(&self, instance: SourceInstance, at: Instant) -> bool {
-        let sources = self.sources.lock().expect("activity sources");
-        if !sources
-            .get(&instance.source)
-            .is_some_and(|state| state.connected && state.generation == instance.generation)
-        {
-            return false;
-        }
-        // Native adapters describe the same desktop activity domain. A duplicate
-        // or older contribution never becomes new input because delivery was late.
-        let mut latest = self.last_delivered.lock().expect("delivered activity");
-        if latest.is_some_and(|latest| at <= latest) {
-            return false;
-        }
-        *latest = Some(at);
-        true
-    }
-
-    pub(crate) fn snapshot(&self) -> Vec<ActivitySnapshot> {
+    pub(crate) fn latest_activity(&self, source: ActivitySource) -> Option<Instant> {
         self.sources
             .lock()
             .expect("activity sources")
-            .iter()
-            .map(|(&source, state)| ActivitySnapshot {
-                source,
-                generation: state.generation,
-                connected: state.connected,
-                latest_activity: state.latest.iter().flatten().max().copied(),
-                diagnostic: state.diagnostic.clone(),
-            })
-            .collect()
-    }
-
-    pub(crate) fn has_connected_source(&self) -> bool {
-        self.sources
-            .lock()
-            .expect("activity sources")
-            .values()
-            .any(|state| state.connected)
+            .get(&source)
+            .and_then(|state| state.latest.iter().flatten().max().copied())
     }
 }
 
@@ -202,84 +100,47 @@ mod tests {
         }
     }
 
-    fn deliver(sources: &ActivityContributions) -> Vec<(InactivityObservation, Instant)> {
-        sources
-            .drain()
-            .into_iter()
-            .filter(|(instance, _, at)| sources.accept(*instance, *at))
-            .map(|(_, observation, at)| (observation, at))
-            .collect()
-    }
-
     #[test]
     fn overlapping_sources_preserve_times_and_do_not_overwrite_newer_input() {
         let sources = ActivityContributions::default();
-        let gnome = sources.begin(ActivitySource::Gnome);
-        let wayland = sources.begin(ActivitySource::Wayland);
-        sources.connected(gnome);
-        sources.connected(wayland);
         let start = Instant::now();
         let latest = start + Duration::from_secs(1);
-        sources.publish(gnome, input(latest));
-        sources.publish(gnome, input(start));
-        sources.publish(wayland, input(latest));
+        sources.publish(ActivitySource::Gnome, input(latest));
+        sources.publish(ActivitySource::Gnome, input(start));
+        sources.publish(ActivitySource::Wayland, input(latest));
         assert_eq!(
-            deliver(&sources),
-            vec![(InactivityObservation::DesktopActivityObserved, latest)]
+            sources.drain(),
+            vec![
+                (
+                    ActivitySource::Gnome,
+                    InactivityObservation::DesktopActivityObserved,
+                    latest
+                ),
+                (
+                    ActivitySource::Wayland,
+                    InactivityObservation::DesktopActivityObserved,
+                    latest
+                ),
+            ]
         );
         assert!(sources.drain().is_empty());
-        sources.publish(gnome, input(start));
+        sources.publish(ActivitySource::Gnome, input(start));
         assert!(sources.drain().is_empty());
+        assert_eq!(sources.latest_activity(ActivitySource::Gnome), Some(latest));
     }
 
     #[test]
-    fn source_loss_invalidates_pending_input_without_affecting_other_sources() {
+    fn first_observation_is_delivered_without_registration_or_readiness() {
         let sources = ActivityContributions::default();
-        let gnome = sources.begin(ActivitySource::Gnome);
-        let wayland = sources.begin(ActivitySource::Wayland);
-        sources.connected(gnome);
-        sources.connected(wayland);
         let at = Instant::now();
-        sources.publish(gnome, input(at));
-        sources.unavailable(gnome, "owner lost");
-        sources.publish(gnome, input(at + Duration::from_secs(1)));
-        assert!(sources.has_connected_source());
-        assert!(sources.drain().is_empty());
-        let replacement = sources.begin(ActivitySource::Gnome);
-        sources.connected(replacement);
-        sources.unavailable(gnome, "late error");
-        sources.publish(gnome, input(at + Duration::from_secs(2)));
-        assert!(sources.drain().is_empty());
-        sources.publish(replacement, input(at + Duration::from_secs(1)));
-        assert_eq!(sources.drain().len(), 1);
-        assert!(sources.snapshot().iter().all(|source| source.connected));
-    }
-
-    #[test]
-    fn quiet_connections_remain_available_and_reports_are_bounded() {
-        let sources = ActivityContributions::default();
-        let instance = sources.begin(ActivitySource::Gnome);
-        sources.connected(instance);
-        assert!(sources.drain().is_empty());
-        assert!(sources.has_connected_source());
-        sources.unavailable(instance, &"x".repeat(1000));
-        assert!(!sources.has_connected_source());
+        sources.publish(ActivitySource::Wayland, input(at));
         assert_eq!(
-            sources.snapshot()[0].diagnostic.as_ref().unwrap().len(),
-            512
+            sources.drain(),
+            vec![(
+                ActivitySource::Wayland,
+                InactivityObservation::DesktopActivityObserved,
+                at,
+            )]
         );
-    }
-    #[test]
-    fn a_batch_taken_before_replacement_cannot_revive_its_source() {
-        let sources = ActivityContributions::default();
-        let old = sources.begin(ActivitySource::Gnome);
-        sources.connected(old);
-        sources.publish(old, input(Instant::now()));
-        let batch = sources.drain();
-        let new = sources.begin(ActivitySource::Gnome);
-        sources.connected(new);
-        assert!(!sources.accept(batch[0].0, batch[0].2));
-        sources.publish(new, input(Instant::now()));
-        assert_eq!(deliver(&sources).len(), 1);
     }
 }

--- a/crates/lg-buddy/src/session/activity.rs
+++ b/crates/lg-buddy/src/session/activity.rs
@@ -1,0 +1,285 @@
+//! Bounded activity contributions from independently connected native sources.
+use std::collections::BTreeMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use super::inactivity::InactivityObservation;
+use super::{SessionEvent, SessionObservation};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum ActivitySource {
+    Gnome,
+    Wayland,
+}
+
+impl ActivitySource {
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Gnome => "gnome",
+            Self::Wayland => "wayland",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SourceInstance {
+    source: ActivitySource,
+    generation: u64,
+}
+
+#[derive(Debug, Default)]
+struct Contribution {
+    generation: u64,
+    connected: bool,
+    latest: [Option<Instant>; 3],
+    pending: [Option<(InactivityObservation, Instant)>; 3],
+    diagnostic: Option<String>,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ActivityContributions {
+    sources: Mutex<BTreeMap<ActivitySource, Contribution>>,
+    last_delivered: Mutex<Option<Instant>>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ActivitySnapshot {
+    pub source: ActivitySource,
+    pub generation: u64,
+    pub connected: bool,
+    pub latest_activity: Option<Instant>,
+    pub diagnostic: Option<String>,
+}
+
+impl ActivityContributions {
+    pub(crate) fn begin(&self, source: ActivitySource) -> SourceInstance {
+        let mut sources = self.sources.lock().expect("activity sources");
+        let state = sources.entry(source).or_default();
+        state.generation += 1;
+        state.connected = false;
+        state.pending = [None; 3];
+        state.latest = [None; 3];
+        SourceInstance {
+            source,
+            generation: state.generation,
+        }
+    }
+
+    pub(crate) fn connected(&self, instance: SourceInstance) {
+        self.update(instance, |state| {
+            state.connected = true;
+            state.diagnostic = None;
+        });
+    }
+
+    pub(crate) fn unavailable(&self, instance: SourceInstance, reason: &str) {
+        self.update(instance, |state| {
+            state.connected = false;
+            state.pending = [None; 3];
+            state.diagnostic = Some(reason.chars().take(512).collect());
+        });
+    }
+
+    fn update(&self, instance: SourceInstance, update: impl FnOnce(&mut Contribution)) {
+        if let Some(state) = self
+            .sources
+            .lock()
+            .expect("activity sources")
+            .get_mut(&instance.source)
+        {
+            if state.generation == instance.generation {
+                update(state);
+            }
+        }
+    }
+
+    pub(crate) fn publish(&self, instance: SourceInstance, observation: SessionObservation) {
+        let (kind, at) = match observation {
+            SessionObservation::Inactivity {
+                observation,
+                observed_at,
+                ..
+            } => (observation, observed_at),
+            SessionObservation::Event {
+                event, observed_at, ..
+            } => match event {
+                SessionEvent::Active => (InactivityObservation::ProviderActive, observed_at),
+                SessionEvent::WakeRequested => (InactivityObservation::WakeRequested, observed_at),
+                // Native idle is never a blanking authority. Lock and lifecycle
+                // observations have their independent sources in the runner.
+                _ => return,
+            },
+        };
+        let index = match kind {
+            InactivityObservation::DesktopActivityObserved
+            | InactivityObservation::UserActivityObserved => 0,
+            InactivityObservation::ProviderActive => 1,
+            InactivityObservation::WakeRequested => 2,
+        };
+        self.update(instance, |state| {
+            if state.connected && state.latest[index].is_none_or(|latest| at > latest) {
+                state.latest[index] = Some(at);
+                state.pending[index] = Some((kind, at));
+            }
+        });
+    }
+
+    pub(crate) fn drain(&self) -> Vec<(SourceInstance, InactivityObservation, Instant)> {
+        let mut observations = Vec::new();
+        for (&source, state) in self.sources.lock().expect("activity sources").iter_mut() {
+            for slot in &mut state.pending {
+                if let Some((observation, at)) = slot.take() {
+                    observations.push((
+                        SourceInstance {
+                            source,
+                            generation: state.generation,
+                        },
+                        observation,
+                        at,
+                    ));
+                }
+            }
+        }
+        observations.sort_by_key(|(_, _, at)| *at);
+        observations
+    }
+
+    /// Recheck the instance immediately before delivery: a previous TV action
+    /// may have blocked while this source disconnected or was replaced.
+    pub(crate) fn accept(&self, instance: SourceInstance, at: Instant) -> bool {
+        let sources = self.sources.lock().expect("activity sources");
+        if !sources
+            .get(&instance.source)
+            .is_some_and(|state| state.connected && state.generation == instance.generation)
+        {
+            return false;
+        }
+        // Native adapters describe the same desktop activity domain. A duplicate
+        // or older contribution never becomes new input because delivery was late.
+        let mut latest = self.last_delivered.lock().expect("delivered activity");
+        if latest.is_some_and(|latest| at <= latest) {
+            return false;
+        }
+        *latest = Some(at);
+        true
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<ActivitySnapshot> {
+        self.sources
+            .lock()
+            .expect("activity sources")
+            .iter()
+            .map(|(&source, state)| ActivitySnapshot {
+                source,
+                generation: state.generation,
+                connected: state.connected,
+                latest_activity: state.latest.iter().flatten().max().copied(),
+                diagnostic: state.diagnostic.clone(),
+            })
+            .collect()
+    }
+
+    pub(crate) fn has_connected_source(&self) -> bool {
+        self.sources
+            .lock()
+            .expect("activity sources")
+            .values()
+            .any(|state| state.connected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EventSource;
+    use std::time::Duration;
+
+    fn input(at: Instant) -> SessionObservation {
+        SessionObservation::Inactivity {
+            observation: InactivityObservation::DesktopActivityObserved,
+            source: EventSource::DesktopSession,
+            observed_at: at,
+        }
+    }
+
+    fn deliver(sources: &ActivityContributions) -> Vec<(InactivityObservation, Instant)> {
+        sources
+            .drain()
+            .into_iter()
+            .filter(|(instance, _, at)| sources.accept(*instance, *at))
+            .map(|(_, observation, at)| (observation, at))
+            .collect()
+    }
+
+    #[test]
+    fn overlapping_sources_preserve_times_and_do_not_overwrite_newer_input() {
+        let sources = ActivityContributions::default();
+        let gnome = sources.begin(ActivitySource::Gnome);
+        let wayland = sources.begin(ActivitySource::Wayland);
+        sources.connected(gnome);
+        sources.connected(wayland);
+        let start = Instant::now();
+        let latest = start + Duration::from_secs(1);
+        sources.publish(gnome, input(latest));
+        sources.publish(gnome, input(start));
+        sources.publish(wayland, input(latest));
+        assert_eq!(
+            deliver(&sources),
+            vec![(InactivityObservation::DesktopActivityObserved, latest)]
+        );
+        assert!(sources.drain().is_empty());
+        sources.publish(gnome, input(start));
+        assert!(sources.drain().is_empty());
+    }
+
+    #[test]
+    fn source_loss_invalidates_pending_input_without_affecting_other_sources() {
+        let sources = ActivityContributions::default();
+        let gnome = sources.begin(ActivitySource::Gnome);
+        let wayland = sources.begin(ActivitySource::Wayland);
+        sources.connected(gnome);
+        sources.connected(wayland);
+        let at = Instant::now();
+        sources.publish(gnome, input(at));
+        sources.unavailable(gnome, "owner lost");
+        sources.publish(gnome, input(at + Duration::from_secs(1)));
+        assert!(sources.has_connected_source());
+        assert!(sources.drain().is_empty());
+        let replacement = sources.begin(ActivitySource::Gnome);
+        sources.connected(replacement);
+        sources.unavailable(gnome, "late error");
+        sources.publish(gnome, input(at + Duration::from_secs(2)));
+        assert!(sources.drain().is_empty());
+        sources.publish(replacement, input(at + Duration::from_secs(1)));
+        assert_eq!(sources.drain().len(), 1);
+        assert!(sources.snapshot().iter().all(|source| source.connected));
+    }
+
+    #[test]
+    fn quiet_connections_remain_available_and_reports_are_bounded() {
+        let sources = ActivityContributions::default();
+        let instance = sources.begin(ActivitySource::Gnome);
+        sources.connected(instance);
+        assert!(sources.drain().is_empty());
+        assert!(sources.has_connected_source());
+        sources.unavailable(instance, &"x".repeat(1000));
+        assert!(!sources.has_connected_source());
+        assert_eq!(
+            sources.snapshot()[0].diagnostic.as_ref().unwrap().len(),
+            512
+        );
+    }
+    #[test]
+    fn a_batch_taken_before_replacement_cannot_revive_its_source() {
+        let sources = ActivityContributions::default();
+        let old = sources.begin(ActivitySource::Gnome);
+        sources.connected(old);
+        sources.publish(old, input(Instant::now()));
+        let batch = sources.drain();
+        let new = sources.begin(ActivitySource::Gnome);
+        sources.connected(new);
+        assert!(!sources.accept(batch[0].0, batch[0].2));
+        sources.publish(new, input(Instant::now()));
+        assert_eq!(deliver(&sources).len(), 1);
+    }
+}

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -34,8 +34,6 @@ enum InactivityPhase {
 pub struct InactivityEngine {
     blank_after: Duration,
     blank_at: Option<Instant>,
-    idle_blanking_allowed: bool,
-    idle_blanking_permission_pending: bool,
     provider_driven_blank: bool,
     power_off_after: Duration,
     power_off_at: Option<Instant>,
@@ -45,6 +43,7 @@ pub struct InactivityEngine {
     lock_activity_floor: Option<Instant>,
     post_lock_activity_grace_until: Option<Instant>,
     latest_independent_activity_at: Option<Instant>,
+    activity_floor: Option<Instant>,
 }
 
 impl InactivityEngine {
@@ -84,8 +83,6 @@ impl InactivityEngine {
         Self {
             blank_after,
             blank_at: Some(started_at + blank_after),
-            idle_blanking_allowed: true,
-            idle_blanking_permission_pending: false,
             provider_driven_blank: false,
             power_off_after,
             power_off_at: None,
@@ -95,6 +92,7 @@ impl InactivityEngine {
             lock_activity_floor: None,
             post_lock_activity_grace_until: None,
             latest_independent_activity_at: None,
+            activity_floor: None,
         }
     }
 
@@ -114,8 +112,6 @@ impl InactivityEngine {
         Self {
             blank_after,
             blank_at: Some(started_at + blank_after),
-            idle_blanking_allowed: true,
-            idle_blanking_permission_pending: false,
             provider_driven_blank: false,
             power_off_after,
             power_off_at: Some(started_at + power_off_after),
@@ -125,23 +121,19 @@ impl InactivityEngine {
             lock_activity_floor: None,
             post_lock_activity_grace_until: None,
             latest_independent_activity_at: None,
+            activity_floor: None,
         }
     }
 
     pub fn time_until_action(&self, now: Instant) -> Option<Duration> {
         match self.phase {
-            InactivityPhase::Unknown | InactivityPhase::Active
-                if self.can_blank_automatically() =>
-            {
-                self.blank_at
-                    .map(|deadline| deadline.saturating_duration_since(now))
-            }
+            InactivityPhase::Unknown | InactivityPhase::Active => self
+                .blank_at
+                .map(|deadline| deadline.saturating_duration_since(now)),
             InactivityPhase::Blanked => self
                 .power_off_at
                 .map(|deadline| deadline.saturating_duration_since(now)),
-            InactivityPhase::Unknown
-            | InactivityPhase::Active
-            | InactivityPhase::BlankRequested
+            InactivityPhase::BlankRequested
             | InactivityPhase::InactiveWithoutEscalation
             | InactivityPhase::TimedPowerOffAttempted => None,
         }
@@ -151,44 +143,11 @@ impl InactivityEngine {
         self.phase == InactivityPhase::Blanked && self.power_off_at.is_some()
     }
 
-    fn can_blank_automatically(&self) -> bool {
-        self.idle_blanking_allowed && !self.idle_blanking_permission_pending
-    }
-
-    pub fn defer_idle_blanking(&mut self) {
-        self.idle_blanking_permission_pending = true;
-    }
-
-    /// An inhibitor changes permission to blank, never activity or ownership.
-    /// Start a full timeout when permission returns, including after startup.
-    pub fn set_idle_blanking_allowed(&mut self, allowed: bool, observed_at: Instant) {
-        self.idle_blanking_permission_pending = false;
-        if self.idle_blanking_allowed == allowed {
-            return;
-        }
-        self.idle_blanking_allowed = allowed;
-        if allowed
-            && !self.provider_driven_blank
-            && matches!(
-                self.phase,
-                InactivityPhase::Unknown | InactivityPhase::Active
-            )
-        {
-            self.blank_at = Some(
-                self.blank_at
-                    .unwrap_or(observed_at)
-                    .max(observed_at + self.blank_after),
-            );
-        }
-    }
-
     pub fn observe_provider_idle(&mut self) -> InactivityDecision {
-        if self.can_blank_automatically()
-            && matches!(
-                self.phase,
-                InactivityPhase::Unknown | InactivityPhase::Active
-            )
-        {
+        if matches!(
+            self.phase,
+            InactivityPhase::Unknown | InactivityPhase::Active
+        ) {
             self.phase = InactivityPhase::BlankRequested;
             self.blank_at = None;
             return InactivityDecision::BlankNow;
@@ -217,6 +176,9 @@ impl InactivityEngine {
         observation: InactivityObservation,
         observed_at: Instant,
     ) -> InactivityDecision {
+        if self.activity_floor.is_some_and(|floor| observed_at < floor) {
+            return InactivityDecision::NoOp;
+        }
         let independent_activity = matches!(
             observation,
             InactivityObservation::DesktopActivityObserved
@@ -262,6 +224,8 @@ impl InactivityEngine {
             return InactivityDecision::NoOp;
         }
 
+        self.activity_floor = Some(observed_at);
+
         if self.provider_driven_blank {
             self.blank_at = None;
         } else {
@@ -301,13 +265,13 @@ impl InactivityEngine {
     pub fn observe_time(&mut self, observed_at: Instant) -> InactivityDecision {
         match self.phase {
             InactivityPhase::Unknown | InactivityPhase::Active
-                if self.can_blank_automatically()
-                    && self
-                        .blank_at
-                        .is_some_and(|deadline| observed_at >= deadline) =>
+                if self
+                    .blank_at
+                    .is_some_and(|deadline| observed_at >= deadline) =>
             {
                 self.phase = InactivityPhase::BlankRequested;
                 self.lock_activity_floor = self.session_locked_since;
+                self.activity_floor = Some(observed_at);
                 InactivityDecision::BlankNow
             }
             InactivityPhase::Blanked
@@ -370,198 +334,6 @@ mod tests {
 
     fn test_engine(started_at: Instant) -> InactivityEngine {
         InactivityEngine::new(Duration::from_secs(5), started_at)
-    }
-
-    #[test]
-    fn pending_permission_blocks_expiry_without_renewing_an_uninhibited_deadline() {
-        let start = Instant::now();
-        let mut engine = test_engine(start);
-        engine.defer_idle_blanking();
-        let after_deadline = start + Duration::from_secs(6);
-        assert_eq!(engine.time_until_action(after_deadline), None);
-        assert_eq!(
-            engine.observe_time(after_deadline),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(engine.observe_provider_idle(), InactivityDecision::NoOp);
-
-        // An unrelated inhibitor change must not give us another full timeout.
-        engine.set_idle_blanking_allowed(true, after_deadline);
-        assert_eq!(
-            engine.time_until_action(after_deadline),
-            Some(Duration::ZERO)
-        );
-        assert_eq!(
-            engine.observe_time(after_deadline),
-            InactivityDecision::BlankNow
-        );
-    }
-
-    #[test]
-    fn a_confirmed_inhibitor_keeps_a_pending_deadline_blocked_until_release() {
-        let start = Instant::now();
-        let mut engine = test_engine(start);
-        engine.defer_idle_blanking();
-        let reply_at = start + Duration::from_secs(6);
-        engine.set_idle_blanking_allowed(false, reply_at);
-        assert_eq!(engine.time_until_action(reply_at), None);
-        assert_eq!(engine.observe_time(reply_at), InactivityDecision::NoOp);
-
-        engine.defer_idle_blanking();
-        let released = start + Duration::from_secs(10);
-        engine.set_idle_blanking_allowed(true, released);
-        assert_eq!(
-            engine.time_until_action(released),
-            Some(Duration::from_secs(5))
-        );
-    }
-
-    #[test]
-    fn pending_permission_preserves_explicit_lock_power_off_and_real_input() {
-        let start = Instant::now();
-        let mut engine = test_engine(start);
-        engine.defer_idle_blanking();
-        assert_eq!(engine.observe_lock(start), InactivityDecision::BlankNow);
-        engine.complete_blank(true, start);
-        assert_eq!(
-            engine.time_until_action(start),
-            Some(InactivityEngine::DEFAULT_POWER_OFF_AFTER)
-        );
-        let mut power_off_engine = engine;
-        assert_eq!(
-            power_off_engine.observe_time(start + InactivityEngine::DEFAULT_POWER_OFF_AFTER),
-            InactivityDecision::TimedPowerOffNow,
-        );
-        assert_eq!(
-            engine.observe_activity(
-                InactivityObservation::DesktopActivityObserved,
-                start + Duration::from_secs(2),
-            ),
-            InactivityDecision::RestoreNow,
-        );
-    }
-
-    #[test]
-    fn inhibition_blocks_startup_until_permission_returns_with_a_fresh_timeout() {
-        let start = Instant::now();
-        let mut engine = test_engine(start);
-        engine.set_idle_blanking_allowed(false, start);
-        let released = start + Duration::from_secs(30);
-        assert_eq!(engine.observe_time(released), InactivityDecision::NoOp);
-        assert_eq!(engine.time_until_action(released), None);
-
-        engine.set_idle_blanking_allowed(true, released);
-        assert_eq!(
-            engine.time_until_action(released),
-            Some(Duration::from_secs(5))
-        );
-        // Repeated observations must not indefinitely extend the deadline.
-        engine.set_idle_blanking_allowed(true, released + Duration::from_secs(4));
-        assert_eq!(
-            engine.observe_time(released + Duration::from_secs(4)),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(
-            engine.observe_time(released + Duration::from_secs(5)),
-            InactivityDecision::BlankNow
-        );
-    }
-
-    #[test]
-    fn inhibition_replaces_an_almost_expired_deadline_after_the_last_release() {
-        let start = Instant::now();
-        let mut engine = test_engine(start);
-        engine.set_idle_blanking_allowed(false, start + Duration::from_secs(4));
-        assert_eq!(
-            engine.observe_time(start + Duration::from_secs(6)),
-            InactivityDecision::NoOp
-        );
-        engine.set_idle_blanking_allowed(true, start + Duration::from_secs(10));
-        assert_eq!(
-            engine.observe_time(start + Duration::from_secs(14)),
-            InactivityDecision::NoOp
-        );
-        assert_eq!(
-            engine.observe_time(start + Duration::from_secs(15)),
-            InactivityDecision::BlankNow
-        );
-    }
-
-    #[test]
-    fn inhibition_is_not_restore_activity_and_does_not_cancel_post_blank_power_off() {
-        let start = Instant::now();
-        let mut engine = InactivityEngine::new_with_power_off_after(
-            Duration::from_secs(5),
-            Duration::from_secs(10),
-            start,
-        );
-        assert_eq!(
-            engine.observe_time(start + Duration::from_secs(5)),
-            InactivityDecision::BlankNow
-        );
-        engine.complete_blank(true, start + Duration::from_secs(5));
-        engine.set_idle_blanking_allowed(false, start + Duration::from_secs(6));
-        engine.set_idle_blanking_allowed(true, start + Duration::from_secs(8));
-        assert!(engine.timed_power_off_pending());
-        assert_eq!(
-            engine.observe_time(start + Duration::from_secs(15)),
-            InactivityDecision::TimedPowerOffNow
-        );
-    }
-
-    #[test]
-    fn real_input_restores_while_inhibited_and_still_resets_the_shared_deadline() {
-        for observation in [
-            InactivityObservation::DesktopActivityObserved,
-            InactivityObservation::UserActivityObserved,
-        ] {
-            let start = Instant::now();
-            let mut engine = test_engine(start);
-            assert_eq!(
-                engine.observe_time(start + Duration::from_secs(5)),
-                InactivityDecision::BlankNow
-            );
-            engine.complete_blank(true, start + Duration::from_secs(5));
-            engine.set_idle_blanking_allowed(false, start + Duration::from_secs(6));
-            assert_eq!(
-                engine.observe_activity(observation, start + Duration::from_secs(7)),
-                InactivityDecision::RestoreNow
-            );
-            assert!(!engine.timed_power_off_pending());
-            assert_eq!(
-                engine.observe_time(start + Duration::from_secs(20)),
-                InactivityDecision::NoOp
-            );
-            engine.set_idle_blanking_allowed(true, start + Duration::from_secs(21));
-            assert_eq!(
-                engine.observe_activity(observation, start + Duration::from_secs(24)),
-                InactivityDecision::NoOp
-            );
-            assert_eq!(
-                engine.observe_time(start + Duration::from_secs(28)),
-                InactivityDecision::NoOp
-            );
-            assert_eq!(
-                engine.observe_time(start + Duration::from_secs(29)),
-                InactivityDecision::BlankNow
-            );
-        }
-    }
-
-    #[test]
-    fn an_explicit_lock_still_blanks_while_idle_blanking_is_inhibited() {
-        let start = Instant::now();
-        let mut engine = test_engine(start);
-        engine.set_idle_blanking_allowed(false, start);
-        assert_eq!(
-            engine.observe_lock(start + Duration::from_secs(1)),
-            InactivityDecision::BlankNow
-        );
-        engine.complete_blank(true, start + Duration::from_secs(1));
-        engine.set_idle_blanking_allowed(true, start + Duration::from_secs(2));
-        assert!(engine.timed_power_off_pending());
-        engine.observe_unlock();
-        assert!(engine.timed_power_off_pending());
     }
 
     #[test]
@@ -1082,6 +854,37 @@ mod tests {
                 started_at + Duration::from_secs(8),
             ),
             InactivityDecision::RestoreNow
+        );
+    }
+    #[test]
+    fn delayed_input_cannot_undo_a_newer_blank_or_extend_to_delivery_time() {
+        let start = Instant::now();
+        let mut engine = InactivityEngine::new(Duration::from_secs(1), start);
+        assert_eq!(
+            engine.observe_time(start + Duration::from_secs(1)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, start + Duration::from_secs(1));
+        assert_eq!(
+            engine.observe_activity(
+                InactivityObservation::DesktopActivityObserved,
+                start + Duration::from_millis(500)
+            ),
+            InactivityDecision::NoOp
+        );
+        assert!(engine.timed_power_off_pending());
+        let input_at = start + Duration::from_millis(1500);
+        assert_eq!(
+            engine.observe_activity(InactivityObservation::UserActivityObserved, input_at),
+            InactivityDecision::RestoreNow
+        );
+        assert_eq!(
+            engine.observe_activity(InactivityObservation::DesktopActivityObserved, start),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_time(input_at + Duration::from_secs(1)),
+            InactivityDecision::BlankNow
         );
     }
 }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -36,7 +36,8 @@ use crate::session_bus::{new_system_bus_client, SessionBusClient};
 use crate::session_notifications::spawn_session_notification_service;
 use crate::sources::desktop::gnome::{monitor_test_timeout, GnomeSource};
 use crate::sources::desktop::swayidle::{run as run_swayidle_source, SwayidleSourceError};
-use crate::sources::desktop::wayland::run_session_source as run_wayland_session_source;
+use crate::sources::desktop::wayland::WaylandSource;
+use crate::sources::desktop::{ActivityAdapter, ActivityStatus};
 use crate::sources::linux::logind::{
     acquire_sleep_delay_inhibitor, add_logind_signal_match, map_prepare_for_sleep_signal,
     spawn_lock_observer, LogindLockObserver,
@@ -562,7 +563,7 @@ fn lifecycle_policy_enabled_from_config(config_path: &Path) -> Result<bool, Sess
 fn prepare_monitor_backend(
     probe: &mut SystemBackendProbe,
     configured: ScreenBackend,
-) -> Result<(BackendResolution, Option<wayland_client::Connection>), BackendDetectionError> {
+) -> Result<(BackendResolution, Option<WaylandSource>), BackendDetectionError> {
     // Probe both interfaces before starting threads: WAYLAND_SOCKET is a
     // one-shot inherited descriptor consumed by the initial connection.
     if configured == ScreenBackend::Auto {
@@ -571,13 +572,13 @@ fn prepare_monitor_backend(
         if gnome || wayland {
             return Ok((
                 BackendResolution::selected(ScreenBackend::Auto, None),
-                probe.take_wayland_connection(),
+                probe.take_wayland_source(),
             ));
         }
     }
     let resolution = resolve_backend_with_probe(probe, configured)?;
-    let connection = probe.take_wayland_connection();
-    Ok((resolution, connection))
+    let source = probe.take_wayland_source();
+    Ok((resolution, source))
 }
 
 fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
@@ -641,7 +642,7 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
         };
 
         match resolution {
-            Ok((resolution, mut wayland_connection)) => {
+            Ok((resolution, mut wayland_source)) => {
                 if configured == ScreenBackend::Auto && resolution.backend() != ScreenBackend::Auto
                 {
                     writeln!(
@@ -671,14 +672,14 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
                         let mut dispatcher = SessionEventDispatcher::new(
                             executor.take().expect("executor available"),
                         );
-                        let connection = wayland_connection.take().ok_or_else(|| {
+                        let source = wayland_source.take().ok_or_else(|| {
                             SessionRunnerError::Failed {
                                 backend: ScreenBackend::Wayland,
-                                message: "native Wayland was selected without retaining its verified connection"
+                                message: "native Wayland was selected without retaining its verified adapter"
                                     .to_string(),
                             }
                         })?;
-                        return run_wayland_monitor(writer, &mut dispatcher, connection);
+                        return run_wayland_monitor(writer, &mut dispatcher, source);
                     }
                     ScreenBackend::Swayidle => {
                         let mut dispatcher = SessionEventDispatcher::new(
@@ -698,7 +699,7 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
                             writer,
                             &mut dispatcher,
                             ScreenBackend::Auto,
-                            wayland_connection.take(),
+                            wayland_source.take(),
                         );
                     }
                 }
@@ -784,91 +785,55 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
 fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
-    connection: wayland_client::Connection,
+    source: WaylandSource,
 ) -> Result<(), SessionRunnerError> {
     writeln!(writer, "LG Buddy Monitor: Using native Wayland backend.")?;
-    run_composed_monitor(writer, dispatcher, ScreenBackend::Wayland, Some(connection))
+    run_composed_monitor(writer, dispatcher, ScreenBackend::Wayland, Some(source))
 }
 
 fn run_composed_monitor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     configured: ScreenBackend,
-    connection: Option<wayland_client::Connection>,
+    wayland: Option<WaylandSource>,
 ) -> Result<(), SessionRunnerError> {
     writeln!(
         writer,
         "LG Buddy Monitor: native inhibition honoring is temporarily unavailable on dev (#216)."
     )?;
+    let mut adapters: Vec<(ActivitySource, Arc<dyn ActivityAdapter>)> = Vec::new();
+    if configured != ScreenBackend::Wayland {
+        adapters.push((ActivitySource::Gnome, Arc::new(GnomeSource::default())));
+    }
+    if configured != ScreenBackend::Gnome {
+        adapters.push((
+            ActivitySource::Wayland,
+            Arc::new(wayland.unwrap_or_default()),
+        ));
+    }
+    let workers = adapters.clone();
     run_native_session_monitor(
         writer,
         dispatcher,
         configured,
+        &adapters,
         move |_sender, contributions, stop| {
             thread::spawn(move || {
-                let mut workers = Vec::new();
-                if configured != ScreenBackend::Wayland {
-                    let sources = Arc::clone(&contributions);
-                    let stop = Arc::clone(&stop);
-                    workers.push(thread::spawn(move || {
-                        while !stop.load(Ordering::SeqCst) {
-                            let instance = sources.begin(ActivitySource::Gnome);
-                            let result = GnomeSource::connect().and_then(|source| {
-                                sources.connected(instance);
-                                source.run(
-                                    |observation| {
-                                        sources.publish(instance, observation);
-                                        !stop.load(Ordering::SeqCst)
-                                    },
-                                    &stop,
-                                )
-                            });
-                            sources.unavailable(
-                                instance,
-                                &result.err().map_or_else(
-                                    || "disconnected".to_string(),
-                                    |err| err.to_string(),
-                                ),
+                let workers: Vec<_> = workers
+                    .into_iter()
+                    .map(|(source, adapter)| {
+                        let contributions = Arc::clone(&contributions);
+                        let stop = Arc::clone(&stop);
+                        thread::spawn(move || {
+                            adapter.run(
+                                Arc::new(move |observation| {
+                                    contributions.publish(source, observation);
+                                }),
+                                &stop,
                             );
-                            wait_for_source_retry(&stop);
-                        }
-                    }));
-                }
-                if configured != ScreenBackend::Gnome {
-                    let sources = Arc::clone(&contributions);
-                    let stop = Arc::clone(&stop);
-                    workers.push(thread::spawn(move || {
-                        let mut connection = connection;
-                        while !stop.load(Ordering::SeqCst) {
-                            let instance = sources.begin(ActivitySource::Wayland);
-                            let report = Arc::clone(&sources);
-                            let publish_stop = Arc::clone(&stop);
-                            let result = connection
-                                .take()
-                                .map(Ok)
-                                .unwrap_or_else(crate::sources::desktop::wayland::reconnect_wayland)
-                                .and_then(|connection| {
-                                    run_wayland_session_source(
-                                        connection,
-                                        move |observation| {
-                                            report.publish(instance, observation);
-                                            !publish_stop.load(Ordering::SeqCst)
-                                        },
-                                        &stop,
-                                        || sources.connected(instance),
-                                    )
-                                });
-                            sources.unavailable(
-                                instance,
-                                &result.err().map_or_else(
-                                    || "disconnected".to_string(),
-                                    |err| err.to_string(),
-                                ),
-                            );
-                            wait_for_source_retry(&stop);
-                        }
-                    }));
-                }
+                        })
+                    })
+                    .collect();
                 for worker in workers {
                     let _ = worker.join();
                 }
@@ -877,19 +842,11 @@ fn run_composed_monitor<W: Write, E: SessionActionExecutor>(
     )
 }
 
-fn wait_for_source_retry(stop: &AtomicBool) {
-    for _ in 0..20 {
-        if stop.load(Ordering::SeqCst) {
-            return;
-        }
-        thread::sleep(Duration::from_millis(100));
-    }
-}
-
 fn run_native_session_monitor<W, E, S>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
+    adapters: &[(ActivitySource, Arc<dyn ActivityAdapter>)],
     spawn_monitor: S,
 ) -> Result<(), SessionRunnerError>
 where
@@ -905,6 +862,7 @@ where
         writer,
         dispatcher,
         backend,
+        adapters,
         spawn_monitor,
         |sender| Some(spawn_logind_lock_monitor(sender)),
     )
@@ -914,6 +872,7 @@ fn run_native_session_monitor_with_lock_monitor<W, E, S, L>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
+    adapters: &[(ActivitySource, Arc<dyn ActivityAdapter>)],
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
@@ -931,6 +890,7 @@ where
         writer,
         dispatcher,
         backend,
+        adapters,
         InitialBlankTrigger::Deadline,
         spawn_monitor,
         spawn_lock_monitor,
@@ -947,6 +907,7 @@ fn run_session_monitor_with_lock_monitor<W, E, S, L>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
+    adapters: &[(ActivitySource, Arc<dyn ActivityAdapter>)],
     initial_blank_trigger: InitialBlankTrigger,
     spawn_monitor: S,
     spawn_lock_monitor: L,
@@ -1002,10 +963,7 @@ where
         if test_timeout_reached(started_at, test_timeout) {
             break;
         }
-        for (instance, observation, observed_at) in contributions.drain() {
-            if !contributions.accept(instance, observed_at) {
-                continue;
-            }
+        for (_, observation, observed_at) in contributions.drain() {
             handle_inactivity_observation(
                 writer,
                 dispatcher,
@@ -1015,25 +973,24 @@ where
                 observed_at,
             )?;
         }
-        let snapshots = contributions.snapshot();
-        let diagnostics: Vec<_> = snapshots
+        let diagnostics: Vec<_> = adapters
             .iter()
-            .map(|snapshot| {
-                (
-                    snapshot.source,
-                    snapshot.connected,
-                    snapshot.diagnostic.clone(),
-                )
-            })
+            .map(|(source, adapter)| (*source, adapter.status()))
             .collect();
         if diagnostics != last_diagnostics {
-            for snapshot in &snapshots {
-                writeln!(writer, "LG Buddy Monitor: activity source={} instance={} connected={} last_activity_age_ms={:?} detail={}", snapshot.source.name(), snapshot.generation, snapshot.connected, snapshot.latest_activity.map(|at| at.elapsed().as_millis()), snapshot.diagnostic.as_deref().unwrap_or(if snapshot.connected { "ready" } else { "connecting" }))?;
+            for (source, status) in &diagnostics {
+                let detail = match status {
+                    ActivityStatus::Available => "ready",
+                    ActivityStatus::Unavailable(reason) => reason,
+                };
+                writeln!(writer, "LG Buddy Monitor: activity source={} available={} last_activity_age_ms={:?} detail={}", source.name(), status.is_available(), contributions.latest_activity(*source).map(|at| at.elapsed().as_millis()), detail)?;
             }
             last_diagnostics = diagnostics;
         }
         let has_activity = initial_blank_trigger == InitialBlankTrigger::Provider
-            || contributions.has_connected_source();
+            || adapters
+                .iter()
+                .any(|(_, adapter)| adapter.status().is_available());
         let wait = if has_activity || inactivity.timed_power_off_pending() {
             inactivity
                 .time_until_action(Instant::now())
@@ -1046,10 +1003,7 @@ where
             Ok(message) => message,
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 // Read activity published while waiting before acting on a deadline.
-                for (instance, observation, observed_at) in contributions.drain() {
-                    if !contributions.accept(instance, observed_at) {
-                        continue;
-                    }
+                for (_, observation, observed_at) in contributions.drain() {
                     handle_inactivity_observation(
                         writer,
                         dispatcher,
@@ -1060,7 +1014,9 @@ where
                     )?;
                 }
                 if initial_blank_trigger == InitialBlankTrigger::Provider
-                    || contributions.has_connected_source()
+                    || adapters
+                        .iter()
+                        .any(|(_, adapter)| adapter.status().is_available())
                     || inactivity.timed_power_off_pending()
                 {
                     handle_inactivity_timeout(writer, dispatcher, &mut inactivity, Instant::now())?;
@@ -1188,6 +1144,7 @@ fn run_swayidle_monitor<W: Write, E: SessionActionExecutor>(
         writer,
         dispatcher,
         ScreenBackend::Swayidle,
+        &[],
         InitialBlankTrigger::Provider,
         move |sender, _contributions, stop| {
             thread::spawn(move || {
@@ -2734,6 +2691,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
+            &[],
             |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     let result = activity_receiver
@@ -2786,6 +2744,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Wayland,
+            &[],
             |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     thread::sleep(Duration::from_millis(150));
@@ -2831,6 +2790,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
+            &[],
             |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     let locked_at = Instant::now();
@@ -3020,7 +2980,59 @@ system_sleep_wake_policy={policy}
         assert_eq!(dispatcher.executor.screen_on_calls, 1);
     }
     #[test]
-    fn composed_sources_restore_once_and_keep_running_after_one_disconnects() {
+    fn ignored_provider_wake_does_not_discard_delayed_input_from_another_source() {
+        use super::{ActivityContributions, ActivitySource};
+        use crate::session::SessionObservation;
+
+        let sources = ActivityContributions::default();
+        let gnome = ActivitySource::Gnome;
+        let wayland = ActivitySource::Wayland;
+        let started_at = Instant::now();
+        let mut inactivity =
+            InactivityEngine::new_with_restore_pending(Duration::from_secs(5), started_at);
+        inactivity.observe_lock(started_at);
+        let mut dispatcher = SessionEventDispatcher::new(FakeActionExecutor::default());
+        let mut output = Vec::new();
+
+        for (source, observation, seconds, restores) in [
+            (gnome, InactivityObservation::WakeRequested, 3, 0),
+            (
+                wayland,
+                InactivityObservation::DesktopActivityObserved,
+                2,
+                1,
+            ),
+            (gnome, InactivityObservation::DesktopActivityObserved, 2, 1),
+        ] {
+            sources.publish(
+                source,
+                SessionObservation::Inactivity {
+                    observation,
+                    source: EventSource::DesktopSession,
+                    observed_at: started_at + Duration::from_secs(seconds),
+                },
+            );
+            for (_, observation, observed_at) in sources.drain() {
+                handle_inactivity_observation(
+                    &mut output,
+                    &mut dispatcher,
+                    &mut inactivity,
+                    EventSource::DesktopSession,
+                    observation,
+                    observed_at,
+                )
+                .unwrap();
+            }
+            assert_eq!(dispatcher.executor.screen_on_calls, restores);
+        }
+        assert_eq!(
+            inactivity.time_until_action(started_at + Duration::from_secs(3)),
+            Some(Duration::from_secs(4))
+        );
+    }
+
+    #[test]
+    fn composed_sources_restore_once_without_availability_reports() {
         let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
         let runtime_dir = unique_config_path("composed-activity");
         ScreenOwnershipMarker::new(runtime_dir.clone())
@@ -3039,13 +3051,12 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
+            &[],
             |sender, sources, _stop| {
                 thread::spawn(move || {
                     use super::ActivitySource;
-                    let gnome = sources.begin(ActivitySource::Gnome);
-                    let wayland = sources.begin(ActivitySource::Wayland);
-                    sources.connected(gnome);
-                    sources.connected(wayland);
+                    let gnome = ActivitySource::Gnome;
+                    let wayland = ActivitySource::Wayland;
                     let at = Instant::now();
                     let input = crate::session::SessionObservation::Inactivity {
                         observation: InactivityObservation::DesktopActivityObserved,
@@ -3060,7 +3071,6 @@ system_sleep_wake_policy={policy}
                             backend: ScreenBackend::Auto,
                             message: err.to_string(),
                         });
-                    sources.unavailable(gnome, "owner replaced");
                     sources.publish(
                         gnome,
                         crate::session::SessionObservation::Event {
@@ -3084,7 +3094,6 @@ system_sleep_wake_policy={policy}
         assert_eq!(dispatcher.executor.screen_on_calls, 1);
         assert_eq!(dispatcher.executor.screen_off_calls, 0);
         let output = String::from_utf8(output).unwrap();
-        assert!(output.contains("source=wayland"));
-        assert!(output.contains("owner replaced"));
+        assert!(output.contains("requests screen restore"));
     }
 }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -8,15 +8,15 @@ use std::path::Path;
 use std::process;
 use std::sync::{
     atomic::{AtomicBool, Ordering},
-    mpsc, Arc, Mutex,
+    mpsc, Arc,
 };
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
 use crate::backend::{
-    configured_backend_from_env_or_config, honor_idle_inhibitors_from_config,
-    resolve_backend_with_probe, BackendDetectionError, BackendResolution, BackendSelectionError,
-    SystemBackendProbe, SWAYIDLE_DEPRECATION_NOTICE,
+    configured_backend_from_env_or_config, resolve_backend_with_probe, BackendDetectionError,
+    BackendProbe, BackendResolution, BackendSelectionError, SystemBackendProbe,
+    SWAYIDLE_DEPRECATION_NOTICE,
 };
 use crate::config::{
     load_config, normalize_idle_timeout_secs, parse_config_entries, parse_idle_timeout_secs,
@@ -25,6 +25,7 @@ use crate::config::{
 };
 use crate::events::{EventSource, RuntimeEvent};
 use crate::lifecycle::LifecycleEvent;
+use crate::session::activity::{ActivityContributions, ActivitySource};
 use crate::session::gamepad::{
     open_system_gamepad_activity_source, open_system_gamepad_device_event_monitor,
     SystemGamepadActivitySource, SystemGamepadDeviceEventMonitor,
@@ -33,7 +34,7 @@ use crate::session::inactivity::{InactivityDecision, InactivityEngine, Inactivit
 use crate::session::{SessionEvent, SessionObservation};
 use crate::session_bus::{new_system_bus_client, SessionBusClient};
 use crate::session_notifications::spawn_session_notification_service;
-use crate::sources::desktop::gnome::{monitor_test_timeout, GnomeSource, GnomeSourceError};
+use crate::sources::desktop::gnome::{monitor_test_timeout, GnomeSource};
 use crate::sources::desktop::swayidle::{run as run_swayidle_source, SwayidleSourceError};
 use crate::sources::desktop::wayland::run_session_source as run_wayland_session_source;
 use crate::sources::linux::logind::{
@@ -562,8 +563,19 @@ fn prepare_monitor_backend(
     probe: &mut SystemBackendProbe,
     configured: ScreenBackend,
 ) -> Result<(BackendResolution, Option<wayland_client::Connection>), BackendDetectionError> {
-    let resolution =
-        resolve_backend_with_probe(probe, configured, honor_idle_inhibitors_from_config())?;
+    // Probe both interfaces before starting threads: WAYLAND_SOCKET is a
+    // one-shot inherited descriptor consumed by the initial connection.
+    if configured == ScreenBackend::Auto {
+        let gnome = resolve_backend_with_probe(probe, ScreenBackend::Gnome).is_ok();
+        let wayland = probe.wayland_capabilities().is_ok();
+        if gnome || wayland {
+            return Ok((
+                BackendResolution::selected(ScreenBackend::Auto, None),
+                probe.take_wayland_connection(),
+            ));
+        }
+    }
+    let resolution = resolve_backend_with_probe(probe, configured)?;
     let connection = probe.take_wayland_connection();
     Ok((resolution, connection))
 }
@@ -630,7 +642,8 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
 
         match resolution {
             Ok((resolution, mut wayland_connection)) => {
-                if configured == ScreenBackend::Auto {
+                if configured == ScreenBackend::Auto && resolution.backend() != ScreenBackend::Auto
+                {
                     writeln!(
                         writer,
                         "LG Buddy Monitor: auto resolved to {}.",
@@ -674,11 +687,19 @@ fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
                         return run_swayidle_monitor(writer, &mut dispatcher);
                     }
                     ScreenBackend::Auto => {
-                        return Err(SessionRunnerError::Failed {
-                            backend: ScreenBackend::Auto,
-                            message: "auto backend should be resolved before starting the runner"
-                                .to_string(),
-                        });
+                        let mut dispatcher = SessionEventDispatcher::new(
+                            executor.take().expect("executor available"),
+                        );
+                        writeln!(
+                            writer,
+                            "LG Buddy Monitor: Composing available native activity sources."
+                        )?;
+                        return run_composed_monitor(
+                            writer,
+                            &mut dispatcher,
+                            ScreenBackend::Auto,
+                            wayland_connection.take(),
+                        );
                     }
                 }
             }
@@ -756,20 +777,8 @@ fn run_gnome_monitor<W: Write, E: SessionActionExecutor>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
 ) -> Result<(), SessionRunnerError> {
-    let honor_idle_inhibitors = honor_idle_inhibitors_from_config();
-    let source = GnomeSource::connect(honor_idle_inhibitors).map_err(map_gnome_source_error)?;
-
     writeln!(writer, "LG Buddy Monitor: Using GNOME backend.")?;
-
-    run_native_session_monitor(
-        writer,
-        dispatcher,
-        ScreenBackend::Gnome,
-        honor_idle_inhibitors,
-        move |sender, latest_observation| {
-            spawn_gnome_monitor_thread(source, sender, latest_observation)
-        },
-    )
+    run_composed_monitor(writer, dispatcher, ScreenBackend::Gnome, None)
 }
 
 fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
@@ -778,41 +787,124 @@ fn run_wayland_monitor<W: Write, E: SessionActionExecutor>(
     connection: wayland_client::Connection,
 ) -> Result<(), SessionRunnerError> {
     writeln!(writer, "LG Buddy Monitor: Using native Wayland backend.")?;
-    let honor_idle_inhibitors = honor_idle_inhibitors_from_config();
+    run_composed_monitor(writer, dispatcher, ScreenBackend::Wayland, Some(connection))
+}
 
+fn run_composed_monitor<W: Write, E: SessionActionExecutor>(
+    writer: &mut W,
+    dispatcher: &mut SessionEventDispatcher<E>,
+    configured: ScreenBackend,
+    connection: Option<wayland_client::Connection>,
+) -> Result<(), SessionRunnerError> {
+    writeln!(
+        writer,
+        "LG Buddy Monitor: native inhibition honoring is temporarily unavailable on dev (#216)."
+    )?;
     run_native_session_monitor(
         writer,
         dispatcher,
-        ScreenBackend::Wayland,
-        honor_idle_inhibitors,
-        move |sender, latest_observation| {
-            spawn_wayland_monitor_thread(
-                connection,
-                honor_idle_inhibitors,
-                sender,
-                latest_observation,
-            )
+        configured,
+        move |_sender, contributions, stop| {
+            thread::spawn(move || {
+                let mut workers = Vec::new();
+                if configured != ScreenBackend::Wayland {
+                    let sources = Arc::clone(&contributions);
+                    let stop = Arc::clone(&stop);
+                    workers.push(thread::spawn(move || {
+                        while !stop.load(Ordering::SeqCst) {
+                            let instance = sources.begin(ActivitySource::Gnome);
+                            let result = GnomeSource::connect().and_then(|source| {
+                                sources.connected(instance);
+                                source.run(
+                                    |observation| {
+                                        sources.publish(instance, observation);
+                                        !stop.load(Ordering::SeqCst)
+                                    },
+                                    &stop,
+                                )
+                            });
+                            sources.unavailable(
+                                instance,
+                                &result.err().map_or_else(
+                                    || "disconnected".to_string(),
+                                    |err| err.to_string(),
+                                ),
+                            );
+                            wait_for_source_retry(&stop);
+                        }
+                    }));
+                }
+                if configured != ScreenBackend::Gnome {
+                    let sources = Arc::clone(&contributions);
+                    let stop = Arc::clone(&stop);
+                    workers.push(thread::spawn(move || {
+                        let mut connection = connection;
+                        while !stop.load(Ordering::SeqCst) {
+                            let instance = sources.begin(ActivitySource::Wayland);
+                            let report = Arc::clone(&sources);
+                            let publish_stop = Arc::clone(&stop);
+                            let result = connection
+                                .take()
+                                .map(Ok)
+                                .unwrap_or_else(crate::sources::desktop::wayland::reconnect_wayland)
+                                .and_then(|connection| {
+                                    run_wayland_session_source(
+                                        connection,
+                                        move |observation| {
+                                            report.publish(instance, observation);
+                                            !publish_stop.load(Ordering::SeqCst)
+                                        },
+                                        &stop,
+                                        || sources.connected(instance),
+                                    )
+                                });
+                            sources.unavailable(
+                                instance,
+                                &result.err().map_or_else(
+                                    || "disconnected".to_string(),
+                                    |err| err.to_string(),
+                                ),
+                            );
+                            wait_for_source_retry(&stop);
+                        }
+                    }));
+                }
+                for worker in workers {
+                    let _ = worker.join();
+                }
+            })
         },
     )
+}
+
+fn wait_for_source_retry(stop: &AtomicBool) {
+    for _ in 0..20 {
+        if stop.load(Ordering::SeqCst) {
+            return;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
 }
 
 fn run_native_session_monitor<W, E, S>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
-    honor_idle_inhibitors: bool,
     spawn_monitor: S,
 ) -> Result<(), SessionRunnerError>
 where
     W: Write,
     E: SessionActionExecutor,
-    S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
+    S: FnOnce(
+        mpsc::Sender<RunnerMessage>,
+        Arc<ActivityContributions>,
+        Arc<AtomicBool>,
+    ) -> JoinHandle<()>,
 {
     run_native_session_monitor_with_lock_monitor(
         writer,
         dispatcher,
         backend,
-        honor_idle_inhibitors,
         spawn_monitor,
         |sender| Some(spawn_logind_lock_monitor(sender)),
     )
@@ -822,14 +914,17 @@ fn run_native_session_monitor_with_lock_monitor<W, E, S, L>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
-    honor_idle_inhibitors: bool,
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
 where
     W: Write,
     E: SessionActionExecutor,
-    S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
+    S: FnOnce(
+        mpsc::Sender<RunnerMessage>,
+        Arc<ActivityContributions>,
+        Arc<AtomicBool>,
+    ) -> JoinHandle<()>,
     L: FnOnce(mpsc::Sender<RunnerMessage>) -> Option<LogindLockObserver>,
 {
     run_session_monitor_with_lock_monitor(
@@ -837,7 +932,6 @@ where
         dispatcher,
         backend,
         InitialBlankTrigger::Deadline,
-        honor_idle_inhibitors,
         spawn_monitor,
         spawn_lock_monitor,
     )
@@ -854,14 +948,17 @@ fn run_session_monitor_with_lock_monitor<W, E, S, L>(
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
     initial_blank_trigger: InitialBlankTrigger,
-    honor_idle_inhibitors: bool,
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
 where
     W: Write,
     E: SessionActionExecutor,
-    S: FnOnce(mpsc::Sender<RunnerMessage>, Arc<LatestInactivityObservation>) -> JoinHandle<()>,
+    S: FnOnce(
+        mpsc::Sender<RunnerMessage>,
+        Arc<ActivityContributions>,
+        Arc<AtomicBool>,
+    ) -> JoinHandle<()>,
     L: FnOnce(mpsc::Sender<RunnerMessage>) -> Option<LogindLockObserver>,
 {
     let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
@@ -883,62 +980,96 @@ where
         InactivityEngine::new_with_power_off_after(blank_after, power_off_after, started_at)
     };
 
-    // No automatic blanking until an enabled native source has established
-    // permission, including when inhibition predates monitor startup.
-    if honor_idle_inhibitors {
-        inactivity.set_idle_blanking_allowed(false, started_at);
-    }
-
     let (sender, receiver) = mpsc::channel();
-    let latest_inactivity = Arc::new(LatestInactivityObservation::default());
-    let monitor_handle = spawn_monitor(sender.clone(), Arc::clone(&latest_inactivity));
+    let contributions = Arc::new(ActivityContributions::default());
+    let stop = Arc::new(AtomicBool::new(false));
+    let monitor_handle = spawn_monitor(
+        sender.clone(),
+        Arc::clone(&contributions),
+        Arc::clone(&stop),
+    );
+    let _monitor = MonitorThread {
+        stop,
+        handle: Some(monitor_handle),
+    };
     let _gamepad_monitor = spawn_gamepad_activity_thread(sender.clone());
     let _logind_lock_monitor = spawn_lock_monitor(sender.clone());
+    let test_timeout = monitor_test_timeout();
+    let mut last_diagnostics = Vec::new();
     let mut monitor_result = Ok(());
 
     loop {
-        let message = match inactivity.time_until_action(Instant::now()) {
-            Some(wait) => match receiver.recv_timeout(wait) {
-                Ok(message) => message,
-                Err(mpsc::RecvTimeoutError::Timeout) => {
-                    handle_inactivity_timeout(writer, dispatcher, &mut inactivity, Instant::now())?;
-                    continue;
-                }
-                Err(mpsc::RecvTimeoutError::Disconnected) => break,
-            },
-            None => match receiver.recv() {
-                Ok(message) => message,
-                Err(_) => break,
-            },
-        };
-
-        match message {
-            RunnerMessage::IdleBlankingPermissionPending { source } => {
-                if honor_idle_inhibitors && source == EventSource::DesktopSession {
-                    inactivity.defer_idle_blanking();
-                }
+        if test_timeout_reached(started_at, test_timeout) {
+            break;
+        }
+        for (instance, observation, observed_at) in contributions.drain() {
+            if !contributions.accept(instance, observed_at) {
+                continue;
             }
-            RunnerMessage::IdleBlankingPermission {
-                allowed,
-                source,
+            handle_inactivity_observation(
+                writer,
+                dispatcher,
+                &mut inactivity,
+                EventSource::DesktopSession,
+                observation,
                 observed_at,
-            } => {
-                if honor_idle_inhibitors && source == EventSource::DesktopSession {
-                    inactivity.set_idle_blanking_allowed(allowed, observed_at);
-                }
+            )?;
+        }
+        let snapshots = contributions.snapshot();
+        let diagnostics: Vec<_> = snapshots
+            .iter()
+            .map(|snapshot| {
+                (
+                    snapshot.source,
+                    snapshot.connected,
+                    snapshot.diagnostic.clone(),
+                )
+            })
+            .collect();
+        if diagnostics != last_diagnostics {
+            for snapshot in &snapshots {
+                writeln!(writer, "LG Buddy Monitor: activity source={} instance={} connected={} last_activity_age_ms={:?} detail={}", snapshot.source.name(), snapshot.generation, snapshot.connected, snapshot.latest_activity.map(|at| at.elapsed().as_millis()), snapshot.diagnostic.as_deref().unwrap_or(if snapshot.connected { "ready" } else { "connecting" }))?;
             }
-            RunnerMessage::InactivityObservationReady => {
-                if let Some(observation) = latest_inactivity.take() {
+            last_diagnostics = diagnostics;
+        }
+        let has_activity = initial_blank_trigger == InitialBlankTrigger::Provider
+            || contributions.has_connected_source();
+        let wait = if has_activity || inactivity.timed_power_off_pending() {
+            inactivity
+                .time_until_action(Instant::now())
+                .unwrap_or(Duration::from_millis(50))
+                .min(Duration::from_millis(50))
+        } else {
+            Duration::from_millis(50)
+        };
+        let message = match receiver.recv_timeout(wait) {
+            Ok(message) => message,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Read activity published while waiting before acting on a deadline.
+                for (instance, observation, observed_at) in contributions.drain() {
+                    if !contributions.accept(instance, observed_at) {
+                        continue;
+                    }
                     handle_inactivity_observation(
                         writer,
                         dispatcher,
                         &mut inactivity,
                         EventSource::DesktopSession,
-                        observation.observation,
-                        observation.observed_at,
+                        observation,
+                        observed_at,
                     )?;
                 }
+                if initial_blank_trigger == InitialBlankTrigger::Provider
+                    || contributions.has_connected_source()
+                    || inactivity.timed_power_off_pending()
+                {
+                    handle_inactivity_timeout(writer, dispatcher, &mut inactivity, Instant::now())?;
+                }
+                continue;
             }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        };
+        match message {
             RunnerMessage::ActivityObservation {
                 source,
                 observation,
@@ -1030,7 +1161,6 @@ where
         }
     }
 
-    let _ = monitor_handle.join();
     monitor_result
 }
 
@@ -1059,39 +1189,27 @@ fn run_swayidle_monitor<W: Write, E: SessionActionExecutor>(
         dispatcher,
         ScreenBackend::Swayidle,
         InitialBlankTrigger::Provider,
-        false,
-        move |sender, _latest_observation| {
+        move |sender, _contributions, stop| {
             thread::spawn(move || {
                 let event_sender = sender.clone();
-                let result =
-                    run_swayidle_source(idle_timeout_secs, &event_path, move |observation| {
-                        send_source_observation(&event_sender, observation)
-                    })
-                    .map_err(|err| match err {
-                        SwayidleSourceError::Io(err) => SessionRunnerError::Io(err.to_string()),
-                        SwayidleSourceError::Exited(_) => SessionRunnerError::Failed {
-                            backend: ScreenBackend::Swayidle,
-                            message: err.to_string(),
-                        },
-                    });
+                let result = run_swayidle_source(
+                    idle_timeout_secs,
+                    &event_path,
+                    &stop,
+                    move |observation| send_source_observation(&event_sender, observation),
+                )
+                .map_err(|err| match err {
+                    SwayidleSourceError::Io(err) => SessionRunnerError::Io(err.to_string()),
+                    SwayidleSourceError::Exited(_) => SessionRunnerError::Failed {
+                        backend: ScreenBackend::Swayidle,
+                        message: err.to_string(),
+                    },
+                });
                 let _ = sender.send(RunnerMessage::MonitorExited(result));
             })
         },
         |sender| Some(spawn_logind_lock_monitor(sender)),
     )
-}
-
-fn map_gnome_source_error(err: GnomeSourceError) -> SessionRunnerError {
-    match err {
-        GnomeSourceError::Unavailable(reason) => SessionRunnerError::BackendUnavailable {
-            backend: ScreenBackend::Gnome,
-            reason,
-        },
-        GnomeSourceError::Failed(message) => SessionRunnerError::Failed {
-            backend: ScreenBackend::Gnome,
-            message,
-        },
-    }
 }
 
 fn resolve_idle_timeout_secs() -> u64 {
@@ -1149,42 +1267,6 @@ fn resolve_lifecycle_monitor_test_event_limit() -> Option<usize> {
         .filter(|value| *value > 0)
 }
 
-fn spawn_gnome_monitor_thread(
-    source: GnomeSource,
-    sender: mpsc::Sender<RunnerMessage>,
-    latest_observation: Arc<LatestInactivityObservation>,
-) -> JoinHandle<()> {
-    thread::spawn(move || {
-        let result = source
-            .run(|observation| {
-                publish_desktop_observation(&sender, &latest_observation, observation)
-            })
-            .map_err(map_gnome_source_error);
-        let _ = sender.send(RunnerMessage::MonitorExited(result));
-    })
-}
-
-fn spawn_wayland_monitor_thread(
-    connection: wayland_client::Connection,
-    honor_idle_inhibitors: bool,
-    sender: mpsc::Sender<RunnerMessage>,
-    latest_observation: Arc<LatestInactivityObservation>,
-) -> JoinHandle<()> {
-    thread::spawn(move || {
-        let result = run_wayland_session_source(connection, honor_idle_inhibitors, {
-            let sender = sender.clone();
-            move |observation| {
-                publish_desktop_observation(&sender, &latest_observation, observation)
-            }
-        })
-        .map_err(|err| SessionRunnerError::Failed {
-            backend: ScreenBackend::Wayland,
-            message: err.to_string(),
-        });
-        let _ = sender.send(RunnerMessage::MonitorExited(result));
-    })
-}
-
 fn spawn_logind_lock_monitor(sender: mpsc::Sender<RunnerMessage>) -> LogindLockObserver {
     let observation_sender = sender.clone();
     spawn_lock_observer(
@@ -1202,42 +1284,11 @@ fn report_logind_lock_monitor_error(
     )));
 }
 
-fn publish_desktop_observation(
-    sender: &mpsc::Sender<RunnerMessage>,
-    latest_observation: &LatestInactivityObservation,
-    observation: SessionObservation,
-) -> bool {
-    match observation {
-        SessionObservation::Inactivity {
-            observation: InactivityObservation::DesktopActivityObserved,
-            source: EventSource::DesktopSession,
-            observed_at,
-        } => latest_observation.publish(
-            sender,
-            InactivityObservation::DesktopActivityObserved,
-            observed_at,
-        ),
-        observation => send_source_observation(sender, observation),
-    }
-}
-
 fn send_source_observation(
     sender: &mpsc::Sender<RunnerMessage>,
     observation: SessionObservation,
 ) -> bool {
     let message = match observation {
-        SessionObservation::IdleBlankingPermissionPending { source } => {
-            RunnerMessage::IdleBlankingPermissionPending { source }
-        }
-        SessionObservation::IdleBlankingPermission {
-            allowed,
-            source,
-            observed_at,
-        } => RunnerMessage::IdleBlankingPermission {
-            allowed,
-            source,
-            observed_at,
-        },
         SessionObservation::Event {
             event,
             source,
@@ -1261,9 +1312,7 @@ fn send_source_observation(
     sender.send(message).is_ok()
 }
 
-fn spawn_gamepad_activity_thread(
-    sender: mpsc::Sender<RunnerMessage>,
-) -> Option<GamepadActivityThread> {
+fn spawn_gamepad_activity_thread(sender: mpsc::Sender<RunnerMessage>) -> Option<MonitorThread> {
     let stop = Arc::new(AtomicBool::new(false));
     let thread_stop = Arc::clone(&stop);
     let handle = match resolve_gamepad_activity_source_mode() {
@@ -1276,7 +1325,7 @@ fn spawn_gamepad_activity_thread(
         }
     };
 
-    Some(GamepadActivityThread {
+    Some(MonitorThread {
         stop,
         handle: Some(handle),
     })
@@ -1438,14 +1487,6 @@ fn run_gamepad_activity_process(sender: mpsc::Sender<RunnerMessage>, stop: Arc<A
 }
 
 enum RunnerMessage {
-    IdleBlankingPermissionPending {
-        source: EventSource,
-    },
-    IdleBlankingPermission {
-        allowed: bool,
-        source: EventSource,
-        observed_at: Instant,
-    },
     SessionEvent {
         event: SessionEvent,
         source: EventSource,
@@ -1456,18 +1497,17 @@ enum RunnerMessage {
         observation: InactivityObservation,
         observed_at: Instant,
     },
-    InactivityObservationReady,
     Diagnostic(String),
     MonitorExited(Result<(), SessionRunnerError>),
 }
 
 #[derive(Debug)]
-struct GamepadActivityThread {
+struct MonitorThread {
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
 
-impl Drop for GamepadActivityThread {
+impl Drop for MonitorThread {
     fn drop(&mut self) {
         self.stop.store(true, Ordering::SeqCst);
         if let Some(handle) = self.handle.take() {
@@ -1583,77 +1623,6 @@ impl GamepadDiagnosticEmitter {
         }
 
         true
-    }
-}
-
-#[derive(Debug, Default)]
-struct LatestInactivityObservation {
-    state: Mutex<LatestInactivityObservationState>,
-}
-
-#[derive(Debug, Default)]
-struct LatestInactivityObservationState {
-    observation: Option<TimedInactivityObservation>,
-    notification_in_flight: bool,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct TimedInactivityObservation {
-    observation: InactivityObservation,
-    observed_at: Instant,
-}
-
-impl LatestInactivityObservation {
-    fn publish(
-        &self,
-        sender: &mpsc::Sender<RunnerMessage>,
-        observation: InactivityObservation,
-        observed_at: Instant,
-    ) -> bool {
-        let should_notify = {
-            let mut state = self
-                .state
-                .lock()
-                .expect("latest inactivity observation lock");
-            state.observation = Some(TimedInactivityObservation {
-                observation,
-                observed_at,
-            });
-            if state.notification_in_flight {
-                false
-            } else {
-                state.notification_in_flight = true;
-                true
-            }
-        };
-
-        if !should_notify {
-            return true;
-        }
-
-        if sender
-            .send(RunnerMessage::InactivityObservationReady)
-            .is_ok()
-        {
-            return true;
-        }
-
-        let mut state = self
-            .state
-            .lock()
-            .expect("latest inactivity observation lock");
-        state.notification_in_flight = false;
-        false
-    }
-
-    fn take(&self) -> Option<TimedInactivityObservation> {
-        let mut state = self
-            .state
-            .lock()
-            .expect("latest inactivity observation lock");
-        let observation = state.observation.take();
-        state.notification_in_flight = false;
-        observation
     }
 }
 
@@ -1803,8 +1772,7 @@ mod tests {
         handle_inactivity_timeout, normalize_idle_timeout_secs, report_logind_lock_monitor_error,
         run_lifecycle_monitor_with_bus, run_native_session_monitor_with_lock_monitor,
         schedule_gamepad_refresh, GamepadDeviceEventMonitor, GamepadDeviceEventRefresh,
-        GamepadDiagnosticEmitter, LatestInactivityObservation, RunnerMessage,
-        SessionActionExecutor, SessionEventDispatcher, TimedInactivityObservation,
+        GamepadDiagnosticEmitter, RunnerMessage, SessionActionExecutor, SessionEventDispatcher,
         GAMEPAD_ACTIVITY_REFRESH_RETRY_INTERVAL, GAMEPAD_ACTIVITY_SEND_INTERVAL,
     };
     use crate::config::ScreenBackend;
@@ -2384,80 +2352,6 @@ system_sleep_wake_policy={policy}
     }
 
     #[test]
-    fn latest_inactivity_observation_coalesces_pending_samples() {
-        let (sender, receiver) = mpsc::channel();
-        let latest = LatestInactivityObservation::default();
-        let first_observed_at = Instant::now();
-        let second_observed_at = first_observed_at + Duration::from_millis(250);
-
-        assert!(latest.publish(
-            &sender,
-            InactivityObservation::DesktopActivityObserved,
-            first_observed_at
-        ));
-        assert!(latest.publish(
-            &sender,
-            InactivityObservation::DesktopActivityObserved,
-            second_observed_at
-        ));
-
-        assert!(matches!(
-            receiver.recv().expect("notification"),
-            RunnerMessage::InactivityObservationReady
-        ));
-        assert_eq!(
-            latest.take(),
-            Some(TimedInactivityObservation {
-                observation: InactivityObservation::DesktopActivityObserved,
-                observed_at: second_observed_at,
-            })
-        );
-        assert!(receiver.try_recv().is_err());
-    }
-
-    #[test]
-    fn latest_inactivity_observation_notifies_again_after_take() {
-        let (sender, receiver) = mpsc::channel();
-        let latest = LatestInactivityObservation::default();
-        let first_observed_at = Instant::now();
-        let second_observed_at = first_observed_at + Duration::from_millis(250);
-
-        assert!(latest.publish(
-            &sender,
-            InactivityObservation::DesktopActivityObserved,
-            first_observed_at
-        ));
-        assert!(matches!(
-            receiver.recv().expect("first notification"),
-            RunnerMessage::InactivityObservationReady
-        ));
-        assert_eq!(
-            latest.take(),
-            Some(TimedInactivityObservation {
-                observation: InactivityObservation::DesktopActivityObserved,
-                observed_at: first_observed_at,
-            })
-        );
-
-        assert!(latest.publish(
-            &sender,
-            InactivityObservation::DesktopActivityObserved,
-            second_observed_at
-        ));
-        assert!(matches!(
-            receiver.recv().expect("second notification"),
-            RunnerMessage::InactivityObservationReady
-        ));
-        assert_eq!(
-            latest.take(),
-            Some(TimedInactivityObservation {
-                observation: InactivityObservation::DesktopActivityObserved,
-                observed_at: second_observed_at,
-            })
-        );
-    }
-
-    #[test]
     fn gamepad_activity_send_due_throttles_repeated_activity() {
         let first_sent_at = Instant::now();
 
@@ -2840,8 +2734,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
-            false,
-            |sender, _latest_inactivity| {
+            |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     let result = activity_receiver
                         .recv_timeout(Duration::from_secs(1))
@@ -2893,8 +2786,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Wayland,
-            false,
-            |sender, _latest_inactivity| {
+            |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     thread::sleep(Duration::from_millis(150));
                     let _ = sender.send(RunnerMessage::MonitorExited(Ok(())));
@@ -2939,8 +2831,7 @@ system_sleep_wake_policy={policy}
             &mut output,
             &mut dispatcher,
             ScreenBackend::Auto,
-            false,
-            |sender, _latest_inactivity| {
+            |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     let locked_at = Instant::now();
                     for event in [SessionEvent::Lock, SessionEvent::Lock] {
@@ -3127,5 +3018,73 @@ system_sleep_wake_policy={policy}
         let output = String::from_utf8(output).expect("utf8");
         assert!(output.contains("active"));
         assert_eq!(dispatcher.executor.screen_on_calls, 1);
+    }
+    #[test]
+    fn composed_sources_restore_once_and_keep_running_after_one_disconnects() {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let runtime_dir = unique_config_path("composed-activity");
+        ScreenOwnershipMarker::new(runtime_dir.clone())
+            .create()
+            .unwrap();
+        std::env::set_var("LG_BUDDY_SESSION_RUNTIME_DIR", &runtime_dir);
+        std::env::set_var("LG_BUDDY_IDLE_TIMEOUT", "300");
+        std::env::set_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV, "disabled");
+        let (restored, received) = mpsc::channel();
+        let mut dispatcher = SessionEventDispatcher::new(FakeActionExecutor {
+            screen_on_signal: Some(restored),
+            ..FakeActionExecutor::default()
+        });
+        let mut output = Vec::new();
+        let result = run_native_session_monitor_with_lock_monitor(
+            &mut output,
+            &mut dispatcher,
+            ScreenBackend::Auto,
+            |sender, sources, _stop| {
+                thread::spawn(move || {
+                    use super::ActivitySource;
+                    let gnome = sources.begin(ActivitySource::Gnome);
+                    let wayland = sources.begin(ActivitySource::Wayland);
+                    sources.connected(gnome);
+                    sources.connected(wayland);
+                    let at = Instant::now();
+                    let input = crate::session::SessionObservation::Inactivity {
+                        observation: InactivityObservation::DesktopActivityObserved,
+                        source: EventSource::DesktopSession,
+                        observed_at: at,
+                    };
+                    sources.publish(gnome, input);
+                    sources.publish(wayland, input);
+                    let result = received
+                        .recv_timeout(Duration::from_secs(1))
+                        .map_err(|err| super::SessionRunnerError::Failed {
+                            backend: ScreenBackend::Auto,
+                            message: err.to_string(),
+                        });
+                    sources.unavailable(gnome, "owner replaced");
+                    sources.publish(
+                        gnome,
+                        crate::session::SessionObservation::Event {
+                            event: SessionEvent::WakeRequested,
+                            source: EventSource::DesktopSession,
+                            observed_at: Instant::now(),
+                        },
+                    );
+                    sources.publish(wayland, input);
+                    thread::sleep(Duration::from_millis(100));
+                    let _ = sender.send(RunnerMessage::MonitorExited(result));
+                })
+            },
+            |_| None,
+        );
+        std::env::remove_var("LG_BUDDY_SESSION_RUNTIME_DIR");
+        std::env::remove_var("LG_BUDDY_IDLE_TIMEOUT");
+        std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+        fs::remove_dir_all(runtime_dir).unwrap();
+        result.unwrap();
+        assert_eq!(dispatcher.executor.screen_on_calls, 1);
+        assert_eq!(dispatcher.executor.screen_off_calls, 0);
+        let output = String::from_utf8(output).unwrap();
+        assert!(output.contains("source=wayland"));
+        assert!(output.contains("owner replaced"));
     }
 }

--- a/crates/lg-buddy/src/sources/desktop/gnome.rs
+++ b/crates/lg-buddy/src/sources/desktop/gnome.rs
@@ -1,7 +1,9 @@
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use super::{wait_for_retry, ActivityAdapter, ActivityPublisher, ActivityStatus};
 use crate::events::EventSource;
 use crate::session::inactivity::InactivityObservation;
 use crate::session::{SessionEvent, SessionObservation};
@@ -37,14 +39,46 @@ impl GnomeServiceStatus {
     }
 }
 
+#[derive(Default)]
 pub(crate) struct GnomeSource {
+    status: Mutex<ActivityStatus>,
+}
+
+impl ActivityAdapter for GnomeSource {
+    fn run(&self, publish: ActivityPublisher, stop: &AtomicBool) {
+        while !stop.load(Ordering::SeqCst) {
+            let result = GnomeConnection::connect().and_then(|connection| {
+                *self.status.lock().expect("GNOME activity status") = ActivityStatus::Available;
+                connection.run(
+                    |observation| {
+                        publish(observation);
+                        !stop.load(Ordering::SeqCst)
+                    },
+                    stop,
+                )
+            });
+            *self.status.lock().expect("GNOME activity status") =
+                ActivityStatus::unavailable(result.err().map_or_else(
+                    || "activity monitoring stopped".to_string(),
+                    |err| err.to_string(),
+                ));
+            wait_for_retry(stop);
+        }
+    }
+
+    fn status(&self) -> ActivityStatus {
+        self.status.lock().expect("GNOME activity status").clone()
+    }
+}
+
+struct GnomeConnection {
     bus: Box<dyn SessionBusClient + Send>,
     trusted_screen_saver_signals: TrustedScreenSaverSignals,
     activity_watch: GnomeActivityWatch,
 }
 
 #[derive(Debug)]
-pub(crate) enum GnomeSourceError {
+enum GnomeSourceError {
     Unavailable(&'static str),
     Failed(String),
 }
@@ -60,8 +94,8 @@ impl fmt::Display for GnomeSourceError {
 
 impl std::error::Error for GnomeSourceError {}
 
-impl GnomeSource {
-    pub(crate) fn connect() -> Result<Self, GnomeSourceError> {
+impl GnomeConnection {
+    fn connect() -> Result<Self, GnomeSourceError> {
         let mut bus = new_session_bus_client().map_err(|err| {
             GnomeSourceError::Failed(format!("failed to open GNOME session bus client: {err}"))
         })?;
@@ -82,11 +116,7 @@ impl GnomeSource {
         })
     }
 
-    pub(crate) fn run<F>(
-        mut self,
-        mut publish: F,
-        stop: &AtomicBool,
-    ) -> Result<(), GnomeSourceError>
+    fn run<F>(mut self, mut publish: F, stop: &AtomicBool) -> Result<(), GnomeSourceError>
     where
         F: FnMut(SessionObservation) -> bool,
     {

--- a/crates/lg-buddy/src/sources/desktop/gnome.rs
+++ b/crates/lg-buddy/src/sources/desktop/gnome.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use crate::events::EventSource;
@@ -10,10 +11,7 @@ use crate::session_bus::{
     DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
 };
 
-const GNOME_WAIT_TIMEOUT: Duration = Duration::from_secs(15);
 const GNOME_BUS_PROCESS_INTERVAL: Duration = Duration::from_millis(50);
-const GNOME_IDLE_POLL_INTERVAL: Duration = Duration::from_millis(250);
-const GNOME_DESKTOP_ACTIVITY_WINDOW: Duration = Duration::from_millis(500);
 const GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV: &str = "LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS";
 
 pub const GNOME_SHELL_NAME: &str = "org.gnome.Shell";
@@ -23,14 +21,8 @@ pub const GNOME_SCREEN_SAVER_INTERFACE: &str = "org.gnome.ScreenSaver";
 pub const GNOME_IDLE_MONITOR_NAME: &str = "org.gnome.Mutter.IdleMonitor";
 pub const GNOME_IDLE_MONITOR_PATH: &str = "/org/gnome/Mutter/IdleMonitor/Core";
 pub const GNOME_IDLE_MONITOR_INTERFACE: &str = "org.gnome.Mutter.IdleMonitor";
-pub const GNOME_SESSION_MANAGER_NAME: &str = "org.gnome.SessionManager";
-pub const GNOME_SESSION_MANAGER_PATH: &str = "/org/gnome/SessionManager";
-pub const GNOME_SESSION_MANAGER_INTERFACE: &str = "org.gnome.SessionManager";
-pub const GNOME_IDLE_INHIBITION_FLAG: u32 = 8;
 pub const GNOME_REQUIRED_SERVICES_REASON: &str =
     "GNOME Shell, org.gnome.ScreenSaver, and org.gnome.Mutter.IdleMonitor are required";
-pub const GNOME_IDLE_INHIBITORS_REQUIRED_REASON: &str =
-    "GNOME SessionManager is required when idle inhibitor honoring is enabled";
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct GnomeServiceStatus {
@@ -48,9 +40,7 @@ impl GnomeServiceStatus {
 pub(crate) struct GnomeSource {
     bus: Box<dyn SessionBusClient + Send>,
     trusted_screen_saver_signals: TrustedScreenSaverSignals,
-    trusted_session_manager_signals: Option<TrustedSessionManagerSignals>,
-    initial_idle_blanking_allowed: Option<bool>,
-    activity_watch: Option<GnomeActivityWatch>,
+    activity_watch: GnomeActivityWatch,
 }
 
 #[derive(Debug)]
@@ -71,86 +61,41 @@ impl fmt::Display for GnomeSourceError {
 impl std::error::Error for GnomeSourceError {}
 
 impl GnomeSource {
-    pub(crate) fn connect(honor_idle_inhibitors: bool) -> Result<Self, GnomeSourceError> {
+    pub(crate) fn connect() -> Result<Self, GnomeSourceError> {
         let mut bus = new_session_bus_client().map_err(|err| {
             GnomeSourceError::Failed(format!("failed to open GNOME session bus client: {err}"))
         })?;
-        bus.wait_for_name(GNOME_SHELL_NAME, GNOME_WAIT_TIMEOUT)
-            .map_err(|err| {
-                GnomeSourceError::Failed(format!(
-                    "failed waiting for GNOME Shell on the session bus: {err}"
-                ))
-            })?;
-
-        let status = gnome_service_status_from_session_bus(&mut bus);
-        if !status.can_start() {
+        if !gnome_service_status_from_session_bus(&mut bus).can_start() {
             return Err(GnomeSourceError::Unavailable(
                 GNOME_REQUIRED_SERVICES_REASON,
             ));
         }
-
-        if honor_idle_inhibitors && !gnome_session_manager_available_from_session_bus(&mut bus) {
-            return Err(GnomeSourceError::Unavailable(
-                GNOME_IDLE_INHIBITORS_REQUIRED_REASON,
-            ));
-        }
-
-        subscribe_to_gnome_signals(&mut bus, honor_idle_inhibitors)?;
-        let activity_watch = honor_idle_inhibitors
-            .then(|| GnomeActivityWatch::connect(&mut bus))
-            .transpose()?;
+        subscribe_to_gnome_signals(&mut bus)?;
+        let activity_watch = GnomeActivityWatch::connect(&mut bus)?;
         let owner = resolve_screen_saver_owner(&mut bus).map_err(|err| {
             GnomeSourceError::Failed(format!("failed to resolve GNOME ScreenSaver owner: {err}"))
         })?;
-        let (trusted_session_manager_signals, initial_idle_blanking_allowed) =
-            if honor_idle_inhibitors {
-                let owner = resolve_session_manager_owner(&mut bus).map_err(|err| {
-                    GnomeSourceError::Failed(format!(
-                        "failed to resolve GNOME SessionManager owner: {err}"
-                    ))
-                })?;
-                let allowed = current_idle_blanking_allowed(&mut bus).map_err(|err| {
-                    GnomeSourceError::Failed(format!(
-                        "failed to read GNOME idle inhibitor state: {err}"
-                    ))
-                })?;
-                (
-                    Some(TrustedSessionManagerSignals::new(Some(owner))),
-                    Some(allowed),
-                )
-            } else {
-                (None, None)
-            };
-
         Ok(Self {
             bus,
             trusted_screen_saver_signals: TrustedScreenSaverSignals::new(Some(owner)),
-            trusted_session_manager_signals,
-            initial_idle_blanking_allowed,
             activity_watch,
         })
     }
 
-    pub(crate) fn run<F>(mut self, mut publish: F) -> Result<(), GnomeSourceError>
+    pub(crate) fn run<F>(
+        mut self,
+        mut publish: F,
+        stop: &AtomicBool,
+    ) -> Result<(), GnomeSourceError>
     where
         F: FnMut(SessionObservation) -> bool,
     {
-        if let Some(allowed) = self.initial_idle_blanking_allowed {
-            if !publish(SessionObservation::IdleBlankingPermission {
-                allowed,
-                source: EventSource::DesktopSession,
-                observed_at: Instant::now(),
-            }) {
-                return Ok(());
-            }
-        }
-
         run_gnome_monitor_process(
             &mut self.bus,
             &mut self.trusted_screen_saver_signals,
-            self.trusted_session_manager_signals.as_mut(),
-            self.activity_watch.as_mut(),
+            &mut self.activity_watch,
             &mut publish,
+            stop,
         )
     }
 }
@@ -174,24 +119,9 @@ pub fn resolve_screen_saver_owner(
     get_name_owner(bus, GNOME_SCREEN_SAVER_NAME)
 }
 
-pub fn resolve_session_manager_owner(
-    bus: &mut impl SessionBusClient,
-) -> Result<String, SessionBusError> {
-    get_name_owner(bus, GNOME_SESSION_MANAGER_NAME)
-}
-
 pub fn screen_saver_owner_changed(signal: &BusSignal) -> Option<Option<String>> {
     let owner_change = parse_name_owner_changed_signal(signal)?;
     if owner_change.name != GNOME_SCREEN_SAVER_NAME {
-        return None;
-    }
-
-    Some(owner_change.new_owner)
-}
-
-pub fn session_manager_owner_changed(signal: &BusSignal) -> Option<Option<String>> {
-    let owner_change = parse_name_owner_changed_signal(signal)?;
-    if owner_change.name != GNOME_SESSION_MANAGER_NAME {
         return None;
     }
 
@@ -210,24 +140,6 @@ pub fn current_idle_monitor_idletime_ms(
     .single_u64()
 }
 
-pub fn current_idle_blanking_allowed(
-    bus: &mut impl SessionBusClient,
-) -> Result<bool, SessionBusError> {
-    let inhibited = bus
-        .call_method(
-            BusMethodCall::new(
-                GNOME_SESSION_MANAGER_NAME,
-                GNOME_SESSION_MANAGER_PATH,
-                GNOME_SESSION_MANAGER_INTERFACE,
-                "IsInhibited",
-            )
-            .with_body(vec![BusValue::U32(GNOME_IDLE_INHIBITION_FLAG)]),
-        )?
-        .single_bool()?;
-
-    Ok(!inhibited)
-}
-
 fn gnome_service_status_from_session_bus(bus: &mut impl SessionBusClient) -> GnomeServiceStatus {
     GnomeServiceStatus {
         shell_available: bus.name_has_owner(GNOME_SHELL_NAME).unwrap_or(false),
@@ -236,54 +148,31 @@ fn gnome_service_status_from_session_bus(bus: &mut impl SessionBusClient) -> Gno
     }
 }
 
-fn subscribe_to_gnome_signals(
-    bus: &mut impl SessionBusClient,
-    honor_idle_inhibitors: bool,
-) -> Result<(), GnomeSourceError> {
-    bus.add_signal_match(BusSignalMatch {
-        sender: None,
-        path: Some(GNOME_SCREEN_SAVER_PATH),
-        interface: Some(GNOME_SCREEN_SAVER_INTERFACE),
-        member: None,
-    })
-    .map_err(|err| {
-        GnomeSourceError::Failed(format!(
-            "failed to subscribe to GNOME ScreenSaver signals: {err}"
-        ))
-    })?;
-    bus.add_signal_match(BusSignalMatch {
-        sender: Some(DBUS_SERVICE_NAME),
-        path: Some(DBUS_OBJECT_PATH),
-        interface: Some(DBUS_INTERFACE),
-        member: Some("NameOwnerChanged"),
-    })
-    .map_err(|err| {
-        GnomeSourceError::Failed(format!("failed to subscribe to D-Bus owner changes: {err}"))
-    })?;
-
-    if honor_idle_inhibitors {
-        bus.add_signal_match(BusSignalMatch {
+fn subscribe_to_gnome_signals(bus: &mut impl SessionBusClient) -> Result<(), GnomeSourceError> {
+    for rule in [
+        BusSignalMatch {
+            sender: None,
+            path: Some(GNOME_SCREEN_SAVER_PATH),
+            interface: Some(GNOME_SCREEN_SAVER_INTERFACE),
+            member: None,
+        },
+        BusSignalMatch {
+            sender: Some(DBUS_SERVICE_NAME),
+            path: Some(DBUS_OBJECT_PATH),
+            interface: Some(DBUS_INTERFACE),
+            member: Some("NameOwnerChanged"),
+        },
+        BusSignalMatch {
             sender: None,
             path: Some(GNOME_IDLE_MONITOR_PATH),
             interface: Some(GNOME_IDLE_MONITOR_INTERFACE),
             member: Some("WatchFired"),
-        })
-        .map_err(|err| {
-            GnomeSourceError::Failed(format!("failed to subscribe to Mutter activity: {err}"))
-        })?;
-        bus.add_signal_match(BusSignalMatch {
-            sender: None,
-            path: Some(GNOME_SESSION_MANAGER_PATH),
-            interface: Some(GNOME_SESSION_MANAGER_INTERFACE),
-            member: None,
-        })
-        .map_err(|err| {
-            GnomeSourceError::Failed(format!(
-                "failed to subscribe to GNOME SessionManager signals: {err}"
-            ))
+        },
+    ] {
+        bus.add_signal_match(rule).map_err(|err| {
+            GnomeSourceError::Failed(format!("failed to subscribe to GNOME activity: {err}"))
         })?;
     }
-
     Ok(())
 }
 
@@ -317,64 +206,6 @@ impl TrustedScreenSaverSignals {
 
         map_screen_saver_signal(signal)
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum SessionManagerSignal {
-    OwnerChanged(Option<String>),
-    InhibitorChanged,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct TrustedSessionManagerSignals {
-    owner: Option<String>,
-}
-
-impl TrustedSessionManagerSignals {
-    fn new(owner: Option<String>) -> Self {
-        Self { owner }
-    }
-
-    fn observe(&mut self, signal: &BusSignal) -> Option<SessionManagerSignal> {
-        if signal.path == DBUS_OBJECT_PATH
-            && signal.interface == DBUS_INTERFACE
-            && signal.member == "NameOwnerChanged"
-        {
-            if signal.sender.as_deref() != Some(DBUS_SERVICE_NAME) {
-                return None;
-            }
-
-            if let Some(new_owner) = session_manager_owner_changed(signal) {
-                self.owner = new_owner.clone();
-                return Some(SessionManagerSignal::OwnerChanged(new_owner));
-            }
-            return None;
-        }
-
-        if signal.sender.as_deref() != self.owner.as_deref() {
-            return None;
-        }
-
-        map_session_manager_signal(signal).map(|_| SessionManagerSignal::InhibitorChanged)
-    }
-}
-
-fn map_session_manager_signal(signal: &BusSignal) -> Option<()> {
-    if signal.path != GNOME_SESSION_MANAGER_PATH
-        || signal.interface != GNOME_SESSION_MANAGER_INTERFACE
-    {
-        return None;
-    }
-
-    match (signal.member.as_str(), signal.body.as_slice()) {
-        ("InhibitorAdded" | "InhibitorRemoved", [BusValue::ObjectPath(_)]) => Some(()),
-        _ => None,
-    }
-}
-
-fn gnome_session_manager_available_from_session_bus(bus: &mut impl SessionBusClient) -> bool {
-    bus.name_has_owner(GNOME_SESSION_MANAGER_NAME)
-        .unwrap_or(false)
 }
 
 /// Mutter resets GetIdletime when inhibition ends, without firing user-active
@@ -429,140 +260,46 @@ impl GnomeActivityWatch {
 fn run_gnome_monitor_process<F>(
     bus: &mut impl SessionBusClient,
     trusted_screen_saver_signals: &mut TrustedScreenSaverSignals,
-    mut trusted_session_manager_signals: Option<&mut TrustedSessionManagerSignals>,
-    mut activity_watch: Option<&mut GnomeActivityWatch>,
+    activity_watch: &mut GnomeActivityWatch,
     publish: &mut F,
+    stop: &AtomicBool,
 ) -> Result<(), GnomeSourceError>
 where
     F: FnMut(SessionObservation) -> bool,
 {
-    let started = Instant::now();
-    let test_timeout = monitor_test_timeout();
-    let mut next_idle_poll = Instant::now();
-
-    loop {
-        if test_timeout.is_some_and(|timeout| started.elapsed() >= timeout) {
-            return Ok(());
-        }
-
-        let now = Instant::now();
-        if activity_watch.is_none() && now >= next_idle_poll {
-            if !poll_idle_monitor_once(bus, publish) {
-                return Ok(());
-            }
-            next_idle_poll = now + GNOME_IDLE_POLL_INTERVAL;
-        }
-
-        let now = Instant::now();
-        let mut process_timeout = if activity_watch.is_some() {
-            GNOME_BUS_PROCESS_INTERVAL
-        } else {
-            next_idle_poll
-                .saturating_duration_since(now)
-                .min(GNOME_BUS_PROCESS_INTERVAL)
-        };
-        if let Some(timeout) = test_timeout {
-            process_timeout = process_timeout.min(timeout.saturating_sub(started.elapsed()));
-        }
-
-        let Some(signal) = bus.process(process_timeout).map_err(|err| {
+    while !stop.load(Ordering::SeqCst) {
+        let Some(signal) = bus.process(GNOME_BUS_PROCESS_INTERVAL).map_err(|err| {
             GnomeSourceError::Failed(format!("GNOME session bus processing failed: {err}"))
         })?
         else {
             continue;
         };
-
-        if let Some(watch) = activity_watch.as_deref_mut() {
-            if watch.owner_changed(&signal) {
-                return Err(GnomeSourceError::Failed(
-                    "Mutter IdleMonitor owner changed while watching user activity".to_string(),
-                ));
-            }
-            if watch.fired(&signal) {
-                if !publish(SessionObservation::Inactivity {
-                    observation: InactivityObservation::DesktopActivityObserved,
-                    source: EventSource::DesktopSession,
-                    observed_at: Instant::now(),
-                }) {
-                    return Ok(());
-                }
-                // User-active watches are one-shot. Keep listening even while
-                // inhibition is active, so real input can always restore.
-                watch.arm(bus)?;
-            }
+        if activity_watch.owner_changed(&signal) {
+            return Err(GnomeSourceError::Failed(
+                "Mutter IdleMonitor owner changed while watching user activity".to_string(),
+            ));
         }
-
-        if let Some(trusted_session_manager_signals) =
-            trusted_session_manager_signals.as_deref_mut()
-        {
-            match trusted_session_manager_signals.observe(&signal) {
-                Some(SessionManagerSignal::OwnerChanged(None)) => {
-                    return Err(GnomeSourceError::Failed(
-                        "GNOME SessionManager disappeared while idle inhibitor honoring was enabled"
-                            .to_string(),
-                    ));
-                }
-                Some(SessionManagerSignal::OwnerChanged(Some(_)))
-                | Some(SessionManagerSignal::InhibitorChanged) => {
-                    // The runner's timer is independent of this blocking call.
-                    // Suspend it before querying, without inventing an inhibitor.
-                    if !publish(SessionObservation::IdleBlankingPermissionPending {
-                        source: EventSource::DesktopSession,
-                    }) {
-                        return Ok(());
-                    }
-                    let allowed = current_idle_blanking_allowed(bus).map_err(|err| {
-                        GnomeSourceError::Failed(format!(
-                            "failed to read GNOME idle inhibitor state after a SessionManager change: {err}"
-                        ))
-                    })?;
-                    if !publish(SessionObservation::IdleBlankingPermission {
-                        allowed,
-                        source: EventSource::DesktopSession,
-                        observed_at: Instant::now(),
-                    }) {
-                        return Ok(());
-                    }
-                }
-                None => {}
+        if activity_watch.fired(&signal) {
+            if !publish(SessionObservation::Inactivity {
+                observation: InactivityObservation::DesktopActivityObserved,
+                source: EventSource::DesktopSession,
+                observed_at: Instant::now(),
+            }) {
+                return Ok(());
             }
+            activity_watch.arm(bus)?;
         }
-
-        let Some(event) = trusted_screen_saver_signals.observe(&signal) else {
-            continue;
-        };
-
-        if !publish(SessionObservation::Event {
-            event,
-            source: EventSource::DesktopSession,
-            observed_at: Instant::now(),
-        }) {
-            return Ok(());
+        if let Some(event) = trusted_screen_saver_signals.observe(&signal) {
+            if !publish(SessionObservation::Event {
+                event,
+                source: EventSource::DesktopSession,
+                observed_at: Instant::now(),
+            }) {
+                return Ok(());
+            }
         }
     }
-}
-
-fn poll_idle_monitor_once<F>(bus: &mut impl SessionBusClient, publish: &mut F) -> bool
-where
-    F: FnMut(SessionObservation) -> bool,
-{
-    let Ok(idletime_ms) = current_idle_monitor_idletime_ms(bus) else {
-        return true;
-    };
-
-    let activity_age = Duration::from_millis(idletime_ms);
-    if activity_age > GNOME_DESKTOP_ACTIVITY_WINDOW {
-        return true;
-    }
-
-    let observed_at = Instant::now();
-    let activity_at = observed_at.checked_sub(activity_age).unwrap_or(observed_at);
-
-    publish(SessionObservation::Inactivity {
-        observation: InactivityObservation::DesktopActivityObserved,
-        source: EventSource::DesktopSession,
-        observed_at: activity_at,
-    })
+    Ok(())
 }
 
 pub(crate) fn monitor_test_timeout() -> Option<Duration> {
@@ -576,12 +313,10 @@ pub(crate) fn monitor_test_timeout() -> Option<Duration> {
 #[cfg(test)]
 mod tests {
     use super::{
-        current_idle_blanking_allowed, current_idle_monitor_idletime_ms,
-        gnome_service_status_from_session_bus, map_screen_saver_signal, map_session_manager_signal,
-        monitor_test_timeout, poll_idle_monitor_once, resolve_screen_saver_owner,
-        run_gnome_monitor_process, screen_saver_owner_changed, session_manager_owner_changed,
-        subscribe_to_gnome_signals, GnomeActivityWatch, GnomeServiceStatus, GnomeSourceError,
-        SessionManagerSignal, TrustedScreenSaverSignals, TrustedSessionManagerSignals,
+        current_idle_monitor_idletime_ms, gnome_service_status_from_session_bus,
+        map_screen_saver_signal, monitor_test_timeout, resolve_screen_saver_owner,
+        run_gnome_monitor_process, screen_saver_owner_changed, subscribe_to_gnome_signals,
+        GnomeActivityWatch, GnomeServiceStatus, GnomeSourceError, TrustedScreenSaverSignals,
         GNOME_MONITOR_TEST_TIMEOUT_SECS_ENV,
     };
     use crate::events::EventSource;
@@ -592,11 +327,8 @@ mod tests {
         SessionBusError, DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
     };
     use std::collections::VecDeque;
-    use std::sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc, Mutex, OnceLock,
-    };
-    use std::time::{Duration, Instant};
+    use std::sync::{atomic::AtomicBool, Mutex, OnceLock};
+    use std::time::Duration;
 
     #[derive(Debug, Default)]
     struct FakeSessionBus {
@@ -605,12 +337,8 @@ mod tests {
         idle_monitor_available: bool,
         idletime_ms: Option<u64>,
         screen_saver_owner: Option<String>,
-        session_manager_owner: Option<String>,
         idle_monitor_owner: Option<String>,
         watch_ids: VecDeque<u32>,
-        inhibited: Option<bool>,
-        inhibited_plan: VecDeque<bool>,
-        permission_pending: Option<Arc<AtomicBool>>,
         method_calls: Vec<(String, String, String, String)>,
         method_bodies: Vec<Vec<BusValue>>,
         signal_matches: Vec<[Option<String>; 4]>,
@@ -630,7 +358,6 @@ mod tests {
                 super::GNOME_SHELL_NAME => Ok(self.shell_available),
                 super::GNOME_SCREEN_SAVER_NAME => Ok(self.screen_saver_available),
                 super::GNOME_IDLE_MONITOR_NAME => Ok(self.idle_monitor_available),
-                super::GNOME_SESSION_MANAGER_NAME => Ok(self.session_manager_owner.is_some()),
                 _ => Ok(false),
             }
         }
@@ -655,7 +382,6 @@ mod tests {
                 };
                 let owner = match name.as_str() {
                     super::GNOME_SCREEN_SAVER_NAME => self.screen_saver_owner.as_deref(),
-                    super::GNOME_SESSION_MANAGER_NAME => self.session_manager_owner.as_deref(),
                     super::GNOME_IDLE_MONITOR_NAME => self.idle_monitor_owner.as_deref(),
                     _ => None,
                 };
@@ -682,15 +408,6 @@ mod tests {
                     .map(|id| BusReply::new(vec![BusValue::U32(id)]))
                     .ok_or_else(|| SessionBusError::Transport("no queued watch id".to_string()));
             }
-            if call.member == "IsInhibited" {
-                if let Some(pending) = &self.permission_pending {
-                    assert!(
-                        pending.load(Ordering::SeqCst),
-                        "permission must be suspended before querying"
-                    );
-                }
-            }
-
             match (
                 call.destination,
                 call.path,
@@ -705,20 +422,6 @@ mod tests {
                     "GetIdletime",
                     Some(value),
                 ) => Ok(BusReply::new(vec![BusValue::U64(value)])),
-                (
-                    super::GNOME_SESSION_MANAGER_NAME,
-                    super::GNOME_SESSION_MANAGER_PATH,
-                    super::GNOME_SESSION_MANAGER_INTERFACE,
-                    "IsInhibited",
-                    _,
-                ) => self
-                    .inhibited_plan
-                    .pop_front()
-                    .or(self.inhibited)
-                    .map(|value| BusReply::new(vec![BusValue::Bool(value)]))
-                    .ok_or_else(|| {
-                        SessionBusError::Transport("no queued inhibition reply".to_string())
-                    }),
                 _ => Err(SessionBusError::Transport(
                     "no queued GNOME method reply".to_string(),
                 )),
@@ -829,192 +532,15 @@ mod tests {
     }
 
     #[test]
-    fn session_manager_is_inhibited_flag_maps_to_blanking_permission() {
-        let mut bus = FakeSessionBus {
-            inhibited: Some(true),
-            ..FakeSessionBus::default()
-        };
-
-        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(false));
-        assert_eq!(
-            bus.method_bodies,
-            vec![vec![BusValue::U32(super::GNOME_IDLE_INHIBITION_FLAG)]]
-        );
-    }
-
-    #[test]
-    fn overlapping_inhibitors_keep_blanking_suppressed_until_last_release() {
-        let mut bus = FakeSessionBus {
-            inhibited_plan: [true, true, false].into_iter().collect(),
-            ..FakeSessionBus::default()
-        };
-
-        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(false));
-        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(false));
-        assert_eq!(current_idle_blanking_allowed(&mut bus), Ok(true));
-    }
-
-    #[test]
-    fn session_manager_signals_require_current_owner_and_valid_inhibitor_path() {
-        let mut trusted = TrustedSessionManagerSignals::new(Some(":1.42".to_string()));
-        let added = BusSignal::new(
-            super::GNOME_SESSION_MANAGER_PATH,
-            super::GNOME_SESSION_MANAGER_INTERFACE,
-            "InhibitorAdded",
-        )
-        .with_sender(":1.42")
-        .with_body(vec![BusValue::ObjectPath(
-            "/org/gnome/SessionManager/Inhibitor1".to_string(),
-        )]);
-        let spoofed = added.clone().with_sender(":1.99");
-        let malformed = added.clone().with_body(vec![BusValue::String(
-            "/org/gnome/SessionManager/Inhibitor1".to_string(),
-        )]);
-
-        assert_eq!(map_session_manager_signal(&added), Some(()));
-        assert_eq!(
-            trusted.observe(&added),
-            Some(SessionManagerSignal::InhibitorChanged)
-        );
-        assert_eq!(trusted.observe(&spoofed), None);
-        assert_eq!(trusted.observe(&malformed), None);
-    }
-
-    #[test]
-    fn session_manager_owner_changes_rebind_and_reject_old_sender() {
-        let mut trusted = TrustedSessionManagerSignals::new(Some(":1.42".to_string()));
-        let owner_change = BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
-            .with_sender(DBUS_SERVICE_NAME)
-            .with_body(vec![
-                BusValue::String(super::GNOME_SESSION_MANAGER_NAME.to_string()),
-                BusValue::String(":1.42".to_string()),
-                BusValue::String(":1.43".to_string()),
-            ]);
-
-        assert_eq!(
-            session_manager_owner_changed(&owner_change),
-            Some(Some(":1.43".to_string()))
-        );
-        assert_eq!(
-            trusted.observe(&owner_change),
-            Some(SessionManagerSignal::OwnerChanged(Some(
-                ":1.43".to_string()
-            )))
-        );
-
-        let signal = BusSignal::new(
-            super::GNOME_SESSION_MANAGER_PATH,
-            super::GNOME_SESSION_MANAGER_INTERFACE,
-            "InhibitorRemoved",
-        )
-        .with_body(vec![BusValue::ObjectPath(
-            "/org/gnome/SessionManager/Inhibitor1".to_string(),
-        )]);
-        assert_eq!(trusted.observe(&signal.clone().with_sender(":1.42")), None);
-        assert_eq!(
-            trusted.observe(&signal.with_sender(":1.43")),
-            Some(SessionManagerSignal::InhibitorChanged)
-        );
-
-        let owner_loss = BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
-            .with_sender(DBUS_SERVICE_NAME)
-            .with_body(vec![
-                BusValue::String(super::GNOME_SESSION_MANAGER_NAME.to_string()),
-                BusValue::String(":1.43".to_string()),
-                BusValue::String(String::new()),
-            ]);
-        assert_eq!(
-            trusted.observe(&owner_loss),
-            Some(SessionManagerSignal::OwnerChanged(None))
-        );
-    }
-
-    #[test]
-    fn idle_inhibitor_read_failures_are_errors_without_allowed_true() {
+    fn activity_watches_do_not_subscribe_to_session_manager() {
         let mut bus = FakeSessionBus::default();
-        assert!(current_idle_blanking_allowed(&mut bus).is_err());
-    }
+        subscribe_to_gnome_signals(&mut bus).expect("subscribe GNOME signals");
 
-    #[test]
-    fn disabled_idle_inhibitor_honoring_keeps_session_manager_out_of_signal_matches() {
-        let mut bus = FakeSessionBus::default();
-        subscribe_to_gnome_signals(&mut bus, false).expect("subscribe GNOME signals");
-
-        assert_eq!(bus.signal_matches.len(), 2);
+        assert_eq!(bus.signal_matches.len(), 3);
         assert!(!bus
             .signal_matches
             .iter()
-            .any(|[_, path, _, _]| { path.as_deref() == Some(super::GNOME_SESSION_MANAGER_PATH) }));
-    }
-
-    #[test]
-    fn enabled_idle_inhibitor_honoring_subscribes_to_session_manager_signals() {
-        let mut bus = FakeSessionBus::default();
-        subscribe_to_gnome_signals(&mut bus, true).expect("subscribe GNOME signals");
-
-        assert_eq!(bus.signal_matches.len(), 4);
-        assert!(bus.signal_matches.iter().any(|[_, path, interface, _]| {
-            path.as_deref() == Some(super::GNOME_SESSION_MANAGER_PATH)
-                && interface.as_deref() == Some(super::GNOME_SESSION_MANAGER_INTERFACE)
-        }));
-    }
-
-    #[test]
-    fn inhibitor_transition_publishes_permission_without_activity_or_restore() {
-        let pending = Arc::new(AtomicBool::new(false));
-        let signal = BusSignal::new(
-            super::GNOME_SESSION_MANAGER_PATH,
-            super::GNOME_SESSION_MANAGER_INTERFACE,
-            "InhibitorAdded",
-        )
-        .with_sender(":1.42")
-        .with_body(vec![BusValue::ObjectPath(
-            "/org/gnome/SessionManager/Inhibitor1".to_string(),
-        )]);
-        let mut bus = FakeSessionBus {
-            permission_pending: Some(Arc::clone(&pending)),
-            inhibited_plan: [true].into_iter().collect(),
-            process_results: [
-                Ok(Some(signal)),
-                Err(SessionBusError::Transport("stop test loop".to_string())),
-            ]
-            .into_iter()
-            .collect(),
-            ..FakeSessionBus::default()
-        };
-        let mut screen_saver = TrustedScreenSaverSignals::new(Some(":1.42".to_string()));
-        let mut session_manager = TrustedSessionManagerSignals::new(Some(":1.42".to_string()));
-        let mut observations = Vec::new();
-
-        assert!(matches!(
-            run_gnome_monitor_process(
-                &mut bus,
-                &mut screen_saver,
-                Some(&mut session_manager),
-                None,
-                &mut |observation| {
-                    if matches!(observation, SessionObservation::IdleBlankingPermissionPending { .. }) {
-                        pending.store(true, Ordering::SeqCst);
-                    }
-                    observations.push(observation);
-                    true
-                },
-            ),
-            Err(GnomeSourceError::Failed(message)) if message.contains("processing failed")
-        ));
-        assert!(matches!(
-            observations.as_slice(),
-            [
-                SessionObservation::IdleBlankingPermissionPending {
-                    source: EventSource::DesktopSession
-                },
-                SessionObservation::IdleBlankingPermission {
-                    allowed: false,
-                    source: EventSource::DesktopSession,
-                    ..
-                }
-            ]
-        ));
+            .any(|[_, path, _, _]| { path.as_deref() == Some("/org/gnome/SessionManager") }));
     }
 
     #[test]
@@ -1123,12 +649,12 @@ mod tests {
         assert!(run_gnome_monitor_process(
             &mut bus,
             &mut screen_saver,
-            None,
-            Some(&mut watch),
+            &mut watch,
             &mut |observation| {
                 observations.push(observation);
                 true
             },
+            &AtomicBool::new(false),
         )
         .is_err());
         assert_eq!(observations.len(), 2);
@@ -1169,9 +695,9 @@ mod tests {
         let result = run_gnome_monitor_process(
             &mut bus,
             &mut screen_saver,
-            None,
-            Some(&mut watch),
+            &mut watch,
             &mut |_| panic!("owner loss is not activity"),
+            &AtomicBool::new(false),
         );
         assert!(
             matches!(result, Err(GnomeSourceError::Failed(message)) if message.contains("owner changed"))
@@ -1193,72 +719,17 @@ mod tests {
         let result = run_gnome_monitor_process(
             &mut bus,
             &mut screen_saver,
-            None,
-            Some(&mut watch),
+            &mut watch,
             &mut |observation| {
                 observations.push(observation);
                 true
             },
+            &AtomicBool::new(false),
         );
         assert!(
             matches!(result, Err(GnomeSourceError::Failed(message)) if message.contains("failed to watch"))
         );
         assert_eq!(observations.len(), 1);
-    }
-
-    #[test]
-    fn idle_monitor_poller_publishes_recent_desktop_activity() {
-        let mut bus = FakeSessionBus {
-            idletime_ms: Some(250),
-            ..FakeSessionBus::default()
-        };
-        let before_poll = Instant::now();
-        let mut observations = Vec::new();
-
-        assert!(poll_idle_monitor_once(&mut bus, &mut |observation| {
-            observations.push(observation);
-            true
-        }));
-
-        let [SessionObservation::Inactivity {
-            observation,
-            source,
-            observed_at,
-        }] = observations.as_slice()
-        else {
-            panic!("expected one inactivity observation");
-        };
-        assert_eq!(*observation, InactivityObservation::DesktopActivityObserved);
-        assert_eq!(*source, EventSource::DesktopSession);
-        assert!(*observed_at < before_poll);
-        assert!(*observed_at <= Instant::now());
-    }
-
-    #[test]
-    fn idle_monitor_poller_does_not_publish_old_activity() {
-        let mut bus = FakeSessionBus {
-            idletime_ms: Some(1_500),
-            ..FakeSessionBus::default()
-        };
-        let mut observations = Vec::new();
-
-        assert!(poll_idle_monitor_once(&mut bus, &mut |observation| {
-            observations.push(observation);
-            true
-        }));
-        assert!(observations.is_empty());
-    }
-
-    #[test]
-    fn idle_monitor_poller_ignores_bus_errors() {
-        let mut bus = FakeSessionBus::default();
-        let mut observations = Vec::new();
-
-        assert!(poll_idle_monitor_once(&mut bus, &mut |observation| {
-            observations.push(observation);
-            true
-        }));
-        assert!(observations.is_empty());
     }
 
     #[test]

--- a/crates/lg-buddy/src/sources/desktop/mod.rs
+++ b/crates/lg-buddy/src/sources/desktop/mod.rs
@@ -1,3 +1,67 @@
 pub mod gnome;
 pub mod swayidle;
 pub mod wayland;
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+use crate::session::SessionObservation;
+
+pub(crate) type ActivityPublisher = Arc<dyn Fn(SessionObservation) + Send + Sync>;
+
+/// Whether an adapter can currently observe activity. This is an assessment for
+/// idle policy and diagnostics, never permission to deliver an observation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ActivityStatus {
+    Available,
+    Unavailable(String),
+}
+
+impl Default for ActivityStatus {
+    fn default() -> Self {
+        Self::Unavailable("activity monitoring has not started".to_string())
+    }
+}
+
+impl ActivityStatus {
+    fn unavailable(reason: impl std::fmt::Display) -> Self {
+        Self::Unavailable(reason.to_string().chars().take(512).collect())
+    }
+
+    pub(crate) fn is_available(&self) -> bool {
+        matches!(self, Self::Available)
+    }
+}
+
+/// Runs for the application's lifetime. Connection recovery and protocol
+/// validation stay inside the adapter; emitted observations are already valid.
+pub(crate) trait ActivityAdapter: Send + Sync {
+    fn run(&self, publish: ActivityPublisher, stop: &AtomicBool);
+    fn status(&self) -> ActivityStatus;
+}
+
+fn wait_for_retry(stop: &AtomicBool) {
+    for _ in 0..20 {
+        if stop.load(Ordering::SeqCst) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActivityStatus;
+
+    #[test]
+    fn unavailable_diagnostics_are_bounded() {
+        let ActivityStatus::Unavailable(reason) = ActivityStatus::unavailable("x".repeat(1000))
+        else {
+            panic!("expected unavailable status");
+        };
+        assert_eq!(reason.len(), 512);
+    }
+}

--- a/crates/lg-buddy/src/sources/desktop/swayidle.rs
+++ b/crates/lg-buddy/src/sources/desktop/swayidle.rs
@@ -5,6 +5,7 @@ use std::io::{self, BufRead, BufReader};
 use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -34,6 +35,7 @@ impl std::error::Error for SwayidleSourceError {}
 pub(crate) fn run(
     idle_timeout_secs: u64,
     event_path: &Path,
+    stop: &AtomicBool,
     mut on_observation: impl FnMut(SessionObservation) -> bool,
 ) -> Result<(), SwayidleSourceError> {
     let event_file = create_event_file(event_path).map_err(SwayidleSourceError::Io)?;
@@ -46,6 +48,9 @@ pub(crate) fn run(
     let mut child = ChildGuard(child);
 
     loop {
+        if stop.load(Ordering::SeqCst) {
+            return Ok(());
+        }
         if !drain_events(&mut reader, &mut on_observation).map_err(SwayidleSourceError::Io)? {
             let _ = child.0.kill();
             let _ = child.0.wait();

--- a/crates/lg-buddy/src/sources/desktop/wayland.rs
+++ b/crates/lg-buddy/src/sources/desktop/wayland.rs
@@ -1,9 +1,14 @@
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;
-use std::time::Instant;
+use std::os::fd::AsRawFd;
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
-use wayland_client::protocol::{wl_registry, wl_seat};
+use wayland_client::protocol::{wl_callback, wl_registry, wl_seat};
 use wayland_client::{Connection, Dispatch, EventQueue, Proxy, QueueHandle};
 use wayland_protocols::ext::idle_notify::v1::client::{
     ext_idle_notification_v1, ext_idle_notifier_v1,
@@ -127,55 +132,6 @@ impl RegistryFacts {
 struct SeatBinding {
     seat: wl_seat::WlSeat,
     input_notification: Option<ext_idle_notification_v1::ExtIdleNotificationV1>,
-    idle_notification: Option<ext_idle_notification_v1::ExtIdleNotificationV1>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NotificationKind {
-    Input(u32),
-    IdlePermission(u32),
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NotificationMeaning {
-    InputActivity,
-    IdlePermission(bool),
-}
-
-#[derive(Debug, Default)]
-struct IdlePermissionTracker {
-    seats: HashMap<u32, bool>,
-    allowed: bool,
-}
-
-impl IdlePermissionTracker {
-    fn add_seat(&mut self, name: u32) -> Option<bool> {
-        self.seats.insert(name, false);
-        self.recompute()
-    }
-
-    fn remove_seat(&mut self, name: u32) -> Option<bool> {
-        self.seats.remove(&name)?;
-        self.recompute()
-    }
-
-    fn set_idle(&mut self, name: u32, idle: bool) -> Option<bool> {
-        let previous = self.seats.get_mut(&name)?;
-        if *previous == idle {
-            return None;
-        }
-        *previous = idle;
-        self.recompute()
-    }
-
-    fn recompute(&mut self) -> Option<bool> {
-        let allowed = !self.seats.is_empty() && self.seats.values().all(|idle| *idle);
-        if self.allowed == allowed {
-            return None;
-        }
-        self.allowed = allowed;
-        Some(allowed)
-    }
 }
 
 struct WaylandProviderState<F> {
@@ -183,8 +139,6 @@ struct WaylandProviderState<F> {
     registry_facts: RegistryFacts,
     idle_notifier: Option<(u32, ext_idle_notifier_v1::ExtIdleNotifierV1)>,
     seats: HashMap<u32, SeatBinding>,
-    idle_permission: IdlePermissionTracker,
-    honor_idle_inhibitors: bool,
     initialized: bool,
     running: bool,
     error: Option<WaylandProviderError>,
@@ -195,14 +149,12 @@ impl<F> WaylandProviderState<F>
 where
     F: FnMut(SessionObservation) -> bool + 'static,
 {
-    fn new(on_observation: F, honor_idle_inhibitors: bool) -> Self {
+    fn new(on_observation: F) -> Self {
         Self {
             registry: None,
             registry_facts: RegistryFacts::default(),
             idle_notifier: None,
             seats: HashMap::new(),
-            idle_permission: IdlePermissionTracker::default(),
-            honor_idle_inhibitors,
             initialized: false,
             running: true,
             error: None,
@@ -214,14 +166,6 @@ where
         if !(self.on_observation)(observation) {
             self.running = false;
         }
-    }
-
-    fn publish_idle_permission_change(&mut self, allowed: bool) {
-        self.publish(SessionObservation::IdleBlankingPermission {
-            allowed,
-            source: EventSource::DesktopSession,
-            observed_at: Instant::now(),
-        });
     }
 
     fn bind_idle_notifier(
@@ -263,14 +207,8 @@ where
             SeatBinding {
                 seat,
                 input_notification: None,
-                idle_notification: None,
             },
         );
-        if self.honor_idle_inhibitors {
-            if let Some(allowed) = self.idle_permission.add_seat(name) {
-                self.publish_idle_permission_change(allowed);
-            }
-        }
         self.attach_seat(name, queue_handle);
     }
 
@@ -292,20 +230,8 @@ where
             return;
         }
 
-        binding.input_notification = Some(notifier.get_input_idle_notification(
-            0,
-            &binding.seat,
-            queue_handle,
-            NotificationKind::Input(name),
-        ));
-        if self.honor_idle_inhibitors {
-            binding.idle_notification = Some(notifier.get_idle_notification(
-                0,
-                &binding.seat,
-                queue_handle,
-                NotificationKind::IdlePermission(name),
-            ));
-        }
+        binding.input_notification =
+            Some(notifier.get_input_idle_notification(0, &binding.seat, queue_handle, name));
     }
 
     fn remove_global(&mut self, name: u32) {
@@ -320,19 +246,10 @@ where
             if let Some(notification) = binding.input_notification.take() {
                 notification.destroy();
             }
-            if let Some(notification) = binding.idle_notification.take() {
-                notification.destroy();
-            }
             true
         } else {
             false
         };
-
-        if removed_seat && self.honor_idle_inhibitors {
-            if let Some(allowed) = self.idle_permission.remove_seat(name) {
-                self.publish_idle_permission_change(allowed);
-            }
-        }
 
         if let Some(err) = global_removal_error(
             self.initialized,
@@ -367,29 +284,6 @@ fn global_removal_error(
 
 fn notification_is_activity(event: &ext_idle_notification_v1::Event) -> bool {
     matches!(event, ext_idle_notification_v1::Event::Resumed)
-}
-
-fn idle_notification_permission(event: &ext_idle_notification_v1::Event) -> Option<bool> {
-    match event {
-        ext_idle_notification_v1::Event::Idled => Some(true),
-        ext_idle_notification_v1::Event::Resumed => Some(false),
-        _ => None,
-    }
-}
-
-fn notification_meaning(
-    kind: NotificationKind,
-    event: &ext_idle_notification_v1::Event,
-) -> Option<NotificationMeaning> {
-    match kind {
-        NotificationKind::Input(_) if notification_is_activity(event) => {
-            Some(NotificationMeaning::InputActivity)
-        }
-        NotificationKind::IdlePermission(_) => {
-            idle_notification_permission(event).map(NotificationMeaning::IdlePermission)
-        }
-        _ => None,
-    }
 }
 
 impl<F> Dispatch<wl_registry::WlRegistry, ()> for WaylandProviderState<F>
@@ -479,35 +373,28 @@ where
     }
 }
 
-impl<F> Dispatch<ext_idle_notification_v1::ExtIdleNotificationV1, NotificationKind>
-    for WaylandProviderState<F>
+impl<F> Dispatch<ext_idle_notification_v1::ExtIdleNotificationV1, u32> for WaylandProviderState<F>
 where
     F: FnMut(SessionObservation) -> bool + 'static,
 {
     fn event(
         state: &mut Self,
-        _: &ext_idle_notification_v1::ExtIdleNotificationV1,
+        notification: &ext_idle_notification_v1::ExtIdleNotificationV1,
         event: ext_idle_notification_v1::Event,
-        kind: &NotificationKind,
+        seat_name: &u32,
         _: &Connection,
         _: &QueueHandle<Self>,
     ) {
-        match notification_meaning(*kind, &event) {
-            Some(NotificationMeaning::InputActivity) => {
-                state.publish(SessionObservation::Inactivity {
-                    observation: InactivityObservation::DesktopActivityObserved,
-                    source: EventSource::DesktopSession,
-                    observed_at: Instant::now(),
-                });
-            }
-            Some(NotificationMeaning::IdlePermission(allowed)) => {
-                if let NotificationKind::IdlePermission(name) = *kind {
-                    if let Some(allowed) = state.idle_permission.set_idle(name, allowed) {
-                        state.publish_idle_permission_change(allowed);
-                    }
-                }
-            }
-            None => {}
+        let current = state
+            .seats
+            .get(seat_name)
+            .and_then(|binding| binding.input_notification.as_ref());
+        if current == Some(notification) && notification_is_activity(&event) {
+            state.publish(SessionObservation::Inactivity {
+                observation: InactivityObservation::DesktopActivityObserved,
+                source: EventSource::DesktopSession,
+                observed_at: Instant::now(),
+            });
         }
     }
 }
@@ -520,8 +407,8 @@ type InitializedWaylandProvider<F> = (
 
 fn initialize_provider<F>(
     connection: Connection,
-    honor_idle_inhibitors: bool,
     on_observation: F,
+    stop: &AtomicBool,
 ) -> Result<InitializedWaylandProvider<F>, WaylandProviderError>
 where
     F: FnMut(SessionObservation) -> bool + 'static,
@@ -529,17 +416,13 @@ where
     let display = connection.display();
     let mut event_queue = connection.new_event_queue();
     let queue_handle = event_queue.handle();
-    let mut state = WaylandProviderState::new(on_observation, honor_idle_inhibitors);
+    let mut state = WaylandProviderState::new(on_observation);
     state.registry = Some(display.get_registry(&queue_handle, ()));
 
-    event_queue
-        .roundtrip(&mut state)
-        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    roundtrip(&connection, &mut event_queue, &mut state, stop)?;
     let capabilities = state.registry_facts.capabilities()?;
     state.initialized = true;
-    event_queue
-        .roundtrip(&mut state)
-        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    roundtrip(&connection, &mut event_queue, &mut state, stop)?;
     if let Some(err) = state.take_error() {
         return Err(err);
     }
@@ -561,43 +444,144 @@ pub(crate) fn probe_wayland_capabilities_on(
     let queue_handle = event_queue.handle();
     let _registry = display.get_registry(&queue_handle, ());
     let mut state = WaylandCapabilityProbeState::default();
-    event_queue
-        .roundtrip(&mut state)
-        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    roundtrip(
+        &connection,
+        &mut event_queue,
+        &mut state,
+        &AtomicBool::new(false),
+    )?;
     state.registry_facts.capabilities()
+}
+
+pub(crate) fn reconnect_wayland() -> Result<Connection, WaylandProviderError> {
+    // Unlike connect_to_env, reconnect never consumes or mutates WAYLAND_SOCKET.
+    let display = std::env::var_os("WAYLAND_DISPLAY").unwrap_or_else(|| "wayland-0".into());
+    let display = PathBuf::from(display);
+    let path = if display.is_absolute() {
+        display
+    } else {
+        PathBuf::from(std::env::var_os("XDG_RUNTIME_DIR").ok_or_else(|| {
+            WaylandProviderError::Connection("XDG_RUNTIME_DIR is unset".to_string())
+        })?)
+        .join(display)
+    };
+    let socket = UnixStream::connect(path)
+        .map_err(|err| WaylandProviderError::Connection(err.to_string()))?;
+    Connection::from_socket(socket).map_err(|err| WaylandProviderError::Connection(err.to_string()))
 }
 
 pub(crate) fn run_session_source<F>(
     connection: Connection,
-    honor_idle_inhibitors: bool,
-    mut publish: F,
+    publish: F,
+    stop: &AtomicBool,
+    connected: impl FnOnce(),
 ) -> Result<(), WaylandProviderError>
 where
     F: FnMut(SessionObservation) -> bool + 'static,
 {
-    let (mut event_queue, mut state, _) =
-        initialize_provider(connection, honor_idle_inhibitors, move |observation| {
-            publish(observation)
-        })?;
-
-    while state.running {
-        event_queue
-            .blocking_dispatch(&mut state)
-            .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    let (mut event_queue, mut state, _) = initialize_provider(connection, publish, stop)?;
+    connected();
+    while state.running && !stop.load(Ordering::SeqCst) {
+        dispatch_once(&mut event_queue, &mut state)?;
         if let Some(err) = state.take_error() {
             return Err(err);
         }
     }
-
     Ok(())
+}
+
+// Bound connection setup as well as idle waits so one stalled interface cannot
+// hold the monitor's startup or cancellation indefinitely.
+fn roundtrip<State>(
+    connection: &Connection,
+    queue: &mut EventQueue<State>,
+    state: &mut State,
+    stop: &AtomicBool,
+) -> Result<(), WaylandProviderError>
+where
+    State: Dispatch<wl_callback::WlCallback, Arc<AtomicBool>> + 'static,
+{
+    let done = Arc::new(AtomicBool::new(false));
+    connection
+        .display()
+        .sync(&queue.handle(), Arc::clone(&done));
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !done.load(Ordering::SeqCst) {
+        if stop.load(Ordering::SeqCst) || Instant::now() >= deadline {
+            return Err(WaylandProviderError::Dispatch(
+                "Wayland initialization cancelled or timed out".to_string(),
+            ));
+        }
+        dispatch_once(queue, state)?;
+    }
+    Ok(())
+}
+
+fn dispatch_once<State: 'static>(
+    queue: &mut EventQueue<State>,
+    state: &mut State,
+) -> Result<(), WaylandProviderError> {
+    queue
+        .dispatch_pending(state)
+        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    queue
+        .flush()
+        .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+    if let Some(guard) = queue.prepare_read() {
+        let mut fd = libc::pollfd {
+            fd: guard.connection_fd().as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: fd points to one initialized pollfd, and the read guard owns
+        // the descriptor throughout this bounded wait.
+        let ready = unsafe { libc::poll(&mut fd, 1, 50) };
+        if ready < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() != std::io::ErrorKind::Interrupted {
+                return Err(WaylandProviderError::Dispatch(err.to_string()));
+            }
+        } else if ready > 0 {
+            guard
+                .read()
+                .map_err(|err| WaylandProviderError::Dispatch(err.to_string()))?;
+        }
+    }
+    Ok(())
+}
+
+impl<F: FnMut(SessionObservation) -> bool + 'static>
+    Dispatch<wl_callback::WlCallback, Arc<AtomicBool>> for WaylandProviderState<F>
+{
+    fn event(
+        _: &mut Self,
+        _: &wl_callback::WlCallback,
+        _: wl_callback::Event,
+        done: &Arc<AtomicBool>,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        done.store(true, Ordering::SeqCst);
+    }
+}
+impl Dispatch<wl_callback::WlCallback, Arc<AtomicBool>> for WaylandCapabilityProbeState {
+    fn event(
+        _: &mut Self,
+        _: &wl_callback::WlCallback,
+        _: wl_callback::Event,
+        done: &Arc<AtomicBool>,
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        done.store(true, Ordering::SeqCst);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        ext_idle_notification_v1, global_removal_error, idle_notification_permission,
-        notification_is_activity, notification_meaning, IdlePermissionTracker, NotificationKind,
-        NotificationMeaning, RegistryFacts, WaylandProviderCapabilities, WaylandProviderError,
+        ext_idle_notification_v1, global_removal_error, notification_is_activity, RegistryFacts,
+        WaylandProviderCapabilities, WaylandProviderError,
     };
 
     const NOTIFIER: &str = "ext_idle_notifier_v1";
@@ -699,58 +683,83 @@ mod tests {
             &ext_idle_notification_v1::Event::Resumed
         ));
     }
-
     #[test]
-    fn idle_permission_stays_blocked_until_every_seat_reports_idle() {
-        let mut tracker = IdlePermissionTracker::default();
-
-        assert_eq!(tracker.add_seat(11), None);
-        assert_eq!(tracker.add_seat(12), None);
-        assert!(!tracker.allowed);
-        assert_eq!(tracker.set_idle(11, true), None);
-        assert_eq!(tracker.set_idle(12, true), Some(true));
-        assert_eq!(tracker.set_idle(12, true), None);
-        assert!(tracker.allowed);
+    fn stalled_initialization_is_cancellable_without_compositor_events() {
+        let (client, mut peer) = std::os::unix::net::UnixStream::pair().unwrap();
+        let connection = wayland_client::Connection::from_socket(client).unwrap();
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let worker_stop = std::sync::Arc::clone(&stop);
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || {
+            let result = super::run_session_source(
+                connection,
+                |_| true,
+                &worker_stop,
+                || panic!("a stalled compositor is not connected"),
+            );
+            sender.send(result).unwrap();
+        });
+        use std::io::Read;
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(1)))
+            .unwrap();
+        let mut request = [0; 256];
+        assert!(
+            peer.read(&mut request).unwrap() > 0,
+            "initialization must be pending before cancellation"
+        );
+        stop.store(true, std::sync::atomic::Ordering::SeqCst);
+        assert!(receiver
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap()
+            .is_err());
+        worker.join().unwrap();
     }
-
     #[test]
-    fn seat_addition_and_removal_recompute_permission_meaningfully() {
-        let mut tracker = IdlePermissionTracker::default();
-        tracker.add_seat(11);
-        tracker.set_idle(11, true);
-        assert!(tracker.allowed);
-
-        assert_eq!(tracker.add_seat(12), Some(false));
-        assert!(!tracker.allowed);
-        assert_eq!(tracker.remove_seat(12), Some(true));
-        assert!(tracker.allowed);
-        assert_eq!(tracker.remove_seat(11), Some(false));
-        assert!(!tracker.allowed);
-    }
-
-    #[test]
-    fn inhibitor_notification_resumed_changes_permission_without_becoming_activity() {
-        assert_eq!(
-            idle_notification_permission(&ext_idle_notification_v1::Event::Idled),
-            Some(true)
+    fn an_obsolete_notification_cannot_report_input_for_a_reused_seat_name() {
+        use wayland_client::Dispatch;
+        let (socket, _peer) = std::os::unix::net::UnixStream::pair().unwrap();
+        let connection = wayland_client::Connection::from_socket(socket).unwrap();
+        let observations = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let output = std::sync::Arc::clone(&observations);
+        let mut state = super::WaylandProviderState::new(move |value| {
+            output.lock().unwrap().push(value);
+            true
+        });
+        let queue = connection.new_event_queue();
+        let handle = queue.handle();
+        let registry = connection.display().get_registry(&handle, ());
+        state.registry_facts.add(10, NOTIFIER, 2);
+        state.bind_idle_notifier(&registry, &handle);
+        state.bind_seat(&registry, &handle, 11, 1);
+        let old = state.seats[&11]
+            .input_notification
+            .as_ref()
+            .unwrap()
+            .clone();
+        state.remove_global(11);
+        state.bind_seat(&registry, &handle, 11, 1);
+        let current = state.seats[&11]
+            .input_notification
+            .as_ref()
+            .unwrap()
+            .clone();
+        <super::WaylandProviderState<_> as Dispatch<_, u32>>::event(
+            &mut state,
+            &old,
+            ext_idle_notification_v1::Event::Resumed,
+            &11,
+            &connection,
+            &handle,
         );
-        assert_eq!(
-            idle_notification_permission(&ext_idle_notification_v1::Event::Resumed),
-            Some(false)
+        assert!(observations.lock().unwrap().is_empty());
+        <super::WaylandProviderState<_> as Dispatch<_, u32>>::event(
+            &mut state,
+            &current,
+            ext_idle_notification_v1::Event::Resumed,
+            &11,
+            &connection,
+            &handle,
         );
-        assert_eq!(
-            notification_meaning(
-                NotificationKind::Input(11),
-                &ext_idle_notification_v1::Event::Resumed
-            ),
-            Some(NotificationMeaning::InputActivity)
-        );
-        assert_eq!(
-            notification_meaning(
-                NotificationKind::IdlePermission(11),
-                &ext_idle_notification_v1::Event::Resumed
-            ),
-            Some(NotificationMeaning::IdlePermission(false))
-        );
+        assert_eq!(observations.lock().unwrap().len(), 1);
     }
 }

--- a/crates/lg-buddy/src/sources/desktop/wayland.rs
+++ b/crates/lg-buddy/src/sources/desktop/wayland.rs
@@ -5,7 +5,7 @@ use std::os::fd::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use wayland_client::protocol::{wl_callback, wl_registry, wl_seat};
@@ -14,11 +14,101 @@ use wayland_protocols::ext::idle_notify::v1::client::{
     ext_idle_notification_v1, ext_idle_notifier_v1,
 };
 
+use super::{wait_for_retry, ActivityAdapter, ActivityPublisher, ActivityStatus};
 use crate::events::EventSource;
 use crate::session::inactivity::InactivityObservation;
 use crate::session::SessionObservation;
 
 const REQUIRED_IDLE_NOTIFIER_VERSION: u32 = 2;
+
+pub(crate) struct WaylandSource {
+    initial_connection: Mutex<Option<Connection>>,
+    status: Mutex<ActivityStatus>,
+}
+
+impl Default for WaylandSource {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl WaylandSource {
+    fn new(connection: Option<Connection>) -> Self {
+        Self {
+            initial_connection: Mutex::new(connection),
+            status: Mutex::default(),
+        }
+    }
+
+    /// Probe before application threads start, retaining any inherited socket
+    /// inside this adapter for monitoring rather than opening it a second time.
+    pub(crate) fn probe_capabilities(
+        &self,
+    ) -> Result<WaylandProviderCapabilities, WaylandProviderError> {
+        let mut initial = self
+            .initial_connection
+            .lock()
+            .expect("initial Wayland connection");
+        let connection = match initial.as_ref() {
+            Some(connection) => connection.clone(),
+            None => connect_wayland()?,
+        };
+        let capabilities = probe_wayland_capabilities_on(connection.clone())?;
+        *initial = Some(connection);
+        Ok(capabilities)
+    }
+
+    fn run_connection(
+        &self,
+        connection: Connection,
+        publish: ActivityPublisher,
+        stop: &AtomicBool,
+    ) -> Result<(), WaylandProviderError> {
+        let (mut event_queue, mut state, _) = initialize_provider(
+            connection,
+            move |observation| {
+                publish(observation);
+                true
+            },
+            stop,
+        )?;
+        *self.status.lock().expect("Wayland activity status") = ActivityStatus::Available;
+        while state.running && !stop.load(Ordering::SeqCst) {
+            dispatch_once(&mut event_queue, &mut state)?;
+            if let Some(err) = state.take_error() {
+                return Err(err);
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ActivityAdapter for WaylandSource {
+    fn run(&self, publish: ActivityPublisher, stop: &AtomicBool) {
+        let mut connection = self
+            .initial_connection
+            .lock()
+            .expect("initial Wayland connection")
+            .take();
+        while !stop.load(Ordering::SeqCst) {
+            let result = connection
+                .take()
+                .map(Ok)
+                .unwrap_or_else(reconnect_wayland)
+                .and_then(|connection| self.run_connection(connection, Arc::clone(&publish), stop));
+            *self.status.lock().expect("Wayland activity status") =
+                ActivityStatus::unavailable(result.err().map_or_else(
+                    || "activity monitoring stopped".to_string(),
+                    |err| err.to_string(),
+                ));
+            wait_for_retry(stop);
+        }
+    }
+
+    fn status(&self) -> ActivityStatus {
+        self.status.lock().expect("Wayland activity status").clone()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WaylandProviderCapabilities {
@@ -430,13 +520,13 @@ where
     Ok((event_queue, state, capabilities))
 }
 
-pub(crate) fn connect_wayland() -> Result<Connection, WaylandProviderError> {
+fn connect_wayland() -> Result<Connection, WaylandProviderError> {
     // `connect_to_env` removes an inherited WAYLAND_SOCKET from the process
     // environment. Monitor startup must call this before spawning any threads.
     Connection::connect_to_env().map_err(|err| WaylandProviderError::Connection(err.to_string()))
 }
 
-pub(crate) fn probe_wayland_capabilities_on(
+fn probe_wayland_capabilities_on(
     connection: Connection,
 ) -> Result<WaylandProviderCapabilities, WaylandProviderError> {
     let display = connection.display();
@@ -453,7 +543,7 @@ pub(crate) fn probe_wayland_capabilities_on(
     state.registry_facts.capabilities()
 }
 
-pub(crate) fn reconnect_wayland() -> Result<Connection, WaylandProviderError> {
+fn reconnect_wayland() -> Result<Connection, WaylandProviderError> {
     // Unlike connect_to_env, reconnect never consumes or mutates WAYLAND_SOCKET.
     let display = std::env::var_os("WAYLAND_DISPLAY").unwrap_or_else(|| "wayland-0".into());
     let display = PathBuf::from(display);
@@ -468,26 +558,6 @@ pub(crate) fn reconnect_wayland() -> Result<Connection, WaylandProviderError> {
     let socket = UnixStream::connect(path)
         .map_err(|err| WaylandProviderError::Connection(err.to_string()))?;
     Connection::from_socket(socket).map_err(|err| WaylandProviderError::Connection(err.to_string()))
-}
-
-pub(crate) fn run_session_source<F>(
-    connection: Connection,
-    publish: F,
-    stop: &AtomicBool,
-    connected: impl FnOnce(),
-) -> Result<(), WaylandProviderError>
-where
-    F: FnMut(SessionObservation) -> bool + 'static,
-{
-    let (mut event_queue, mut state, _) = initialize_provider(connection, publish, stop)?;
-    connected();
-    while state.running && !stop.load(Ordering::SeqCst) {
-        dispatch_once(&mut event_queue, &mut state)?;
-        if let Some(err) = state.take_error() {
-            return Err(err);
-        }
-    }
-    Ok(())
 }
 
 // Bound connection setup as well as idle waits so one stalled interface cannot
@@ -683,6 +753,136 @@ mod tests {
             &ext_idle_notification_v1::Event::Resumed
         ));
     }
+    // Model only the registry, sync and input-notification messages consumed by
+    // this adapter. Hold the final sync reply so input definitely precedes setup.
+    fn serve_input_during_setup(
+        mut peer: std::os::unix::net::UnixStream,
+        finish_setup: std::sync::mpsc::Receiver<()>,
+    ) {
+        use std::io::{Read, Write};
+        fn number(bytes: &[u8]) -> u32 {
+            u32::from_ne_bytes(bytes[..4].try_into().unwrap())
+        }
+        fn event(peer: &mut std::os::unix::net::UnixStream, id: u32, opcode: u32, body: &[u8]) {
+            peer.write_all(&id.to_ne_bytes()).unwrap();
+            peer.write_all(&(((body.len() as u32 + 8) << 16) | opcode).to_ne_bytes())
+                .unwrap();
+            peer.write_all(body).unwrap();
+        }
+        fn global(
+            peer: &mut std::os::unix::net::UnixStream,
+            registry: u32,
+            name: u32,
+            interface: &str,
+            version: u32,
+        ) {
+            let mut body = name.to_ne_bytes().to_vec();
+            body.extend_from_slice(&(interface.len() as u32 + 1).to_ne_bytes());
+            body.extend_from_slice(interface.as_bytes());
+            body.push(0);
+            while !body.len().is_multiple_of(4) {
+                body.push(0);
+            }
+            body.extend_from_slice(&version.to_ne_bytes());
+            event(peer, registry, 0, &body);
+        }
+        peer.set_read_timeout(Some(std::time::Duration::from_secs(3)))
+            .unwrap();
+        let mut registry = 0;
+        let mut notifier = 0;
+        let mut syncs = 0;
+        loop {
+            let mut header = [0; 8];
+            match peer.read_exact(&mut header) {
+                Ok(()) => (),
+                Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return,
+                Err(err) => panic!("mock Wayland read: {err}"),
+            }
+            let id = number(&header);
+            let size_opcode = number(&header[4..]);
+            let opcode = size_opcode & 0xffff;
+            let mut body = vec![0; (size_opcode >> 16) as usize - 8];
+            peer.read_exact(&mut body).unwrap();
+            if id == 1 && opcode == 1 {
+                registry = number(&body);
+                global(&mut peer, registry, 10, NOTIFIER, 2);
+                global(&mut peer, registry, 11, SEAT, 1);
+            } else if id == 1 && opcode == 0 {
+                syncs += 1;
+                if syncs == 2 {
+                    finish_setup
+                        .recv_timeout(std::time::Duration::from_secs(2))
+                        .unwrap();
+                }
+                let callback = number(&body);
+                event(&mut peer, callback, 0, &0u32.to_ne_bytes());
+                event(&mut peer, 1, 1, &callback.to_ne_bytes());
+            } else if id == registry && opcode == 0 {
+                if number(&body) == 10 {
+                    notifier = number(&body[body.len() - 4..]);
+                }
+            } else if id == notifier && opcode == 2 {
+                let notification = number(&body);
+                event(&mut peer, notification, 0, &[]);
+                event(&mut peer, notification, 1, &[]);
+            }
+        }
+    }
+
+    #[test]
+    fn input_is_published_before_initialization_completes_and_quiet_shutdown_finishes() {
+        use super::{ActivityAdapter, WaylandSource};
+        use crate::session::{inactivity::InactivityObservation, SessionObservation};
+        use std::sync::{
+            atomic::{AtomicBool, Ordering},
+            mpsc, Arc,
+        };
+        use std::time::{Duration, Instant};
+        let (socket, peer) = std::os::unix::net::UnixStream::pair().unwrap();
+        let (finish_setup, setup) = mpsc::channel();
+        let server = std::thread::spawn(move || serve_input_during_setup(peer, setup));
+        let source = Arc::new(WaylandSource::new(Some(
+            wayland_client::Connection::from_socket(socket).unwrap(),
+        )));
+        let stop = Arc::new(AtomicBool::new(false));
+        let (input, observed) = mpsc::channel();
+        let (finished, completion) = mpsc::channel();
+        let adapter = Arc::clone(&source);
+        let worker_stop = Arc::clone(&stop);
+        let worker = std::thread::spawn(move || {
+            adapter.run(
+                Arc::new(move |observation| {
+                    input.send(observation).unwrap();
+                }),
+                &worker_stop,
+            );
+            finished.send(()).unwrap();
+        });
+        let observation = observed.recv_timeout(Duration::from_secs(1));
+        let status_during_setup = source.status();
+        finish_setup.send(()).unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !source.status().is_available() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let status_after_setup = source.status();
+        stop.store(true, Ordering::SeqCst);
+        completion
+            .recv_timeout(Duration::from_secs(1))
+            .expect("quiet adapter stops");
+        worker.join().unwrap();
+        server.join().unwrap();
+        assert!(matches!(
+            observation.unwrap(),
+            SessionObservation::Inactivity {
+                observation: InactivityObservation::DesktopActivityObserved,
+                ..
+            }
+        ));
+        assert!(!status_during_setup.is_available());
+        assert!(status_after_setup.is_available());
+    }
+
     #[test]
     fn stalled_initialization_is_cancellable_without_compositor_events() {
         let (client, mut peer) = std::os::unix::net::UnixStream::pair().unwrap();
@@ -691,12 +891,9 @@ mod tests {
         let worker_stop = std::sync::Arc::clone(&stop);
         let (sender, receiver) = std::sync::mpsc::channel();
         let worker = std::thread::spawn(move || {
-            let result = super::run_session_source(
-                connection,
-                |_| true,
-                &worker_stop,
-                || panic!("a stalled compositor is not connected"),
-            );
+            let source = super::WaylandSource::new(None);
+            let result =
+                source.run_connection(connection, std::sync::Arc::new(|_| {}), &worker_stop);
             sender.send(result).unwrap();
         });
         use std::io::Read;

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -253,6 +253,11 @@ fn gnome_shell_available(world: &mut LgBuddyWorld) {
     world.install_gnome_shell_stub();
 }
 
+#[given("GNOME SessionManager is unavailable")]
+fn gnome_session_manager_unavailable(world: &mut LgBuddyWorld) {
+    world.set_gnome_session_manager_available(false);
+}
+
 #[given("GNOME idle monitor is unavailable")]
 fn gnome_idle_monitor_unavailable(world: &mut LgBuddyWorld) {
     world.set_gnome_idle_monitor_available(false);

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -513,6 +513,11 @@ exit 1\n",
         bus.set_idle_monitor_available(true);
     }
 
+    pub fn set_gnome_session_manager_available(&mut self, value: bool) {
+        self.ensure_mock_session_bus_idle_monitor()
+            .set_session_manager_available(value);
+    }
+
     pub fn set_gnome_idle_monitor_available(&mut self, value: bool) {
         self.ensure_mock_session_bus_idle_monitor()
             .set_idle_monitor_available(value);

--- a/crates/lg-buddy/tests/features/detect_backend.feature
+++ b/crates/lg-buddy/tests/features/detect_backend.feature
@@ -27,7 +27,7 @@ Feature: Detect backend
     Then the command succeeds
     And stdout is "gnome"
 
-  Scenario: Automatic falls back when GNOME cannot honor keep-awake requests
+  Scenario: Automatic activity detection does not require inhibition services
     Given a temporary LG Buddy config using input HDMI_2
     And the executable PATH is isolated
     And GNOME Shell is available
@@ -35,17 +35,17 @@ Feature: Detect backend
     And swayidle is installed
     When I run the command "detect-backend"
     Then the command succeeds
-    And stdout is "swayidle"
+    And stdout is "gnome"
 
-  Scenario: Explicit GNOME reports a missing keep-awake dependency
+  Scenario: Explicit GNOME activity does not require inhibition services
     Given a temporary LG Buddy config using input HDMI_2
     And the executable PATH is isolated
     And GNOME Shell is available
     And honoring app keep-awake requests is "enabled"
     And the backend override is "gnome"
     When I run the command "detect-backend"
-    Then the command fails
-    And stderr contains "GNOME SessionManager is required"
+    Then the command succeeds
+    And stdout is "gnome"
 
   Scenario: Missing GNOME idle monitor is reported explicitly when no fallback exists
     Given a temporary LG Buddy config using input HDMI_2

--- a/crates/lg-buddy/tests/features/idle_inhibition.feature
+++ b/crates/lg-buddy/tests/features/idle_inhibition.feature
@@ -1,6 +1,7 @@
-Feature: App keep-awake requests
-  Users can choose whether desktop keep-awake requests prevent automatic blanking.
-  Keep-awake requests are not user input and must not restore the TV.
+Feature: Native activity during the dev inhibition refactor
+  Issue #221 removes inhibition from activity. Native honoring is temporarily
+  absent on dev until #225; this intermediate runtime cannot be promoted.
+  Activity remains independent of inhibition services and preferences.
 
   Background:
     Given a temporary LG Buddy config using input HDMI_2
@@ -21,71 +22,21 @@ Feature: App keep-awake requests
     And the TV client received "turn_screen_off" exactly 1 times
     And the TV screen is blanked
 
-  Scenario: Enabled keep-awake support covers playback already active at startup
+  Scenario: Native activity remains usable with the stored honoring preference enabled
     Given honoring app keep-awake requests is "enabled"
     And GNOME monitor stays open for 1.3 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And the TV client did not receive "turn_screen_off"
-    And the TV client did not receive "turn_screen_on"
-    And the TV screen is visible
-
-  Scenario: An inhibitor added before the blanking deadline survives a slow GNOME refresh
-    Given honoring app keep-awake requests is "enabled"
-    And GNOME has 0 idle inhibitors
-    And GNOME changes to 1 idle inhibitors after 0.8 seconds
-    And GNOME delays the next inhibited query by 0.5 seconds
-    And GNOME monitor stays open for 1.6 seconds
-    When I run the command "monitor"
-    Then the command succeeds
-    And the TV client did not receive "turn_screen_off"
-    And the TV screen is visible
-
-  Scenario: Ending one of several keep-awake requests does not permit blanking
-    Given honoring app keep-awake requests is "enabled"
-    And GNOME has 2 idle inhibitors
-    And GNOME changes to 1 idle inhibitors after 0.2 seconds
-    And GNOME monitor stays open for 1.5 seconds
-    When I run the command "monitor"
-    Then the command succeeds
-    And the TV client did not receive "turn_screen_off"
-    And the TV client did not receive "turn_screen_on"
-
-  Scenario Outline: Ending the last keep-awake request starts a fresh full timeout
-    Given honoring app keep-awake requests is "enabled"
-    And GNOME has 2 idle inhibitors
-    And GNOME changes to 1 idle inhibitors after 0.2 seconds
-    And GNOME changes to 0 idle inhibitors after 1.5 seconds
-    And GNOME monitor stays open for <duration> seconds
-    When I run the command "monitor"
-    Then the command succeeds
-    And the TV client received "turn_screen_off" exactly <blanks> times
-    And the TV client did not receive "turn_screen_on"
-
-    Examples:
-      | duration | blanks |
-      | 2.2      | 0      |
-      | 2.9      | 1      |
-
-  Scenario: Releasing inhibition does not restore an already blanked screen
-    Given honoring app keep-awake requests is "enabled"
+    And stdout contains "native inhibition honoring is temporarily unavailable on dev"
+    And the TV client received "turn_screen_off" exactly 1 times
     And the TV screen is blanked
-    And the session marker exists
-    And GNOME changes to 0 idle inhibitors after 0.2 seconds
-    And GNOME idle monitor will report idletimes "1000, 50, 300, 550"
-    And GNOME monitor stays open for 0.8 seconds
-    When I run the command "monitor"
-    Then the command succeeds
-    And the TV client did not receive "turn_screen_on"
-    And the TV screen is blanked
-    And the session marker exists
 
-  Scenario: Gamepad input still restores the screen during inhibition
+  Scenario: Gamepad input restores independently of desktop inhibition
     Given honoring app keep-awake requests is "enabled"
     And the TV screen is blanked
     And the session marker exists
     And gamepad activity is observed after 0.2 seconds
-    And GNOME monitor stays open for 1.6 seconds
+    And GNOME monitor stays open for 0.8 seconds
     When I run the command "monitor"
     Then the command succeeds
     And the TV client received "turn_screen_on" exactly 1 times
@@ -99,20 +50,6 @@ Feature: App keep-awake requests
     And the session marker exists
     And genuine desktop input occurs after 0.2 seconds
     And GNOME monitor stays open for 0.8 seconds
-    When I run the command "monitor"
-    Then the command succeeds
-    And the TV client received "turn_screen_on" exactly 1 times
-    And the TV client did not receive "turn_screen_off"
-    And the TV screen is visible
-    And the session marker is absent
-
-  Scenario: Genuine desktop input immediately after release restores the screen
-    Given honoring app keep-awake requests is "enabled"
-    And the TV screen is blanked
-    And the session marker exists
-    And GNOME changes to 0 idle inhibitors after 0.2 seconds
-    And genuine desktop input occurs after 0.3 seconds
-    And GNOME monitor stays open for 0.9 seconds
     When I run the command "monitor"
     Then the command succeeds
     And the TV client received "turn_screen_on" exactly 1 times

--- a/crates/lg-buddy/tests/features/monitor_gnome.feature
+++ b/crates/lg-buddy/tests/features/monitor_gnome.feature
@@ -105,7 +105,7 @@ Feature: GNOME monitor
     And GNOME monitor stays open for 0.6 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And stdout contains "Using GNOME backend."
+    And stdout contains "activity source=gnome"
     And stdout does not contain "Session became idle."
     And the TV client did not receive "get_input"
     And the TV client did not receive "turn_screen_off"
@@ -121,7 +121,7 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 1000, 0, 1000"
+    And genuine desktop input occurs after 0.5 seconds
     And GNOME monitor stays open for 1.2 seconds
     When I run the command "monitor"
     Then the command succeeds
@@ -142,7 +142,7 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "0"
+    And genuine desktop input occurs after 0.05 seconds
     And GNOME monitor stays open for 0.4 seconds
     When I run the command "monitor"
     Then the command succeeds
@@ -164,7 +164,7 @@ Feature: GNOME monitor
     And GNOME monitor stays open for 1.2 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And stdout contains "Using GNOME backend."
+    And stdout contains "activity source=gnome"
     And the TV client received "get_input"
     And the TV client received "turn_screen_off"
     And the session marker exists
@@ -277,7 +277,7 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 1000, 0"
+    And genuine desktop input occurs after 0.5 seconds
     And mock system logind reports LockedHint=true
     And GNOME monitor stays open for 0.8 seconds
     When I run the command "monitor"
@@ -399,7 +399,7 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And genuine desktop input occurs after 1.5 seconds
     And GNOME monitor stays open for 1.8 seconds
     When I run the command "monitor"
     Then the command succeeds
@@ -442,7 +442,7 @@ Feature: GNOME monitor
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And genuine desktop input occurs after 1.5 seconds
     And GNOME monitor stays open for 1.8 seconds
     When I run the command "monitor"
     Then the command succeeds
@@ -450,3 +450,26 @@ Feature: GNOME monitor
     And the TV client received "turn_screen_on" exactly 1 times
     And the session marker is absent
     And the TV screen is visible
+
+  Scenario: Native activity works without an inhibition service
+    Given a temporary LG Buddy config using input HDMI_2
+    And the idle timeout is 1 seconds
+    And LG Buddy session runtime is isolated
+    And a mock TV client
+    And the TV is on input HDMI_2
+    And the TV screen is blanked
+    And the session marker exists
+    And the executable PATH is isolated
+    And GNOME Shell is available
+    And GNOME SessionManager is unavailable
+    And honoring app keep-awake requests is "enabled"
+    And GNOME emits no ScreenSaver signals
+    And genuine desktop input occurs after 0.2 seconds
+    And GNOME monitor stays open for 0.8 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And stdout contains "activity source=gnome"
+    And the TV client received "turn_screen_on" exactly 1 times
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+    And the session marker is absent

--- a/crates/lg-buddy/tests/features/monitor_swayidle.feature
+++ b/crates/lg-buddy/tests/features/monitor_swayidle.feature
@@ -1,22 +1,6 @@
 Feature: swayidle monitor
   LG Buddy should consume swayidle idle and activity facts through the shared monitor policy.
 
-  Scenario: Automatic starts a fallback when GNOME cannot honor keep-awake requests
-    Given a temporary LG Buddy config using input HDMI_2
-    And LG Buddy session runtime is isolated
-    And a mock TV client
-    And the TV is on input HDMI_2
-    And the executable PATH is isolated
-    And GNOME Shell is available
-    And honoring app keep-awake requests is "enabled"
-    And swayidle is installed
-    And swayidle will emit an idle timeout
-    When I run the command "monitor"
-    Then the command succeeds
-    And stdout contains "auto resolved to swayidle"
-    And stdout contains "GNOME SessionManager is required"
-    And the TV screen is blanked
-
   Scenario: swayidle timeout blanks the configured TV input
     Given a temporary LG Buddy config using input HDMI_2
     And LG Buddy session runtime is isolated

--- a/crates/lg-buddy/tests/features/webos.feature
+++ b/crates/lg-buddy/tests/features/webos.feature
@@ -216,11 +216,11 @@ Feature: Native webOS TV platform
     And the executable PATH is isolated
     And GNOME Shell is available
     And GNOME emits no ScreenSaver signals
-    And GNOME idle monitor will report idletimes "1000, 1000, 1000, 1000, 1000, 1000, 0"
+    And genuine desktop input occurs after 1.5 seconds
     And GNOME monitor stays open for 1.8 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And stdout contains "Using GNOME backend."
+    And stdout contains "activity source=gnome"
     And the session marker is absent
     And the TV screen is visible
     And the native TV connection count is 1

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -10,9 +10,72 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 use support::{
-    ExecutableScript, MockBscpylgtv, MockNmOnline, MockSystemLogind, RuntimeStateLayout,
-    TestConfigFile, TestEnv,
+    ExecutableScript, MockBscpylgtv, MockNmOnline, MockSessionBusIdleMonitor, MockSystemLogind,
+    RuntimeStateLayout, TestConfigFile, TestEnv,
 };
+
+#[test]
+fn monitor_recovers_gnome_activity_after_the_service_disappears() {
+    let _env = TestEnv::new();
+    let bus = MockSessionBusIdleMonitor::new("entrypoint-gnome-recovery-bus");
+    bus.set_shell_available(true);
+    bus.set_screen_saver_available(true);
+    bus.set_idle_monitor_available(true);
+    let logind = MockSystemLogind::new("entrypoint-gnome-recovery-logind");
+    logind.reset();
+    let mock = MockBscpylgtv::new("entrypoint-gnome-recovery-tv");
+    mock.set_input("HDMI_2");
+    mock.set_screen_on(false);
+    let wrapper = mock.command_wrapper("entrypoint-gnome-recovery-wrapper");
+    let config = TestConfigFile::new("entrypoint-gnome-recovery-config");
+    config.write_sample("HDMI_2");
+    let runtime = RuntimeStateLayout::new("entrypoint-gnome-recovery-runtime");
+    runtime.create_session_marker();
+    let log_path = config.path().with_file_name("monitor.log");
+    let child = std::process::Command::new(env!("CARGO_BIN_EXE_lg-buddy"))
+        .arg("monitor")
+        .env("LG_BUDDY_CONFIG", config.path())
+        .env("LG_BUDDY_BSCPYLGTV_COMMAND", wrapper.path())
+        .env("LG_BUDDY_SESSION_RUNTIME_DIR", runtime.session_dir())
+        .env("DBUS_SESSION_BUS_ADDRESS", bus.address())
+        .env("DBUS_SYSTEM_BUS_ADDRESS", logind.address())
+        .env("LG_BUDDY_SCREEN_BACKEND", "gnome")
+        .env("LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE", "disabled")
+        .env("LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS", "8")
+        .stdout(fs::File::create(&log_path).unwrap())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let output = || fs::read_to_string(&log_path).unwrap();
+    wait_until(Duration::from_secs(3), || {
+        output().contains("source=gnome available=true")
+    });
+    bus.set_idle_monitor_available(false);
+    wait_until(Duration::from_secs(2), || {
+        output().contains("Mutter IdleMonitor owner changed")
+    });
+    bus.set_idle_monitor_available(true);
+    wait_until(Duration::from_secs(4), || {
+        output().matches("source=gnome available=true").count() == 2
+    });
+    bus.schedule_user_activity(Duration::ZERO);
+    wait_until(Duration::from_secs(2), || {
+        mock.calls()
+            .iter()
+            .any(|call| call.command == "turn_screen_on")
+    });
+    let result = child.wait_with_output().unwrap();
+    assert!(result.status.success(), "{result:?}\n{}", output());
+    assert_eq!(output().matches("Using GNOME backend").count(), 1);
+    assert_eq!(
+        mock.calls()
+            .iter()
+            .filter(|call| call.command == "turn_screen_on")
+            .count(),
+        1
+    );
+    runtime.assert_session_marker_absent();
+}
 
 #[test]
 fn desktop_entry_opens_the_application_through_the_stable_launcher() {

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -452,6 +452,11 @@ impl MockSessionBusIdleMonitor {
         self.patch_state(|state| state.default_idletime = value);
     }
 
+    pub fn set_session_manager_available(&self, available: bool) {
+        self.patch_state(|state| state.session_manager_available = available);
+        wait_for_mock_bus_name_sync();
+    }
+
     pub fn set_idle_inhibitor_count(&self, count: u32) {
         self.patch_state(|state| {
             state.session_manager_available = true;

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -944,9 +944,11 @@ outcomes.
 Desktop backends are treated as adapters, not owners of policy.
 
 The automatic monitor composes available GNOME and Wayland activity sources.
-Each reconnects independently and contributes identified observations with their
-original time. `session/activity.rs` bounds pending observations and rejects
-obsolete source instances. The compatibility backend resolver still serves
+Each adapter lives for the application lifetime, manages its own connections,
+and contributes validated observations with their original time.
+`session/activity.rs` bounds pending observations without tracking connections or
+invalidating facts on connection loss. The runner queries adapter activity
+availability separately for idle policy and diagnostics. The compatibility backend resolver still serves
 existing settings/CLI callers; it does not select the automatic native source
 set. See [Session backend model](session-backend-model.md) for the current
 contracts and the temporary dev-only absence of native inhibition honoring

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -943,6 +943,15 @@ outcomes.
 
 Desktop backends are treated as adapters, not owners of policy.
 
+The automatic monitor composes available GNOME and Wayland activity sources.
+Each reconnects independently and contributes identified observations with their
+original time. `session/activity.rs` bounds pending observations and rejects
+obsolete source instances. The compatibility backend resolver still serves
+existing settings/CLI callers; it does not select the automatic native source
+set. See [Session backend model](session-backend-model.md) for the current
+contracts and the temporary dev-only absence of native inhibition honoring
+between #221 and #225.
+
 The runtime core owns:
 
 - config
@@ -977,10 +986,10 @@ The detailed session model is documented in `docs/session-backend-model.md`.
 
 - the GNOME session-bus connection and subscriptions
 - ScreenSaver sender ownership validation and signal mapping
-- Mutter user-active watches when honoring inhibitors, legacy idletime polling
-  otherwise, and normalized activity observations
+- Mutter user-active watches independent of inhibition, and normalized activity
+  observations
 
-`sources/desktop/wayland.rs` is the native non-GNOME adapter. It owns the
+`sources/desktop/wayland.rs` is the native Wayland adapter. It owns the
 Wayland connection, registry, every advertised seat, and zero-timeout idle
 notifications. Resumed notifications become desktop activity observations in
 the shared inactivity runtime; compositor idle does not directly blank the TV.

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,7 +37,12 @@ For GNOME end-to-end work, the running session also needs the full GNOME contrac
 - GNOME Shell
 - `org.gnome.ScreenSaver`
 - `org.gnome.Mutter.IdleMonitor`
-- `org.gnome.SessionManager` when testing **Allow apps to prevent idle blanking**
+
+On dev, #221 removes native inhibition from the activity path. The persisted
+**Allow apps to prevent idle blanking** setting is temporarily ineffective until
+#225 integrates the separate subsystem. This intermediate work cannot be
+promoted to prerelease or main. Activity tests require Mutter user-active watches;
+SessionManager availability must not determine whether activity monitoring works.
 
 The C toolchain is required because `cargo build` now compiles vendored
 `libdbus` as part of the dependency graph. On common Linux distributions that

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -72,23 +72,31 @@ These are the semantic events the runtime should reason about.
 ## Runtime Contract
 
 Native sources publish activity observations with an `EventSource` and original
-observation time. In automatic operation the runner connects GNOME/Mutter and
-native Wayland independently, including interfaces that appear after startup.
+observation time. In automatic operation the runner starts GNOME/Mutter and
+native Wayland adapters once. Each adapter owns discovery, subscriptions,
+validation and reconnection, including interfaces that appear after startup.
 Explicit `gnome` and `wayland` configurations restrict activity to that source.
 The compatibility `detect-backend` presentation remains until #218; its single
 reported value does not select the automatic runtime's source set.
 
-`session/activity.rs` keeps bounded contributions per source instance and activity
+`session/activity.rs` keeps bounded contributions per source and activity
 kind. Newer observations replace pending observations of the same kind. Delivery
-uses the original monotonic time, coalesces overlap and rejects older input.
-Disconnect clears that instance's pending observations; obsolete instances cannot
-publish or change the replacement's availability. A quiet connection stays
-available. Connection state, instance, last activity time and bounded failure
-reasons form the runtime diagnostics.
+preserves the original monotonic time without deduplicating across sources or
+kinds. The inactivity engine decides how each observation affects policy;
+overlapping reports do not extend a deadline beyond their observation times or
+repeat an already completed restore. Valid observations survive a later
+connection failure; transport loss does not undo activity that already happened.
+Connection handles, owner changes and obsolete protocol objects stay private to
+each adapter. Input received during setup is delivered immediately without a
+separate readiness gate in the collector.
 
 The runner owns one inactivity deadline. Loss of one source leaves the others
 running; loss of all native activity sources suspends automatic idle blanking
-until a source reconnects. Gamepad input, explicit lock and post-blank power-off
+until an adapter can observe activity again. This policy queries each adapter's
+current `ActivityStatus`; that assessment never authorizes or rejects an event.
+A quiet usable adapter remains available. Availability, bounded failure reasons
+and the last activity time form runtime diagnostics.
+Gamepad input, explicit lock and post-blank power-off
 remain independent. Reconnection itself does not count as input. Worker shutdown
 cancels quiet connections and joins their threads.
 
@@ -134,8 +142,8 @@ Notes:
 - Activity always uses Mutter's one-shot user-active watches, rearmed after each
   signal. SessionManager is neither required nor queried by the activity source.
   Unlike `GetIdletime`, watches do not treat the idle-counter reset on inhibitor
-  release as input. Losing the Mutter owner ends only that source instance; the
-  runner reconnects it independently.
+  release as input. When the Mutter owner disappears or changes, the adapter
+  reacquires its bus subscriptions and watches internally.
 - LG Buddy owns the configured timeout value for this backend.
 - LG Buddy owns one inactivity deadline. Desktop, auxiliary, active, and wake
   activity reports reset it; expiry after `screen_idle_timeout` triggers blanking.
@@ -217,9 +225,9 @@ Only `get_input_idle_notification` is used by this activity adapter. Inhibitor
 queries belong to the separate subsystem under #223.
 
 Seats are added and removed dynamically. Connection or dispatch loss, removal
-of the bound notifier, or removal of the last seat ends this source instance.
-The runner invalidates its contribution and reconnects while other sources keep
-running. Explicit selection does not enable another native source. Automatic
+of the bound notifier, or removal of the last seat causes the adapter to rebuild
+its connection and subscriptions while other adapters keep running. Previously
+published observations remain valid. Explicit selection does not enable another native source. Automatic
 operation attempts both native interfaces without desktop-name selection.
 
 ### `swayidle`

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -71,26 +71,39 @@ These are the semantic events the runtime should reason about.
 
 ## Runtime Contract
 
-Native sources publish `SessionObservation` values: canonical session events,
-inactivity facts, or idle-blanking permission updates, with an `EventSource` and
-observation time. A pending permission refresh suspends automatic blanking
-without changing the last confirmed permission or renewing the deadline.
-Source modules do not decide whether to blank or restore the screen.
+Native sources publish activity observations with an `EventSource` and original
+observation time. In automatic operation the runner connects GNOME/Mutter and
+native Wayland independently, including interfaces that appear after startup.
+Explicit `gnome` and `wayland` configurations restrict activity to that source.
+The compatibility `detect-backend` presentation remains until #218; its single
+reported value does not select the automatic runtime's source set.
 
-GNOME and native Wayland feed activity facts to the shared runner, which owns
-their configured inactivity deadline. `swayidle` owns its initial timeout but
-publishes `Idle` and independent desktop-activity observations back to the same
-runner. All three backends therefore share blank, restore, and post-blank
-power-off policy.
+`session/activity.rs` keeps bounded contributions per source instance and activity
+kind. Newer observations replace pending observations of the same kind. Delivery
+uses the original monotonic time, coalesces overlap and rejects older input.
+Disconnect clears that instance's pending observations; obsolete instances cannot
+publish or change the replacement's availability. A quiet connection stays
+available. Connection state, instance, last activity time and bounded failure
+reasons form the runtime diagnostics.
 
-`screen.honor_idle_inhibitors` defaults to `disabled`. When enabled, native
-sources also publish `IdleBlankingPermission`. The runner initially withholds
-automatic blanking until the source establishes permission, including when an
-inhibitor predates startup. Restoring permission starts a fresh full timeout;
-duplicate observations do not extend it. Permission changes are never activity
-or restore requests. Real desktop and gamepad input still share the inactivity
-deadline. Explicit lock behavior and an already pending post-blank power-off
-deadline are unaffected.
+The runner owns one inactivity deadline. Loss of one source leaves the others
+running; loss of all native activity sources suspends automatic idle blanking
+until a source reconnects. Gamepad input, explicit lock and post-blank power-off
+remain independent. Reconnection itself does not count as input. Worker shutdown
+cancels quiet connections and joins their threads.
+
+`swayidle` still owns its initial timeout and publishes `Idle` and independent
+desktop activity to the shared policy. Its existing automatic fallback remains
+when no native activity capability is available at startup; #132 removes it.
+
+**Dev boundary (#221):** native inhibition honoring is temporarily absent.
+Inhibition notifications, permission state and release timing have been removed
+from the activity stream and inactivity engine. The stored preference remains
+compatible, and monitor startup reports the temporary limitation. #222-#225
+implement the separate inhibition subsystem and Boolean gate. This intermediate
+runtime must not be promoted to prerelease or main before that integration and
+#89's MVP readiness checks are complete. Explicit lock, ownership/restore and
+ordinary activity deadlines retain their existing policy.
 
 ## Provider Map
 
@@ -113,29 +126,19 @@ Current mapping:
 | `org.gnome.ScreenSaver.ActiveChanged (true,)` | Idle observation that cannot bypass LG Buddy's timeout | Implemented |
 | `org.gnome.ScreenSaver.ActiveChanged (false,)` | `Active` | Implemented |
 | `org.gnome.ScreenSaver.WakeUpScreen` | `WakeRequested` | Implemented |
-| Recent activity from `org.gnome.Mutter.IdleMonitor.GetIdletime` (honoring disabled) | `UserActivity` | Implemented |
-| Mutter `WatchFired` for the current `AddUserActiveWatch` (honoring enabled) | `UserActivity` | Implemented |
-| `org.gnome.SessionManager.IsInhibited(8)` | Idle-blanking permission when honoring is enabled | Implemented |
+| Mutter `WatchFired` for the current `AddUserActiveWatch` | `UserActivity` | Implemented |
 
 Notes:
 
 - GNOME requires GNOME Shell, `org.gnome.ScreenSaver`, and `org.gnome.Mutter.IdleMonitor`.
-- Enabling inhibitor honoring additionally requires `org.gnome.SessionManager`.
-  The source reads its current aggregate idle-inhibition state at startup and
-  after trusted `InhibitorAdded`, `InhibitorRemoved`, or owner-change signals.
-  Automatic blanking pauses while each refresh is pending; an unchanged result
-  preserves the existing deadline. User input comes from Mutter's one-shot
-  user-active watches, rearmed after each signal. Unlike `GetIdletime`, these
-  do not treat the idle-counter reset on inhibitor release as activity.
-  Other inhibition flags do not block blanking. Losing the service or failing
-  to read its state ends the source with a diagnostic error rather than assuming
-  blanking is allowed. With the setting disabled, this extra dependency is not
-  queried or subscribed to.
+- Activity always uses Mutter's one-shot user-active watches, rearmed after each
+  signal. SessionManager is neither required nor queried by the activity source.
+  Unlike `GetIdletime`, watches do not treat the idle-counter reset on inhibitor
+  release as input. Losing the Mutter owner ends only that source instance; the
+  runner reconnects it independently.
 - LG Buddy owns the configured timeout value for this backend.
 - LG Buddy owns one inactivity deadline. Desktop, auxiliary, active, and wake
   activity reports reset it; expiry after `screen_idle_timeout` triggers blanking.
-- With honoring disabled, Mutter idletime is used only to detect recent desktop
-  activity. Its absolute value does not trigger blanking.
 - ScreenSaver idle cannot trigger blanking by itself. ScreenSaver active and
   wake signals reset the same LG Buddy deadline and remain restore observations
   evaluated by screen policy.
@@ -210,17 +213,14 @@ notifications from `get_input_idle_notification`. Its `resumed` maps to desktop
 activity; `idled` remains observational, so only LG Buddy's inactivity deadline
 can trigger blanking.
 
-When inhibitor honoring is enabled, a separate zero-timeout
-`get_idle_notification` observes permission on each seat. Blanking is allowed
-only once every seat reports idle. Its inhibitor-aware `resumed` withdraws
-permission without reporting input or restoring the TV. New seats initially
-withhold permission, and removing a seat recomputes the aggregate state.
+Only `get_input_idle_notification` is used by this activity adapter. Inhibitor
+queries belong to the separate subsystem under #223.
 
 Seats are added and removed dynamically. Connection or dispatch loss, removal
-of the bound notifier, or removal of the last seat is fatal to the provider and
-causes the user service to retry. Explicit selection reports capability errors
-without falling back. `auto` selects native Wayland after the complete GNOME
-contract and before the deprecated `swayidle` compatibility backend.
+of the bound notifier, or removal of the last seat ends this source instance.
+The runner invalidates its contribution and reconnects while other sources keep
+running. Explicit selection does not enable another native source. Automatic
+operation attempts both native interfaces without desktop-name selection.
 
 ### `swayidle`
 
@@ -257,6 +257,8 @@ The code split is:
 - `crates/lg-buddy/src/session/runner.rs`
   - source selection, worker lifetime, observation multiplexing, shared
     inactivity state, and policy dispatch
+- `crates/lg-buddy/src/session/activity.rs`
+  - bounded, identified contributions, observation ordering and source diagnostics
 - `crates/lg-buddy/src/session/actions.rs`
   - action dependency assembly and native TV client ownership across compatible
     events; one-shot commands use the same assembly with a finite lifetime
@@ -264,7 +266,7 @@ The code split is:
   - desktop-independent auxiliary input discovery and activity observations
 - `crates/lg-buddy/src/sources/desktop/gnome.rs`
   - GNOME session-bus connection, subscriptions, owner validation, Mutter
-    polling, event loop, and observation mapping
+    activity watches, event loop, and observation mapping
 - `crates/lg-buddy/src/sources/desktop/wayland.rs`
   - native Wayland registry, seat, idle-notification, and activity mapping
 - `crates/lg-buddy/src/sources/linux/logind.rs`

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -110,8 +110,8 @@ Examples:
 - GNOME monitor/runtime tests should use the private session-bus harness for
   ScreenSaver signals and Mutter user-active watches
 - native Wayland provider tests should model registry discovery, protocol-version
-  rejection, every advertised seat, input-notification resumed activity, separate
-  rejection of obsolete source instances, and provider loss without
+  rejection, every advertised seat, input-notification resumed activity during
+  setup, rejection of obsolete protocol objects, and provider loss without
   requiring a compositor
 - logind lifecycle/runtime tests should use the private system-bus harness for
   `PreparingForSleep` and `PrepareForSleep` behavior
@@ -257,7 +257,7 @@ Examples:
 - GNOME signal mapping
 - GNOME monitor setup, sender ownership and one-shot user-active watches over
   the session-bus seam, independent of SessionManager availability
-- overlapping source observations, source replacement, stale input and original
+- overlapping source observations, adapter recovery, stale input and original
   observation times surviving delayed delivery
 - native Wayland protocol-version and seat discovery
 - native Wayland resumed-notification and registry-removal mapping

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -108,11 +108,10 @@ Examples:
 
 - the TV mock reproduces `bscpylgtvcommand` command line, exit status, stdout, and stderr behavior that LG Buddy cares about
 - GNOME monitor/runtime tests should use the private session-bus harness for
-  ScreenSaver signals, Mutter idletime, and SessionManager idle-inhibition
-  snapshots and signals
+  ScreenSaver signals and Mutter user-active watches
 - native Wayland provider tests should model registry discovery, protocol-version
   rejection, every advertised seat, input-notification resumed activity, separate
-  inhibitor-aware permission notifications, and fatal provider loss without
+  rejection of obsolete source instances, and provider loss without
   requiring a compositor
 - logind lifecycle/runtime tests should use the private system-bus harness for
   `PreparingForSleep` and `PrepareForSleep` behavior
@@ -256,15 +255,16 @@ Secondary concern:
 Examples:
 
 - GNOME signal mapping
-- GNOME monitor setup, sender ownership, idletime polling, and one-shot
-  user-active watches over the session-bus seam
-- delayed inhibitor replies crossing the blanking deadline, and inhibitor
-  release resetting Mutter's idle counter without reporting user input
+- GNOME monitor setup, sender ownership and one-shot user-active watches over
+  the session-bus seam, independent of SessionManager availability
+- overlapping source observations, source replacement, stale input and original
+  observation times surviving delayed delivery
 - native Wayland protocol-version and seat discovery
 - native Wayland resumed-notification and registry-removal mapping
 - gamepad activity integration with the LG Buddy inactivity deadline
-- opt-in idle inhibition at startup, overlapping inhibitors, a fresh timeout
-  after the last release, and release never acting as restore activity
+- the explicit dev-only absence of native inhibition after #221; #225 restores
+  integrated inhibition tests before promotion, including overlap, playback
+  before/after startup and a full timeout after the last release
 - screen runtime-phase eligibility over the private logind system-bus seam
 - logind lock state entering the shared blanked state without making unlock a
   restore trigger, while observation-time tests cover pre-lock, post-lock grace,
@@ -280,11 +280,12 @@ than reconstructing provider buses and process protocols.
 Native Wayland changes also require manual checks on Plasma/KWin and at least
 one other target compositor. Verify that explicit and automatic `wayland`
 detection and monitor startup succeed, unsupported capability or connection
-cases report a precise fallback reason, and `auto` retains the
-GNOME-then-native-Wayland-then-`swayidle` order. Release-facing changes must
+cases report a precise reason, and automatic native monitoring composes available
+sources. Existing swayidle fallback coverage remains until #132. Release-facing changes must
 keep the static x86_64 musl build and release-bundle smoke test green, including
 preservation and deprecation reporting for an existing `swayidle` config.
-For inhibitor changes, start real video playback before the monitor: disabled
+For the completed inhibition integration (#225), start real video playback
+before and after the monitor: disabled
 must still blank, enabled must remain visible past the timeout, and stopping
 playback must leave the screen visible for a fresh full timeout before blanking.
 


### PR DESCRIPTION
## Summary

Automatic monitoring now composes GNOME/Mutter and Wayland activity instead of choosing one native desktop backend. Each adapter lives for the application lifetime and owns its connections, subscriptions, protocol validation and retries. The shared collector receives validated observations with source identity and original observation time, with bounded coalescing per source and event kind.

Availability is a separate adapter query used for diagnostics and pausing idle blanking when every native source is unavailable. It never gates observation delivery or invalidates previously observed activity. Global timestamp deduplication is removed so a newer observation ignored by policy cannot suppress valid input from another source.

Inhibition is excised from the activity stream and inactivity engine as agreed for #221. GNOME uses Mutter input watches without requiring SessionManager; Wayland uses input notifications. Adapters support cancellation and joining even during quiet connections or pending initialization.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

`auto` composes native sources and recovers one source without stopping the others. Input received during Wayland initialization is delivered, and valid observations remain usable after a connection drops. Original observation times preserve inactivity deadlines when delivery is delayed.

Explicit backend values remain compatible; existing swayidle fallback/removal remains #132's scope. Gamepad, logind lock and system lifecycle responsibilities remain independent.

**This targets dev only. Native app-inhibition honoring is temporarily absent until #222–#225 implement and integrate its replacement.** The preference stays stored and startup reports the gap. Do not promote this intermediate runtime to prerelease or main; #89 defines the completed MVP readiness gate.

## Validation

- Full `cargo test -p lg-buddy` passed: 988 library tests, 143 Cucumber scenarios and all runtime integration suites; one library test ignored.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`, formatting and diff checks passed.
- Independent review reran session, desktop adapter and GNOME recovery tests: 156 passed, one ignored.
- Regression coverage includes overlapping sources, delayed input after an ignored GNOME wake, activity without availability reports, Wayland input before initialization completes, cancellation during pending initialization, and GNOME service loss/recovery within the same running monitor.
- Isolated KWin 6.7.4 and Sway 1.11 smoke tests with the native webOS mock TV passed timeout blanking, independent gamepad restore and quiet shutdown. KWin recovered after compositor restart; Sway cursor input restored the TV through native input notifications. Protocol traces contain no inhibitor-aware notifications.

The compositor smoke tests used a mock TV. Full GNOME/Plasma logout/login and inhibition validation remain #217/#225.

## Related Issue

Fixes #221. Part of #216 and #89.
