### PR TITLE
Add pull-based PowerDevil inhibition capability

### DIFF
--- a/crates/lg-buddy/src/inhibition.rs
+++ b/crates/lg-buddy/src/inhibition.rs
@@ -1,7 +1,7 @@
-//! Inhibition capabilities are independent of activity tracking. The push
-//! section reads maintained permission; it performs no protocol I/O or TV action.
+//! Inhibition capabilities are independent of activity tracking. Push reads
+//! maintained permission; pull requests current permission. Neither acts on TVs.
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
 /// Only observed inhibition denies permission; other statuses are diagnostic.
@@ -24,7 +24,7 @@ pub struct InhibitionDiagnostics {
     pub last_release_at: Option<Instant>,
 }
 
-/// Permission and diagnostics captured together from the same maintained state.
+/// Permission and diagnostics captured together from the same observation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InhibitionEvaluation {
     pub allowed: bool,
@@ -38,8 +38,16 @@ pub trait PushInhibitionAdapter: Send + Sync {
     fn evaluate(&self) -> InhibitionEvaluation;
 }
 
+/// A source-owned, blocking check, suitable for execution on a worker. Each call
+/// queries current state; it never returns cached permission. Exclusive access
+/// orders requests, and cancellation discards the reply rather than granting a
+/// verdict. Protocol I/O and owner validation remain inside the adapter.
+pub trait PullInhibitionAdapter: Send {
+    fn query(&mut self, cancelled: &AtomicBool) -> Option<InhibitionEvaluation>;
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PushInhibitionEvaluation {
+pub struct InhibitionSectionEvaluation {
     pub allowed: bool,
     pub contributions: Vec<InhibitionEvaluation>,
 }
@@ -48,12 +56,36 @@ pub struct PushInhibitionEvaluation {
 /// diagnostics describe the same evaluation, even when an earlier source denies.
 pub fn evaluate_push_inhibition(
     adapters: &[&dyn PushInhibitionAdapter],
-) -> PushInhibitionEvaluation {
+) -> InhibitionSectionEvaluation {
     let contributions: Vec<_> = adapters.iter().map(|adapter| adapter.evaluate()).collect();
-    PushInhibitionEvaluation {
+    InhibitionSectionEvaluation {
         allowed: contributions.iter().all(|result| result.allowed),
         contributions,
     }
+}
+
+/// Query every pull contributor for this attempt, including when another
+/// denies permission. Run on a worker: cancellation is checked between bounded
+/// adapter calls and before returning. A cancelled attempt has no verdict, and
+/// completed permission must not be reused for a later blank attempt.
+pub fn evaluate_pull_inhibition(
+    adapters: &mut [&mut dyn PullInhibitionAdapter],
+    cancelled: &AtomicBool,
+) -> Option<InhibitionSectionEvaluation> {
+    let mut contributions = Vec::with_capacity(adapters.len());
+    for adapter in adapters {
+        if cancelled.load(Ordering::SeqCst) {
+            return None;
+        }
+        contributions.push(adapter.query(cancelled)?);
+    }
+    if cancelled.load(Ordering::SeqCst) {
+        return None;
+    }
+    Some(InhibitionSectionEvaluation {
+        allowed: contributions.iter().all(|result| result.allowed),
+        contributions,
+    })
 }
 
 /// Adapter-owned evidence. Source loss drops its inhibition contribution without
@@ -219,5 +251,90 @@ mod tests {
             panic!("expected unavailable");
         };
         assert_eq!(reason.chars().count(), 512);
+    }
+
+    struct FakePull {
+        state: InhibitionState,
+        queries: usize,
+        cancel: bool,
+    }
+
+    impl FakePull {
+        fn new(source: &'static str) -> Self {
+            Self {
+                state: InhibitionState::new(source),
+                queries: 0,
+                cancel: false,
+            }
+        }
+    }
+
+    impl PullInhibitionAdapter for FakePull {
+        fn query(&mut self, cancelled: &AtomicBool) -> Option<InhibitionEvaluation> {
+            self.queries += 1;
+            if self.cancel {
+                cancelled.store(true, Ordering::SeqCst);
+            }
+            Some(self.state.evaluate())
+        }
+    }
+
+    #[test]
+    fn pull_section_queries_every_source_on_every_attempt_with_matching_diagnostics() {
+        let cancelled = AtomicBool::new(false);
+        let mut first = FakePull::new("first");
+        let mut second = FakePull::new("second");
+        for (index, (a, b)) in [(false, false), (true, false), (true, true), (false, true)]
+            .into_iter()
+            .enumerate()
+        {
+            first.state.observe(a, Instant::now());
+            second.state.observe(b, Instant::now());
+            let result =
+                evaluate_pull_inhibition(&mut [&mut first, &mut second], &cancelled).unwrap();
+            assert_eq!(result.allowed, !a && !b);
+            assert_eq!(
+                result.contributions,
+                [first.state.evaluate(), second.state.evaluate()]
+            );
+            assert_eq!((first.queries, second.queries), (index + 1, index + 1));
+        }
+        first.state.absent();
+        assert!(
+            !evaluate_pull_inhibition(&mut [&mut first, &mut second], &cancelled)
+                .unwrap()
+                .allowed
+        );
+        second.state.unavailable("failed current check");
+        let result = evaluate_pull_inhibition(&mut [&mut first, &mut second], &cancelled).unwrap();
+        assert!(result.allowed);
+        assert_eq!(
+            result.contributions,
+            [first.state.evaluate(), second.state.evaluate()]
+        );
+        assert!(
+            evaluate_pull_inhibition(&mut [], &cancelled)
+                .unwrap()
+                .allowed
+        );
+    }
+
+    #[test]
+    fn cancelled_pull_sections_have_no_verdict_or_further_queries() {
+        let cancelled = AtomicBool::new(true);
+        let mut first = FakePull::new("first");
+        let mut second = FakePull::new("second");
+        assert!(evaluate_pull_inhibition(&mut [&mut first], &cancelled).is_none());
+        assert!(evaluate_pull_inhibition(&mut [], &cancelled).is_none());
+        assert_eq!(first.queries, 0);
+
+        cancelled.store(false, Ordering::SeqCst);
+        first.cancel = true;
+        assert!(evaluate_pull_inhibition(&mut [&mut first, &mut second], &cancelled).is_none());
+        assert_eq!((first.queries, second.queries), (1, 0));
+
+        cancelled.store(false, Ordering::SeqCst);
+        // Even cancellation during the last adapter discards the whole verdict.
+        assert!(evaluate_pull_inhibition(&mut [&mut first], &cancelled).is_none());
     }
 }

--- a/crates/lg-buddy/src/sources/desktop/mod.rs
+++ b/crates/lg-buddy/src/sources/desktop/mod.rs
@@ -1,4 +1,5 @@
 pub mod gnome;
+pub mod powerdevil;
 pub mod swayidle;
 pub mod wayland;
 

--- a/crates/lg-buddy/src/sources/desktop/powerdevil.rs
+++ b/crates/lg-buddy/src/sources/desktop/powerdevil.rs
@@ -1,0 +1,330 @@
+//! PowerDevil's pull inhibition capability. Its effective screen policy already
+//! includes desktop filtering; do not reinterpret raw logind inhibitors here.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Instant;
+
+use crate::inhibition::{InhibitionEvaluation, InhibitionState, PullInhibitionAdapter};
+use crate::session_bus::{
+    get_name_owner, new_session_bus_client, BusMethodCall, BusValue, SessionBusClient,
+    SessionBusError,
+};
+
+const SERVICE: &str = "org.kde.Solid.PowerManagement";
+const PATH: &str = "/org/kde/Solid/PowerManagement/PolicyAgent";
+const INTERFACE: &str = "org.kde.Solid.PowerManagement.PolicyAgent";
+const CHANGE_SCREEN_SETTINGS: u32 = 4;
+
+pub struct PowerDevilInhibition {
+    // History is diagnostic only. Every request obtains a fresh answer.
+    state: InhibitionState,
+    owner: Option<String>,
+}
+
+impl Default for PowerDevilInhibition {
+    fn default() -> Self {
+        Self {
+            state: InhibitionState::new("powerdevil"),
+            owner: None,
+        }
+    }
+}
+
+impl PullInhibitionAdapter for PowerDevilInhibition {
+    fn query(&mut self, cancelled: &AtomicBool) -> Option<InhibitionEvaluation> {
+        if cancelled.load(Ordering::SeqCst) {
+            return None;
+        }
+        // ponytail: connect per request; the next check also handles late service
+        // startup or connection recovery without a background monitor.
+        let result = new_session_bus_client().and_then(|mut bus| read(&mut bus, cancelled));
+        self.complete(result, cancelled)
+    }
+}
+
+impl PowerDevilInhibition {
+    fn complete(
+        &mut self,
+        result: Result<Option<(String, bool, Instant)>, SessionBusError>,
+        cancelled: &AtomicBool,
+    ) -> Option<InhibitionEvaluation> {
+        if cancelled.load(Ordering::SeqCst) {
+            self.owner = None;
+            self.state.unavailable("inhibition check cancelled");
+            return None;
+        }
+        match result {
+            Ok(Some((owner, inhibited, observed_at))) => {
+                if self.owner.as_ref() != Some(&owner) {
+                    // A new owner's clear answer is not an observed release by
+                    // the old owner. Neither is recovery after a failed check.
+                    self.state.unavailable("PowerDevil owner changed");
+                }
+                self.owner = Some(owner);
+                self.state.observe(inhibited, observed_at);
+            }
+            Ok(None) => {
+                self.owner = None;
+                self.state.absent();
+            }
+            Err(error) => {
+                self.owner = None;
+                self.state.unavailable(error);
+            }
+        }
+        Some(self.state.evaluate())
+    }
+}
+
+fn read(
+    bus: &mut impl SessionBusClient,
+    cancelled: &AtomicBool,
+) -> Result<Option<(String, bool, Instant)>, SessionBusError> {
+    // Discovery does not activate PowerDevil on a desktop where it is absent.
+    if !bus.name_has_owner(SERVICE)? || cancelled.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    let owner = get_name_owner(bus, SERVICE)?;
+    if cancelled.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    let inhibited = bus
+        .call_method(
+            BusMethodCall::new(&owner, PATH, INTERFACE, "HasInhibition")
+                .with_body(vec![BusValue::U32(CHANGE_SCREEN_SETTINGS)]),
+        )?
+        .single_bool()?;
+    let observed_at = Instant::now();
+    if cancelled.load(Ordering::SeqCst) {
+        return Ok(None);
+    }
+    if get_name_owner(bus, SERVICE)? != owner {
+        return Err(SessionBusError::Transport(
+            "PowerDevil owner changed during check".into(),
+        ));
+    }
+    Ok(Some((owner, inhibited, observed_at)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inhibition::InhibitionStatus;
+    use crate::session_bus::{
+        BusReply, BusSignal, BusSignalMatch, DBUS_INTERFACE, DBUS_OBJECT_PATH, DBUS_SERVICE_NAME,
+    };
+    use std::collections::VecDeque;
+    use std::time::Duration;
+
+    struct FakeBus<'a> {
+        present: bool,
+        replies: VecDeque<Result<BusReply, SessionBusError>>,
+        destinations: Vec<String>,
+        cancelled: &'a AtomicBool,
+        cancel_after_call: Option<usize>,
+    }
+
+    impl<'a> FakeBus<'a> {
+        fn new(cancelled: &'a AtomicBool, owner: &str, inhibited: bool, final_owner: &str) -> Self {
+            Self {
+                present: true,
+                replies: [
+                    BusValue::String(owner.into()),
+                    BusValue::Bool(inhibited),
+                    BusValue::String(final_owner.into()),
+                ]
+                .into_iter()
+                .map(|value| Ok(BusReply::new(vec![value])))
+                .collect(),
+                destinations: Vec::new(),
+                cancelled,
+                cancel_after_call: None,
+            }
+        }
+    }
+
+    impl SessionBusClient for FakeBus<'_> {
+        fn name_has_owner(&mut self, name: &str) -> Result<bool, SessionBusError> {
+            assert_eq!(name, SERVICE);
+            Ok(self.present)
+        }
+
+        fn call_method(&mut self, call: BusMethodCall<'_>) -> Result<BusReply, SessionBusError> {
+            match call.member {
+                "GetNameOwner" => {
+                    assert_eq!(
+                        (call.destination, call.path, call.interface),
+                        (DBUS_SERVICE_NAME, DBUS_OBJECT_PATH, DBUS_INTERFACE)
+                    );
+                    assert_eq!(call.body, [BusValue::String(SERVICE.into())]);
+                }
+                "HasInhibition" => {
+                    assert_eq!((call.path, call.interface), (PATH, INTERFACE));
+                    assert_eq!(call.body, [BusValue::U32(4)]);
+                    assert!(call.destination.starts_with(':'));
+                }
+                other => panic!("unexpected query: {other}"),
+            }
+            self.destinations.push(call.destination.to_string());
+            if self.cancel_after_call == Some(self.destinations.len()) {
+                self.cancelled.store(true, Ordering::SeqCst);
+            }
+            self.replies.pop_front().expect("unexpected extra call")
+        }
+
+        fn add_signal_match(&mut self, _: BusSignalMatch<'_>) -> Result<(), SessionBusError> {
+            panic!("pull inhibition must not subscribe to signals");
+        }
+
+        fn process(&mut self, _: Duration) -> Result<Option<BusSignal>, SessionBusError> {
+            panic!("pull inhibition must not wait for signals");
+        }
+    }
+
+    fn query(
+        adapter: &mut PowerDevilInhibition,
+        bus: &mut FakeBus<'_>,
+    ) -> Option<InhibitionEvaluation> {
+        let result = read(bus, bus.cancelled);
+        adapter.complete(result, bus.cancelled)
+    }
+
+    #[test]
+    fn effective_screen_policy_is_queried_each_time_and_release_is_observed_once() {
+        let cancelled = AtomicBool::new(false);
+        let mut adapter = PowerDevilInhibition::default();
+        let mut release = None;
+        // Effective answers with no signals: initially clear, playback begins,
+        // one of two inhibitors ends, then the last ends (or Plasma suppresses it).
+        for inhibited in [false, true, true, false, false, true] {
+            let mut bus = FakeBus::new(&cancelled, ":1.1", inhibited, ":1.1");
+            let result = query(&mut adapter, &mut bus).unwrap();
+            assert_eq!(result.allowed, !inhibited);
+            assert_eq!(
+                result.diagnostics.status == InhibitionStatus::Inhibited,
+                inhibited
+            );
+            assert_eq!(result.diagnostics.source, "powerdevil");
+            assert!(result.diagnostics.observed_at.is_some());
+            assert_eq!(
+                bus.destinations,
+                [DBUS_SERVICE_NAME, ":1.1", DBUS_SERVICE_NAME]
+            );
+            assert!(bus.replies.is_empty());
+            if release.is_none() {
+                release = result.diagnostics.last_release_at;
+            } else {
+                assert_eq!(result.diagnostics.last_release_at, release);
+            }
+        }
+        assert!(release.is_some());
+    }
+
+    #[test]
+    fn absent_powerdevil_is_neutral_without_a_policy_call_and_can_appear_later() {
+        let cancelled = AtomicBool::new(false);
+        let mut adapter = PowerDevilInhibition::default();
+        let mut bus = FakeBus::new(&cancelled, ":1.1", true, ":1.1");
+        bus.present = false;
+        let absent = query(&mut adapter, &mut bus).unwrap();
+        assert!(absent.allowed);
+        assert_eq!(absent.diagnostics.status, InhibitionStatus::Absent);
+        assert!(bus.destinations.is_empty());
+        bus.present = true;
+        assert!(!query(&mut adapter, &mut bus).unwrap().allowed);
+    }
+
+    #[test]
+    fn failed_or_malformed_queries_drop_previous_inhibition_without_a_release() {
+        let cancelled = AtomicBool::new(false);
+        for reply in [
+            Err(SessionBusError::Transport("é".repeat(1000))),
+            Ok(BusReply::new(vec![BusValue::U32(0)])),
+        ] {
+            let mut adapter = PowerDevilInhibition::default();
+            assert!(
+                !query(
+                    &mut adapter,
+                    &mut FakeBus::new(&cancelled, ":1.1", true, ":1.1")
+                )
+                .unwrap()
+                .allowed
+            );
+            let mut bus = FakeBus::new(&cancelled, ":1.1", false, ":1.1");
+            bus.replies[1] = reply;
+            let failed = query(&mut adapter, &mut bus).unwrap();
+            assert!(failed.allowed);
+            let InhibitionStatus::Unavailable(reason) = failed.diagnostics.status else {
+                panic!("expected failure");
+            };
+            assert!(reason.chars().count() <= 512);
+            assert_eq!(failed.diagnostics.last_release_at, None);
+            let recovered = query(
+                &mut adapter,
+                &mut FakeBus::new(&cancelled, ":1.1", false, ":1.1"),
+            )
+            .unwrap();
+            assert_eq!(recovered.diagnostics.status, InhibitionStatus::Clear);
+            assert_eq!(recovered.diagnostics.last_release_at, None);
+        }
+    }
+
+    #[test]
+    fn owner_replacement_rejects_old_replies_and_does_not_invent_a_release() {
+        let cancelled = AtomicBool::new(false);
+        for replace_during_query in [false, true] {
+            let mut adapter = PowerDevilInhibition::default();
+            query(
+                &mut adapter,
+                &mut FakeBus::new(&cancelled, ":1.1", true, ":1.1"),
+            )
+            .unwrap();
+            if replace_during_query {
+                let result = query(
+                    &mut adapter,
+                    &mut FakeBus::new(&cancelled, ":1.1", false, ":1.2"),
+                )
+                .unwrap();
+                assert!(matches!(
+                    result.diagnostics.status,
+                    InhibitionStatus::Unavailable(_)
+                ));
+                assert_eq!(result.diagnostics.last_release_at, None);
+            }
+            let current = query(
+                &mut adapter,
+                &mut FakeBus::new(&cancelled, ":1.2", false, ":1.2"),
+            )
+            .unwrap();
+            assert!(current.allowed);
+            assert_eq!(current.diagnostics.last_release_at, None);
+        }
+    }
+
+    #[test]
+    fn cancellation_at_each_io_boundary_discards_the_result_and_later_checks_are_fresh() {
+        let cancelled = AtomicBool::new(true);
+        let mut adapter = PowerDevilInhibition::default();
+        assert!(adapter.query(&cancelled).is_none()); // No connection needed.
+        for boundary in 1..=3 {
+            cancelled.store(false, Ordering::SeqCst);
+            query(
+                &mut adapter,
+                &mut FakeBus::new(&cancelled, ":1.1", true, ":1.1"),
+            )
+            .unwrap();
+            let mut bus = FakeBus::new(&cancelled, ":1.1", false, ":1.1");
+            bus.cancel_after_call = Some(boundary);
+            assert!(query(&mut adapter, &mut bus).is_none());
+            assert_eq!(bus.destinations.len(), boundary);
+            cancelled.store(false, Ordering::SeqCst);
+            let next = query(
+                &mut adapter,
+                &mut FakeBus::new(&cancelled, ":1.1", false, ":1.1"),
+            )
+            .unwrap();
+            assert!(next.allowed);
+            assert_eq!(next.diagnostics.last_release_at, None);
+        }
+    }
+}

--- a/crates/lg-buddy/tests/inhibition.rs
+++ b/crates/lg-buddy/tests/inhibition.rs
@@ -1,12 +1,16 @@
 mod support;
 
-use lg_buddy::inhibition::{evaluate_push_inhibition, InhibitionStatus, PushInhibitionAdapter};
+use lg_buddy::inhibition::{
+    evaluate_pull_inhibition, evaluate_push_inhibition, InhibitionStatus, PullInhibitionAdapter,
+    PushInhibitionAdapter,
+};
 use lg_buddy::sources::desktop::gnome::inhibition::GnomeInhibition;
+use lg_buddy::sources::desktop::powerdevil::PowerDevilInhibition;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
-use support::{MockSessionBusIdleMonitor, TestEnv};
+use support::{MockPowerDevil, MockSessionBusIdleMonitor, TestEnv};
 
 // Run the production capability against a private bus, without activity or TV
 // machinery. Drop stops the worker even if an assertion fails.
@@ -48,7 +52,7 @@ fn wait_until(mut condition: impl FnMut() -> bool) {
 }
 
 #[test]
-fn gnome_push_inhibition_works_without_activity_services() {
+fn independent_inhibition_capabilities_work_without_activity_services() {
     let mut env = TestEnv::new();
     let bus = MockSessionBusIdleMonitor::new("inhibition-capability");
     // libdbus caches the session-bus address process-wide. Exercise all scenarios
@@ -57,6 +61,107 @@ fn gnome_push_inhibition_works_without_activity_services() {
     a_late_source_is_discovered_and_loss_drops_its_contribution(&bus);
     playback_inhibitors_release_only_when_all_end(&bus);
     permission_reads_do_not_wait_for_dbus_and_a_quiet_worker_can_stop(&bus);
+    powerdevil_queries_current_permission_and_recovers(&bus);
+    powerdevil_discards_delayed_cancelled_and_obsolete_replies(&bus);
+}
+
+fn powerdevil_queries_current_permission_and_recovers(bus: &MockSessionBusIdleMonitor) {
+    let cancelled = AtomicBool::new(false);
+    let mut adapter = PowerDevilInhibition::default();
+    let absent = adapter.query(&cancelled).unwrap();
+    assert!(absent.allowed);
+    assert_eq!(absent.diagnostics.status, InhibitionStatus::Absent);
+
+    let service = MockPowerDevil::new(bus.address());
+    // Playback already active when the first request arrives.
+    service.set_inhibited(true);
+    assert!(
+        !evaluate_pull_inhibition(&mut [&mut adapter], &cancelled)
+            .unwrap()
+            .allowed
+    );
+    // The fixture supplies effective policy, including overlapping requests or
+    // a user suppressing them in Plasma. It emits no change notifications.
+    for inhibited in [true, false, false, true] {
+        service.set_inhibited(inhibited);
+        let previous_queries = service.query_count();
+        let result = evaluate_pull_inhibition(&mut [&mut adapter], &cancelled).unwrap();
+        assert_eq!(result.allowed, !inhibited);
+        assert_eq!(result.contributions.len(), 1);
+        assert_eq!(result.contributions[0].diagnostics.source, "powerdevil");
+        assert_eq!(service.query_count(), previous_queries + 1);
+    }
+    let release = adapter
+        .query(&cancelled)
+        .unwrap()
+        .diagnostics
+        .last_release_at;
+    assert!(release.is_some());
+    service.fail_next_query();
+    let failed = adapter.query(&cancelled).unwrap();
+    assert!(failed.allowed);
+    assert!(matches!(
+        failed.diagnostics.status,
+        InhibitionStatus::Unavailable(_)
+    ));
+    service.set_inhibited(false);
+    let recovered = adapter.query(&cancelled).unwrap();
+    assert_eq!(recovered.diagnostics.status, InhibitionStatus::Clear);
+    assert_eq!(recovered.diagnostics.last_release_at, release);
+    drop(service);
+    assert_eq!(
+        adapter.query(&cancelled).unwrap().diagnostics.status,
+        InhibitionStatus::Absent
+    );
+}
+
+fn powerdevil_discards_delayed_cancelled_and_obsolete_replies(bus: &MockSessionBusIdleMonitor) {
+    let cancelled = AtomicBool::new(false);
+    let mut adapter = PowerDevilInhibition::default();
+    let service = MockPowerDevil::new(bus.address());
+    service.delay_next_query(Duration::from_millis(400));
+    thread::scope(|scope| {
+        let worker = scope.spawn(|| evaluate_pull_inhibition(&mut [&mut adapter], &cancelled));
+        wait_until(|| service.query_count() == 1);
+        // The caller is free while the source is replying. Cancelling discards
+        // the delayed clear response; it cannot authorize this or a later attempt.
+        cancelled.store(true, Ordering::SeqCst);
+        assert!(worker.join().unwrap().is_none());
+    });
+    cancelled.store(false, Ordering::SeqCst);
+    service.set_inhibited(true);
+    assert!(!adapter.query(&cancelled).unwrap().allowed);
+
+    // A reply arriving after the transport timeout cannot answer the next check.
+    service.set_inhibited(false);
+    service.delay_next_query(Duration::from_millis(1200));
+    let timed_out = adapter.query(&cancelled).unwrap();
+    assert!(matches!(
+        timed_out.diagnostics.status,
+        InhibitionStatus::Unavailable(_)
+    ));
+    service.set_inhibited(true);
+    assert!(!adapter.query(&cancelled).unwrap().allowed);
+
+    service.delay_next_query(Duration::from_millis(400));
+    service.set_inhibited(false);
+    let queries = service.query_count();
+    let replacement = thread::scope(|scope| {
+        let worker = scope.spawn(|| adapter.query(&cancelled));
+        wait_until(|| service.query_count() > queries);
+        let replacement = MockPowerDevil::new(bus.address());
+        replacement.set_inhibited(true);
+        let obsolete = worker.join().unwrap().unwrap();
+        assert!(matches!(
+            obsolete.diagnostics.status,
+            InhibitionStatus::Unavailable(_)
+        ));
+        assert_eq!(obsolete.diagnostics.last_release_at, None);
+        replacement
+    });
+    assert!(!adapter.query(&cancelled).unwrap().allowed);
+    replacement.set_inhibited(false);
+    assert!(adapter.query(&cancelled).unwrap().allowed);
 }
 
 fn playback_inhibitors_release_only_when_all_end(bus: &MockSessionBusIdleMonitor) {

--- a/crates/lg-buddy/tests/support/mod.rs
+++ b/crates/lg-buddy/tests/support/mod.rs
@@ -667,6 +667,116 @@ extern "C" fn kill_mock_system_logind_daemon() {
     }
 }
 
+/// Contract mock for PowerDevil's effective answer, not its policy engine.
+/// Attaches to an existing private bus; a second instance replaces the owner.
+#[allow(dead_code)]
+pub struct MockPowerDevil {
+    state: Arc<Mutex<MockPowerDevilState>>,
+    stop: Arc<AtomicBool>,
+    worker: Option<JoinHandle<()>>,
+}
+
+#[derive(Default)]
+struct MockPowerDevilState {
+    inhibited: bool,
+    next_delay: Duration,
+    fail_next: bool,
+    queries: usize,
+}
+
+#[allow(dead_code)]
+impl MockPowerDevil {
+    pub fn new(address: &str) -> Self {
+        let state = Arc::new(Mutex::new(MockPowerDevilState::default()));
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker_state = Arc::clone(&state);
+        let worker_stop = Arc::clone(&stop);
+        let address = address.to_string();
+        let (ready_tx, ready_rx) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            let connection = DbusConnection::new_address(&address).unwrap();
+            let mut crossroads = Crossroads::new();
+            let interface =
+                crossroads.register("org.kde.Solid.PowerManagement.PolicyAgent", |builder| {
+                    builder.method(
+                        "HasInhibition",
+                        ("types",),
+                        ("has_inhibition",),
+                        move |_, _: &mut (), (types,): (u32,)| {
+                            assert_eq!(
+                                types, 4,
+                                "only effective screen inhibition should be queried"
+                            );
+                            let (inhibited, delay, fail) = {
+                                let mut state = worker_state.lock().unwrap();
+                                state.queries += 1;
+                                (
+                                    state.inhibited,
+                                    std::mem::take(&mut state.next_delay),
+                                    std::mem::take(&mut state.fail_next),
+                                )
+                            };
+                            thread::sleep(delay);
+                            if fail {
+                                Err(MethodErr::failed("PowerDevil check failed"))
+                            } else {
+                                Ok((inhibited,))
+                            }
+                        },
+                    );
+                });
+            crossroads.insert(
+                "/org/kde/Solid/PowerManagement/PolicyAgent",
+                &[interface],
+                (),
+            );
+            connection.start_receive(
+                dbus::message::MatchRule::new_method_call(),
+                Box::new(move |message, conn| {
+                    crossroads.handle_message(message, conn).unwrap();
+                    true
+                }),
+            );
+            connection
+                .request_name("org.kde.Solid.PowerManagement", true, true, true)
+                .unwrap();
+            ready_tx.send(()).unwrap();
+            while !worker_stop.load(Ordering::SeqCst) {
+                connection.process(Duration::from_millis(10)).unwrap();
+            }
+        });
+        ready_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        Self {
+            state,
+            stop,
+            worker: Some(worker),
+        }
+    }
+
+    pub fn set_inhibited(&self, inhibited: bool) {
+        self.state.lock().unwrap().inhibited = inhibited;
+    }
+
+    pub fn delay_next_query(&self, delay: Duration) {
+        self.state.lock().unwrap().next_delay = delay;
+    }
+
+    pub fn fail_next_query(&self) {
+        self.state.lock().unwrap().fail_next = true;
+    }
+
+    pub fn query_count(&self) -> usize {
+        self.state.lock().unwrap().queries
+    }
+}
+
+impl Drop for MockPowerDevil {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::SeqCst);
+        self.worker.take().unwrap().join().unwrap();
+    }
+}
+
 fn start_private_session_bus() -> (String, i32) {
     let output = ProcessCommand::new(dbus_daemon_path())
         .args([

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -407,11 +407,14 @@ The current split is:
   - owns GNOME session-bus setup, subscriptions, sender validation, Mutter
     user-active watches, and translation into normalized observations
 - `inhibition.rs`
-  - independent push inhibition contract, Boolean aggregation and diagnostics;
+  - independent push/pull inhibition contracts, Boolean aggregation and diagnostics;
     standalone until the monitor integration in #225
 - `sources/desktop/gnome/inhibition.rs`
   - SessionManager inhibition subscriptions, state refresh and recovery,
     independent of GNOME activity
+- `sources/desktop/powerdevil.rs`
+  - fresh effective screen-policy queries, cancellation and owner validation;
+    independent of activity and GNOME's maintained inhibition
 - `sources/desktop/wayland.rs`
   - native Wayland capability probing and dynamic registry/seat ownership
   - maps zero-timeout resumed notifications into desktop activity facts
@@ -962,7 +965,9 @@ between #221 and #225.
 
 Adapters may expose activity and inhibition independently, each through push or
 pull according to the source. The standalone push inhibition section (#222)
-combines maintained Boolean permissions with diagnostics. Its GNOME capability
+combines maintained Boolean permissions with diagnostics. The pull section (#223)
+combines fresh, cancellable requests in the same diagnostic shape; its PowerDevil
+capability delegates screen policy to Plasma. The GNOME capability
 requires only SessionManager and keeps subscriptions, state queries and owner
 recovery internal. It contributes no activity observations. #225 connects the
 two paths only at the `can_blank()` decision; runtime honoring remains absent

--- a/docs/development.md
+++ b/docs/development.md
@@ -306,13 +306,14 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/runtime_phase.rs` | Runtime sleep-phase provider abstraction |
 | `crates/lg-buddy/src/session/runner.rs` | Session monitor loop |
 | `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity deadline and phase synthesis |
-| `crates/lg-buddy/src/inhibition.rs` | Standalone push inhibition contract, Boolean aggregation and diagnostics (#222) |
+| `crates/lg-buddy/src/inhibition.rs` | Standalone push/pull inhibition contracts, Boolean aggregation and diagnostics (#222/#223) |
 | `crates/lg-buddy/src/session/gamepad/` | Gamepad activity discovery, device-event refresh, adapters, capture, registry, and policy |
 | `crates/lg-buddy/src/session_bus.rs` | Generic D-Bus transport used by session and system event sources |
 | `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle and current-session lock-state adapter |
 | `crates/lg-buddy/src/sources/linux/network_manager.rs` | NetworkManager pre-down lifecycle source adapter |
 | `crates/lg-buddy/src/sources/desktop/gnome.rs` | GNOME backend integration |
 | `crates/lg-buddy/src/sources/desktop/gnome/inhibition.rs` | Independent SessionManager inhibition capability |
+| `crates/lg-buddy/src/sources/desktop/powerdevil.rs` | Independent pull inhibition through PowerDevil's effective screen policy |
 | `crates/lg-buddy/src/sources/desktop/wayland.rs` | Native Wayland idle/activity provider |
 | `crates/lg-buddy/src/sources/desktop/swayidle.rs` | `swayidle` backend integration |
 | `crates/lg-buddy/src/tv.rs` | TV transport boundary and facade |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -108,12 +108,13 @@ when no native activity capability is available at startup; #132 removes it.
 Inhibition notifications, permission state and release timing have been removed
 from the activity stream and inactivity engine. The stored preference remains
 compatible, and monitor startup reports the temporary limitation. #222 provides
-standalone push inhibition; #223-#225 complete the subsystem and Boolean gate. This intermediate
+standalone push inhibition and #223 provides pull inhibition; #224-#225 complete
+the subsystem and Boolean gate. This intermediate
 runtime must not be promoted to prerelease or main before that integration and
 #89's MVP readiness checks are complete. Explicit lock, ownership/restore and
 ordinary activity deadlines retain their existing policy.
 
-### Independent inhibition capabilities (#222)
+### Independent inhibition capabilities (#222, #223)
 
 An adapter can supply activity, inhibition, or both. Each capability independently
 uses push or pull according to its source. Activity observations stay in the
@@ -142,10 +143,54 @@ Diagnostics retain the observation time, a bounded failure reason, and the last
 observed inhibited-to-clear transition. Source loss and subsequent recovery do
 not create an observed release.
 
-This capability is independently testable but is not started by the monitor yet.
-It reads no preferences, applies no aggregate release delay, and sends no
+`PullInhibitionAdapter::query()` performs a fresh source check on each call.
+`evaluate_pull_inhibition()` queries every participating adapter, ANDs their
+permissions, and returns the same section result and per-source diagnostic
+shape as push evaluation. It runs on a worker; exclusive mutable access orders
+requests without a separate request-generation tracker. Cancellation returns
+no verdict. A completed result belongs to that attempt and cannot be reused to
+authorize a later blank attempt. #225 owns consuming completions for the current
+attempt and joining the sections.
+
+PowerDevil's capability lives in `sources/desktop/powerdevil.rs`. It opens a
+session-bus connection per check, discovers `org.kde.Solid.PowerManagement`
+without activating it, and queries `HasInhibition(4)` on
+`/org/kde/Solid/PowerManagement/PolicyAgent` using the resolved unique owner.
+It rechecks the owner before accepting the answer. No signals or background
+worker are required to maintain its state. Cancellation is checked between
+method calls and before completion; an in-flight call is bounded by the
+transport's one-second timeout. The next request handles discovery/recovery.
+Only diagnostic history survives between requests, recording inhibited-to-clear
+transitions within the same owner's successful observations. Failed checks,
+absence, cancelled in-flight checks and owner replacement break that continuity;
+recovery does not manufacture a release. Failures and absence are neutral under
+the same observed-inhibition rule as push. GNOME remains one push contribution.
+
+These capabilities are independently testable but are not started by the monitor yet.
+They read no preferences, apply no aggregate release delay, and send no
 activity events or TV actions. Those integration responsibilities remain in
 #224 and #225.
+
+### PowerDevil route coverage
+
+The query delegates policy to PowerDevil, including activation delays, filtering
+and user overrides; LG Buddy does not count requested inhibitors or separately
+interpret logind's list. The following routes were traced in upstream source,
+not validated in a live Plasma session:
+
+| Application route | Relationship to the effective screen-policy query |
+| --- | --- |
+| PowerDevil `AddInhibition(4, ...)` | Direct screen-policy contribution; suppressed requests are excluded. [Policy implementation](https://github.com/KDE/powerdevil/blob/c075216f737a47b1979e2c0b679ed597ac8ea131/daemon/powerdevilpolicyagent.cpp#L549-L588) |
+| KDE portal `Inhibit` with Idle flag `8` | Translates to PowerDevil policy `4`. Suspend-only flag `4` translates to policy `1`, not screen inhibition. [Portal implementation](https://github.com/KDE/xdg-desktop-portal-kde/blob/9427f3bc8712532f4599dc54b19bd4975609d7f9/src/inhibit.cpp#L165-L182) |
+| `org.freedesktop.ScreenSaver.Inhibit` in Plasma | KScreenLocker forwards the request to PowerDevil `AddInhibition(4, ...)`. [KScreenLocker implementation](https://github.com/KDE/kscreenlocker/blob/4f8927000c3f5c5caa52f775580487b5c782132a/interface.cpp#L46-L68) |
+| logind `idle` inhibitors | PowerDevil imports qualifying `block` inhibitors, excluding its own; LG Buddy consumes the resulting policy. [Import/filter implementation](https://github.com/KDE/powerdevil/blob/c075216f737a47b1979e2c0b679ed597ac8ea131/daemon/powerdevilpolicyagent.cpp#L423-L501) |
+| `org.freedesktop.PowerManagement.Inhibit` | PowerDevil maps this to session interruption policy `1`; it does not by itself inhibit screen policy `4`. [FDO connector](https://github.com/KDE/powerdevil/blob/c075216f737a47b1979e2c0b679ed597ac8ea131/daemon/powerdevilfdoconnector.cpp#L84-L93) |
+| Native Wayland idle inhibitor | KWin feeds this into its own input idle-inhibitor set. This is a separate path; PowerDevil coverage is not established. [KWin implementation](https://github.com/KDE/kwin/blob/b3e286c172bb9df7ee8ba8f1ef3a8ca21a8c770f/src/idle_inhibition.cpp#L58-L81) |
+
+These are version-specific source findings, not a promise that every application
+uses a covered route. Live Plasma validation and native Wayland coverage remain
+open under #216/#223; see [Testing strategy](testing-strategy.md). Idle-notify
+remains an activity protocol and is not used as an inhibition query.
 
 ## Provider Map
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -289,6 +289,36 @@ inhibition denies permission; tests verify that pending reads retain the last
 value and source loss removes its contribution. These are
 component checks; full monitor/TV acceptance remains part of #225.
 
+Pull inhibition has colocated contract and adapter tests for fresh queries,
+Boolean aggregation, neutral absence/failure, bounded diagnostics, cancellation,
+owner replacement and release history. The same private-bus integration test
+also runs PowerDevil's production capability against `MockPowerDevil`, which
+exposes only `HasInhibition(4)` and emits no signals. It covers initial and later
+inhibition, effective clear answers, failure recovery, transport timeout, worker
+cancellation during delayed replies, and replacement by a new unique owner.
+The mock supplies effective policy; it does not prove Plasma's filtering,
+overlap handling or application route coverage.
+
+For live Plasma validation of #223, record Plasma/PowerDevil and application
+versions and the application's inhibition route, then inspect effective state:
+
+```sh
+busctl --user call org.kde.Solid.PowerManagement \
+  /org/kde/Solid/PowerManagement/PolicyAgent \
+  org.kde.Solid.PowerManagement.PolicyAgent HasInhibition u 4
+```
+
+Check playback that starts before the first query and after a clear query, two
+overlapping inhibitors with only one ending, and Plasma's per-application
+suppression/reenabling. Allow PowerDevil's own activation delay to pass. Record
+the effective answer after each change and repeat after PowerDevil restarts.
+Test at least the KDE portal idle route and ScreenSaver D-Bus route where used
+by the reporter's applications. Test native Wayland-only inhibition separately;
+do not infer its coverage from portal success. The source-traced route table in
+[Session backend model](session-backend-model.md#powerdevil-route-coverage) is
+not live validation. This work was implemented on GNOME; the Plasma checks and
+remaining native Wayland coverage belong to #216/#223 before MVP completion.
+
 Native Wayland changes also require manual checks on Plasma/KWin and at least
 one other target compositor. Verify that explicit and automatic `wayland`
 detection and monitor startup succeed, unsupported capability or connection


### PR DESCRIPTION
## Summary

Add the pull inhibition section and a PowerDevil adapter that checks effective screen policy on every request. The adapter calls `HasInhibition(4)`, leaving Plasma's filtering and user overrides with PowerDevil, and returns Boolean permission with bounded diagnostics.

Requests support worker execution and cancellation. Owner validation rejects replies from replaced services; cancelled attempts return no verdict. Only observed inhibition blocks, while absence and failed checks are neutral. Diagnostic history distinguishes observed releases from recovery without caching permission for future blank attempts.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

GNOME remains a single push contribution. Preferences, aggregate release timing and monitor integration remain in #224/#225. The documentation records upstream application routes and the separate native Wayland coverage question under #216.

## User-Visible Behavior

None yet. This is a standalone capability on `dev`; native inhibition honoring remains disconnected from the monitor until #225. The intermediate runtime must not be promoted to `prerelease` or `main`.

## Validation

- `cargo fmt --all --check` passed.
- Full `cargo test -p lg-buddy` passed with host system-bus isolation and the legacy TV helper disabled: 1,009 unit tests, all 143 Cucumber scenarios, and all integration tests. The ignored subprocess helper was exercised by its parent test.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed.
- Focused inhibition and PowerDevil tests were rerun during review, including the production adapter on a private D-Bus service. Coverage includes fresh effective answers, Boolean aggregation, absence/failure recovery, timeout, cancellation during delayed replies, and replacement by a new unique owner.
- Live Plasma validation is still pending. Contract mocks and upstream source inspection do not establish real application route coverage or native Wayland inhibitor support. The remaining checks are documented and tracked in #216/#223.

## Related Issue

Implements the code portion of #223; keep that issue open for live Plasma validation. Part of #216 and the #89 GNOME/Plasma MVP. Related regression: #195.
