### PR TITLE
Integrate inhibition at the Boolean blanking gate

### DIFF
--- a/crates/lg-buddy/src/inhibition.rs
+++ b/crates/lg-buddy/src/inhibition.rs
@@ -2,7 +2,9 @@
 //! maintained permission; pull requests current permission. Neither acts on TVs.
 
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Instant;
+use std::sync::{mpsc, Arc};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use crate::config::{Config, ScreenHonorIdleInhibitorsPolicy};
 
@@ -117,6 +119,237 @@ pub fn evaluate_pull_inhibition(
         allowed: contributions.iter().all(|result| result.allowed),
         contributions,
     })
+}
+
+/// The Boolean gate and its supporting evidence, captured together. A missing
+/// section was not evaluated on this call (bypass, pending work or retry delay).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BlankingEvaluation {
+    pub can_blank: bool,
+    pub preference: InhibitionPreferenceEvaluation,
+    pub push: Option<InhibitionSectionEvaluation>,
+    pub pull: Option<InhibitionSectionEvaluation>,
+    pub checking: bool,
+    pub release_not_before: Option<Instant>,
+}
+
+fn reconcile(
+    preference: InhibitionPreferenceEvaluation,
+    push: Option<InhibitionSectionEvaluation>,
+    pull: Option<InhibitionSectionEvaluation>,
+    release_delay: Duration,
+    now: Instant,
+    checking: bool,
+) -> BlankingEvaluation {
+    // Adapter history already distinguishes a release from a clear poll or
+    // recovery. Do not infer another transition from aggregate permission.
+    let release_not_before = push
+        .iter()
+        .chain(pull.iter())
+        .flat_map(|section| &section.contributions)
+        .filter_map(|result| result.diagnostics.last_release_at)
+        .max()
+        .and_then(|released_at| released_at.checked_add(release_delay));
+    let can_blank = preference.bypass_inhibition
+        || (push.as_ref().is_some_and(|section| section.allowed)
+            && pull.as_ref().is_some_and(|section| section.allowed)
+            && release_not_before.is_none_or(|deadline| now >= deadline));
+    BlankingEvaluation {
+        can_blank,
+        preference,
+        push,
+        pull,
+        checking,
+        release_not_before,
+    }
+}
+
+struct PullRequest {
+    cancelled: Arc<AtomicBool>,
+    reply: mpsc::Sender<Option<InhibitionSectionEvaluation>>,
+}
+
+struct PendingCheck {
+    cancelled: Arc<AtomicBool>,
+    reply: mpsc::Receiver<Option<InhibitionSectionEvaluation>>,
+    push: InhibitionSectionEvaluation,
+}
+
+/// Long-lived inhibition subsystem. The caller polls a quick Boolean gate only
+/// when idle, and cancels the attempt when activity or runtime eligibility changes.
+/// No protocol I/O runs on that caller's thread.
+pub struct Inhibition {
+    preference: InhibitionPreferenceEvaluation,
+    release_delay: Duration,
+    push: Vec<Arc<dyn PushInhibitionAdapter>>,
+    requests: Option<mpsc::SyncSender<PullRequest>>,
+    pending: Option<PendingCheck>,
+    retry_at: Option<Instant>,
+    diagnostics: Option<BlankingEvaluation>,
+    stop: Arc<AtomicBool>,
+    workers: Vec<JoinHandle<()>>,
+}
+
+impl Inhibition {
+    const RETRY_INTERVAL: Duration = Duration::from_secs(1);
+
+    pub fn new(
+        config: &Config,
+        release_delay: Duration,
+        push: Vec<Arc<dyn PushInhibitionAdapter>>,
+        mut pull: Vec<Box<dyn PullInhibitionAdapter>>,
+    ) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let mut workers: Vec<_> = push
+            .iter()
+            .map(|adapter| {
+                let adapter = Arc::clone(adapter);
+                let stop = Arc::clone(&stop);
+                thread::spawn(move || adapter.run(&stop))
+            })
+            .collect();
+        // One worker retains the adapters' diagnostic history; each attempt has
+        // its own reply channel. Cancelled replies cannot answer a later attempt.
+        // The bounded queue also limits work if input repeatedly cancels checks.
+        let (requests, receiver) = mpsc::sync_channel::<PullRequest>(1);
+        let worker_stop = Arc::clone(&stop);
+        workers.push(thread::spawn(move || {
+            while let Ok(request) = receiver.recv() {
+                if worker_stop.load(Ordering::SeqCst) {
+                    break;
+                }
+                let mut adapters: Vec<&mut dyn PullInhibitionAdapter> = pull
+                    .iter_mut()
+                    .map(|adapter| adapter.as_mut() as &mut dyn PullInhibitionAdapter)
+                    .collect();
+                let result = evaluate_pull_inhibition(&mut adapters, &request.cancelled);
+                let _ = request.reply.send(result);
+            }
+        }));
+        Self {
+            preference: evaluate_inhibition_preference(config),
+            release_delay,
+            push,
+            requests: Some(requests),
+            pending: None,
+            retry_at: None,
+            diagnostics: None,
+            stop,
+            workers,
+        }
+    }
+
+    /// Settings currently restart the service. This also makes an in-process
+    /// preference/timeout change safe: discard old work before using new policy.
+    pub fn configure(&mut self, config: &Config, release_delay: Duration) {
+        let preference = evaluate_inhibition_preference(config);
+        if self.preference != preference || self.release_delay != release_delay {
+            self.cancel();
+            self.preference = preference;
+            self.release_delay = release_delay;
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            pending.cancelled.store(true, Ordering::SeqCst);
+        }
+        self.retry_at = None;
+        self.diagnostics = None;
+    }
+
+    pub fn diagnostics(&self) -> Option<&BlankingEvaluation> {
+        self.diagnostics.as_ref()
+    }
+
+    pub fn can_blank(&mut self, now: Instant) -> bool {
+        if self.preference.bypass_inhibition {
+            self.cancel();
+            return self.record(None, None, now, false);
+        }
+        let adapters: Vec<_> = self.push.iter().map(|adapter| adapter.as_ref()).collect();
+        let push = evaluate_push_inhibition(&adapters);
+        if self.pending.as_ref().is_some_and(|pending| {
+            // Refreshing the same Boolean does not invalidate a check. A source
+            // change or intervening observed release does.
+            pending
+                .push
+                .contributions
+                .iter()
+                .zip(&push.contributions)
+                .any(|(old, new)| {
+                    old.allowed != new.allowed
+                        || old.diagnostics.status != new.diagnostics.status
+                        || old.diagnostics.last_release_at != new.diagnostics.last_release_at
+                })
+        }) {
+            self.cancel();
+        }
+        if let Some(pending) = &self.pending {
+            match pending.reply.try_recv() {
+                Ok(pull) => {
+                    self.pending = None;
+                    self.retry_at = Some(now + Self::RETRY_INTERVAL);
+                    return self.record(Some(push), pull, now, false);
+                }
+                Err(mpsc::TryRecvError::Empty) => {
+                    return self.record(Some(push), None, now, true);
+                }
+                Err(mpsc::TryRecvError::Disconnected) => {
+                    self.cancel();
+                    self.retry_at = Some(now + Self::RETRY_INTERVAL);
+                }
+            }
+        }
+        if self.retry_at.is_none_or(|deadline| now >= deadline) {
+            let (reply, receiver) = mpsc::channel();
+            let cancelled = Arc::new(AtomicBool::new(false));
+            let request = PullRequest {
+                cancelled: Arc::clone(&cancelled),
+                reply,
+            };
+            if self.requests.as_ref().unwrap().try_send(request).is_ok() {
+                self.pending = Some(PendingCheck {
+                    cancelled,
+                    reply: receiver,
+                    push: push.clone(),
+                });
+            }
+            self.retry_at = Some(now + Self::RETRY_INTERVAL);
+        }
+        self.record(Some(push), None, now, self.pending.is_some())
+    }
+
+    fn record(
+        &mut self,
+        push: Option<InhibitionSectionEvaluation>,
+        pull: Option<InhibitionSectionEvaluation>,
+        now: Instant,
+        checking: bool,
+    ) -> bool {
+        let evaluation = reconcile(
+            self.preference,
+            push,
+            pull,
+            self.release_delay,
+            now,
+            checking,
+        );
+        let allowed = evaluation.can_blank;
+        self.diagnostics = Some(evaluation);
+        allowed
+    }
+}
+
+impl Drop for Inhibition {
+    fn drop(&mut self) {
+        self.cancel();
+        self.stop.store(true, Ordering::SeqCst);
+        self.requests.take();
+        for worker in self.workers.drain(..) {
+            let _ = worker.join();
+        }
+    }
 }
 
 /// Adapter-owned evidence. Source loss drops its inhibition contribution without
@@ -244,12 +477,201 @@ mod tests {
 
     impl PushInhibitionAdapter for FakeAdapter {
         fn run(&self, _: &AtomicBool) {
-            panic!("section evaluation must not run an adapter or perform I/O");
+            // The fake publishes directly into its maintained state.
         }
 
         fn evaluate(&self) -> InhibitionEvaluation {
             self.0.lock().unwrap().evaluate()
         }
+    }
+
+    fn enabled_config() -> Config {
+        parse_config("tv_ip=192.168.1.42\ntv_mac=aa:bb:cc:dd:ee:ff\ninput=HDMI_1\nscreen_honor_idle_inhibitors=enabled\n").unwrap()
+    }
+
+    fn section(state: &InhibitionState) -> InhibitionSectionEvaluation {
+        let result = state.evaluate();
+        InhibitionSectionEvaluation {
+            allowed: result.allowed,
+            contributions: vec![result],
+        }
+    }
+
+    #[test]
+    fn reconciliation_combines_sources_and_only_observed_releases_delay_blanking() {
+        let config = enabled_config();
+        let preference = evaluate_inhibition_preference(&config);
+        let start = Instant::now();
+        let delay = Duration::from_secs(10);
+        let mut push = InhibitionState::new("push");
+        let mut pull = InhibitionState::new("pull");
+        let evaluate = |push: &InhibitionState, pull: &InhibitionState, now| {
+            reconcile(
+                preference,
+                Some(section(push)),
+                Some(section(pull)),
+                delay,
+                now,
+                false,
+            )
+        };
+        assert!(
+            evaluate(&push, &pull, start).can_blank,
+            "no observed inhibitors"
+        );
+        for push_inhibited in [false, true] {
+            for pull_inhibited in [false, true] {
+                push.observe(push_inhibited, start);
+                pull.observe(pull_inhibited, start);
+                assert_eq!(
+                    evaluate(&push, &pull, start + delay).can_blank,
+                    !push_inhibited && !pull_inhibited
+                );
+            }
+        }
+        push.observe(true, start);
+        pull.observe(true, start);
+        push.observe(false, start + Duration::from_secs(1));
+        assert!(
+            !evaluate(&push, &pull, start + delay * 2).can_blank,
+            "overlapping inhibitor still active"
+        );
+        pull.observe(false, start + Duration::from_secs(4));
+        let deadline = start + Duration::from_secs(14);
+        let denied = evaluate(&push, &pull, deadline - Duration::from_nanos(1));
+        assert!(!denied.can_blank);
+        assert_eq!(denied.release_not_before, Some(deadline));
+        // Repeated clear replies and a delayed completion do not restart delay.
+        pull.observe(false, start + Duration::from_secs(12));
+        assert!(evaluate(&push, &pull, deadline).can_blank);
+        assert!(evaluate(&push, &pull, deadline + delay).can_blank);
+        // Failure drops known inhibition; clear recovery is not a release.
+        push.observe(true, deadline);
+        push.unavailable("query failed");
+        pull.absent();
+        assert!(evaluate(&push, &pull, deadline).can_blank);
+        push.observe(false, deadline);
+        assert!(evaluate(&push, &pull, deadline).can_blank);
+    }
+
+    struct ControlledPull {
+        calls: mpsc::Sender<Arc<AtomicBool>>,
+        replies: mpsc::Receiver<InhibitionEvaluation>,
+    }
+
+    impl PullInhibitionAdapter for ControlledPull {
+        fn query(&mut self, cancelled: &AtomicBool) -> Option<InhibitionEvaluation> {
+            // Deliberately complete even after cancellation. The section and
+            // facade must discard this reply independently of adapter goodwill.
+            let seen_cancel = Arc::new(AtomicBool::new(false));
+            self.calls.send(Arc::clone(&seen_cancel)).unwrap();
+            let reply = self.replies.recv_timeout(Duration::from_secs(2)).unwrap();
+            seen_cancel.store(cancelled.load(Ordering::SeqCst), Ordering::SeqCst);
+            Some(reply)
+        }
+    }
+
+    fn finish_check(gate: &mut Inhibition, now: Instant) -> bool {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let allowed = gate.can_blank(now);
+            if !gate.diagnostics().unwrap().checking {
+                return allowed;
+            }
+            assert!(Instant::now() < deadline, "worker completion timed out");
+            thread::sleep(Duration::from_millis(1));
+        }
+    }
+
+    #[test]
+    fn gate_discards_cancelled_answers_bounds_retries_and_never_reuses_permission() {
+        let (calls, called) = mpsc::channel();
+        let (reply, replies) = mpsc::channel();
+        let config = enabled_config();
+        let mut gate = Inhibition::new(
+            &config,
+            Duration::from_secs(5),
+            vec![],
+            vec![Box::new(ControlledPull { calls, replies })],
+        );
+        let now = Instant::now();
+        let mut source = InhibitionState::new("pull");
+        source.observe(false, now);
+        assert!(!gate.can_blank(now));
+        let cancelled = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(!gate.can_blank(now)); // nonblocking while adapter waits
+        assert!(gate.diagnostics().unwrap().checking);
+        gate.cancel(); // activity or lifecycle invalidates the attempt
+        reply.send(source.evaluate()).unwrap();
+        assert!(!gate.can_blank(now));
+        let _ = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(cancelled.load(Ordering::SeqCst));
+        source.observe(true, now);
+        reply.send(source.evaluate()).unwrap();
+        assert!(!finish_check(&mut gate, now));
+        for _ in 0..100 {
+            assert!(!gate.can_blank(now + Duration::from_millis(999)));
+        }
+        assert!(called.try_recv().is_err(), "no busy query retry");
+        let next = now + Duration::from_secs(1);
+        assert!(!gate.can_blank(next));
+        let _ = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        // An absent source is neutral and does not manufacture a release.
+        source.absent();
+        reply.send(source.evaluate()).unwrap();
+        assert!(finish_check(&mut gate, next));
+        assert!(
+            !gate.can_blank(next),
+            "permission was consumed by its attempt"
+        );
+    }
+
+    #[test]
+    fn preference_and_push_changes_invalidate_in_flight_checks() {
+        let (calls, called) = mpsc::channel();
+        let (reply, replies) = mpsc::channel();
+        let mut config = enabled_config();
+        let push = Arc::new(FakeAdapter::new("push"));
+        let now = Instant::now();
+        push.0.lock().unwrap().observe(false, now);
+        let mut gate = Inhibition::new(
+            &config,
+            Duration::from_secs(5),
+            vec![push.clone()],
+            vec![Box::new(ControlledPull { calls, replies })],
+        );
+        let mut pull = InhibitionState::new("pull");
+        pull.observe(false, now);
+        assert!(!gate.can_blank(now));
+        let cancelled = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        push.0.lock().unwrap().observe(true, now);
+        assert!(!gate.can_blank(now));
+        reply.send(pull.evaluate()).unwrap();
+        let cancelled_by_config = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(cancelled.load(Ordering::SeqCst));
+        config.screen_honor_idle_inhibitors = ScreenHonorIdleInhibitorsPolicy::Disabled;
+        gate.configure(&config, Duration::from_secs(5));
+        assert!(
+            gate.can_blank(now),
+            "disabled honoring bypasses pending work"
+        );
+        assert!(gate.diagnostics().unwrap().push.is_none());
+        reply.send(pull.evaluate()).unwrap();
+        config.screen_honor_idle_inhibitors = ScreenHonorIdleInhibitorsPolicy::Enabled;
+        gate.configure(&config, Duration::from_secs(5));
+        assert!(!gate.can_blank(now));
+        let _ = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(cancelled_by_config.load(Ordering::SeqCst));
+        reply.send(pull.evaluate()).unwrap();
+        assert!(!finish_check(&mut gate, now), "push inhibitor still blocks");
+
+        push.0.lock().unwrap().observe(false, now);
+        // A timeout edit changes release delay, without inventing a release.
+        gate.configure(&config, Duration::ZERO);
+        assert!(!gate.can_blank(now));
+        let _ = called.recv_timeout(Duration::from_secs(1)).unwrap();
+        reply.send(pull.evaluate()).unwrap();
+        assert!(finish_check(&mut gate, now));
     }
 
     #[test]

--- a/crates/lg-buddy/src/session/inactivity.rs
+++ b/crates/lg-buddy/src/session/inactivity.rs
@@ -262,13 +262,20 @@ impl InactivityEngine {
         }
     }
 
-    pub fn observe_time(&mut self, observed_at: Instant) -> InactivityDecision {
+    pub fn observe_time(
+        &mut self,
+        observed_at: Instant,
+        can_blank: impl FnOnce() -> bool,
+    ) -> InactivityDecision {
         match self.phase {
             InactivityPhase::Unknown | InactivityPhase::Active
                 if self
                     .blank_at
                     .is_some_and(|deadline| observed_at >= deadline) =>
             {
+                if !can_blank() {
+                    return InactivityDecision::NoOp;
+                }
                 self.phase = InactivityPhase::BlankRequested;
                 self.lock_activity_floor = self.session_locked_since;
                 self.activity_floor = Some(observed_at);
@@ -337,20 +344,72 @@ mod tests {
     }
 
     #[test]
+    fn boolean_gate_is_consulted_only_when_idle_and_does_not_consume_denied_deadline() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        assert_eq!(
+            engine.observe_time(start, || panic!("not idle")),
+            InactivityDecision::NoOp
+        );
+        let before = engine;
+        let due = start + Duration::from_secs(5);
+        assert_eq!(engine.observe_time(due, || false), InactivityDecision::NoOp);
+        assert_eq!(
+            engine, before,
+            "inhibition must not change activity or phase"
+        );
+        assert_eq!(engine.time_until_action(due), Some(Duration::ZERO));
+        assert_eq!(
+            engine.observe_time(due + Duration::from_secs(2), || true),
+            InactivityDecision::BlankNow
+        );
+        assert_eq!(
+            engine.observe_time(due + Duration::from_secs(3), || panic!("already requested")),
+            InactivityDecision::NoOp
+        );
+    }
+
+    #[test]
+    fn input_rearms_a_denied_deadline_and_explicit_lock_bypasses_the_gate() {
+        let start = Instant::now();
+        let mut engine = test_engine(start);
+        let due = start + Duration::from_secs(5);
+        assert_eq!(engine.observe_time(due, || false), InactivityDecision::NoOp);
+        engine.observe_activity(InactivityObservation::UserActivityObserved, due);
+        assert_eq!(
+            engine.observe_time(due + Duration::from_secs(1), || panic!(
+                "input postponed blanking"
+            )),
+            InactivityDecision::NoOp
+        );
+        assert_eq!(
+            engine.observe_lock(due + Duration::from_secs(1)),
+            InactivityDecision::BlankNow
+        );
+        engine.complete_blank(true, due);
+        assert_eq!(
+            engine.observe_time(due + InactivityEngine::DEFAULT_POWER_OFF_AFTER, || panic!(
+                "post-blank policy is independent"
+            )),
+            InactivityDecision::TimedPowerOffNow
+        );
+    }
+
+    #[test]
     fn timeout_blanks_once() {
         let started_at = Instant::now();
         let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_millis(4_999)),
+            engine.observe_time(started_at + Duration::from_millis(4_999), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(6)),
+            engine.observe_time(started_at + Duration::from_secs(6), || true),
             InactivityDecision::NoOp
         );
     }
@@ -368,11 +427,11 @@ mod tests {
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(9)),
+            engine.observe_time(started_at + Duration::from_secs(9), || true),
             InactivityDecision::BlankNow
         );
     }
@@ -402,11 +461,11 @@ mod tests {
         );
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_millis(4_999)),
+            engine.observe_time(started_at + Duration::from_millis(4_999), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::TimedPowerOffNow
         );
     }
@@ -421,20 +480,20 @@ mod tests {
         );
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(true, started_at + Duration::from_secs(7));
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(11)),
+            engine.observe_time(started_at + Duration::from_secs(11), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(12)),
+            engine.observe_time(started_at + Duration::from_secs(12), || true),
             InactivityDecision::TimedPowerOffNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(20)),
+            engine.observe_time(started_at + Duration::from_secs(20), || true),
             InactivityDecision::NoOp
         );
     }
@@ -449,12 +508,12 @@ mod tests {
         );
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(false, started_at + Duration::from_secs(5));
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(30)),
+            engine.observe_time(started_at + Duration::from_secs(30), || true),
             InactivityDecision::NoOp
         );
         assert!(!engine.timed_power_off_pending());
@@ -471,7 +530,7 @@ mod tests {
         let deadline = started_at + Duration::from_secs(10);
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(true, started_at + Duration::from_secs(5));
@@ -479,7 +538,10 @@ mod tests {
             engine.observe_activity(InactivityObservation::UserActivityObserved, deadline),
             InactivityDecision::RestoreNow
         );
-        assert_eq!(engine.observe_time(deadline), InactivityDecision::NoOp);
+        assert_eq!(
+            engine.observe_time(deadline, || true),
+            InactivityDecision::NoOp
+        );
     }
 
     #[test]
@@ -491,7 +553,7 @@ mod tests {
         assert_eq!(engine.observe_provider_idle(), InactivityDecision::BlankNow);
         engine.complete_blank(true, started_at);
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::TimedPowerOffNow
         );
     }
@@ -511,7 +573,7 @@ mod tests {
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(30)),
+            engine.observe_time(started_at + Duration::from_secs(30), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(engine.observe_provider_idle(), InactivityDecision::BlankNow);
@@ -527,12 +589,12 @@ mod tests {
         );
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(1)),
+            engine.observe_time(started_at + Duration::from_secs(1), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(true, started_at + Duration::from_secs(1));
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(2)),
+            engine.observe_time(started_at + Duration::from_secs(2), || true),
             InactivityDecision::TimedPowerOffNow
         );
         assert_eq!(
@@ -543,12 +605,12 @@ mod tests {
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(4)),
+            engine.observe_time(started_at + Duration::from_secs(4), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(true, started_at + Duration::from_secs(4));
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::TimedPowerOffNow
         );
     }
@@ -558,7 +620,7 @@ mod tests {
         let started_at = Instant::now();
         let mut engine = test_engine(started_at);
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
 
@@ -570,11 +632,11 @@ mod tests {
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(10)),
+            engine.observe_time(started_at + Duration::from_secs(10), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(11)),
+            engine.observe_time(started_at + Duration::from_secs(11), || true),
             InactivityDecision::BlankNow
         );
     }
@@ -593,11 +655,11 @@ mod tests {
                 InactivityDecision::RestoreNow
             );
             assert_eq!(
-                engine.observe_time(started_at + Duration::from_secs(5)),
+                engine.observe_time(started_at + Duration::from_secs(5), || true),
                 InactivityDecision::NoOp
             );
             assert_eq!(
-                engine.observe_time(started_at + Duration::from_secs(9)),
+                engine.observe_time(started_at + Duration::from_secs(9), || true),
                 InactivityDecision::BlankNow
             );
         }
@@ -623,11 +685,11 @@ mod tests {
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(7)),
+            engine.observe_time(started_at + Duration::from_secs(7), || true),
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(9)),
+            engine.observe_time(started_at + Duration::from_secs(9), || true),
             InactivityDecision::BlankNow
         );
     }
@@ -642,7 +704,7 @@ mod tests {
             Some(Duration::from_secs(5))
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
         assert_eq!(engine.time_until_action(started_at), None);
@@ -665,7 +727,7 @@ mod tests {
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(7)),
+            engine.observe_time(started_at + Duration::from_secs(7), || true),
             InactivityDecision::BlankNow
         );
     }
@@ -729,7 +791,7 @@ mod tests {
         let mut engine = test_engine(started_at);
 
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(5)),
+            engine.observe_time(started_at + Duration::from_secs(5), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(true, started_at + Duration::from_secs(5));
@@ -838,7 +900,7 @@ mod tests {
             InactivityDecision::RestoreNow
         );
         assert_eq!(
-            engine.observe_time(started_at + Duration::from_secs(7)),
+            engine.observe_time(started_at + Duration::from_secs(7), || true),
             InactivityDecision::BlankNow
         );
         assert_eq!(
@@ -861,7 +923,7 @@ mod tests {
         let start = Instant::now();
         let mut engine = InactivityEngine::new(Duration::from_secs(1), start);
         assert_eq!(
-            engine.observe_time(start + Duration::from_secs(1)),
+            engine.observe_time(start + Duration::from_secs(1), || true),
             InactivityDecision::BlankNow
         );
         engine.complete_blank(true, start + Duration::from_secs(1));
@@ -883,7 +945,7 @@ mod tests {
             InactivityDecision::NoOp
         );
         assert_eq!(
-            engine.observe_time(input_at + Duration::from_secs(1)),
+            engine.observe_time(input_at + Duration::from_secs(1), || true),
             InactivityDecision::BlankNow
         );
     }

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -857,11 +857,30 @@ where
         Arc<AtomicBool>,
     ) -> JoinHandle<()>,
 {
+    // Assemble production inhibition here, alongside the production lock
+    // observer. Tests can omit it instead of relying on an installed config
+    // and real desktop inhibition services.
+    let inhibition = match resolve_config_path_from_env() {
+        Ok(path) => {
+            let config = load_config(&path).map_err(|err| SessionRunnerError::Failed {
+                backend,
+                message: format!("failed to load inhibition config: {err}"),
+            })?;
+            Some(Inhibition::new(
+                &config,
+                Duration::from_millis(resolve_idle_timeout_ms()),
+                vec![Arc::new(GnomeInhibition::default())],
+                vec![Box::new(PowerDevilInhibition::default())],
+            ))
+        }
+        Err(ConfigPathError::NotConfigured) => None,
+    };
     run_native_session_monitor_with_lock_monitor(
         writer,
         dispatcher,
         backend,
         adapters,
+        inhibition,
         spawn_monitor,
         |sender| Some(spawn_logind_lock_monitor(sender)),
     )
@@ -872,6 +891,7 @@ fn run_native_session_monitor_with_lock_monitor<W, E, S, L>(
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
     adapters: &[(ActivitySource, Arc<dyn ActivityAdapter>)],
+    inhibition: Option<Inhibition>,
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
@@ -891,6 +911,7 @@ where
         backend,
         adapters,
         InitialBlankTrigger::Deadline,
+        inhibition,
         spawn_monitor,
         spawn_lock_monitor,
     )
@@ -902,12 +923,14 @@ enum InitialBlankTrigger {
     Provider,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_session_monitor_with_lock_monitor<W, E, S, L>(
     writer: &mut W,
     dispatcher: &mut SessionEventDispatcher<E>,
     backend: ScreenBackend,
     adapters: &[(ActivitySource, Arc<dyn ActivityAdapter>)],
     initial_blank_trigger: InitialBlankTrigger,
+    mut inhibition: Option<Inhibition>,
     spawn_monitor: S,
     spawn_lock_monitor: L,
 ) -> Result<(), SessionRunnerError>
@@ -923,27 +946,6 @@ where
 {
     let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
     let power_off_after = resolve_timed_power_off_after();
-    // Inhibition capabilities are independent of the chosen activity sources.
-    // The legacy provider continues to own its initial timeout and inhibition.
-    let mut inhibition = if initial_blank_trigger == InitialBlankTrigger::Deadline {
-        match resolve_config_path_from_env() {
-            Ok(path) => {
-                let config = load_config(&path).map_err(|err| SessionRunnerError::Failed {
-                    backend,
-                    message: format!("failed to load inhibition config: {err}"),
-                })?;
-                Some(Inhibition::new(
-                    &config,
-                    blank_after,
-                    vec![Arc::new(GnomeInhibition::default())],
-                    vec![Box::new(PowerDevilInhibition::default())],
-                ))
-            }
-            Err(ConfigPathError::NotConfigured) => None,
-        }
-    } else {
-        None
-    };
     let started_at = Instant::now();
     let marker_exists = session_screen_ownership_marker_exists(backend)?;
     let mut inactivity = if marker_exists && initial_blank_trigger == InitialBlankTrigger::Provider
@@ -1193,6 +1195,7 @@ fn run_swayidle_monitor<W: Write, E: SessionActionExecutor>(
         ScreenBackend::Swayidle,
         &[],
         InitialBlankTrigger::Provider,
+        None,
         move |sender, _contributions, stop| {
             thread::spawn(move || {
                 let event_sender = sender.clone();
@@ -2759,6 +2762,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             ScreenBackend::Auto,
             &[],
+            None,
             |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     let result = activity_receiver
@@ -2812,6 +2816,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             ScreenBackend::Wayland,
             &[],
+            None,
             |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     thread::sleep(Duration::from_millis(150));
@@ -2858,6 +2863,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             ScreenBackend::Auto,
             &[],
+            None,
             |sender, _contributions, _stop| {
                 thread::spawn(move || {
                     let locked_at = Instant::now();
@@ -3106,6 +3112,13 @@ system_sleep_wake_policy={policy}
     #[test]
     fn composed_sources_restore_once_without_availability_reports() {
         let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        // The shared loop's injected capabilities must not require an installed
+        // config. A developer's real config otherwise hides this CI regression.
+        let previous_config = std::env::var_os("LG_BUDDY_CONFIG");
+        std::env::set_var(
+            "LG_BUDDY_CONFIG",
+            unique_config_path("missing-monitor-config"),
+        );
         let runtime_dir = unique_config_path("composed-activity");
         ScreenOwnershipMarker::new(runtime_dir.clone())
             .create()
@@ -3124,6 +3137,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             ScreenBackend::Auto,
             &[],
+            None,
             |sender, sources, _stop| {
                 thread::spawn(move || {
                     use super::ActivitySource;
@@ -3161,6 +3175,10 @@ system_sleep_wake_policy={policy}
         std::env::remove_var("LG_BUDDY_SESSION_RUNTIME_DIR");
         std::env::remove_var("LG_BUDDY_IDLE_TIMEOUT");
         std::env::remove_var(super::GAMEPAD_ACTIVITY_SOURCE_ENV);
+        match previous_config {
+            Some(path) => std::env::set_var("LG_BUDDY_CONFIG", path),
+            None => std::env::remove_var("LG_BUDDY_CONFIG"),
+        }
         fs::remove_dir_all(runtime_dir).unwrap();
         result.unwrap();
         assert_eq!(dispatcher.executor.screen_on_calls, 1);

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -24,6 +24,7 @@ use crate::config::{
     DEFAULT_IDLE_TIMEOUT,
 };
 use crate::events::{EventSource, RuntimeEvent};
+use crate::inhibition::Inhibition;
 use crate::lifecycle::LifecycleEvent;
 use crate::session::activity::{ActivityContributions, ActivitySource};
 use crate::session::gamepad::{
@@ -34,7 +35,9 @@ use crate::session::inactivity::{InactivityDecision, InactivityEngine, Inactivit
 use crate::session::{SessionEvent, SessionObservation};
 use crate::session_bus::{new_system_bus_client, SessionBusClient};
 use crate::session_notifications::spawn_session_notification_service;
+use crate::sources::desktop::gnome::inhibition::GnomeInhibition;
 use crate::sources::desktop::gnome::{monitor_test_timeout, GnomeSource};
+use crate::sources::desktop::powerdevil::PowerDevilInhibition;
 use crate::sources::desktop::swayidle::{run as run_swayidle_source, SwayidleSourceError};
 use crate::sources::desktop::wayland::WaylandSource;
 use crate::sources::desktop::{ActivityAdapter, ActivityStatus};
@@ -797,10 +800,6 @@ fn run_composed_monitor<W: Write, E: SessionActionExecutor>(
     configured: ScreenBackend,
     wayland: Option<WaylandSource>,
 ) -> Result<(), SessionRunnerError> {
-    writeln!(
-        writer,
-        "LG Buddy Monitor: native inhibition honoring is temporarily unavailable on dev (#216)."
-    )?;
     let mut adapters: Vec<(ActivitySource, Arc<dyn ActivityAdapter>)> = Vec::new();
     if configured != ScreenBackend::Wayland {
         adapters.push((ActivitySource::Gnome, Arc::new(GnomeSource::default())));
@@ -924,6 +923,27 @@ where
 {
     let blank_after = Duration::from_millis(resolve_idle_timeout_ms());
     let power_off_after = resolve_timed_power_off_after();
+    // Inhibition capabilities are independent of the chosen activity sources.
+    // The legacy provider continues to own its initial timeout and inhibition.
+    let mut inhibition = if initial_blank_trigger == InitialBlankTrigger::Deadline {
+        match resolve_config_path_from_env() {
+            Ok(path) => {
+                let config = load_config(&path).map_err(|err| SessionRunnerError::Failed {
+                    backend,
+                    message: format!("failed to load inhibition config: {err}"),
+                })?;
+                Some(Inhibition::new(
+                    &config,
+                    blank_after,
+                    vec![Arc::new(GnomeInhibition::default())],
+                    vec![Box::new(PowerDevilInhibition::default())],
+                ))
+            }
+            Err(ConfigPathError::NotConfigured) => None,
+        }
+    } else {
+        None
+    };
     let started_at = Instant::now();
     let marker_exists = session_screen_ownership_marker_exists(backend)?;
     let mut inactivity = if marker_exists && initial_blank_trigger == InitialBlankTrigger::Provider
@@ -964,6 +984,9 @@ where
             break;
         }
         for (_, observation, observed_at) in contributions.drain() {
+            if let Some(inhibition) = &mut inhibition {
+                inhibition.cancel();
+            }
             handle_inactivity_observation(
                 writer,
                 dispatcher,
@@ -978,6 +1001,9 @@ where
             .map(|(source, adapter)| (*source, adapter.status()))
             .collect();
         if diagnostics != last_diagnostics {
+            if let Some(inhibition) = &mut inhibition {
+                inhibition.cancel();
+            }
             for (source, status) in &diagnostics {
                 let detail = match status {
                     ActivityStatus::Available => "ready",
@@ -987,23 +1013,16 @@ where
             }
             last_diagnostics = diagnostics;
         }
-        let has_activity = initial_blank_trigger == InitialBlankTrigger::Provider
-            || adapters
-                .iter()
-                .any(|(_, adapter)| adapter.status().is_available());
-        let wait = if has_activity || inactivity.timed_power_off_pending() {
-            inactivity
-                .time_until_action(Instant::now())
-                .unwrap_or(Duration::from_millis(50))
-                .min(Duration::from_millis(50))
-        } else {
-            Duration::from_millis(50)
-        };
-        let message = match receiver.recv_timeout(wait) {
+        // A denied gate leaves the original deadline due. Keep a bounded poll
+        // cadence rather than repeatedly waiting zero time on that deadline.
+        let message = match receiver.recv_timeout(Duration::from_millis(50)) {
             Ok(message) => message,
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 // Read activity published while waiting before acting on a deadline.
                 for (_, observation, observed_at) in contributions.drain() {
+                    if let Some(inhibition) = &mut inhibition {
+                        inhibition.cancel();
+                    }
                     handle_inactivity_observation(
                         writer,
                         dispatcher,
@@ -1019,12 +1038,35 @@ where
                         .any(|(_, adapter)| adapter.status().is_available())
                     || inactivity.timed_power_off_pending()
                 {
-                    handle_inactivity_timeout(writer, dispatcher, &mut inactivity, Instant::now())?;
+                    let now = Instant::now();
+                    handle_inactivity_timeout(writer, dispatcher, &mut inactivity, now, || {
+                        inhibition.as_mut().is_none_or(|gate| gate.can_blank(now))
+                    })?;
+                } else if let Some(inhibition) = &mut inhibition {
+                    inhibition.cancel();
                 }
                 continue;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         };
+        if matches!(
+            &message,
+            RunnerMessage::ActivityObservation { .. }
+                | RunnerMessage::SessionEvent {
+                    event: SessionEvent::Active
+                        | SessionEvent::WakeRequested
+                        | SessionEvent::UserActivity
+                        | SessionEvent::Lock
+                        | SessionEvent::Unlock
+                        | SessionEvent::BeforeSleep
+                        | SessionEvent::AfterResume,
+                    ..
+                }
+        ) {
+            if let Some(inhibition) = &mut inhibition {
+                inhibition.cancel();
+            }
+        }
         match message {
             RunnerMessage::ActivityObservation {
                 source,
@@ -1109,6 +1151,11 @@ where
             }
             RunnerMessage::Diagnostic(message) => {
                 writeln!(writer, "LG Buddy Monitor: {message}")?;
+            }
+            RunnerMessage::EligibilityChanged => {
+                if let Some(inhibition) = &mut inhibition {
+                    inhibition.cancel();
+                }
             }
             RunnerMessage::MonitorExited(result) => {
                 monitor_result = result;
@@ -1226,9 +1273,15 @@ fn resolve_lifecycle_monitor_test_event_limit() -> Option<usize> {
 
 fn spawn_logind_lock_monitor(sender: mpsc::Sender<RunnerMessage>) -> LogindLockObserver {
     let observation_sender = sender.clone();
+    let lifecycle_sender = sender.clone();
     spawn_lock_observer(
         move |observation| send_source_observation(&observation_sender, observation),
         move |err| report_logind_lock_monitor_error(&sender, err),
+        move || {
+            lifecycle_sender
+                .send(RunnerMessage::EligibilityChanged)
+                .is_ok()
+        },
     )
 }
 
@@ -1444,6 +1497,7 @@ fn run_gamepad_activity_process(sender: mpsc::Sender<RunnerMessage>, stop: Arc<A
 }
 
 enum RunnerMessage {
+    EligibilityChanged,
     SessionEvent {
         event: SessionEvent,
         source: EventSource,
@@ -1628,8 +1682,9 @@ fn handle_inactivity_timeout<W: Write, E: SessionActionExecutor>(
     dispatcher: &mut SessionEventDispatcher<E>,
     inactivity: &mut InactivityEngine,
     observed_at: Instant,
+    can_blank: impl FnOnce() -> bool,
 ) -> Result<(), SessionRunnerError> {
-    match inactivity.observe_time(observed_at) {
+    match inactivity.observe_time(observed_at, can_blank) {
         InactivityDecision::BlankNow => handle_blank_request(
             writer,
             dispatcher,
@@ -2425,6 +2480,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("blank when the LG Buddy timeout expires");
         handle_inactivity_timeout(
@@ -2432,6 +2488,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
+            || true,
         )
         .expect("do not blank repeatedly");
 
@@ -2461,6 +2518,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("blank at inactivity deadline");
         handle_inactivity_timeout(
@@ -2468,6 +2526,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
+            || true,
         )
         .expect("power off at post-blank deadline");
         handle_inactivity_timeout(
@@ -2475,6 +2534,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(3),
+            || true,
         )
         .expect("do not retry timed power-off");
 
@@ -2508,6 +2568,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("screen-off skip completes");
         handle_inactivity_timeout(
@@ -2515,6 +2576,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(30),
+            || true,
         )
         .expect("no escalation follows the skip");
 
@@ -2544,6 +2606,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("blank at inactivity deadline");
         handle_inactivity_observation(
@@ -2560,6 +2623,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
+            || true,
         )
         .expect("canceled escalation remains canceled");
 
@@ -2586,6 +2650,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("blank when the timeout expires");
         let mut output = Vec::new();
@@ -2604,6 +2669,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
+            || true,
         )
         .expect("activity reset should keep the screen active");
 
@@ -2630,6 +2696,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("blank when the timeout expires");
 
@@ -2882,6 +2949,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("blank when the timeout expires");
 
@@ -2900,6 +2968,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
+            || true,
         )
         .expect("the original deadline must stay retired");
         handle_inactivity_timeout(
@@ -2907,6 +2976,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_millis(2_100),
+            || true,
         )
         .expect("blank at the reset deadline");
 
@@ -2930,6 +3000,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(1),
+            || true,
         )
         .expect("initial blank attempt should be logged");
         handle_inactivity_timeout(
@@ -2937,6 +3008,7 @@ system_sleep_wake_policy={policy}
             &mut dispatcher,
             &mut inactivity,
             started_at + Duration::from_secs(2),
+            || true,
         )
         .expect("elapsed time should not retry blank");
 

--- a/crates/lg-buddy/src/sources/linux/logind.rs
+++ b/crates/lg-buddy/src/sources/linux/logind.rs
@@ -112,17 +112,29 @@ impl Drop for LogindLockObserver {
     }
 }
 
-pub(crate) fn spawn_lock_observer<F, E>(mut publish: F, report_error: E) -> LogindLockObserver
+pub(crate) fn spawn_lock_observer<F, E, C>(
+    mut publish: F,
+    report_error: E,
+    mut lifecycle_changed: C,
+) -> LogindLockObserver
 where
     F: FnMut(SessionObservation) -> bool + Send + 'static,
     E: FnOnce(LogindSessionError) + Send + 'static,
+    C: FnMut() -> bool + Send + 'static,
 {
     let stop = Arc::new(AtomicBool::new(false));
     let thread_stop = Arc::clone(&stop);
     let handle = thread::spawn(move || {
         let result = new_system_bus_client()
             .map_err(Into::into)
-            .and_then(|mut bus| run_lock_observer_process(&mut bus, &mut publish, &thread_stop));
+            .and_then(|mut bus| {
+                run_lock_observer_process(
+                    &mut bus,
+                    &mut publish,
+                    &thread_stop,
+                    &mut lifecycle_changed,
+                )
+            });
         if let Err(err) = result {
             report_error(err);
         }
@@ -138,6 +150,7 @@ fn run_lock_observer_process<F>(
     bus: &mut impl SessionBusClient,
     publish: &mut F,
     stop: &AtomicBool,
+    lifecycle_changed: &mut impl FnMut() -> bool,
 ) -> Result<(), LogindSessionError>
 where
     F: FnMut(SessionObservation) -> bool,
@@ -150,6 +163,7 @@ where
         stop,
         explicit_session_id.as_deref(),
         current_uid,
+        lifecycle_changed,
     )
 }
 
@@ -159,11 +173,13 @@ fn run_lock_observer_for_session<F>(
     stop: &AtomicBool,
     explicit_session_id: Option<&str>,
     current_uid: u32,
+    lifecycle_changed: &mut impl FnMut() -> bool,
 ) -> Result<(), LogindSessionError>
 where
     F: FnMut(SessionObservation) -> bool,
 {
     add_logind_owner_signal_match(bus)?;
+    add_logind_signal_match(bus)?;
     let (mut session, owner, initial_locked) =
         bind_lock_target(bus, explicit_session_id, current_uid)?;
     let mut logind_owner = Some(owner);
@@ -179,6 +195,9 @@ where
         };
 
         if let Some(new_owner) = logind_owner_changed(&signal) {
+            if !lifecycle_changed() {
+                return Ok(());
+            }
             if new_owner.is_none() {
                 logind_owner = None;
                 continue;
@@ -197,6 +216,14 @@ where
         let Some(logind_owner) = logind_owner.as_deref() else {
             continue;
         };
+        // Sleep/resume invalidates pending idle decisions, but is not activity
+        // and must not dispatch the lifecycle service's TV actions a second time.
+        if signal.sender.as_deref() == Some(logind_owner)
+            && map_prepare_for_sleep_signal(&signal).is_some()
+            && !lifecycle_changed()
+        {
+            return Ok(());
+        }
         let Some(change) = map_locked_hint_change(&signal, &session, logind_owner) else {
             continue;
         };
@@ -1155,6 +1182,7 @@ mod tests {
             &stop,
             Some("34"),
             1000,
+            &mut || true,
         )
         .expect("initial LockedHint should be reconciled before the signal loop");
 
@@ -1166,7 +1194,7 @@ mod tests {
                 ..
             }]
         ));
-        assert_eq!(bus.matches.len(), 2);
+        assert_eq!(bus.matches.len(), 3);
         assert_eq!(
             bus.calls
                 .iter()
@@ -1174,6 +1202,39 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["GetSession", "GetAll", "GetNameOwner", "Get"]
         );
+    }
+
+    #[test]
+    fn sleep_transitions_invalidate_checks_without_publishing_activity_or_lifecycle_actions() {
+        let target = session("34");
+        let mut bus = FakeBus::default();
+        bus.replies.extend([
+            BusReply::new(vec![BusValue::ObjectPath(target.path.clone())]),
+            session_properties_reply(1000, false, "wayland", "user", true),
+            BusReply::new(vec![BusValue::String(LOGIND_OWNER.to_string())]),
+            BusReply::new(vec![variant(BusValue::Bool(false))]),
+        ]);
+        for (sender, sleeping) in [(":1.99", true), (LOGIND_OWNER, true), (LOGIND_OWNER, false)] {
+            bus.process_results.push_back(Ok(Some(
+                prepare_for_sleep_signal(sleeping).with_sender(sender),
+            )));
+        }
+        bus.process_results
+            .push_back(Err(SessionBusError::Transport("end".into())));
+        let mut changes = 0;
+        let result = run_lock_observer_for_session(
+            &mut bus,
+            &mut |_| panic!("sleep is not activity or a TV action here"),
+            &AtomicBool::new(false),
+            Some("34"),
+            1000,
+            &mut || {
+                changes += 1;
+                true
+            },
+        );
+        assert!(result.is_err());
+        assert_eq!(changes, 2);
     }
 
     #[test]
@@ -1219,6 +1280,7 @@ mod tests {
                 &stop,
                 Some("34"),
                 1000,
+                &mut || true,
             ),
             Err(LogindSessionError::Bus(SessionBusError::Transport(
                 "stop test loop".to_string()
@@ -1233,7 +1295,7 @@ mod tests {
                 ..
             }]
         ));
-        assert_eq!(bus.matches.len(), 3);
+        assert_eq!(bus.matches.len(), 4);
         assert_eq!(
             bus.calls
                 .iter()

--- a/crates/lg-buddy/tests/cucumber_support/steps.rs
+++ b/crates/lg-buddy/tests/cucumber_support/steps.rs
@@ -26,6 +26,21 @@ fn honor_idle_inhibitors(world: &mut LgBuddyWorld, policy: String) {
     world.set_honor_idle_inhibitors(&policy);
 }
 
+#[given(regex = r#"PowerDevil screen inhibition is "(active|clear)""#)]
+fn powerdevil_inhibition(world: &mut LgBuddyWorld, state: String) {
+    world.set_powerdevil_inhibited(state == "active");
+}
+
+#[given("PowerDevil fails its next inhibition query")]
+fn powerdevil_failure(world: &mut LgBuddyWorld) {
+    world.fail_next_powerdevil_query();
+}
+
+#[given(regex = r#"PowerDevil delays its next inhibition query by ([0-9]+(?:\.[0-9]+)?) seconds"#)]
+fn powerdevil_delay(world: &mut LgBuddyWorld, seconds: String) {
+    world.delay_next_powerdevil_query(seconds.parse().expect("query delay"));
+}
+
 #[given(regex = r#"GNOME has (\d+) idle inhibitors"#)]
 fn gnome_idle_inhibitors(world: &mut LgBuddyWorld, count: u32) {
     world.set_gnome_idle_inhibitors(count);

--- a/crates/lg-buddy/tests/cucumber_support/world.rs
+++ b/crates/lg-buddy/tests/cucumber_support/world.rs
@@ -1,7 +1,7 @@
 use crate::support::{
     prime_isolated_path_dependencies, ExecutableScript, MockBscpylgtv, MockNmOnline,
-    MockSessionBusIdleMonitor, MockSwayidle, MockSystemLogind, RuntimeStateLayout, TestConfigFile,
-    TestEnv,
+    MockPowerDevil, MockSessionBusIdleMonitor, MockSwayidle, MockSystemLogind, RuntimeStateLayout,
+    TestConfigFile, TestEnv,
 };
 use crate::web_os::{MockWebOsTv, MockWebOsTvSnapshot, MockWebOsVersion, VALID_WEBOS_ACCESS_TOKEN};
 use cucumber::World;
@@ -19,6 +19,7 @@ pub struct LgBuddyWorld {
     tv: Option<MockBscpylgtv>,
     webos_tv: Option<MockWebOsTv>,
     system_logind: Option<MockSystemLogind>,
+    powerdevil: Option<MockPowerDevil>,
     session_bus_idle_monitor: Option<MockSessionBusIdleMonitor>,
     nm_online: Option<MockNmOnline>,
     swayidle: Option<MockSwayidle>,
@@ -526,6 +527,26 @@ exit 1\n",
     pub fn set_gnome_idle_inhibitors(&mut self, count: u32) {
         self.ensure_mock_session_bus_idle_monitor()
             .set_idle_inhibitor_count(count);
+    }
+
+    pub fn set_powerdevil_inhibited(&mut self, inhibited: bool) {
+        let service = MockPowerDevil::new(self.ensure_mock_session_bus_idle_monitor().address());
+        service.set_inhibited(inhibited);
+        self.powerdevil = Some(service);
+    }
+
+    pub fn fail_next_powerdevil_query(&self) {
+        self.powerdevil
+            .as_ref()
+            .expect("PowerDevil fixture")
+            .fail_next_query();
+    }
+
+    pub fn delay_next_powerdevil_query(&self, seconds: f64) {
+        self.powerdevil
+            .as_ref()
+            .expect("PowerDevil fixture")
+            .delay_next_query(std::time::Duration::from_secs_f64(seconds));
     }
 
     pub fn schedule_gnome_idle_inhibitors(&mut self, count: u32, after_secs: f64) {

--- a/crates/lg-buddy/tests/features/idle_inhibition.feature
+++ b/crates/lg-buddy/tests/features/idle_inhibition.feature
@@ -1,7 +1,6 @@
-Feature: Native activity during the dev inhibition refactor
-  Issue #221 removes inhibition from activity. Native honoring is temporarily
-  absent on dev until #225; this intermediate runtime cannot be promoted.
-  Activity remains independent of inhibition services and preferences.
+Feature: Applications can prevent automatic idle blanking
+  Honoring is opt-in. Inhibition gates automatic idle blanking independently of
+  activity, with a full idle timeout after the last observed inhibitor release.
 
   Background:
     Given a temporary LG Buddy config using input HDMI_2
@@ -22,14 +21,87 @@ Feature: Native activity during the dev inhibition refactor
     And the TV client received "turn_screen_off" exactly 1 times
     And the TV screen is blanked
 
-  Scenario: Native activity remains usable with the stored honoring preference enabled
+  Scenario: Playback already running prevents blanking when honoring is enabled
     Given honoring app keep-awake requests is "enabled"
     And GNOME monitor stays open for 1.3 seconds
     When I run the command "monitor"
     Then the command succeeds
-    And stdout contains "native inhibition honoring is temporarily unavailable on dev"
+    And the TV client did not receive "turn_screen_off"
+    And the TV screen is visible
+
+  Scenario: Playback started after monitoring prevents blanking
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 0 idle inhibitors
+    And GNOME changes to 1 idle inhibitors after 0.3 seconds
+    And GNOME monitor stays open for 1.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+
+  Scenario: Missing inhibition support does not remove GNOME activity support
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME SessionManager is unavailable
+    And GNOME monitor stays open for 1.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
     And the TV client received "turn_screen_off" exactly 1 times
+
+  Scenario: Ending one of two playback inhibitors keeps the screen visible
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 2 idle inhibitors
+    And GNOME changes to 1 idle inhibitors after 0.3 seconds
+    And GNOME monitor stays open for 1.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+
+  Scenario: The last release waits a full timeout without requiring user input
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME changes to 0 idle inhibitors after 0.7 seconds
+    And GNOME monitor stays open for 1.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+
+  Scenario: Blanking resumes after the release delay
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME changes to 0 idle inhibitors after 0.3 seconds
+    And GNOME monitor stays open for 2.5 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_off" exactly 1 times
+    And the TV client did not receive "turn_screen_on"
     And the TV screen is blanked
+
+  Scenario: A PowerDevil inhibitor blocks even when GNOME is clear
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 0 idle inhibitors
+    And PowerDevil screen inhibition is "active"
+    And GNOME monitor stays open for 1.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
+
+  Scenario: A failed PowerDevil check contributes no inhibitor
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 0 idle inhibitors
+    And PowerDevil screen inhibition is "active"
+    And PowerDevil fails its next inhibition query
+    And GNOME monitor stays open for 1.4 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client received "turn_screen_off" exactly 1 times
+
+  Scenario: Input cancels a delayed clear answer before it can blank
+    Given honoring app keep-awake requests is "enabled"
+    And GNOME has 0 idle inhibitors
+    And PowerDevil screen inhibition is "clear"
+    And PowerDevil delays its next inhibition query by 0.6 seconds
+    And gamepad activity is observed after 1.2 seconds
+    And GNOME monitor stays open for 1.9 seconds
+    When I run the command "monitor"
+    Then the command succeeds
+    And the TV client did not receive "turn_screen_off"
 
   Scenario: Gamepad input restores independently of desktop inhibition
     Given honoring app keep-awake requests is "enabled"

--- a/crates/lg-buddy/tests/inhibition.rs
+++ b/crates/lg-buddy/tests/inhibition.rs
@@ -1,8 +1,8 @@
 mod support;
 
 use lg_buddy::inhibition::{
-    evaluate_pull_inhibition, evaluate_push_inhibition, InhibitionStatus, PullInhibitionAdapter,
-    PushInhibitionAdapter,
+    evaluate_pull_inhibition, evaluate_push_inhibition, Inhibition, InhibitionStatus,
+    PullInhibitionAdapter, PushInhibitionAdapter,
 };
 use lg_buddy::sources::desktop::gnome::inhibition::GnomeInhibition;
 use lg_buddy::sources::desktop::powerdevil::PowerDevilInhibition;
@@ -63,6 +63,68 @@ fn independent_inhibition_capabilities_work_without_activity_services() {
     permission_reads_do_not_wait_for_dbus_and_a_quiet_worker_can_stop(&bus);
     powerdevil_queries_current_permission_and_recovers(&bus);
     powerdevil_discards_delayed_cancelled_and_obsolete_replies(&bus);
+    composed_gate_uses_both_capabilities_and_the_observed_release_clock(&bus);
+}
+
+fn composed_gate_uses_both_capabilities_and_the_observed_release_clock(
+    bus: &MockSessionBusIdleMonitor,
+) {
+    let mut config = lg_buddy::config::parse_config(
+        "tv_ip=192.168.1.42\ntv_mac=aa:bb:cc:dd:ee:ff\ninput=HDMI_1\nscreen_honor_idle_inhibitors=enabled\n"
+    ).unwrap();
+    let push = Arc::new(GnomeInhibition::default());
+    let service = MockPowerDevil::new(bus.address());
+    bus.set_idle_inhibitor_count(1);
+    service.set_inhibited(true);
+    let delay = Duration::from_secs(10);
+    let mut gate = Inhibition::new(
+        &config,
+        delay,
+        vec![push.clone()],
+        vec![Box::new(PowerDevilInhibition::default())],
+    );
+    wait_until(|| !push.evaluate().allowed);
+    let check = |gate: &mut Inhibition, now| {
+        let mut allowed = false;
+        wait_until(|| {
+            allowed = gate.can_blank(now);
+            gate.diagnostics().unwrap().pull.is_some()
+        });
+        let diagnostic = gate.diagnostics().unwrap();
+        assert_eq!(diagnostic.can_blank, allowed);
+        assert_eq!(diagnostic.push.as_ref().unwrap().contributions.len(), 1);
+        assert_eq!(diagnostic.pull.as_ref().unwrap().contributions.len(), 1);
+        allowed
+    };
+    let now = Instant::now();
+    assert!(!check(&mut gate, now));
+    bus.schedule_idle_inhibitor_count(Duration::ZERO, 0);
+    wait_until(|| push.evaluate().allowed);
+    assert!(!check(&mut gate, now + delay), "PowerDevil still inhibits");
+    service.set_inhibited(false);
+    // The next successful query records PowerDevil's real observation time.
+    gate.cancel();
+    assert!(!check(&mut gate, Instant::now()));
+    let release_deadline = gate.diagnostics().unwrap().release_not_before.unwrap();
+    assert!(check(&mut gate, release_deadline));
+    assert_eq!(
+        gate.diagnostics().unwrap().release_not_before,
+        Some(release_deadline),
+        "clear queries do not restart the clock"
+    );
+    service.set_inhibited(true);
+    assert!(!check(&mut gate, release_deadline + Duration::from_secs(1)));
+    let before = service.query_count();
+    config.screen_honor_idle_inhibitors =
+        lg_buddy::config::ScreenHonorIdleInhibitorsPolicy::Disabled;
+    gate.configure(&config, delay);
+    assert!(gate.can_blank(Instant::now()));
+    assert_eq!(
+        service.query_count(),
+        before,
+        "override does not need a successful pull"
+    );
+    drop(gate);
 }
 
 fn powerdevil_queries_current_permission_and_recovers(bus: &MockSessionBusIdleMonitor) {

--- a/crates/lg-buddy/tests/runtime_entrypoints.rs
+++ b/crates/lg-buddy/tests/runtime_entrypoints.rs
@@ -10,9 +10,68 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 use support::{
-    ExecutableScript, MockBscpylgtv, MockNmOnline, MockSessionBusIdleMonitor, MockSystemLogind,
-    RuntimeStateLayout, TestConfigFile, TestEnv,
+    ExecutableScript, MockBscpylgtv, MockNmOnline, MockPowerDevil, MockSessionBusIdleMonitor,
+    MockSystemLogind, RuntimeStateLayout, TestConfigFile, TestEnv,
 };
+
+#[test]
+fn monitor_discards_a_pre_suspend_inhibition_answer_after_resume() {
+    let _env = TestEnv::new();
+    let bus = MockSessionBusIdleMonitor::new("monitor-inhibition-resume-bus");
+    bus.set_shell_available(true);
+    bus.set_screen_saver_available(true);
+    bus.set_idle_monitor_available(true);
+    bus.set_idle_inhibitor_count(0);
+    let powerdevil = MockPowerDevil::new(bus.address());
+    powerdevil.delay_next_query(Duration::from_millis(600));
+    let logind = MockSystemLogind::new("monitor-inhibition-resume-logind");
+    logind.reset();
+    let mock = MockBscpylgtv::new("monitor-inhibition-resume-tv");
+    mock.set_input("HDMI_2");
+    let wrapper = mock.command_wrapper("monitor-inhibition-resume-wrapper");
+    let config = TestConfigFile::new("monitor-inhibition-resume-config");
+    config.write_sample("HDMI_2");
+    let contents = fs::read_to_string(config.path()).unwrap();
+    fs::write(
+        config.path(),
+        format!("{contents}\nscreen_honor_idle_inhibitors=enabled\n"),
+    )
+    .unwrap();
+    let runtime = RuntimeStateLayout::new("monitor-inhibition-resume-runtime");
+    let child = std::process::Command::new(env!("CARGO_BIN_EXE_lg-buddy"))
+        .arg("monitor")
+        .env("LG_BUDDY_CONFIG", config.path())
+        .env("LG_BUDDY_BSCPYLGTV_COMMAND", wrapper.path())
+        .env("LG_BUDDY_SESSION_RUNTIME_DIR", runtime.session_dir())
+        .env("DBUS_SESSION_BUS_ADDRESS", bus.address())
+        .env("DBUS_SYSTEM_BUS_ADDRESS", logind.address())
+        .env("XDG_SESSION_ID", "test-session")
+        .env("LG_BUDDY_SCREEN_BACKEND", "gnome")
+        .env("LG_BUDDY_IDLE_TIMEOUT", "1")
+        .env("LG_BUDDY_GAMEPAD_ACTIVITY_SOURCE", "disabled")
+        .env("LG_BUDDY_GNOME_MONITOR_TEST_TIMEOUT_SECS", "2.8")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    wait_until(Duration::from_secs(2), || powerdevil.query_count() > 0);
+    // The old query captured clear. Playback starts across a lifecycle change;
+    // the completed old reply must not authorize a post-resume blank.
+    powerdevil.set_inhibited(true);
+    logind.queue_prepare_for_sleep_signal(true);
+    logind.queue_prepare_for_sleep_signal(false);
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert!(
+        powerdevil.query_count() >= 2,
+        "resume must trigger a fresh query"
+    );
+    assert!(
+        mock.calls().is_empty(),
+        "invalidation must neither blank nor dispatch sleep/wake TV actions"
+    );
+    runtime.assert_session_marker_absent();
+}
 
 #[test]
 fn monitor_recovers_gnome_activity_after_the_service_disappears() {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -407,9 +407,8 @@ The current split is:
   - owns GNOME session-bus setup, subscriptions, sender validation, Mutter
     user-active watches, and translation into normalized observations
 - `inhibition.rs`
-  - independent push/pull inhibition contracts, Boolean aggregation, preference
-    override evaluation from loaded configuration, and diagnostics;
-    standalone until the monitor integration in #225
+  - independent push/pull inhibition, preference override, release timing,
+    cancellable checks and diagnostics behind the Boolean blanking gate
 - `sources/desktop/gnome/inhibition.rs`
   - SessionManager inhibition subscriptions, state refresh and recovery,
     independent of GNOME activity
@@ -961,24 +960,25 @@ invalidating facts on connection loss. The runner queries adapter activity
 availability separately for idle policy and diagnostics. The compatibility backend resolver still serves
 existing settings/CLI callers; it does not select the automatic native source
 set. See [Session backend model](session-backend-model.md) for the current
-contracts and the temporary dev-only absence of native inhibition honoring
-between #221 and #225.
+activity and inhibition contracts, timing and coverage limits.
 
 Adapters may expose activity and inhibition independently, each through push or
-pull according to the source. The standalone push inhibition section (#222)
-combines maintained Boolean permissions with diagnostics. The pull section (#223)
+pull according to the source. The push inhibition section
+combines maintained Boolean permissions with diagnostics. The pull section
 combines fresh, cancellable requests in the same diagnostic shape; its PowerDevil
 capability delegates screen policy to Plasma. The GNOME capability
 requires only SessionManager and keeps subscriptions, state queries and owner
-recovery internal. It contributes no activity observations. #225 connects the
-two paths only at the `can_blank()` decision; runtime honoring remains absent
-until then.
+recovery internal. It contributes no activity observations. The `Inhibition`
+facade joins the sections, owns release timing and cancellable pull work, and
+exposes `can_blank()` when the ordinary activity deadline is due. A denial leaves
+that deadline unchanged and is retried at a bounded cadence. Explicit lock and
+post-blank policy remain independent.
 
-The separate preference section (#224) evaluates the existing honoring setting
+The separate preference section evaluates the existing honoring setting
 without I/O. Disabled honoring supplies a bypass for inhibition restrictions and
 release delay; it does not grant activity eligibility. Settings retain their
-screen-service restart apply path. #225 owns cancelling pending attempts on
-in-process configuration changes and consuming the current preference.
+screen-service restart apply path. The facade also cancels pending attempts
+before applying an in-process preference or timeout change.
 
 The runtime core owns:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,11 +38,12 @@ For GNOME end-to-end work, the running session also needs the full GNOME contrac
 - `org.gnome.ScreenSaver`
 - `org.gnome.Mutter.IdleMonitor`
 
-On dev, #221 removes native inhibition from the activity path. The persisted
-**Allow apps to prevent idle blanking** setting is temporarily ineffective until
-#225 integrates the separate subsystem. This intermediate work cannot be
-promoted to prerelease or main. Activity tests require Mutter user-active watches;
-SessionManager availability must not determine whether activity monitoring works.
+Native monitoring honors the opt-in **Allow apps to prevent idle blanking**
+setting through independent GNOME SessionManager and PowerDevil inhibition
+capabilities. Activity tests require Mutter user-active watches; SessionManager
+availability must not determine whether activity monitoring works. Private-bus
+fixtures cover the integrated gate. Live Plasma/application-route validation and
+native Wayland inhibition coverage remain open before the #89 MVP can be promoted.
 
 The C toolchain is required because `cargo build` now compiles vendored
 `libdbus` as part of the dependency graph. On common Linux distributions that
@@ -306,7 +307,7 @@ the branch contract and recovery process, see
 | `crates/lg-buddy/src/runtime_phase.rs` | Runtime sleep-phase provider abstraction |
 | `crates/lg-buddy/src/session/runner.rs` | Session monitor loop |
 | `crates/lg-buddy/src/session/inactivity.rs` | Session inactivity deadline and phase synthesis |
-| `crates/lg-buddy/src/inhibition.rs` | Standalone push/pull inhibition contracts, Boolean aggregation, preference override and diagnostics (#222/#223/#224) |
+| `crates/lg-buddy/src/inhibition.rs` | Push/pull inhibition, preference override, release timing and cancellable Boolean blanking gate |
 | `crates/lg-buddy/src/session/gamepad/` | Gamepad activity discovery, device-event refresh, adapters, capture, registry, and policy |
 | `crates/lg-buddy/src/session_bus.rs` | Generic D-Bus transport used by session and system event sources |
 | `crates/lg-buddy/src/sources/linux/logind.rs` | Linux logind lifecycle and current-session lock-state adapter |

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -104,22 +104,42 @@ cancels quiet connections and joins their threads.
 desktop activity to the shared policy. Its existing automatic fallback remains
 when no native activity capability is available at startup; #132 removes it.
 
-**Dev boundary (#221):** native inhibition honoring is temporarily absent.
-Inhibition notifications, permission state and release timing have been removed
-from the activity stream and inactivity engine. The stored preference remains
-compatible, and monitor startup reports the temporary limitation. #222 provides
-standalone push inhibition, #223 provides pull inhibition, and #224 evaluates the
-honoring preference; #225 integrates the subsystem and Boolean gate. This intermediate
-runtime must not be promoted to prerelease or main before that integration and
-#89's MVP readiness checks are complete. Explicit lock, ownership/restore and
-ordinary activity deadlines retain their existing policy.
-
-### Independent inhibition capabilities (#222, #223, #224)
+### Independent inhibition and the blanking gate
 
 An adapter can supply activity, inhibition, or both. Each capability independently
 uses push or pull according to its source. Activity observations stay in the
-activity path. Inhibition supplies permission; the intended meeting point is
-`can_blank()` at the automatic idle-blanking decision, integrated in #225.
+activity path. The native monitor starts GNOME's push inhibition and PowerDevil's
+pull inhibition independently of the configured activity sources. Their only
+policy meeting point is `can_blank()` at an automatic idle-blanking decision.
+
+The inactivity engine invokes this Boolean gate only when its ordinary activity
+deadline is due. A false result leaves the deadline and phase untouched. Explicit
+lock, restore/ownership and post-blank power-off retain their existing semantics.
+The runner checks deadlines at a bounded 50 ms cadence, so a denied deadline
+does not cause a busy loop.
+
+`Inhibition` owns the source sections, honoring preference, release delay and
+pending pull work. Push workers live with the facade; one pull worker retains
+adapter diagnostic history and services bounded requests. Each attempt has its
+own cancellation flag and reply channel. Input, activity availability changes,
+logind sleep/resume or owner changes, configuration changes and shutdown discard
+affected pending checks. The logind observer supplies cancellation separately
+from activity and never duplicates the lifecycle service's TV actions.
+
+`can_blank()` performs no protocol I/O. Pending work returns false for that
+attempt; completed failures remain neutral source contributions. Both sections
+must allow and the configured idle timeout must have elapsed since the latest
+observed release. Release timestamps come from adapters, not from aggregate
+Boolean changes, so repeated clear checks, delayed delivery, absence and recovery
+do not manufacture releases. Pull-only transitions between checks cannot be
+reconstructed. A completed pull answer is consumed once; another attempt needs a
+fresh query. Retries are limited to once per second after completion. Push source
+changes invalidate pending work; refreshing an unchanged value does not.
+
+`diagnostics()` returns the same evaluation as the most recent Boolean call,
+including the preference, evaluated source contributions, pending work and
+release deadline. A missing section means it was not evaluated on that call.
+Diagnostics are separate from the inactivity engine's decision.
 
 `inhibition.rs` defines `PushInhibitionAdapter`: its worker maintains one source's
 state, and `evaluate()` returns a Boolean permission with matching diagnostics
@@ -149,8 +169,8 @@ permissions, and returns the same section result and per-source diagnostic
 shape as push evaluation. It runs on a worker; exclusive mutable access orders
 requests without a separate request-generation tracker. Cancellation returns
 no verdict. A completed result belongs to that attempt and cannot be reused to
-authorize a later blank attempt. #225 owns consuming completions for the current
-attempt and joining the sections.
+authorize a later blank attempt. The facade consumes completions only for the
+current attempt and joins the sections.
 
 PowerDevil's capability lives in `sources/desktop/powerdevil.rs`. It opens a
 session-bus connection per check, discovers `org.kde.Solid.PowerManagement`
@@ -166,9 +186,8 @@ absence, cancelled in-flight checks and owner replacement break that continuity;
 recovery does not manufacture a release. Failures and absence are neutral under
 the same observed-inhibition rule as push. GNOME remains one push contribution.
 
-These capabilities are independently testable but are not started by the monitor yet.
-They read no preferences, apply no aggregate release delay, and send no
-activity events or TV actions. #225 owns their runtime integration.
+The adapters read no preferences, apply no aggregate release delay, and send no
+activity events or TV actions. Their facade owns that reconciliation.
 
 `evaluate_inhibition_preference(&Config)` is a separate, pure section. It reads
 the existing effective `screen_honor_idle_inhibitors` value and returns
@@ -184,9 +203,9 @@ CLI and GUI preference edits retain the existing persist-then-restart path for
 `LG_Buddy_screen.service`. A successful restart replaces the process and its
 pending attempts; the new runtime reads the new configuration. Apply failures
 remain reported separately from saved values and use the existing retry path.
-The preference evaluator retains no state. #225 must evaluate it for the current
-attempt and cancel any pending attempt before applying an in-process config
-reload; old completions cannot become authoritative under a new preference.
+The preference evaluator retains no state. The facade consumes the loaded policy
+and `configure()` cancels any pending attempt before changing the preference or
+release delay. Old completions cannot become authoritative under a new policy.
 
 ### PowerDevil route coverage
 
@@ -365,7 +384,8 @@ The code split is:
 - `crates/lg-buddy/src/session/activity.rs`
   - bounded, identified contributions, observation ordering and source diagnostics
 - `crates/lg-buddy/src/inhibition.rs`
-  - independent push inhibition contract, Boolean aggregation, and diagnostics
+  - push/pull contracts, source reconciliation, preference, release timing,
+    cancellable checks and Boolean gate diagnostics
 - `crates/lg-buddy/src/session/actions.rs`
   - action dependency assembly and native TV client ownership across compatible
     events; one-shot commands use the same assembly with a finite lifetime

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -262,9 +262,9 @@ Examples:
 - native Wayland protocol-version and seat discovery
 - native Wayland resumed-notification and registry-removal mapping
 - gamepad activity integration with the LG Buddy inactivity deadline
-- the explicit dev-only absence of native inhibition after #221; #225 restores
-  integrated inhibition tests before promotion, including overlap, playback
-  before/after startup and a full timeout after the last release
+- the Boolean inhibition gate, including overlapping sources, playback
+  before/after startup, a full timeout after the last observed release, and
+  cancelled input/configuration/lifecycle attempts without stale actions
 - screen runtime-phase eligibility over the private logind system-bus seam
 - logind lock state entering the shared blanked state without making unlock a
   restore trigger, while observation-time tests cover pre-lock, post-lock grace,
@@ -287,7 +287,9 @@ checks existing and later playback inhibitors, overlap, quiet subscriptions,
 loss/recovery and prompt permission reads during a slow query. Only observed
 inhibition denies permission; tests verify that pending reads retain the last
 value and source loss removes its contribution. These are
-component checks; full monitor/TV acceptance remains part of #225.
+component checks. `idle_inhibition.feature` exercises the real monitor and TV
+policy with private GNOME/PowerDevil services: playback, release delay, neutral
+query failure, delayed replies cancelled by gamepad input, restore and lock.
 
 Pull inhibition has colocated contract and adapter tests for fresh queries,
 Boolean aggregation, neutral absence/failure, bounded diagnostics, cancellation,
@@ -305,8 +307,11 @@ from desktop selection and activity policy. `tests/settings_operations.rs`
 exercises set, disable, re-enable and reset through the real settings writer and
 a mocked systemctl restart. It verifies that the restart sees the saved file and
 that the inhibition evaluator agrees with the effective setting after reload.
-Preference evaluation has no source or release-timing dependency. #225 owns the
-end-to-end override matrix and cancellation of attempts on in-process reload.
+Preference evaluation has no source or release-timing dependency. Facade tests
+cover the override, release timing, cancellation on policy changes, and bounded
+retries. Engine tests use only Boolean gates and verify that denial changes
+neither the activity deadline nor the phase. Private-bus composition tests check
+GNOME and PowerDevil together through the production facade.
 
 For live Plasma validation of #223, record Plasma/PowerDevil and application
 versions and the application's inhibition route, then inspect effective state:


### PR DESCRIPTION
## Summary

Restore native inhibition honoring through the Boolean `can_blank()` gate. GNOME's maintained inhibition and PowerDevil's fresh queries are reconciled with the honoring preference and release delay inside the inhibition subsystem. A denied check leaves the inactivity deadline and phase intact.

Pull work runs on one worker with bounded retries and a separate reply channel per attempt. Input, source and lifecycle changes cancel affected attempts; configuration changes cancel before applying new policy. The existing logind observer invalidates pending checks on sleep/resume without synthesizing activity or duplicating lifecycle TV actions. Diagnostics accompany the Boolean separately.

## Scope

- [x] This PR addresses one concern only.
- [x] I split unrelated fixes, refactors, cleanup, or formatting into separate PRs.
- [x] I read `CONTRIBUTING.md` and the relevant docs linked there.
- [x] I discussed design-sensitive changes first, or this is a small obvious bug fix.

## User-Visible Behavior

With **Allow apps to prevent idle blanking** enabled, observed GNOME or PowerDevil screen inhibition keeps the screen visible. After the last observed release, automatic blanking waits a full configured idle timeout. Absence and failed source checks contribute no inhibitor; clear polls and recovery do not create releases. Disabled honoring bypasses source restrictions and release delay. Explicit lock, ownership/restore and post-blank policy retain their existing behavior.

This completes the runtime wiring for #225. Live Plasma/application-route validation and native Wayland inhibitor coverage remain open under #216/#223. PowerDevil support does not establish native Wayland coverage; #217/#218 and the remaining #89 MVP criteria still precede prerelease readiness.

## Validation

- Full `cargo test -p lg-buddy` passed with `RUST_TEST_THREADS=4`, a nonexistent `LG_BUDDY_CONFIG` override, and isolated system bus/TV launcher: 1,017 unit tests, 151 acceptance scenarios (1,885 steps), and all integration suites, including 22 runtime entrypoint tests.
- Reproduced the initial hosted failure by running a shared-monitor test with a nonexistent config. Production inhibition setup now lives at the production entrypoint; shared-monitor tests inject their dependencies. All 32 runner tests pass with a missing-config override, and a permanent regression test explicitly sets one.
- Review reran inhibition and inactivity unit tests, private-bus capability/composition integration, and the monitor's pre-suspend reply cancellation test; all passed.
- `cargo fmt --all --check`, `git diff --check`, and `cargo clippy --workspace --all-targets --all-features -- -D warnings` passed.
- An unchanged diagnostics test, `bounded_command_does_not_join_a_descendant_holding_stdout`, failed in the initial full run, then passed in isolation and the full rerun. Its cause is not established.
- Bundle/distro checks await CI. No live Plasma or hardware validation is claimed.

## Related Issue

Fixes #225. Relates to #216, #89 and #195.
