### PR TITLE
Add inhibition preference evaluation

### DIFF
--- a/crates/lg-buddy/src/inhibition.rs
+++ b/crates/lg-buddy/src/inhibition.rs
@@ -4,6 +4,37 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 
+use crate::config::{Config, ScreenHonorIdleInhibitorsPolicy};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InhibitionPreferenceDiagnostics {
+    pub honoring: ScreenHonorIdleInhibitorsPolicy,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InhibitionPreferenceEvaluation {
+    /// Overrides source restrictions and release delay, never activity eligibility.
+    /// This is an override, not a third permission to AND with the source sections.
+    pub bypass_inhibition: bool,
+    pub diagnostics: InhibitionPreferenceDiagnostics,
+}
+
+/// Evaluate the preference from the runtime's loaded configuration, without
+/// source queries or retained state. Disabled honoring bypasses inhibition;
+/// enabled honoring leaves source permission and release delay to the reconciler.
+///
+/// Settings apply through a screen-service restart. A new runtime evaluates its
+/// newly loaded Config; old attempts cannot survive that process boundary. For
+/// an in-process reload, the reconciler must cancel the pending attempt before
+/// using the new configuration and must not reuse this result across attempts.
+pub fn evaluate_inhibition_preference(config: &Config) -> InhibitionPreferenceEvaluation {
+    let honoring = config.screen_honor_idle_inhibitors;
+    InhibitionPreferenceEvaluation {
+        bypass_inhibition: !honoring.is_enabled(),
+        diagnostics: InhibitionPreferenceDiagnostics { honoring },
+    }
+}
+
 /// Only observed inhibition denies permission; other statuses are diagnostic.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InhibitionStatus {
@@ -138,8 +169,70 @@ impl InhibitionState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::{parse_config, ScreenBackend, ScreenIdleBlankPolicy};
     use std::sync::Mutex;
     use std::time::Duration;
+
+    #[test]
+    fn preference_uses_the_runtime_config_default_and_effective_value() {
+        for (setting, honoring, bypass) in [
+            ("", ScreenHonorIdleInhibitorsPolicy::Disabled, true),
+            (
+                "screen_honor_idle_inhibitors=enabled",
+                ScreenHonorIdleInhibitorsPolicy::Enabled,
+                false,
+            ),
+            (
+                "screen_honor_idle_inhibitors=disabled",
+                ScreenHonorIdleInhibitorsPolicy::Disabled,
+                true,
+            ),
+            // Keep the runtime loader's existing invalid-value fallback. The
+            // settings editor still rejects invalid new writes independently.
+            (
+                "screen_honor_idle_inhibitors=invalid",
+                ScreenHonorIdleInhibitorsPolicy::Disabled,
+                true,
+            ),
+        ] {
+            let config = parse_config(&format!(
+                "tv_ip=192.168.1.42\ntv_mac=aa:bb:cc:dd:ee:ff\ninput=HDMI_1\n{setting}\n"
+            ))
+            .unwrap();
+            let result = evaluate_inhibition_preference(&config);
+            assert_eq!(result.bypass_inhibition, bypass);
+            assert_eq!(result.diagnostics.honoring, honoring);
+        }
+    }
+
+    #[test]
+    fn preference_has_no_desktop_or_activity_policy_gate() {
+        let mut config =
+            parse_config("tv_ip=192.168.1.42\ntv_mac=aa:bb:cc:dd:ee:ff\ninput=HDMI_1\n").unwrap();
+        for backend in [
+            ScreenBackend::Auto,
+            ScreenBackend::Gnome,
+            ScreenBackend::Wayland,
+            ScreenBackend::Swayidle,
+        ] {
+            config.screen_backend = backend;
+            for idle_blank in [
+                ScreenIdleBlankPolicy::Enabled,
+                ScreenIdleBlankPolicy::Disabled,
+            ] {
+                config.screen_idle_blank = idle_blank;
+                for (honoring, bypass) in [
+                    (ScreenHonorIdleInhibitorsPolicy::Disabled, true),
+                    (ScreenHonorIdleInhibitorsPolicy::Enabled, false),
+                ] {
+                    config.screen_honor_idle_inhibitors = honoring;
+                    let result = evaluate_inhibition_preference(&config);
+                    assert_eq!(result.bypass_inhibition, bypass);
+                    assert_eq!(result.diagnostics.honoring, honoring);
+                }
+            }
+        }
+    }
 
     struct FakeAdapter(Mutex<InhibitionState>);
 

--- a/crates/lg-buddy/tests/settings_operations.rs
+++ b/crates/lg-buddy/tests/settings_operations.rs
@@ -2,6 +2,8 @@ mod support;
 
 use std::fs;
 
+use lg_buddy::config::load_config;
+use lg_buddy::inhibition::evaluate_inhibition_preference;
 use lg_buddy::presentation::settings::{
     SettingsEditStatus, SettingsFeedbackSeverity, SettingsPresentation, SettingsStatus,
 };
@@ -14,6 +16,77 @@ use lg_buddy::settings_view::{
     SettingsIntent, SettingsTransition,
 };
 use support::{ExecutableScript, TestConfigFile, TestEnv};
+
+#[test]
+fn inhibition_preference_follows_persisted_settings_and_existing_restart_application() {
+    let config = TestConfigFile::new("inhibition-preference-settings");
+    config.write_contents("tv_ip=192.168.1.42\ntv_mac=aa:bb:cc:dd:ee:ff\ninput=HDMI_1\n");
+    let restart_snapshot = config.path().with_extension("applied");
+    let systemctl = ExecutableScript::new(
+        "inhibition-preference-systemctl",
+        "systemctl",
+        r#"#!/bin/sh
+[ "$1" = "--user" ] || exit 23
+case "$2" in
+  cat|is-active|is-enabled) exit 0 ;;
+  restart)
+    [ "$3" = "LG_Buddy_screen.service" ] || exit 23
+    cp "$LG_BUDDY_CONFIG" "$LG_BUDDY_TEST_RESTART_SNAPSHOT"
+    ;;
+  *) exit 23 ;;
+esac
+"#,
+    );
+    let mut env = TestEnv::new();
+    env.set("LG_BUDDY_CONFIG", config.path());
+    env.set("LG_BUDDY_SYSTEMCTL", systemctl.path());
+    env.set("LG_BUDDY_TEST_RESTART_SNAPSHOT", &restart_snapshot);
+    env.remove("LG_BUDDY_SKIP_SYSTEMD_ACTIONS");
+    let key = "screen.honor_idle_inhibitors";
+    assert!(evaluate_inhibition_preference(&load_config(config.path()).unwrap()).bypass_inhibition);
+
+    for (value, bypass) in [
+        (Some("enabled"), false),
+        (Some("disabled"), true),
+        (Some("enabled"), false),
+        (None, true),
+    ] {
+        let command = match value {
+            Some(value) => SettingsCommand::Set {
+                key: key.into(),
+                value: value.into(),
+            },
+            None => SettingsCommand::Unset(key.into()),
+        };
+        let runner = SettingsCommandRunner::new(SettingsStore::load(config.path()).unwrap());
+        let mut output = Vec::new();
+        runner.run(command, &mut output).unwrap();
+        assert!(String::from_utf8(output)
+            .unwrap()
+            .contains("apply: restarted LG_Buddy_screen.service"));
+        // The normal apply path sees the new file, including resetting to the
+        // default. Evaluate what the restarted monitor would actually load.
+        assert_eq!(
+            fs::read(&restart_snapshot).unwrap(),
+            fs::read(config.path()).unwrap()
+        );
+        let result = evaluate_inhibition_preference(&load_config(&restart_snapshot).unwrap());
+        assert_eq!(result.bypass_inhibition, bypass);
+        let effective = SettingsStore::load(config.path())
+            .unwrap()
+            .effective_by_name(key)
+            .unwrap();
+        assert_eq!(
+            effective.value().unwrap().to_string(),
+            result.diagnostics.honoring.as_str()
+        );
+        if value.is_none() {
+            assert!(!fs::read_to_string(config.path())
+                .unwrap()
+                .contains("screen_honor_idle_inhibitors="));
+        }
+    }
+}
 
 const BEHAVIOR_CONFIG: &str = "screen_backend=auto
 screen_idle_blank=enabled

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -407,7 +407,8 @@ The current split is:
   - owns GNOME session-bus setup, subscriptions, sender validation, Mutter
     user-active watches, and translation into normalized observations
 - `inhibition.rs`
-  - independent push/pull inhibition contracts, Boolean aggregation and diagnostics;
+  - independent push/pull inhibition contracts, Boolean aggregation, preference
+    override evaluation from loaded configuration, and diagnostics;
     standalone until the monitor integration in #225
 - `sources/desktop/gnome/inhibition.rs`
   - SessionManager inhibition subscriptions, state refresh and recovery,
@@ -972,6 +973,12 @@ requires only SessionManager and keeps subscriptions, state queries and owner
 recovery internal. It contributes no activity observations. #225 connects the
 two paths only at the `can_blank()` decision; runtime honoring remains absent
 until then.
+
+The separate preference section (#224) evaluates the existing honoring setting
+without I/O. Disabled honoring supplies a bypass for inhibition restrictions and
+release delay; it does not grant activity eligibility. Settings retain their
+screen-service restart apply path. #225 owns cancelling pending attempts on
+in-process configuration changes and consuming the current preference.
 
 The runtime core owns:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -306,7 +306,7 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/runtime_phase.rs` | Runtime sleep-phase provider abstraction |
 | `crates/lg-buddy/src/session/runner.rs` | Session monitor loop |
 | `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity deadline and phase synthesis |
-| `crates/lg-buddy/src/inhibition.rs` | Standalone push/pull inhibition contracts, Boolean aggregation and diagnostics (#222/#223) |
+| `crates/lg-buddy/src/inhibition.rs` | Standalone push/pull inhibition contracts, Boolean aggregation, preference override and diagnostics (#222/#223/#224) |
 | `crates/lg-buddy/src/session/gamepad/` | Gamepad activity discovery, device-event refresh, adapters, capture, registry, and policy |
 | `crates/lg-buddy/src/session_bus.rs` | Generic D-Bus transport used by session and system event sources |
 | `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle and current-session lock-state adapter |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -108,13 +108,13 @@ when no native activity capability is available at startup; #132 removes it.
 Inhibition notifications, permission state and release timing have been removed
 from the activity stream and inactivity engine. The stored preference remains
 compatible, and monitor startup reports the temporary limitation. #222 provides
-standalone push inhibition and #223 provides pull inhibition; #224-#225 complete
-the subsystem and Boolean gate. This intermediate
+standalone push inhibition, #223 provides pull inhibition, and #224 evaluates the
+honoring preference; #225 integrates the subsystem and Boolean gate. This intermediate
 runtime must not be promoted to prerelease or main before that integration and
 #89's MVP readiness checks are complete. Explicit lock, ownership/restore and
 ordinary activity deadlines retain their existing policy.
 
-### Independent inhibition capabilities (#222, #223)
+### Independent inhibition capabilities (#222, #223, #224)
 
 An adapter can supply activity, inhibition, or both. Each capability independently
 uses push or pull according to its source. Activity observations stay in the
@@ -168,8 +168,25 @@ the same observed-inhibition rule as push. GNOME remains one push contribution.
 
 These capabilities are independently testable but are not started by the monitor yet.
 They read no preferences, apply no aggregate release delay, and send no
-activity events or TV actions. Those integration responsibilities remain in
-#224 and #225.
+activity events or TV actions. #225 owns their runtime integration.
+
+`evaluate_inhibition_preference(&Config)` is a separate, pure section. It reads
+the existing effective `screen_honor_idle_inhibitors` value and returns
+`bypass_inhibition` with diagnostics identifying the honoring policy. Disabled
+honoring (the existing default) returns `true`: bypass source restrictions and
+release delay. Enabled honoring returns `false`: the reconciler must evaluate
+both. This override must not be ANDed as a third source permission and never
+makes a non-idle session eligible to blank. It depends on no source availability,
+protocol I/O, activity state or release history. The legacy `swayidle` process
+still controls its own initial idle notification and honors its own inhibitors.
+
+CLI and GUI preference edits retain the existing persist-then-restart path for
+`LG_Buddy_screen.service`. A successful restart replaces the process and its
+pending attempts; the new runtime reads the new configuration. Apply failures
+remain reported separately from saved values and use the existing retry path.
+The preference evaluator retains no state. #225 must evaluate it for the current
+attempt and cancel any pending attempt before applying an in-process config
+reload; old completions cannot become authoritative under a new preference.
 
 ### PowerDevil route coverage
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -299,6 +299,15 @@ cancellation during delayed replies, and replacement by a new unique owner.
 The mock supplies effective policy; it does not prove Plasma's filtering,
 overlap handling or application route coverage.
 
+Preference-section tests in `inhibition.rs` cover the runtime configuration's
+default and explicit values, its existing invalid-value fallback, and independence
+from desktop selection and activity policy. `tests/settings_operations.rs`
+exercises set, disable, re-enable and reset through the real settings writer and
+a mocked systemctl restart. It verifies that the restart sees the saved file and
+that the inhibition evaluator agrees with the effective setting after reload.
+Preference evaluation has no source or release-timing dependency. #225 owns the
+end-to-end override matrix and cancellation of attempts on in-process reload.
+
 For live Plasma validation of #223, record Plasma/PowerDevil and application
 versions and the application's inhibition route, then inspect effective state:
 


### PR DESCRIPTION
## Summary

Add a pure inhibition preference evaluator that reads the existing runtime configuration and returns `bypass_inhibition` with matching diagnostics. Disabled honoring supplies the override; enabled honoring leaves source permission and release delay to the reconciler. The override never grants activity eligibility.

Defaults, persistence and the existing screen-service restart apply path are preserved. Tests cover effective configuration values and settings changes through save, restart, reload and reset. The documented contract requires #225 to cancel pending attempts before an in-process configuration change takes effect.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

None yet. This section is independently testable; #225 owns monitor integration, source reconciliation and release timing. Native inhibition honoring remains temporarily disconnected on `dev`, and the intermediate runtime must not be promoted to `prerelease` or `main`.

## Validation

- `cargo fmt --all --check` passed.
- Full `cargo test -p lg-buddy` passed with host system-bus isolation and the legacy TV helper disabled: 1,011 unit tests, all 143 Cucumber scenarios, and all integration tests. The ignored subprocess helper was exercised by its parent test.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed.
- Focused preference unit tests and the settings integration test passed again during review.
- The unchanged `diagnostics::tests::busctl_owner_queries_preserve_positive_and_negative_replies` test failed on the initial full run, then passed alone and in the full rerun. No diagnostics code was changed.

## Related Issue

Fixes #224. Part of #216 and the #89 GNOME/Plasma MVP; final integration is #225.
