### PR TITLE
Add independent GNOME push inhibition capability

### DIFF
--- a/crates/lg-buddy/src/inhibition.rs
+++ b/crates/lg-buddy/src/inhibition.rs
@@ -1,0 +1,223 @@
+//! Inhibition capabilities are independent of activity tracking. The push
+//! section reads maintained permission; it performs no protocol I/O or TV action.
+
+use std::sync::atomic::AtomicBool;
+use std::time::Instant;
+
+/// Only observed inhibition denies permission; other statuses are diagnostic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InhibitionStatus {
+    Absent,
+    Unavailable(String),
+    Clear,
+    Inhibited,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InhibitionDiagnostics {
+    pub source: &'static str,
+    pub status: InhibitionStatus,
+    /// Time of the last confirmed state query, not the time diagnostics are read.
+    pub observed_at: Option<Instant>,
+    /// Last observed inhibited -> clear transition. Repeated clear queries and
+    /// recovery after source loss do not create a release.
+    pub last_release_at: Option<Instant>,
+}
+
+/// Permission and diagnostics captured together from the same maintained state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InhibitionEvaluation {
+    pub allowed: bool,
+    pub diagnostics: InhibitionDiagnostics,
+}
+
+/// A source-owned worker maintains the capability; evaluating it is a quick
+/// local read. Connection recovery and event ordering stay inside the adapter.
+pub trait PushInhibitionAdapter: Send + Sync {
+    fn run(&self, stop: &AtomicBool);
+    fn evaluate(&self) -> InhibitionEvaluation;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PushInhibitionEvaluation {
+    pub allowed: bool,
+    pub contributions: Vec<InhibitionEvaluation>,
+}
+
+/// Combine independent inhibition capabilities. Evaluate every contributor so
+/// diagnostics describe the same evaluation, even when an earlier source denies.
+pub fn evaluate_push_inhibition(
+    adapters: &[&dyn PushInhibitionAdapter],
+) -> PushInhibitionEvaluation {
+    let contributions: Vec<_> = adapters.iter().map(|adapter| adapter.evaluate()).collect();
+    PushInhibitionEvaluation {
+        allowed: contributions.iter().all(|result| result.allowed),
+        contributions,
+    }
+}
+
+/// Adapter-owned evidence. Source loss drops its inhibition contribution without
+/// inventing an observed release.
+pub(crate) struct InhibitionState {
+    diagnostics: InhibitionDiagnostics,
+}
+
+impl InhibitionState {
+    pub(crate) fn new(source: &'static str) -> Self {
+        Self {
+            diagnostics: InhibitionDiagnostics {
+                source,
+                status: InhibitionStatus::Unavailable("monitoring has not started".into()),
+                observed_at: None,
+                last_release_at: None,
+            },
+        }
+    }
+
+    pub(crate) fn unavailable(&mut self, reason: impl std::fmt::Display) {
+        self.diagnostics.status =
+            InhibitionStatus::Unavailable(reason.to_string().chars().take(512).collect());
+    }
+
+    pub(crate) fn absent(&mut self) {
+        self.diagnostics.status = InhibitionStatus::Absent;
+    }
+
+    pub(crate) fn observe(&mut self, inhibited: bool, at: Instant) {
+        if !inhibited && self.diagnostics.status == InhibitionStatus::Inhibited {
+            self.diagnostics.last_release_at = Some(at);
+        }
+        self.diagnostics.observed_at = Some(at);
+        self.diagnostics.status = if inhibited {
+            InhibitionStatus::Inhibited
+        } else {
+            InhibitionStatus::Clear
+        };
+    }
+
+    pub(crate) fn evaluate(&self) -> InhibitionEvaluation {
+        InhibitionEvaluation {
+            allowed: self.diagnostics.status != InhibitionStatus::Inhibited,
+            diagnostics: self.diagnostics.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    struct FakeAdapter(Mutex<InhibitionState>);
+
+    impl FakeAdapter {
+        fn new(name: &'static str) -> Self {
+            Self(Mutex::new(InhibitionState::new(name)))
+        }
+    }
+
+    impl PushInhibitionAdapter for FakeAdapter {
+        fn run(&self, _: &AtomicBool) {
+            panic!("section evaluation must not run an adapter or perform I/O");
+        }
+
+        fn evaluate(&self) -> InhibitionEvaluation {
+            self.0.lock().unwrap().evaluate()
+        }
+    }
+
+    #[test]
+    fn only_observed_inhibition_denies_permission() {
+        let mut state = InhibitionState::new("test");
+        assert!(state.evaluate().allowed);
+        state.absent();
+        assert!(state.evaluate().allowed);
+        assert_eq!(
+            state.evaluate().diagnostics.status,
+            InhibitionStatus::Absent
+        );
+        for inhibited in [true, false] {
+            state.observe(inhibited, Instant::now());
+            let result = state.evaluate();
+            assert_eq!(result.allowed, !inhibited);
+            assert_eq!(
+                result.diagnostics.status == InhibitionStatus::Inhibited,
+                inhibited
+            );
+        }
+        state.observe(true, Instant::now());
+        assert!(!state.evaluate().allowed);
+        state.unavailable("connection lost");
+        assert!(state.evaluate().allowed);
+        state.observe(true, Instant::now());
+        state.absent();
+        assert!(state.evaluate().allowed);
+    }
+
+    #[test]
+    fn release_history_records_only_observed_transitions() {
+        let now = Instant::now();
+        let mut state = InhibitionState::new("test");
+        state.observe(false, now);
+        state.observe(false, now + Duration::from_secs(1));
+        assert_eq!(state.evaluate().diagnostics.last_release_at, None);
+        state.observe(true, now + Duration::from_secs(2));
+        state.observe(true, now + Duration::from_secs(3));
+        assert_eq!(state.evaluate().diagnostics.last_release_at, None);
+        let released = now + Duration::from_secs(4);
+        state.observe(false, released);
+        let quiet = state.evaluate();
+        assert_eq!(quiet, state.evaluate());
+        state.observe(false, now + Duration::from_secs(5));
+        assert_eq!(state.evaluate().diagnostics.last_release_at, Some(released));
+        state.observe(true, now + Duration::from_secs(6));
+        state.unavailable("connection lost");
+        assert!(state.evaluate().allowed);
+        state.observe(false, now + Duration::from_secs(7));
+        assert_eq!(state.evaluate().diagnostics.last_release_at, Some(released));
+    }
+
+    #[test]
+    fn section_combines_independent_sources_without_losing_other_denials() {
+        let first = FakeAdapter::new("first");
+        let second = FakeAdapter::new("second");
+        for first_inhibited in [false, true] {
+            for second_inhibited in [false, true] {
+                first
+                    .0
+                    .lock()
+                    .unwrap()
+                    .observe(first_inhibited, Instant::now());
+                second
+                    .0
+                    .lock()
+                    .unwrap()
+                    .observe(second_inhibited, Instant::now());
+                let result = evaluate_push_inhibition(&[&first, &second]);
+                assert_eq!(result.allowed, !first_inhibited && !second_inhibited);
+                assert_eq!(result.contributions, [first.evaluate(), second.evaluate()]);
+            }
+        }
+        first.0.lock().unwrap().absent();
+        assert!(!evaluate_push_inhibition(&[&first, &second]).allowed);
+        second.0.lock().unwrap().unavailable("refresh failed");
+        assert!(evaluate_push_inhibition(&[&first, &second]).allowed);
+        first.0.lock().unwrap().observe(true, Instant::now());
+        assert!(!evaluate_push_inhibition(&[&first, &second]).allowed);
+        first.0.lock().unwrap().observe(false, Instant::now());
+        second.0.lock().unwrap().observe(false, Instant::now());
+        assert!(evaluate_push_inhibition(&[&first, &second]).allowed);
+        assert!(evaluate_push_inhibition(&[]).allowed);
+    }
+
+    #[test]
+    fn failure_diagnostics_are_bounded() {
+        let mut state = InhibitionState::new("test");
+        state.unavailable("é".repeat(1000));
+        let InhibitionStatus::Unavailable(reason) = state.evaluate().diagnostics.status else {
+            panic!("expected unavailable");
+        };
+        assert_eq!(reason.chars().count(), 512);
+    }
+}

--- a/crates/lg-buddy/src/lib.rs
+++ b/crates/lg-buddy/src/lib.rs
@@ -15,6 +15,7 @@ pub mod config;
 pub mod diagnostics;
 pub mod diagnostics_view;
 pub mod events;
+pub mod inhibition;
 pub mod lifecycle;
 pub mod navigation;
 pub mod notifications;

--- a/crates/lg-buddy/src/sources/desktop/gnome.rs
+++ b/crates/lg-buddy/src/sources/desktop/gnome.rs
@@ -1,3 +1,5 @@
+pub mod inhibition;
+
 use std::fmt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;

--- a/crates/lg-buddy/src/sources/desktop/gnome/inhibition.rs
+++ b/crates/lg-buddy/src/sources/desktop/gnome/inhibition.rs
@@ -1,0 +1,449 @@
+//! GNOME's inhibition capability. It does not depend on Mutter, ScreenSaver,
+//! activity observations, the honoring preference, or TV actions.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::inhibition::{InhibitionEvaluation, InhibitionState, PushInhibitionAdapter};
+use crate::session_bus::{
+    get_name_owner, new_session_bus_client, parse_name_owner_changed_signal, BusMethodCall,
+    BusSignal, BusSignalMatch, BusValue, SessionBusClient, SessionBusError, DBUS_INTERFACE,
+    DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
+};
+
+const SERVICE: &str = "org.gnome.SessionManager";
+const PATH: &str = "/org/gnome/SessionManager";
+const IDLE_FLAG: u32 = 8;
+const PROCESS_INTERVAL: Duration = Duration::from_millis(50);
+const DRAIN_INTERVAL: Duration = Duration::from_millis(1);
+const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
+pub struct GnomeInhibition {
+    state: Mutex<InhibitionState>,
+}
+
+impl Default for GnomeInhibition {
+    fn default() -> Self {
+        Self {
+            state: Mutex::new(InhibitionState::new("gnome-session-manager")),
+        }
+    }
+}
+
+impl PushInhibitionAdapter for GnomeInhibition {
+    fn run(&self, stop: &AtomicBool) {
+        while !stop.load(Ordering::SeqCst) {
+            let result = new_session_bus_client()
+                .and_then(|mut bus| self.watch(&mut bus, stop, RECONCILE_INTERVAL));
+            if let Err(error) = result {
+                self.unavailable(error);
+            }
+            super::super::wait_for_retry(stop);
+        }
+        self.unavailable("inhibition monitoring stopped");
+    }
+
+    fn evaluate(&self) -> InhibitionEvaluation {
+        self.state
+            .lock()
+            .expect("GNOME inhibition state")
+            .evaluate()
+    }
+}
+
+impl GnomeInhibition {
+    fn unavailable(&self, reason: impl std::fmt::Display) {
+        self.state
+            .lock()
+            .expect("GNOME inhibition state")
+            .unavailable(reason);
+    }
+
+    fn watch(
+        &self,
+        bus: &mut impl SessionBusClient,
+        stop: &AtomicBool,
+        reconcile_interval: Duration,
+    ) -> Result<(), SessionBusError> {
+        // Subscribe before discovering/querying, so changes during initial
+        // synchronization remain queued and are reconciled before publication.
+        for member in ["InhibitorAdded", "InhibitorRemoved"] {
+            bus.add_signal_match(BusSignalMatch {
+                sender: None,
+                path: Some(PATH),
+                interface: Some(SERVICE),
+                member: Some(member),
+            })?;
+        }
+        bus.add_signal_match(BusSignalMatch {
+            sender: Some(DBUS_SERVICE_NAME),
+            path: Some(DBUS_OBJECT_PATH),
+            interface: Some(DBUS_INTERFACE),
+            member: Some("NameOwnerChanged"),
+        })?;
+
+        if !bus.name_has_owner(SERVICE)? {
+            self.state.lock().expect("GNOME inhibition state").absent();
+            return Ok(());
+        }
+        let owner = get_name_owner(bus, SERVICE)?;
+        self.refresh(bus, &owner, stop)?;
+        let mut last_refresh = Instant::now();
+        while !stop.load(Ordering::SeqCst) {
+            let source_changed = match bus.process(PROCESS_INTERVAL)? {
+                Some(signal) => changed(&signal, &owner)?,
+                None => false,
+            };
+            if stop.load(Ordering::SeqCst) {
+                break;
+            }
+            if source_changed || last_refresh.elapsed() >= reconcile_interval {
+                self.refresh(bus, &owner, stop)?;
+                last_refresh = Instant::now();
+            }
+        }
+        Ok(())
+    }
+
+    fn refresh(
+        &self,
+        bus: &mut impl SessionBusClient,
+        owner: &str,
+        stop: &AtomicBool,
+    ) -> Result<(), SessionBusError> {
+        // A refresh keeps the last observation until a valid result replaces it.
+        while !stop.load(Ordering::SeqCst) {
+            let inhibited = bus
+                .call_method(
+                    BusMethodCall::new(owner, PATH, SERVICE, "IsInhibited")
+                        .with_body(vec![BusValue::U32(IDLE_FLAG)]),
+                )?
+                .single_bool()?;
+            let observed_at = Instant::now();
+            if get_name_owner(bus, SERVICE)? != owner {
+                return Err(owner_changed());
+            }
+
+            // Blocking queries may queue signals. A change after the queried
+            // snapshot requires another query, not publication of stale clear.
+            let mut dirty = false;
+            while !stop.load(Ordering::SeqCst) {
+                let Some(signal) = bus.process(DRAIN_INTERVAL)? else {
+                    break;
+                };
+                dirty |= changed(&signal, owner)?;
+            }
+            if stop.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            if !dirty {
+                self.state
+                    .lock()
+                    .expect("GNOME inhibition state")
+                    .observe(inhibited, observed_at);
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+}
+
+fn owner_changed() -> SessionBusError {
+    SessionBusError::Transport("GNOME SessionManager owner changed".into())
+}
+
+fn changed(signal: &BusSignal, owner: &str) -> Result<bool, SessionBusError> {
+    if signal.sender.as_deref() == Some(DBUS_SERVICE_NAME) {
+        if let Some(change) = parse_name_owner_changed_signal(signal) {
+            // A previous owner's loss may have been queued before we resolved this one.
+            if change.name == SERVICE
+                && change.old_owner.as_deref() == Some(owner)
+                && change.new_owner.as_deref() != Some(owner)
+            {
+                return Err(owner_changed());
+            }
+        }
+    }
+    Ok(signal.sender.as_deref() == Some(owner)
+        && signal.path == PATH
+        && signal.interface == SERVICE
+        && matches!(
+            signal.member.as_str(),
+            "InhibitorAdded" | "InhibitorRemoved"
+        )
+        && matches!(signal.body.as_slice(), [BusValue::ObjectPath(_)]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inhibition::InhibitionStatus;
+    use crate::session_bus::BusReply;
+    use std::collections::VecDeque;
+
+    const OWNER: &str = ":1.42";
+
+    struct FakeBus<'a> {
+        adapter: &'a GnomeInhibition,
+        stop: &'a AtomicBool,
+        present: bool,
+        owner: &'static str,
+        replies: VecDeque<Result<bool, SessionBusError>>,
+        signals: VecDeque<Option<BusSignal>>,
+        subscriptions: usize,
+        queries: Vec<InhibitionEvaluation>,
+        stop_on_query: bool,
+        polls_before_stop: usize,
+    }
+
+    impl<'a> FakeBus<'a> {
+        fn new(adapter: &'a GnomeInhibition, stop: &'a AtomicBool, values: &[bool]) -> Self {
+            Self {
+                adapter,
+                stop,
+                present: true,
+                owner: OWNER,
+                replies: values.iter().copied().map(Ok).collect(),
+                signals: VecDeque::new(),
+                subscriptions: 0,
+                queries: Vec::new(),
+                stop_on_query: false,
+                polls_before_stop: 1,
+            }
+        }
+    }
+
+    impl SessionBusClient for FakeBus<'_> {
+        fn name_has_owner(&mut self, name: &str) -> Result<bool, SessionBusError> {
+            assert_eq!(
+                name, SERVICE,
+                "inhibition must not require activity services"
+            );
+            assert_eq!(self.subscriptions, 3, "subscribe before discovery");
+            Ok(self.present)
+        }
+
+        fn add_signal_match(&mut self, _: BusSignalMatch<'_>) -> Result<(), SessionBusError> {
+            self.subscriptions += 1;
+            Ok(())
+        }
+
+        fn call_method(&mut self, call: BusMethodCall<'_>) -> Result<BusReply, SessionBusError> {
+            match call.member {
+                "IsInhibited" => {
+                    assert_eq!(call.destination, OWNER);
+                    assert_eq!(call.path, PATH);
+                    assert_eq!(call.interface, SERVICE);
+                    assert_eq!(call.body, [BusValue::U32(8)]);
+                    self.queries.push(self.adapter.evaluate());
+                    if self.stop_on_query {
+                        self.stop.store(true, Ordering::SeqCst);
+                    }
+                    self.replies
+                        .pop_front()
+                        .expect("unexpected query")
+                        .map(|value| BusReply::new(vec![BusValue::Bool(value)]))
+                }
+                "GetNameOwner" => Ok(BusReply::new(vec![BusValue::String(self.owner.into())])),
+                member => panic!("unexpected method: {member}"),
+            }
+        }
+
+        fn process(&mut self, timeout: Duration) -> Result<Option<BusSignal>, SessionBusError> {
+            if timeout == PROCESS_INTERVAL && self.signals.is_empty() {
+                self.polls_before_stop -= 1;
+                if self.polls_before_stop == 0 {
+                    self.stop.store(true, Ordering::SeqCst);
+                }
+            }
+            Ok(self.signals.pop_front().flatten())
+        }
+    }
+
+    fn inhibitor_changed(owner: &str, member: &str) -> BusSignal {
+        BusSignal::new(PATH, SERVICE, member)
+            .with_sender(owner)
+            .with_body(vec![BusValue::ObjectPath("/inhibitor/1".into())])
+    }
+
+    fn owner_change(old: &str, new: &str) -> BusSignal {
+        BusSignal::new(DBUS_OBJECT_PATH, DBUS_INTERFACE, "NameOwnerChanged")
+            .with_sender(DBUS_SERVICE_NAME)
+            .with_body(vec![
+                BusValue::String(SERVICE.into()),
+                BusValue::String(old.into()),
+                BusValue::String(new.into()),
+            ])
+    }
+
+    #[test]
+    fn subscribes_before_startup_snapshot_and_retains_quiet_inhibition() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[true]);
+        adapter.watch(&mut bus, &stop, RECONCILE_INTERVAL).unwrap();
+        assert_eq!(bus.queries.len(), 1);
+        assert_eq!(
+            adapter.evaluate().diagnostics.status,
+            InhibitionStatus::Inhibited
+        );
+        assert!(!adapter.evaluate().allowed);
+    }
+
+    #[test]
+    fn periodic_reads_reconcile_missed_additions_and_removals() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        // The source changes without sending any notification.
+        let mut bus = FakeBus::new(&adapter, &stop, &[false, true, false]);
+        bus.polls_before_stop = 3;
+        adapter.watch(&mut bus, &stop, Duration::ZERO).unwrap();
+        assert_eq!(bus.queries.len(), 3);
+        assert!(bus.queries[0].allowed);
+        assert_eq!(bus.queries[1].diagnostics.status, InhibitionStatus::Clear);
+        assert!(bus.queries[1].allowed);
+        assert_eq!(
+            bus.queries[2].diagnostics.status,
+            InhibitionStatus::Inhibited
+        );
+        assert!(!bus.queries[2].allowed);
+        assert!(adapter.evaluate().allowed);
+        assert!(adapter.evaluate().diagnostics.last_release_at.is_some());
+    }
+
+    #[test]
+    fn changes_during_snapshot_are_requeried_before_publishing() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[false, true]);
+        let before = adapter.evaluate();
+        bus.signals
+            .extend([Some(inhibitor_changed(OWNER, "InhibitorAdded")), None]);
+        adapter.refresh(&mut bus, OWNER, &stop).unwrap();
+        assert_eq!(bus.queries, [before.clone(), before]);
+        assert_eq!(
+            adapter.evaluate().diagnostics.status,
+            InhibitionStatus::Inhibited
+        );
+        assert_eq!(adapter.evaluate().diagnostics.last_release_at, None);
+    }
+
+    #[test]
+    fn refresh_retains_the_last_known_value_until_a_result_arrives() {
+        for inhibited in [false, true] {
+            let adapter = GnomeInhibition::default();
+            adapter
+                .state
+                .lock()
+                .unwrap()
+                .observe(inhibited, Instant::now());
+            let before = adapter.evaluate();
+            let stop = AtomicBool::new(false);
+            let mut bus = FakeBus::new(&adapter, &stop, &[!inhibited]);
+            adapter.refresh(&mut bus, OWNER, &stop).unwrap();
+            assert_eq!(bus.queries, [before]);
+            assert_eq!(adapter.evaluate().allowed, inhibited);
+        }
+    }
+
+    #[test]
+    fn only_the_last_inhibitor_ending_records_a_release() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[true, true, false, false]);
+        for _ in 0..2 {
+            adapter.refresh(&mut bus, OWNER, &stop).unwrap();
+            assert!(!adapter.evaluate().allowed);
+            assert_eq!(adapter.evaluate().diagnostics.last_release_at, None);
+        }
+        adapter.refresh(&mut bus, OWNER, &stop).unwrap();
+        let release = adapter.evaluate().diagnostics.last_release_at.unwrap();
+        adapter.refresh(&mut bus, OWNER, &stop).unwrap();
+        assert!(adapter.evaluate().allowed);
+        assert_eq!(
+            adapter.evaluate().diagnostics.last_release_at,
+            Some(release)
+        );
+    }
+
+    #[test]
+    fn absence_drops_any_previous_inhibition_contribution() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[]);
+        bus.present = false;
+        adapter.watch(&mut bus, &stop, RECONCILE_INTERVAL).unwrap();
+        assert!(adapter.evaluate().allowed);
+        assert_eq!(
+            adapter.evaluate().diagnostics.status,
+            InhibitionStatus::Absent
+        );
+        adapter.state.lock().unwrap().observe(true, Instant::now());
+        bus.subscriptions = 0;
+        adapter.watch(&mut bus, &stop, RECONCILE_INTERVAL).unwrap();
+        assert!(adapter.evaluate().allowed);
+        assert_eq!(adapter.evaluate().diagnostics.last_release_at, None);
+    }
+
+    #[test]
+    fn validates_owners_and_ignores_delayed_or_unrelated_signals() {
+        assert!(changed(&inhibitor_changed(OWNER, "InhibitorRemoved"), OWNER).unwrap());
+        assert!(!changed(&inhibitor_changed(":1.41", "InhibitorRemoved"), OWNER).unwrap());
+        assert!(!changed(&inhibitor_changed(OWNER, "ActiveChanged"), OWNER).unwrap());
+        let mut signal = inhibitor_changed(OWNER, "InhibitorAdded");
+        signal.body.clear();
+        assert!(!changed(&signal, OWNER).unwrap());
+        assert!(changed(&owner_change(OWNER, ""), OWNER).is_err());
+        assert!(changed(&owner_change(OWNER, ":1.43"), OWNER).is_err());
+        assert!(!changed(&owner_change("", OWNER), OWNER).unwrap());
+        assert!(!changed(&owner_change(OWNER, "").with_sender(":1.99"), OWNER).unwrap());
+    }
+
+    #[test]
+    fn queued_loss_of_a_previous_owner_preserves_the_current_reading() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[true]);
+        // These notifications were queued before GetNameOwner resolved OWNER.
+        bus.signals.extend([
+            Some(owner_change(":1.41", "")),
+            Some(owner_change("", OWNER)),
+            None,
+        ]);
+        adapter.watch(&mut bus, &stop, RECONCILE_INTERVAL).unwrap();
+        assert_eq!(bus.queries.len(), 1);
+        assert_eq!(
+            adapter.evaluate().diagnostics.status,
+            InhibitionStatus::Inhibited
+        );
+        assert!(!adapter.evaluate().allowed);
+    }
+
+    #[test]
+    fn owner_replacement_during_query_rejects_the_old_reply() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[true]);
+        bus.owner = ":1.43";
+        assert!(adapter.refresh(&mut bus, OWNER, &stop).is_err());
+        assert!(adapter.evaluate().allowed);
+        assert_eq!(adapter.evaluate().diagnostics.observed_at, None);
+    }
+
+    #[test]
+    fn read_failure_and_cancellation_do_not_publish_a_result() {
+        let adapter = GnomeInhibition::default();
+        let stop = AtomicBool::new(false);
+        let mut bus = FakeBus::new(&adapter, &stop, &[]);
+        bus.replies
+            .push_back(Err(SessionBusError::Transport("read failed".into())));
+        assert!(adapter.refresh(&mut bus, OWNER, &stop).is_err());
+        assert!(adapter.evaluate().allowed);
+        bus.replies.push_back(Ok(true));
+        bus.stop_on_query = true;
+        adapter.refresh(&mut bus, OWNER, &stop).unwrap();
+        assert!(adapter.evaluate().allowed);
+        assert_eq!(adapter.evaluate().diagnostics.observed_at, None);
+    }
+}

--- a/crates/lg-buddy/tests/inhibition.rs
+++ b/crates/lg-buddy/tests/inhibition.rs
@@ -1,0 +1,155 @@
+mod support;
+
+use lg_buddy::inhibition::{evaluate_push_inhibition, InhibitionStatus, PushInhibitionAdapter};
+use lg_buddy::sources::desktop::gnome::inhibition::GnomeInhibition;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+use support::{MockSessionBusIdleMonitor, TestEnv};
+
+// Run the production capability against a private bus, without activity or TV
+// machinery. Drop stops the worker even if an assertion fails.
+struct RunningInhibition {
+    adapter: Arc<GnomeInhibition>,
+    stop: Arc<AtomicBool>,
+    worker: Option<JoinHandle<()>>,
+}
+
+impl RunningInhibition {
+    fn start() -> Self {
+        let adapter = Arc::new(GnomeInhibition::default());
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_adapter = Arc::clone(&adapter);
+        let worker_stop = Arc::clone(&stop);
+        let worker = thread::spawn(move || worker_adapter.run(&worker_stop));
+        Self {
+            adapter,
+            stop,
+            worker: Some(worker),
+        }
+    }
+}
+
+impl Drop for RunningInhibition {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        self.worker.take().unwrap().join().unwrap();
+    }
+}
+
+#[track_caller]
+fn wait_until(mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !condition() {
+        assert!(Instant::now() < deadline, "inhibition condition timed out");
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[test]
+fn gnome_push_inhibition_works_without_activity_services() {
+    let mut env = TestEnv::new();
+    let bus = MockSessionBusIdleMonitor::new("inhibition-capability");
+    // libdbus caches the session-bus address process-wide. Exercise all scenarios
+    // on one private bus; each gets a fresh worker, and the fixture is cleaned up.
+    env.set("DBUS_SESSION_BUS_ADDRESS", bus.address());
+    a_late_source_is_discovered_and_loss_drops_its_contribution(&bus);
+    playback_inhibitors_release_only_when_all_end(&bus);
+    permission_reads_do_not_wait_for_dbus_and_a_quiet_worker_can_stop(&bus);
+}
+
+fn playback_inhibitors_release_only_when_all_end(bus: &MockSessionBusIdleMonitor) {
+    // SessionManager alone: Shell, Mutter and ScreenSaver remain absent.
+    bus.set_idle_inhibitor_count(2);
+    let running = RunningInhibition::start();
+    let adapter = &*running.adapter;
+    wait_until(|| adapter.evaluate().diagnostics.status == InhibitionStatus::Inhibited);
+    assert!(!evaluate_push_inhibition(&[adapter]).allowed);
+
+    let before = adapter.evaluate().diagnostics.observed_at;
+    bus.schedule_idle_inhibitor_count(Duration::ZERO, 1);
+    wait_until(|| adapter.evaluate().diagnostics.observed_at != before);
+    assert!(!evaluate_push_inhibition(&[adapter]).allowed);
+    assert_eq!(adapter.evaluate().diagnostics.last_release_at, None);
+
+    bus.schedule_idle_inhibitor_count(Duration::ZERO, 0);
+    wait_until(|| adapter.evaluate().allowed);
+    let clear = adapter.evaluate();
+    assert!(clear.diagnostics.last_release_at.is_some());
+    let queries = bus.inhibition_query_count();
+    thread::sleep(Duration::from_millis(200));
+    assert_eq!(
+        adapter.evaluate(),
+        clear,
+        "quiet subscriptions retain state"
+    );
+    assert_eq!(
+        bus.inhibition_query_count(),
+        queries,
+        "quiet sources are not polled before reconciliation is due"
+    );
+
+    // Playback starting after monitoring began blocks the same contribution.
+    bus.schedule_idle_inhibitor_count(Duration::ZERO, 1);
+    wait_until(|| adapter.evaluate().diagnostics.status == InhibitionStatus::Inhibited);
+    assert!(!evaluate_push_inhibition(&[adapter]).allowed);
+}
+
+fn a_late_source_is_discovered_and_loss_drops_its_contribution(bus: &MockSessionBusIdleMonitor) {
+    let running = RunningInhibition::start();
+    let adapter = &*running.adapter;
+    wait_until(|| adapter.evaluate().diagnostics.status == InhibitionStatus::Absent);
+    assert!(adapter.evaluate().allowed);
+
+    bus.set_idle_inhibitor_count(1);
+    wait_until(|| adapter.evaluate().diagnostics.status == InhibitionStatus::Inhibited);
+    let inhibited = adapter.evaluate();
+    bus.set_session_manager_available(false);
+    wait_until(|| {
+        matches!(
+            adapter.evaluate().diagnostics.status,
+            InhibitionStatus::Unavailable(_)
+        )
+    });
+    assert!(adapter.evaluate().allowed);
+    assert_eq!(adapter.evaluate().diagnostics.last_release_at, None);
+    assert_eq!(
+        adapter.evaluate().diagnostics.observed_at,
+        inhibited.diagnostics.observed_at
+    );
+
+    // Reconnect updates the same long-lived capability from current state.
+    bus.set_idle_inhibitor_count(0);
+    wait_until(|| adapter.evaluate().diagnostics.status == InhibitionStatus::Clear);
+    assert!(adapter.evaluate().allowed);
+    assert_eq!(adapter.evaluate().diagnostics.last_release_at, None);
+}
+
+fn permission_reads_do_not_wait_for_dbus_and_a_quiet_worker_can_stop(
+    bus: &MockSessionBusIdleMonitor,
+) {
+    bus.set_idle_inhibitor_count(1);
+    bus.delay_next_inhibited_query(Duration::from_millis(800));
+    let queries_before = bus.inhibition_query_count();
+    let running = RunningInhibition::start();
+    wait_until(|| bus.inhibition_query_count() > queries_before);
+    let started = Instant::now();
+    let evaluation = running.adapter.evaluate();
+    assert!(started.elapsed() < Duration::from_millis(300));
+    assert!(evaluation.allowed);
+    assert!(matches!(
+        evaluation.diagnostics.status,
+        InhibitionStatus::Unavailable(_)
+    ));
+    wait_until(|| running.adapter.evaluate().diagnostics.status == InhibitionStatus::Inhibited);
+    let adapter = Arc::clone(&running.adapter);
+    let started = Instant::now();
+    drop(running);
+    assert!(started.elapsed() < Duration::from_millis(500));
+    assert!(adapter.evaluate().allowed);
+    assert!(matches!(
+        adapter.evaluate().diagnostics.status,
+        InhibitionStatus::Unavailable(_)
+    ));
+}

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -367,6 +367,7 @@ struct MockSessionBusIdleMonitorState {
     inhibitor_plan: VecDeque<(Duration, u32)>,
     inhibitor_started_at: Option<Instant>,
     next_inhibitor_query_delay: Option<Duration>,
+    inhibition_query_count: usize,
     default_idletime: u64,
     idletime_plan: VecDeque<u64>,
     idletime_reset_at: Option<Instant>,
@@ -471,6 +472,13 @@ impl MockSessionBusIdleMonitor {
 
     pub fn delay_next_inhibited_query(&self, delay: Duration) {
         self.patch_state(|state| state.next_inhibitor_query_delay = Some(delay));
+    }
+
+    pub fn inhibition_query_count(&self) -> usize {
+        self.state
+            .lock()
+            .expect("mock session manager state lock")
+            .inhibition_query_count
     }
 
     pub fn set_idle_monitor_idletime_plan(&self, values: &[u64]) {
@@ -719,6 +727,7 @@ fn spawn_mock_idle_monitor_service(
                                 .lock()
                                 .expect("mock session manager state lock");
                             state.inhibitor_started_at.get_or_insert_with(Instant::now);
+                            state.inhibition_query_count += 1;
                             let inhibited = flags & 8 != 0 && state.idle_inhibitor_count > 0;
                             let delay = if inhibited {
                                 state.next_inhibitor_query_delay.take()

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -405,7 +405,13 @@ The current split is:
   - emits `NetworkTeardownImminent` with the logind sleep-phase reading
 - `sources/desktop/gnome.rs`
   - owns GNOME session-bus setup, subscriptions, sender validation, Mutter
-    polling, and translation into normalized observations
+    user-active watches, and translation into normalized observations
+- `inhibition.rs`
+  - independent push inhibition contract, Boolean aggregation and diagnostics;
+    standalone until the monitor integration in #225
+- `sources/desktop/gnome/inhibition.rs`
+  - SessionManager inhibition subscriptions, state refresh and recovery,
+    independent of GNOME activity
 - `sources/desktop/wayland.rs`
   - native Wayland capability probing and dynamic registry/seat ownership
   - maps zero-timeout resumed notifications into desktop activity facts
@@ -953,6 +959,14 @@ existing settings/CLI callers; it does not select the automatic native source
 set. See [Session backend model](session-backend-model.md) for the current
 contracts and the temporary dev-only absence of native inhibition honoring
 between #221 and #225.
+
+Adapters may expose activity and inhibition independently, each through push or
+pull according to the source. The standalone push inhibition section (#222)
+combines maintained Boolean permissions with diagnostics. Its GNOME capability
+requires only SessionManager and keeps subscriptions, state queries and owner
+recovery internal. It contributes no activity observations. #225 connects the
+two paths only at the `can_blank()` decision; runtime honoring remains absent
+until then.
 
 The runtime core owns:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -306,11 +306,13 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/runtime_phase.rs` | Runtime sleep-phase provider abstraction |
 | `crates/lg-buddy/src/session/runner.rs` | Session monitor loop |
 | `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity deadline and phase synthesis |
+| `crates/lg-buddy/src/inhibition.rs` | Standalone push inhibition contract, Boolean aggregation and diagnostics (#222) |
 | `crates/lg-buddy/src/session/gamepad/` | Gamepad activity discovery, device-event refresh, adapters, capture, registry, and policy |
 | `crates/lg-buddy/src/session_bus.rs` | Generic D-Bus transport used by session and system event sources |
 | `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle and current-session lock-state adapter |
 | `crates/lg-buddy/src/sources/linux/network_manager.rs` | NetworkManager pre-down lifecycle source adapter |
 | `crates/lg-buddy/src/sources/desktop/gnome.rs` | GNOME backend integration |
+| `crates/lg-buddy/src/sources/desktop/gnome/inhibition.rs` | Independent SessionManager inhibition capability |
 | `crates/lg-buddy/src/sources/desktop/wayland.rs` | Native Wayland idle/activity provider |
 | `crates/lg-buddy/src/sources/desktop/swayidle.rs` | `swayidle` backend integration |
 | `crates/lg-buddy/src/tv.rs` | TV transport boundary and facade |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -107,11 +107,45 @@ when no native activity capability is available at startup; #132 removes it.
 **Dev boundary (#221):** native inhibition honoring is temporarily absent.
 Inhibition notifications, permission state and release timing have been removed
 from the activity stream and inactivity engine. The stored preference remains
-compatible, and monitor startup reports the temporary limitation. #222-#225
-implement the separate inhibition subsystem and Boolean gate. This intermediate
+compatible, and monitor startup reports the temporary limitation. #222 provides
+standalone push inhibition; #223-#225 complete the subsystem and Boolean gate. This intermediate
 runtime must not be promoted to prerelease or main before that integration and
 #89's MVP readiness checks are complete. Explicit lock, ownership/restore and
 ordinary activity deadlines retain their existing policy.
+
+### Independent inhibition capabilities (#222)
+
+An adapter can supply activity, inhibition, or both. Each capability independently
+uses push or pull according to its source. Activity observations stay in the
+activity path. Inhibition supplies permission; the intended meeting point is
+`can_blank()` at the automatic idle-blanking decision, integrated in #225.
+
+`inhibition.rs` defines `PushInhibitionAdapter`: its worker maintains one source's
+state, and `evaluate()` returns a Boolean permission with matching diagnostics
+without protocol I/O. `evaluate_push_inhibition()` combines these permissions:
+every contributor must allow blanking, and diagnostics retain each result.
+
+GNOME's capability lives in `sources/desktop/gnome/inhibition.rs` and requires
+only SessionManager. It subscribes before querying `IsInhibited(8)` and refreshes
+that same contribution on `InhibitorAdded`/`InhibitorRemoved`. It validates the
+unique owner and reconciles queued changes before publishing a snapshot.
+While connected, it also refreshes after 30 seconds without a successful refresh
+to correct drift when notifications are missed. Event-driven refreshes restart
+that interval. These internal queries update the same maintained contribution;
+they do not make GNOME a second pull contributor.
+
+Only observed inhibition denies permission. Startup, absence and source loss
+contribute no inhibitor. A healthy quiet subscription and an in-progress refresh
+retain the last observed value; a completed read updates it. If reading or
+monitoring fails, the adapter drops that source's contribution and retries.
+Diagnostics retain the observation time, a bounded failure reason, and the last
+observed inhibited-to-clear transition. Source loss and subsequent recovery do
+not create an observed release.
+
+This capability is independently testable but is not started by the monitor yet.
+It reads no preferences, applies no aggregate release delay, and sends no
+activity events or TV actions. Those integration responsibilities remain in
+#224 and #225.
 
 ## Provider Map
 
@@ -138,7 +172,7 @@ Current mapping:
 
 Notes:
 
-- GNOME requires GNOME Shell, `org.gnome.ScreenSaver`, and `org.gnome.Mutter.IdleMonitor`.
+- GNOME activity requires GNOME Shell, `org.gnome.ScreenSaver`, and `org.gnome.Mutter.IdleMonitor`.
 - Activity always uses Mutter's one-shot user-active watches, rearmed after each
   signal. SessionManager is neither required nor queried by the activity source.
   Unlike `GetIdletime`, watches do not treat the idle-counter reset on inhibitor
@@ -221,8 +255,9 @@ notifications from `get_input_idle_notification`. Its `resumed` maps to desktop
 activity; `idled` remains observational, so only LG Buddy's inactivity deadline
 can trigger blanking.
 
-Only `get_input_idle_notification` is used by this activity adapter. Inhibitor
-queries belong to the separate subsystem under #223.
+Only `get_input_idle_notification` is used by this activity adapter. Idle-notify
+does not supply an inhibition capability; #216 tracks native Wayland inhibition
+coverage separately.
 
 Seats are added and removed dynamically. Connection or dispatch loss, removal
 of the bound notifier, or removal of the last seat causes the adapter to rebuild
@@ -267,6 +302,8 @@ The code split is:
     inactivity state, and policy dispatch
 - `crates/lg-buddy/src/session/activity.rs`
   - bounded, identified contributions, observation ordering and source diagnostics
+- `crates/lg-buddy/src/inhibition.rs`
+  - independent push inhibition contract, Boolean aggregation, and diagnostics
 - `crates/lg-buddy/src/session/actions.rs`
   - action dependency assembly and native TV client ownership across compatible
     events; one-shot commands use the same assembly with a finite lifetime
@@ -275,6 +312,8 @@ The code split is:
 - `crates/lg-buddy/src/sources/desktop/gnome.rs`
   - GNOME session-bus connection, subscriptions, owner validation, Mutter
     activity watches, event loop, and observation mapping
+- `crates/lg-buddy/src/sources/desktop/gnome/inhibition.rs`
+  - independent SessionManager inhibition state, subscriptions and recovery
 - `crates/lg-buddy/src/sources/desktop/wayland.rs`
   - native Wayland registry, seat, idle-notification, and activity mapping
 - `crates/lg-buddy/src/sources/linux/logind.rs`

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -277,6 +277,18 @@ Source-specific tests live with their source modules. Runner tests should use
 normalized observations and focus on multiplexing or policy behavior rather
 than reconstructing provider buses and process protocols.
 
+Push inhibition is tested independently of activity. Colocated tests in
+`inhibition.rs` cover Boolean aggregation and diagnostics; GNOME's inhibition
+module covers startup synchronization, queued changes, owner validation,
+cancellation, release history and periodic reconciliation of missed additions
+and removals. `tests/inhibition.rs` runs the production
+worker on the shared private D-Bus fixture with only SessionManager present. It
+checks existing and later playback inhibitors, overlap, quiet subscriptions,
+loss/recovery and prompt permission reads during a slow query. Only observed
+inhibition denies permission; tests verify that pending reads retain the last
+value and source loss removes its contribution. These are
+component checks; full monitor/TV acceptance remains part of #225.
+
 Native Wayland changes also require manual checks on Plasma/KWin and at least
 one other target compositor. Verify that explicit and automatic `wayland`
 detection and monitor startup succeed, unsupported capability or connection


### PR DESCRIPTION
## Summary

Add standalone push-based inhibition with GNOME SessionManager as the first capability. It maintains one contribution through initial reads, change notifications, reconnects, and reconciliation after 30 seconds without a successful refresh. The section combines source permissions with bounded diagnostics and observed-release history.

Only observed inhibitors block permission. Pending refreshes retain the last known value; startup, absence, and source failure are neutral. Owner validation rejects stale replies and ignores queued loss notifications for previous owners.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

None yet. This capability works independently of GNOME activity and is not started by the monitor. Preference handling, aggregate release delay, and the `can_blank()` integration remain in #224 and #225. Native inhibition honoring remains absent from the intermediate dev runtime until that integration is complete.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- Full core suite: `cargo test -p lg-buddy`, with the host system bus isolated and the legacy-helper fallback disabled.
- Colocated tests cover Boolean aggregation, overlap, pending reads, periodic correction of missed notifications, release history, cancellation, and owner replacement/stale notifications.
- Private D-Bus integration covers existing and later inhibitors, overlap, discovery/reconnect, quiet subscriptions, and prompt reads during a delayed query with only SessionManager present.
- No manual desktop or TV smoke test; full monitor/TV acceptance belongs to #225.

## Related Issue

Fixes #222. Part of #216 and the #89 GNOME/Plasma MVP.
