### PR TITLE
Validate GNOME and Plasma desktop lifecycle end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         run: |
           cargo build -p lg-buddy -p lg-buddy-gui
           cargo build --locked -p lg-buddy --example gui_journey_tv
+          python3 scripts/test-tv-fixture.py ./target/debug/lg-buddy ./target/debug/examples/gui_journey_tv
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy-gui
           dbus-run-session -- xvfb-run -a bash ./scripts/test-gui-launch.sh ./target/debug/lg-buddy
           dbus-run-session -- xvfb-run -a bash ./scripts/test-installed-gui.sh \

--- a/crates/lg-buddy/examples/gui_journey_tv.rs
+++ b/crates/lg-buddy/examples/gui_journey_tv.rs
@@ -2,11 +2,15 @@
 //!
 //! Start it with one control directory argument. The fixture publishes one
 //! atomic `state.json` there and consumes atomically-written command files:
-//! `stateful`, `pairing-rejected`, `stall`, `interrupted`, or `stop`.
+//! `stateful`, `pairing-rejected`, `stall`, `interrupted`, `wake [delay-ms]`, `ready`, or `stop`.
+//! Optionally listen for WoL: `<control-dir> <bind-address> <mac> [wake-delay-ms]`.
 
+use lg_buddy::config::MacAddress;
+use lg_buddy::wol::MAGIC_PACKET_LEN;
 use std::env;
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
+use std::net::UdpSocket;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread;
@@ -49,7 +53,7 @@ impl Scenario {
             "stall" => Ok(Self::Stall),
             "interrupted" => Ok(Self::Interrupted),
             other => Err(format!(
-                "unsupported fixture command `{other}`; use stateful, pairing-rejected, stall, interrupted, or stop"
+                "unsupported fixture command `{other}`; use stateful, pairing-rejected, stall, interrupted, wake [delay-ms], ready, or stop"
             )),
         }
     }
@@ -85,7 +89,7 @@ impl Fixture {
         Self::start(scenario)
     }
 
-    fn state(&self, status: &str, scenario: Scenario) -> String {
+    fn state(&self, status: &str, scenario: Scenario, wake: Option<&WakeListener>) -> String {
         let snapshot = self.tv.snapshot();
         format!(
             "{}\n",
@@ -93,6 +97,7 @@ impl Fixture {
                 "status": status,
                 "scenario": scenario.name(),
                 "endpoint": "wss://127.0.0.1:3001",
+                "wol_address": wake.map(|listener| listener.socket.local_addr().unwrap().to_string()),
                 "power_on": snapshot.power_on,
                 "screen_on": snapshot.screen_on,
                 "input": snapshot.input,
@@ -100,6 +105,10 @@ impl Fixture {
                 "volume": snapshot.volume,
                 "muted": snapshot.muted,
                 "connection_count": snapshot.connection_count,
+                "active_connection_count": snapshot.active_connection_count,
+                "tv_ready": snapshot.ready,
+                "wake_count": snapshot.wake_count,
+                "power_off_count": snapshot.power_off_count,
                 "pairing_prompt_count": snapshot.pairing_prompt_count,
                 "registration_tokens": snapshot.registration_tokens,
             })
@@ -109,15 +118,68 @@ impl Fixture {
 
 enum Command {
     Scenario(Scenario),
+    Wake(Duration),
+    Ready,
     Stop,
 }
 
+struct WakeListener {
+    socket: UdpSocket,
+    mac: MacAddress,
+    ready_after: Duration,
+}
+
+impl WakeListener {
+    fn poll(&self, tv: &MockWebOsTv) -> io::Result<()> {
+        // One datagram per iteration keeps command/stop handling responsive.
+        let mut packet = [0u8; MAGIC_PACKET_LEN + 1];
+        match self.socket.recv(&mut packet) {
+            Ok(len) if valid_magic_packet(&packet[..len], &self.mac) => {
+                tv.simulate_wake(self.ready_after);
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {}
+            Err(error) => return Err(error),
+        }
+        Ok(())
+    }
+}
+
+fn valid_magic_packet(packet: &[u8], mac: &MacAddress) -> bool {
+    packet.len() == MAGIC_PACKET_LEN
+        && packet[..6] == [0xff; 6]
+        && packet[6..]
+            .chunks_exact(6)
+            .all(|chunk| chunk == mac.octets())
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = env::args_os();
-    let _program = args.next();
-    let control_dir = args.next().ok_or("usage: gui_journey_tv <control-dir>")?;
+    const USAGE: &str =
+        "usage: gui_journey_tv <control-dir> [<wol-bind-address> <mac> [wake-delay-ms]]";
+    let mut args = env::args_os().skip(1);
+    let control_dir = args.next().ok_or(USAGE)?;
+    let wake_listener = if let Some(address) = args.next() {
+        let mac = args.next().ok_or(USAGE)?;
+        let ready_after = args
+            .next()
+            .map(|value| value.to_string_lossy().parse::<u64>())
+            .transpose()?
+            .unwrap_or(0);
+        let socket = UdpSocket::bind(address.to_string_lossy().as_ref())?;
+        socket.set_nonblocking(true)?;
+        Some(WakeListener {
+            socket,
+            mac: mac
+                .to_string_lossy()
+                .parse()
+                .map_err(|_| "invalid WoL MAC address")?,
+            ready_after: Duration::from_millis(ready_after),
+        })
+    } else {
+        None
+    };
     if args.next().is_some() {
-        return Err("usage: gui_journey_tv <control-dir>".into());
+        return Err(USAGE.into());
     }
     let control_dir = PathBuf::from(control_dir);
     fs::create_dir_all(&control_dir)?;
@@ -128,7 +190,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut scenario = Scenario::Stateful;
     let mut fixture = Fixture::start(scenario);
-    atomic_write(&state_path, &fixture.state("ready", scenario))?;
+    atomic_write(
+        &state_path,
+        &fixture.state("ready", scenario, wake_listener.as_ref()),
+    )?;
     let mut last_state = String::new();
 
     loop {
@@ -139,8 +204,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     fixture = fixture.restart(scenario);
                     last_state.clear();
                 }
+                Command::Wake(delay) => fixture.tv.simulate_wake(delay),
+                Command::Ready => fixture.tv.finish_wake(),
                 Command::Stop => {
-                    let stopped = fixture.state("stopped", scenario);
+                    let stopped = fixture.state("stopped", scenario, wake_listener.as_ref());
                     drop(fixture);
                     atomic_write(&state_path, &stopped)?;
                     return Ok(());
@@ -148,7 +215,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
 
-        let state = fixture.state("ready", scenario);
+        if let Some(listener) = &wake_listener {
+            listener.poll(&fixture.tv)?;
+        }
+        let state = fixture.state("ready", scenario, wake_listener.as_ref());
         if state != last_state {
             atomic_write(&state_path, &state)?;
             last_state = state;
@@ -160,6 +230,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn parse_command(raw: &str) -> Result<Command, String> {
     match raw.trim() {
         "stop" => Ok(Command::Stop),
+        "wake" => Ok(Command::Wake(Duration::ZERO)),
+        "ready" => Ok(Command::Ready),
+        value if value.starts_with("wake ") => {
+            let delay = value[5..].trim().parse::<u64>().map_err(|_| {
+                "wake delay must be a non-negative number of milliseconds".to_string()
+            })?;
+            Ok(Command::Wake(Duration::from_millis(delay)))
+        }
         value => Ok(Command::Scenario(Scenario::parse(value)?)),
     }
 }

--- a/crates/lg-buddy/examples/gui_journey_tv.rs
+++ b/crates/lg-buddy/examples/gui_journey_tv.rs
@@ -149,8 +149,10 @@ fn valid_magic_packet(packet: &[u8], mac: &MacAddress) -> bool {
     packet.len() == MAGIC_PACKET_LEN
         && packet[..6] == [0xff; 6]
         && packet[6..]
-            .chunks_exact(6)
-            .all(|chunk| chunk == mac.octets())
+            .as_chunks::<6>()
+            .0
+            .iter()
+            .all(|chunk| *chunk == mac.octets())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/lg-buddy/src/session/actions/tests.rs
+++ b/crates/lg-buddy/src/session/actions/tests.rs
@@ -239,7 +239,7 @@ fn closed_session_recovers_input_before_next_idle_decision() {
 
         // Model switching inputs on the TV while the monitor's socket closes.
         server.set_input(input);
-        server.close_active_connection();
+        server.close_active_connections();
         output.clear();
         dispatcher
             .dispatch_event(&mut output, SessionEvent::Idle)

--- a/crates/lg-buddy/src/session/runner.rs
+++ b/crates/lg-buddy/src/session/runner.rs
@@ -567,21 +567,36 @@ fn prepare_monitor_backend(
     probe: &mut SystemBackendProbe,
     configured: ScreenBackend,
 ) -> Result<(BackendResolution, Option<WaylandSource>), BackendDetectionError> {
+    let resolution = resolve_monitor_backend(probe, configured)?;
+    Ok((resolution, probe.take_wayland_source()))
+}
+
+fn resolve_monitor_backend(
+    probe: &impl BackendProbe,
+    configured: ScreenBackend,
+) -> Result<BackendResolution, BackendDetectionError> {
     // Probe both interfaces before starting threads: WAYLAND_SOCKET is a
     // one-shot inherited descriptor consumed by the initial connection.
     if configured == ScreenBackend::Auto {
         let gnome = resolve_backend_with_probe(probe, ScreenBackend::Gnome).is_ok();
         let wayland = probe.wayland_capabilities().is_ok();
         if gnome || wayland {
-            return Ok((
-                BackendResolution::selected(ScreenBackend::Auto, None),
-                probe.take_wayland_source(),
-            ));
+            return Ok(BackendResolution::selected(ScreenBackend::Auto, None));
         }
     }
     let resolution = resolve_backend_with_probe(probe, configured)?;
-    let source = probe.take_wayland_source();
-    Ok((resolution, source))
+    // A native interface may appear between the first probes and the legacy
+    // fallback probe. Automatic monitoring still composes both adapters.
+    if configured == ScreenBackend::Auto
+        && matches!(
+            resolution.backend(),
+            ScreenBackend::Gnome | ScreenBackend::Wayland
+        )
+    {
+        Ok(BackendResolution::selected(ScreenBackend::Auto, None))
+    } else {
+        Ok(resolution)
+    }
 }
 
 fn run_monitor_with_executor<W: Write, E: SessionActionExecutor>(
@@ -1815,6 +1830,99 @@ mod tests {
 
     fn env_lock() -> &'static Mutex<()> {
         crate::session::test_env_lock()
+    }
+
+    struct StartingDesktop {
+        backend: ScreenBackend,
+        probes: std::cell::Cell<usize>,
+        ready_after: usize,
+    }
+
+    impl StartingDesktop {
+        fn available(&self, backend: ScreenBackend) -> bool {
+            if self.backend != backend {
+                return false;
+            }
+            let count = self.probes.get();
+            self.probes.set(count + 1);
+            count >= self.ready_after
+        }
+    }
+
+    impl crate::backend::BackendProbe for StartingDesktop {
+        fn has_command(&self, command: &str) -> bool {
+            command == "swayidle" && self.backend == ScreenBackend::Swayidle
+        }
+
+        fn gnome_shell_available(&self) -> bool {
+            self.available(ScreenBackend::Gnome)
+        }
+
+        fn gnome_screen_saver_available(&self) -> bool {
+            true
+        }
+
+        fn gnome_idle_monitor_available(&self) -> bool {
+            true
+        }
+
+        fn wayland_capabilities(
+            &self,
+        ) -> Result<crate::sources::desktop::wayland::WaylandProviderCapabilities, String> {
+            if self.available(ScreenBackend::Wayland) {
+                Ok(
+                    crate::sources::desktop::wayland::WaylandProviderCapabilities {
+                        idle_notifier_version: 2,
+                        seat_count: 1,
+                    },
+                )
+            } else {
+                Err("compositor is starting".to_string())
+            }
+        }
+    }
+
+    #[test]
+    fn automatic_monitor_composes_native_sources_that_appear_during_fallback_probing() {
+        for backend in [ScreenBackend::Gnome, ScreenBackend::Wayland] {
+            let probe = StartingDesktop {
+                backend,
+                probes: std::cell::Cell::new(0),
+                ready_after: 1,
+            };
+            let resolution = super::resolve_monitor_backend(&probe, ScreenBackend::Auto).unwrap();
+            assert_eq!(resolution.backend(), ScreenBackend::Auto, "{backend:?}");
+            assert_eq!(probe.probes.get(), 2);
+        }
+    }
+
+    #[test]
+    fn monitor_preserves_explicit_selection_and_automatic_swayidle_compatibility() {
+        for backend in [
+            ScreenBackend::Gnome,
+            ScreenBackend::Wayland,
+            ScreenBackend::Swayidle,
+        ] {
+            let probe = StartingDesktop {
+                backend,
+                probes: std::cell::Cell::new(0),
+                ready_after: 0,
+            };
+            assert_eq!(
+                super::resolve_monitor_backend(&probe, backend)
+                    .unwrap()
+                    .backend(),
+                backend
+            );
+            if backend == ScreenBackend::Swayidle {
+                assert_eq!(
+                    super::resolve_monitor_backend(&probe, ScreenBackend::Auto)
+                        .unwrap()
+                        .backend(),
+                    backend
+                );
+            }
+        }
     }
 
     #[derive(Debug, Default)]

--- a/crates/lg-buddy/src/web_os/adapter.rs
+++ b/crates/lg-buddy/src/web_os/adapter.rs
@@ -993,7 +993,7 @@ mod tests {
         let token_fixture = TestAccessTokenStore::new();
         let client = client_for_server(&server, &token_fixture);
         client.current_input().expect("establish initial session");
-        server.close_active_connection();
+        server.close_active_connections();
         server.set_scenario(WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff);
 
         let error = client

--- a/crates/lg-buddy/src/web_os/observed_behavior.rs
+++ b/crates/lg-buddy/src/web_os/observed_behavior.rs
@@ -385,3 +385,25 @@ fn power_off_transitions_active_tv_and_rejects_immediate_registration() {
     assert_eq!(server.snapshot().connection_count, 2);
     server.finish();
 }
+
+// Two LG Buddy services operated together against the physical TV:
+// https://github.com/Staphylococcus/LG_Buddy/issues/217#issuecomment-5647209853
+// This characterizes shared TV state, not compositor HDMI signal availability.
+#[test]
+fn independent_clients_observe_the_same_tv_screen_state() {
+    let server =
+        WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
+    let mut monitor = server.connect_authenticated().expect("monitor connection");
+    let mut lifecycle = server
+        .connect_authenticated()
+        .expect("lifecycle connection");
+    assert_eq!(server.snapshot().active_connection_count, 2);
+    monitor.turn_screen_off().expect("blank through monitor");
+    assert_eq!(lifecycle.power_state().unwrap(), WebOsPowerState::ScreenOff);
+    lifecycle
+        .turn_screen_on()
+        .expect("unblank through other client");
+    assert_eq!(monitor.power_state().unwrap(), WebOsPowerState::Active);
+    assert_eq!(server.snapshot().connection_count, 2);
+    server.finish();
+}

--- a/crates/lg-buddy/src/web_os/test_support/test_server.rs
+++ b/crates/lg-buddy/src/web_os/test_support/test_server.rs
@@ -11,7 +11,7 @@ use rustls::crypto::ring;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::{ServerConfig, ServerConnection, StreamOwned};
 use serde_json::{json, Value};
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::{self, Read, Write};
 use std::net::{Shutdown, TcpListener, TcpStream};
@@ -19,7 +19,7 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::thread::{self, JoinHandle};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tungstenite::error::ProtocolError;
 use tungstenite::protocol::frame::coding::CloseCode;
 use tungstenite::protocol::CloseFrame;
@@ -134,6 +134,10 @@ pub(crate) struct WebOsTestTvSnapshot {
     pub(crate) volume: i16,
     pub(crate) muted: bool,
     pub(crate) connection_count: u64,
+    pub(crate) active_connection_count: usize,
+    pub(crate) ready: bool,
+    pub(crate) wake_count: u64,
+    pub(crate) power_off_count: u64,
     pub(crate) pairing_prompt_count: u64,
     pub(crate) registration_tokens: Vec<Option<String>>,
     pub(crate) request_uris: Vec<String>,
@@ -570,13 +574,46 @@ struct WebOsTestRuntime {
     ambiguous_input_write_injected: bool,
     stalled_request_injected: bool,
     restore_session_interruption_injected: bool,
+    ready_at: Option<Instant>,
+    wake_count: u64,
+    power_off_count: u64,
+}
+
+impl WebOsTestRuntime {
+    fn ready(&self) -> bool {
+        self.tv.power_state != WebOsPowerState::PowerOff
+            && self
+                .ready_at
+                .is_none_or(|deadline| Instant::now() >= deadline)
+    }
+}
+
+type Connections = Arc<Mutex<HashMap<u64, TcpStream>>>;
+
+struct ActiveConnection {
+    id: u64,
+    connections: Connections,
+}
+
+impl Drop for ActiveConnection {
+    fn drop(&mut self) {
+        self.connections.lock().unwrap().remove(&self.id);
+    }
+}
+
+fn shutdown_connections(connections: &Connections, except: Option<u64>) {
+    for (id, stream) in connections.lock().unwrap().iter() {
+        if Some(*id) != except {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+    }
 }
 
 pub(crate) struct WebOsTestServer {
     endpoint: WebOsEndpoint,
     address: std::net::SocketAddr,
     runtime: Arc<Mutex<WebOsTestRuntime>>,
-    active_connection: Arc<Mutex<Option<TcpStream>>>,
+    active_connections: Connections,
     stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
@@ -686,30 +723,59 @@ impl WebOsTestServer {
             ambiguous_input_write_injected: false,
             stalled_request_injected: false,
             restore_session_interruption_injected: false,
+            ready_at: None,
+            wake_count: 0,
+            power_off_count: 0,
         }));
-        let active_connection = Arc::new(Mutex::new(None));
+        let active_connections = Arc::new(Mutex::new(HashMap::new()));
         let stop = Arc::new(AtomicBool::new(false));
         let server_runtime = Arc::clone(&runtime);
-        let server_active_connection = Arc::clone(&active_connection);
+        let server_connections = Arc::clone(&active_connections);
         let server_stop = Arc::clone(&stop);
         let handle = thread::spawn(move || {
+            let mut workers: Vec<JoinHandle<()>> = Vec::new();
+            let mut next_id = 0;
+            let mut failed = false;
             while !server_stop.load(Ordering::Acquire) {
+                let mut index = 0;
+                while index < workers.len() {
+                    if workers[index].is_finished() {
+                        failed |= workers.swap_remove(index).join().is_err();
+                    } else {
+                        index += 1;
+                    }
+                }
+                if failed {
+                    break;
+                }
                 match listener.accept() {
                     Ok((stream, _)) => {
                         if server_stop.load(Ordering::Acquire) {
                             break;
                         }
-                        *server_active_connection
-                            .lock()
-                            .expect("webOS test active connection") = Some(
+                        let id = next_id;
+                        next_id += 1;
+                        server_connections.lock().unwrap().insert(
+                            id,
                             stream
                                 .try_clone()
-                                .expect("clone webOS test connection for shutdown"),
+                                .expect("clone webOS connection for shutdown"),
                         );
-                        serve_accepted_connection(stream, transport, &server_runtime, &server_stop);
-                        *server_active_connection
-                            .lock()
-                            .expect("webOS test active connection") = None;
+                        let connection = ActiveConnection {
+                            id,
+                            connections: Arc::clone(&server_connections),
+                        };
+                        let runtime = Arc::clone(&server_runtime);
+                        let stop = Arc::clone(&server_stop);
+                        workers.push(thread::spawn(move || {
+                            serve_accepted_connection(
+                                stream,
+                                transport,
+                                &runtime,
+                                &stop,
+                                &connection,
+                            );
+                        }));
                     }
                     Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
                         thread::sleep(Duration::from_millis(5));
@@ -717,13 +783,19 @@ impl WebOsTestServer {
                     Err(error) => panic!("accept webOS test connection: {error}"),
                 }
             }
+            server_stop.store(true, Ordering::Release);
+            shutdown_connections(&server_connections, None);
+            for worker in workers {
+                failed |= worker.join().is_err();
+            }
+            assert!(!failed, "webOS test connection worker panicked");
         });
 
         Self {
             endpoint,
             address,
             runtime,
-            active_connection,
+            active_connections,
             stop,
             handle: Some(handle),
         }
@@ -767,28 +839,34 @@ impl WebOsTestServer {
             .input = input;
     }
 
-    /// Close an established connection between operations, leaving the TV
-    /// available for the next connection.
+    /// Simulate an external wake without resetting settings or observations.
+    /// The delay is deterministic fault injection, not a firmware timing claim.
     #[allow(dead_code)]
-    pub(crate) fn close_active_connection(&self) {
-        self.active_connection
+    pub(crate) fn simulate_wake(&self, ready_after: Duration) {
+        let mut runtime = self.runtime.lock().expect("webOS test server state");
+        if runtime.tv.power_state == WebOsPowerState::PowerOff {
+            runtime.tv.power_state = WebOsPowerState::Active;
+            runtime.ready_at = Some(Instant::now() + ready_after);
+            runtime.wake_count += 1;
+        }
+    }
+
+    /// Release an injected startup delay; this does not power on an off TV.
+    #[allow(dead_code)]
+    pub(crate) fn finish_wake(&self) {
+        self.runtime
             .lock()
-            .expect("webOS test active connection")
-            .as_ref()
-            .expect("an established webOS connection")
-            .shutdown(Shutdown::Both)
-            .expect("close webOS test connection");
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
-        while self
-            .active_connection
-            .lock()
-            .expect("webOS test active connection")
-            .is_some()
-        {
-            assert!(
-                std::time::Instant::now() < deadline,
-                "connection did not close"
-            );
+            .expect("webOS test server state")
+            .ready_at = None;
+    }
+
+    /// Close existing connections between operations, leaving the TV available.
+    #[allow(dead_code)]
+    pub(crate) fn close_active_connections(&self) {
+        shutdown_connections(&self.active_connections, None);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !self.active_connections.lock().unwrap().is_empty() {
+            assert!(Instant::now() < deadline, "connections did not close");
             thread::sleep(Duration::from_millis(5));
         }
     }
@@ -829,6 +907,10 @@ impl WebOsTestServer {
             volume: runtime.tv.volume,
             muted: runtime.tv.muted,
             connection_count: runtime.connection_count,
+            active_connection_count: self.active_connections.lock().unwrap().len(),
+            ready: runtime.ready(),
+            wake_count: runtime.wake_count,
+            power_off_count: runtime.power_off_count,
             pairing_prompt_count: runtime.pairing_prompt_count,
             registration_tokens: runtime.registration_tokens.clone(),
             request_uris: runtime.request_uris.clone(),
@@ -844,14 +926,7 @@ impl WebOsTestServer {
             return Ok(());
         };
         self.stop.store(true, Ordering::Release);
-        if let Some(connection) = self
-            .active_connection
-            .lock()
-            .expect("webOS test active connection")
-            .as_ref()
-        {
-            let _ = connection.shutdown(Shutdown::Both);
-        }
+        shutdown_connections(&self.active_connections, None);
         let _ = TcpStream::connect(self.address);
         handle.join()
     }
@@ -868,18 +943,21 @@ fn serve_accepted_connection(
     transport: WebOsTestTransport,
     runtime: &Arc<Mutex<WebOsTestRuntime>>,
     stop: &AtomicBool,
+    connection: &ActiveConnection,
 ) {
     match transport {
         WebOsTestTransport::Plain => {
-            let socket = accept(stream).expect("accept webOS test websocket");
-            serve_connection(socket, runtime, stop);
+            if let Ok(socket) = accept(stream) {
+                serve_connection(socket, runtime, stop, connection);
+            }
         }
         WebOsTestTransport::Tls => {
-            let connection =
+            let tls_connection =
                 ServerConnection::new(test_tls_config()).expect("create webOS test TLS connection");
-            let stream = StreamOwned::new(connection, stream);
-            let socket = accept(stream).expect("accept secure webOS test websocket");
-            serve_connection(socket, runtime, stop);
+            let stream = StreamOwned::new(tls_connection, stream);
+            if let Ok(socket) = accept(stream) {
+                serve_connection(socket, runtime, stop, connection);
+            }
         }
     }
 }
@@ -888,6 +966,7 @@ fn serve_connection<S>(
     mut socket: WebSocket<S>,
     runtime: &Arc<Mutex<WebOsTestRuntime>>,
     stop: &AtomicBool,
+    connection: &ActiveConnection,
 ) where
     S: Read + Write,
 {
@@ -967,7 +1046,10 @@ fn serve_connection<S>(
             | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff => {
                 let response = {
                     let mut runtime = runtime.lock().expect("webOS test server state");
-                    if scenario == WebOsTestScenario::PowerStatePermissionDenied
+                    if !runtime.ready() {
+                        return;
+                    }
+                    let response = if scenario == WebOsTestScenario::PowerStatePermissionDenied
                         && request["uri"] == GET_POWER_STATE_URI
                     {
                         Some(webos_error_without_payload(
@@ -1013,11 +1095,23 @@ fn serve_connection<S>(
                                         | WebOsTestScenario::RestoreSessionInterruptedAndInputAckLeavesScreenOff
                                 ),
                             ))
+                    };
+                    if request["uri"] == POWER_OFF_URI
+                        && runtime.tv.power_state == WebOsPowerState::PowerOff
+                    {
+                        runtime.power_off_count += 1;
+                        // Finish disconnecting old peers before exposing the
+                        // power-off acknowledgement to a controller that can wake us.
+                        shutdown_connections(&connection.connections, Some(connection.id));
                     }
+                    response
                 };
                 match response {
                     Some(response) => {
                         send_json(&mut socket, response);
+                        if request["uri"] == POWER_OFF_URI {
+                            return;
+                        }
                         true
                     }
                     None => false,
@@ -1040,21 +1134,18 @@ fn handle_registration<S>(
 where
     S: Read + Write,
 {
-    let (scenario, power_state, version) = {
+    let (scenario, ready, version) = {
         let runtime = runtime.lock().expect("webOS test server state");
-        (
-            runtime.scenario,
-            runtime.tv.power_state.clone(),
-            runtime.tv.version,
-        )
+        (runtime.scenario, runtime.ready(), runtime.tv.version)
     };
-    if power_state == WebOsPowerState::PowerOff {
-        socket
-            .send(Message::Close(Some(CloseFrame {
+    if !ready {
+        send_message(
+            socket,
+            Message::Close(Some(CloseFrame {
                 code: CloseCode::Policy,
                 reason: "Try Again Later (EWS)".into(),
-            })))
-            .expect("send post-power-off close");
+            })),
+        );
         return false;
     }
 
@@ -1286,9 +1377,21 @@ fn send_json<S>(socket: &mut WebSocket<S>, value: Value)
 where
     S: Read + Write,
 {
-    socket
-        .send(Message::text(value.to_string()))
-        .expect("send webOS test response");
+    send_message(socket, Message::text(value.to_string()));
+}
+
+fn send_message<S: Read + Write>(socket: &mut WebSocket<S>, message: Message) {
+    if let Err(error) = socket.send(message) {
+        assert!(
+            matches!(
+                error,
+                WebSocketError::Io(_)
+                    | WebSocketError::ConnectionClosed
+                    | WebSocketError::AlreadyClosed
+            ),
+            "send webOS test response: {error}"
+        );
+    }
 }
 
 fn test_tls_config() -> Arc<ServerConfig> {
@@ -1462,6 +1565,117 @@ mod tests {
     use std::net::TcpStream;
     use tungstenite::stream::MaybeTlsStream;
     use tungstenite::{connect, Message, WebSocket};
+
+    // Synthetic transport scheduling: an idle/incomplete handshake must not
+    // monopolize the accept loop, and shutdown must close every worker.
+    #[test]
+    fn concurrent_clients_and_pending_handshake_shut_down_in_both_transports() {
+        for transport in [
+            super::WebOsTestTransport::Plain,
+            super::WebOsTestTransport::Tls,
+        ] {
+            let mut server = WebOsTestServer::spawn(
+                WebOsTestVersion::WebOs24Version92261,
+                super::WebOsPowerState::Active,
+                WebOsTestInput::Hdmi3,
+                WebOsTestScenario::StatefulTv,
+                transport,
+            );
+            let _unfinished_handshake = TcpStream::connect(server.address).unwrap();
+            let mut first = server.connect_authenticated().unwrap();
+            let mut second = server.connect_authenticated().unwrap();
+            first.turn_screen_off().unwrap();
+            assert_eq!(
+                second.power_state().unwrap(),
+                super::WebOsPowerState::ScreenOff
+            );
+            assert_eq!(server.snapshot().active_connection_count, 3);
+            let (finished, result) = std::sync::mpsc::channel();
+            std::thread::spawn(move || finished.send(server.stop_and_join()).unwrap());
+            result
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .unwrap()
+                .unwrap();
+        }
+    }
+
+    // Peer invalidation and wake latency are controlled fault injection. Hardware
+    // establishes retries before restoration, not exact close timing or failures:
+    // https://github.com/Staphylococcus/LG_Buddy/issues/217#issuecomment-5647209853
+    #[test]
+    fn power_cycle_disconnects_peers_and_wake_preserves_state_and_history() {
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi2);
+        server.set_volume(37);
+        let mut monitor = server.connect_authenticated().unwrap();
+        let lifecycle = server.connect_authenticated().unwrap();
+        lifecycle.power_off().unwrap();
+        assert_eq!(
+            server.snapshot().power_state,
+            super::WebOsPowerState::PowerOff
+        );
+        assert!(!server.snapshot().ready);
+        assert!(
+            monitor.power_state().is_err(),
+            "old peer must be disconnected"
+        );
+        assert!(
+            server.connect_authenticated().is_err(),
+            "off TV cannot register"
+        );
+        server.simulate_wake(std::time::Duration::from_secs(60));
+        assert!(!server.snapshot().ready);
+        assert!(
+            server.connect_authenticated().is_err(),
+            "wake can precede readiness"
+        );
+        // A later packet does not replace the pending startup transition.
+        server.simulate_wake(std::time::Duration::ZERO);
+        assert!(!server.snapshot().ready);
+        server.finish_wake();
+        assert!(server.snapshot().ready);
+        let mut restored = server.connect_authenticated().unwrap();
+        assert_eq!(
+            restored.power_state().unwrap(),
+            super::WebOsPowerState::Active
+        );
+        let snapshot = server.snapshot();
+        assert_eq!(snapshot.input, WebOsTestInput::Hdmi2);
+        assert_eq!(snapshot.volume, 37);
+        assert_eq!(snapshot.power_off_count, 1);
+        assert_eq!(snapshot.wake_count, 1);
+        assert_eq!(snapshot.connection_count, 5);
+        assert_eq!(snapshot.pairing_prompt_count, 0);
+        assert!(snapshot
+            .registration_tokens
+            .iter()
+            .all(|token| token.as_deref() == Some(super::TEST_ACCESS_TOKEN)));
+        assert!(snapshot
+            .request_uris
+            .iter()
+            .any(|uri| uri == super::POWER_OFF_URI));
+        server.finish();
+    }
+
+    #[test]
+    fn connection_worker_failure_is_reported_and_other_clients_are_stopped() {
+        let server =
+            WebOsTestServer::active(WebOsTestVersion::WebOs24Version92261, WebOsTestInput::Hdmi3);
+        let _idle = server.connect_authenticated().unwrap();
+        let mut invalid = connect_registered(&server, &[], None);
+        invalid
+            .send(Message::text(
+                json!({
+                    "type": "request", "id": "invalid", "uri": "ssap://unmodeled", "payload": {}
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        assert!(invalid.read().is_err());
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| server.finish())).is_err()
+        );
+    }
 
     type TestClient = WebSocket<MaybeTlsStream<TcpStream>>;
 

--- a/crates/lg-buddy/tests/cucumber_support/webos.rs
+++ b/crates/lg-buddy/tests/cucumber_support/webos.rs
@@ -4,6 +4,7 @@ pub use lg_buddy::web_os::{
 };
 use serde_json::Value;
 use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
 
 mod test_support;
 
@@ -38,6 +39,10 @@ pub struct MockWebOsTvSnapshot {
     pub volume: i16,
     pub muted: bool,
     pub connection_count: u64,
+    pub active_connection_count: usize,
+    pub ready: bool,
+    pub wake_count: u64,
+    pub power_off_count: u64,
     pub pairing_prompt_count: u64,
     pub registration_tokens: Vec<Option<String>>,
 }
@@ -91,6 +96,16 @@ impl MockWebOsTv {
         self.server.set_muted(muted);
     }
 
+    #[allow(dead_code)] // Used by the process fixture, which shares this adapter.
+    pub fn simulate_wake(&self, ready_after: Duration) {
+        self.server.simulate_wake(ready_after);
+    }
+
+    #[allow(dead_code)] // Used by the process fixture, which shares this adapter.
+    pub fn finish_wake(&self) {
+        self.server.finish_wake();
+    }
+
     pub fn snapshot(&self) -> MockWebOsTvSnapshot {
         self.assert_healthy();
         let snapshot = self.server.snapshot();
@@ -102,6 +117,10 @@ impl MockWebOsTv {
             volume: snapshot.volume,
             muted: snapshot.muted,
             connection_count: snapshot.connection_count,
+            active_connection_count: snapshot.active_connection_count,
+            ready: snapshot.ready,
+            wake_count: snapshot.wake_count,
+            power_off_count: snapshot.power_off_count,
             pairing_prompt_count: snapshot.pairing_prompt_count,
             registration_tokens: snapshot.registration_tokens,
         }

--- a/docs/desktop-session-validation.md
+++ b/docs/desktop-session-validation.md
@@ -1,0 +1,389 @@
+# GNOME/Plasma session validation
+
+Recorded on 2026-09-12 for [#217](https://github.com/Staphylococcus/LG_Buddy/issues/217).
+This is a development validation record, not approval to promote the #89 MVP.
+
+## Environment and provenance
+
+The dedicated Incus VM `lg-buddy-desktop-217` runs Fedora 44 with both desktops
+installed, GDM, six virtual CPUs, 8 GiB RAM and a 32 GiB disk. Tests use one local
+graphical account (`lgtest`, UID 1001), lingering and a concurrent SSH session.
+SELinux stays enforcing. The VM tests left other machines unchanged; the separate
+Hearth hardware pass below temporarily substituted the runtime in its two services.
+
+| Component | Version |
+| --- | --- |
+| GNOME Shell / Mutter | 50.4 |
+| gnome-session / GDM | 50.1 / 50.3 |
+| Plasma / KWin / PowerDevil | 6.7.5 |
+| systemd | 259.8 |
+| Kernel | 7.1.12 |
+| mpv | 0.41.0 |
+
+The initial installation used the runtime, GUI and TV fixture from
+[CI run 34664139930](https://github.com/Staphylococcus/LG_Buddy/actions/runs/34664139930).
+Its build commit `fb9574c9fd614cf0b6a2ba45e64a47ad99792b7f` and merged `dev`
+commit `f777a5fe351dc96cf74443bfd09197e9eff000bd` have the same tree,
+`edf1246679f9ade9a02f3fbf6f8d59a6f5d4d312`. The CI version string is
+`1.4.0-beta.2.ci`; it is not a published release.
+
+SHA-256 identifiers:
+
+```text
+CI bundle: e2b4c5c8a91dfdf49a7cf4a09cf9d1ee94bb4544071adcaa4be5ff0a7ddba82f
+CI runtime: a205afd1e01c5ffda70974db7e579ad3a2bfc5ac73831ab49bc3ddb5a51c7404
+TV fixture: f8327bd304d86d4a362c8e40f709e24ca360ffcc35a69c586ad3b2407c8f9aea
+Patched runtime: 7b516c1816ebd3bfd6b523452341138b9b44458e54cd71101d23a3949d9e8904
+runner.rs patch: 0d93542d9ff484af0e7b5055c5fa9da25befe9a0c0da02e52b4923cd4a74b9e6
+```
+
+The patched runtime is a local GNU debug build from that merged commit plus the
+`runner.rs` startup fix. A copy was relocated to Fedora's dynamic loader and
+`/usr/lib64` with `patchelf`; its reported identity remains `dev`, commit
+`unknown`. This verifies runtime behavior, not a new release bundle. Hashes were
+checked again inside the guest. Original CI binaries were retained for comparison.
+
+## Test setup and observations
+
+The normal installer installed the original bundle and system/user units.
+Configuration used `screen_backend=auto`, idle blanking and inhibitor honoring
+enabled, a 10-second idle timeout, conservative restore and system sleep/wake
+enabled. Updates were disabled. The configuration SHA-256 before and after each
+round trip was:
+
+```text
+ecc582d5a7b52dd56952ef0ef41682e4a5f0f7d1d9f172c3399c1e580fc52b6e
+```
+
+TV actions target the repository's `gui_journey_tv` TLS fixture at
+`127.0.0.1:3001`, configured on HDMI_3 with a test MAC address. Assertions read
+its atomic `state.json`; no physical TV is involved. Virtual keyboard and
+gamepad devices enter through Linux `uinput` and the production input adapters.
+
+Desktop changes use normal GNOME/Plasma logout and GDM authentication/session
+selection. No LG Buddy configuration edits or manual service restarts occur
+inside a round trip. Snapshots collect `loginctl`, the user manager's PID and
+invocation ID, `graphical-session.target`, the screen service PID/environment,
+ownership markers, TV state, binary/configuration hashes and the service journal.
+
+The original CI runtime completed GNOME -> Plasma -> GNOME. The user manager
+remained PID 891, invocation `eaa64dc0c414414b8de5a7cd4792b7ff`, with SSH session
+10 present. Screen monitor PIDs were 3468 -> 6786 -> 9803. Each logout stopped
+the old monitor; each graphical login started a new one with the appropriate
+environment. Input after login restored an existing blanked-screen marker.
+
+For each desktop leg, the behavioral check:
+
+1. Restores with input and starts two independent inhibitor clients.
+2. Verifies the screen remains on for 12 seconds, releases one client, then
+   verifies another 12 seconds with the second client still present.
+3. Releases the last client, verifies at least 9.5 seconds without blanking,
+   then observes blanking after the configured full idle interval.
+4. Restores with gamepad input, supplies another gamepad event six seconds
+   later and verifies that event resets the deadline; ordinary input restores
+the subsequent blank.
+
+All three original legs passed. GNOME uses SessionManager `Inhibit` with idle
+flag 8. Plasma uses `org.freedesktop.ScreenSaver.Inhibit`; PowerDevil reports
+effective screen inhibition through `HasInhibition(4)`. Observed final-release
+delays were about 10.2 seconds on GNOME and 11.2 seconds on Plasma, including
+the pull cadence.
+
+After installing the startup fix, a fresh boot completed the same round trip
+with user manager PID 901, invocation `fc33d35e1716456297c6b59e90442c1e`, and
+SSH session 5 retained. Monitor PIDs were 1404 -> 4879 -> 7356. All three
+instances composed native sources; the expected unavailable counterpart did
+not disable the working adapter. Runtime and configuration hashes stayed
+unchanged. The overlap/gamepad checks passed on patched GNOME, Plasma and
+return GNOME. The first patched GNOME behavioral check preceded the fresh
+boot; the first GNOME leg in that fresh loop verified startup, idle blanking
+and marker recovery at the subsequent Plasma login.
+
+On both Plasma and the final GNOME login, locking blanked the screen promptly;
+unlocking alone kept it blank for the two-second observation, and fresh input
+restored it. An earlier post-suspend GNOME lock request did not produce the
+expected blank; it is not counted as passing. The follow-up below distinguishes an invalid lock-test precondition from a
+later compositor stall.
+
+Additional real Plasma route checks found:
+
+- Portal idle flag 8 and ScreenSaver inhibitors both kept the TV fixture on
+  beyond the idle timeout, with `HasInhibition(4)` true.
+- A logind `idle` block inhibitor appeared in PowerDevil's effective policy.
+- `SetInhibitionAllowed(app, reason, false)` made the effective query false
+  while the request remained alive; setting it true restored inhibition.
+- Restarting `plasma-powerdevil.service`, then creating a new ScreenSaver
+  inhibitor, again prevented blanking. Monitor PID 4879 remained unchanged.
+  The test waits for the replacement bus owner before asserting its state.
+
+Disabling `screen.idle_blank` on GNOME leaves the passive session service alive.
+`ShowUpdateNotification` returned `sent`, with its forwarded `Notify` call
+observed on the real desktop bus. The installed GUI process remained active
+and the CLI read fixture volume `20`. The screen stayed on beyond the timeout.
+The preference was restored and the original configuration hash rechecked.
+This is process/API verification, not visual GUI acceptance.
+
+## Startup fix
+
+On the original return to GNOME, automatic monitoring logged `Using GNOME
+backend` instead of composing native sources. The first native probes had found
+no ready interface; the legacy fallback probed again and found GNOME ready.
+That result selected only GNOME for the lifetime of this monitor.
+
+Automatic resolution now converts a native result from that fallback probe to
+the composed source set. Explicit backend selection and automatic `swayidle`
+compatibility retain their existing behavior. Regression tests reproduce late
+GNOME and late Wayland availability between the two probes.
+
+Local validation passed: 1,019 runtime unit tests, 151 Cucumber scenarios,
+runtime integration tests, formatting and workspace Clippy with warnings denied.
+One hardware gamepad smoke test remains ignored; VM gamepad checks use `uinput`.
+
+## Confirmed native Wayland coverage gap
+
+On Plasma, mpv was started with `--no-config --no-audio --loop-file=inf
+--vo=wlshm` and `WAYLAND_DEBUG=1`, playing a generated clip. Its protocol trace
+showed `zwp_idle_inhibit_manager_v1.create_inhibitor` for the player surface.
+PowerDevil still returned `HasInhibition(4) = false` and empty active
+inhibitions. LG Buddy restored on input at 04:16:52 UTC and blanked at 04:17:02
+while playback continued.
+
+This is live evidence of a native Wayland inhibition route that the current
+PowerDevil adapter does not cover. The subsequent scope decision keeps PowerDevil
+as the Plasma inhibition boundary for the 1.8.0 MVP; native-only KWin coverage
+does not block #217 or the MVP prerelease. Success through ScreenSaver or portal
+routes must not be presented as native Wayland coverage. Idle-notify remains an
+activity interface, not an inhibition-state getter.
+
+## VM limitations and remaining acceptance
+
+- Host CPU passthrough caused widespread guest process crashes, including init.
+  Selecting the QEMU `EPYC` CPU model allowed the desktop tests to run. The
+  virtualization failure's root cause was not established.
+- SELinux denies execution of the Incus agent from its `nfs_t`-labelled runtime
+  file. SSH was used instead; no permissive mode or broad policy exception was
+  introduced.
+- GNOME entered and resumed from real guest s2idle. The monitor survived with
+  its PID unchanged. RTC wake did not resume this VM; a virtual power button
+  did. The TV fixture serves one persistent connection at a time, so the
+  monitor occupied the connection while the separate lifecycle service tried
+  to act. Complete TV sleep/wake behavior is therefore **not validated** here.
+- A later logout in that boot stalled the guest's login machinery during GNOME's
+  user-bus restart. LG Buddy had already stopped cleanly. New SSH and console
+  logins waited too; the guest required a reboot. This interrupted run is not
+  counted as a successful patched round trip or assigned a product root cause.
+- Physical TV/Wake-on-LAN behavior, the reporter's application, simultaneous
+  graphical sessions and additional desktops are outside this record.
+
+Keep #217 open until the joint lifecycle checks have reliable evidence. Keep
+#216/#89 coverage gates explicit; this run does not authorize prerelease or main
+promotion.
+
+
+## Gap investigation follow-up
+
+Later on 2026-09-12, the same VM separated the remaining gaps as follows.
+
+### Native Wayland: no exposed inhibition observation
+
+KWin tag `v6.7.5`, commit `ab7df7ccb7c6af20f4b279cd6220f7cd3d2267d7`,
+maintains effective native inhibitors in `InputRedirection::m_idleInhibitors`.
+Its visibility checks and source updates live in
+[`idle_inhibition.cpp`](https://github.com/KDE/kwin/blob/ab7df7ccb7c6af20f4b279cd6220f7cd3d2267d7/src/idle_inhibition.cpp),
+which still contains the comment `TODO: notify powerdevil?`.
+
+The inspected D-Bus XML, implementation and scripting wrappers expose neither
+that aggregate nor the underlying surface inhibition state. The Wayland
+idle-inhibit protocol lets a client create/destroy its own inhibitors; it has
+no facility to observe other clients' inhibitors. A supported KWin state
+interface, or an upstream bridge to PowerDevil, would let LG Buddy consume the
+fact through the existing inhibition boundary. This is an interface gap, not
+missing Boolean reconciliation. No production workaround was added.
+
+### Sleep service: isolated path passes
+
+The screen monitor was stopped temporarily to free the fixture's single
+connection. A test-only UDP observer accepted the exact 102-byte magic packet
+for `02:00:00:00:02:17` and reset the existing fixture to simulate TV wake.
+It verified that the fixture was powered off before accepting the packet.
+
+At 14:47:32 UTC, the installed lifecycle service powered off the fixture before
+real guest s2idle. At 14:47:56 it resumed and sent that packet; at 14:48:02 it
+reported successful HDMI_3 restoration and reacquired its sleep inhibitor.
+The monitor was then started again. This verifies the system service's path
+with simulated hardware; it does not verify simultaneous monitor/lifecycle
+connections or physical WoL. The existing fixture needs concurrent connections
+and an explicit simulated-wake operation for the joint test.
+
+### Lock: test precondition and compositor stall are separate
+
+A controlled test began with `LockedHint=yes`: input restored the TV while the
+session remained locked, and another `lock-session` request caused no new lock
+transition or blank. Explicitly unlocking first, then locking, blanked promptly;
+unlock alone left the TV blank, and fresh input restored it. The original lock
+test omitted that precondition, so its failure alone did not prove recovery
+was broken.
+
+In a separate suspend run, the lifecycle service was stopped temporarily to
+isolate the live screen monitor. Monitor PID 10393 and invocation
+`be91e0a541974210b53c8910d2236423` survived s2idle without restarting. Its journal
+observed the sleep lock, deferred TV actions to lifecycle while sleep was
+pending, and handled input after resume. The lifecycle service was restored.
+A subsequent genuine lock transition reached LG Buddy and blanked the TV.
+
+Later unlock attempts stopped changing `LockedHint`; GNOME's `GetActive`
+request timed out. A debugger snapshot located the wait outside LG Buddy:
+
+```text
+gnome-shell main thread:
+  g_cond_wait -> run_impl_task_sync_kernel
+  -> meta_monitor_manager_native_set_power_save_mode
+
+Mutter KMS thread:
+  ioctl -> drmModeAtomicCommit
+  -> meta_kms_impl_device_atomic_disable
+```
+
+GNOME's cgroup was not frozen. The guest uses virtio GPU, and LG Buddy remained
+running with `NRestarts=0`. This identifies the compositor/display wait behind
+the observed unresponsiveness; it does not establish the underlying graphics
+bug or prove that the earlier logout stall had the same cause. Further joint
+validation needs a working VM graphics path as well as the fixture improvements.
+Both LG Buddy services and the original configuration were restored after the
+isolated tests. After preserving the debugger evidence, the VM was rebooted:
+both services were active, GNOME answered `GetActive` again, and the configuration
+hash was unchanged. No production changes were made during this follow-up.
+
+## Hearth hardware observations
+
+On 2026-09-12, the physical Hearth host ran the candidate from
+[`c50f3ea`](https://github.com/Staphylococcus/LG_Buddy/commit/c50f3eab67ef9214e3173284189dcb5cd0979ad7)
+([PR #231](https://github.com/Staphylococcus/LG_Buddy/pull/231)) in both the
+screen and lifecycle services. This was a local debug build, reporting version
+1.7.0, channel `dev`, and that exact commit; it was not a release installation.
+Its SHA-256 was
+`5f4019fc329bc559bd5c6eb8d4fe0cd3b7f256a568ac48f8191731686fbf8210`.
+
+Hearth ran NixOS 26.05, kernel 7.2.3 and GNOME Shell 50.4 on an X870 AORUS
+ELITE WIFI7 board. The physical display identified as `LG TV SSCR2` over HDMI;
+LG Buddy controlled HDMI_3 through native webOS. One local Wayland session and
+concurrent non-graphical sessions remained present. Automatic composition used
+GNOME activity; the compositor did not advertise the required idle-notify v2
+interface. Configuration stayed unchanged: automatic backend, 120-second idle
+timeout, aggressive restore, inhibitor honoring disabled, sleep/wake enabled.
+This pass therefore does not validate inhibition behavior.
+
+Both candidate services remained running throughout the checks: monitor PID
+1716243 and lifecycle PID 1716211, each with zero restarts. Times below are UTC.
+
+| Check | Runtime evidence | Human observation |
+| --- | --- | --- |
+| Lock before suspend | Lock at 16:24:09; successful TV blank at 16:24:10; timed CLI unblank succeeded at 16:24:24. | The TV showed no signal after the timed recovery. Moving the mouse returned the login screen; normal unlock worked. |
+| Joint suspend/resume | Lifecycle completed TV power-off at 16:27:45 before deep/S3 suspend. Resume reached lifecycle at 16:28:19; network became ready and WoL began at 16:28:25. Two restore attempts failed before HDMI_3 restoration succeeded at 16:28:39. | The user confirmed the picture was back and unlocked normally. |
+| Lock after suspend | A fresh lock at 16:30:20 blanked successfully. Timed CLI unblank succeeded at 16:30:35. Later input canceled the pending timed power-off and another unblank succeeded. | Mouse or keyboard input was needed before normal unlock. No compositor stall was observed in this cycle. |
+
+During suspend, the screen monitor received the lock event but deferred its TV
+action because sleep was pending. Activity immediately after resume likewise
+deferred to the lifecycle restore. Lifecycle reacquired its logind sleep delay
+inhibitor after restoration, and both ownership markers were absent afterward.
+This supplies real-TV evidence for the two services operating together on GNOME.
+
+The first timed recovery woke only the TV: GNOME's `PowerSaveMode` was 3 and the
+connected HDMI connector was disabled. A diagnostic write enabled it, but the
+user also moved the mouse, so visual recovery cannot be attributed to that write
+alone. The final helper included an HDMI-output wake request, yet the user still
+reported needing input. Successful TV unblank is not evidence of a visible
+desktop while the compositor's output is asleep.
+
+An RTC alarm was armed for the suspend test. The user confirmed return but did
+not separately establish whether manual input helped resume the PC. The delayed
+emergency TV-wake helper launched after lifecycle had already restored HDMI_3;
+it failed before executing LG Buddy because its transient-unit PATH could not
+resolve `env`. It contributed no TV action to the successful recovery. These are
+test-helper details, not demonstrated LG Buddy failures.
+
+The original installed runtime was restored in both services at 16:31:54–55.
+Both services were active, the session was unlocked, a TV read succeeded, and all
+test timers and service overrides were removed. Configuration SHA-256 before
+and after was
+`b1e62287d6cd110f726f595b84255a18940469113c87f1708181fb23e2b2273a`.
+
+Evidence is retained locally under
+`~/.local/state/lg-buddy-validation/217-2026-09-12/hearth/`, including service and
+kernel journals, exact helper scripts, binary identity and user observations.
+This single GNOME hardware pass does not complete #217's GNOME/Plasma matrix.
+The next fixture work should support concurrent clients and controlled power-off,
+wake and readiness transitions while keeping TV screen state separate from the
+desktop's HDMI signal. The fixture was not changed during this pass.
+
+## Concurrent fixture follow-up
+
+The subsequent fixture extension kept the existing central webOS server and
+added concurrent clients, power-off invalidation of old connections, and an
+explicit wake that preserves settings and history. The process fixture can
+receive exact WoL packets for its test MAC and delay registration readiness.
+These transport/readiness controls are fault injection, not claims about exact
+firmware timing. `screen_on` still describes the TV, independently of the
+desktop's HDMI signal. See [Native webOS testing](webos-testing.md) for controls.
+
+The dedicated VM used an eight-second readiness delay and the existing patched
+runtime (`7b516c18...` above). The fixture build used for the following two
+suspend checks had SHA-256
+`0cebd07e0ece0108597a41de67a8c42c98897081d531a52a1a2645ac2b0ee441`.
+The local debug executable was relocated to Fedora's loader and library path.
+Configuration was unchanged, including inhibitor honoring. A temporary desktop
+inhibitor kept automatic idle blanking from interrupting the observation window;
+it did not inhibit explicit lock or system sleep.
+
+| Desktop | Power-off before guest s2idle | Resume | HDMI_3 restored | Monitor / lifecycle PIDs |
+| --- | --- | --- | --- | --- |
+| Plasma | 16:55:35 UTC | 16:55:50 | 16:55:58 | 5004 / 866 |
+| GNOME | 16:59:45 UTC | 17:00:20 | 17:00:28 | 1383 / 856 |
+
+Both services remained running with unchanged invocation IDs and zero restarts
+in each cycle. The monitor already held a TV connection before sleep. Lifecycle
+then completed power-off, received resume, sent WoL and retried once during the
+injected delay before restoring HDMI_3 and reacquiring its sleep inhibitor.
+The monitor deferred the sleep lock and early post-resume activity to lifecycle.
+Each fixture snapshot recorded exactly one power-off and one effective wake,
+with no pairing prompts. The final GNOME snapshot had two simultaneous clients.
+Virtual power-button requests resumed the guest; this is not RTC-wake validation.
+
+GNOME lock/unlock checks passed before and after suspend: lock blanked, unlock
+alone left the fixture blank for two seconds, and input restored it. Plasma's
+pre-suspend lock check passed, but its post-resume unlock request did not clear
+`LockedHint`; the ScreenSaver query and later logout also failed to complete.
+That desktop recovery check remains unresolved despite successful TV recovery.
+
+An earlier GNOME-to-Plasma login after a successful GNOME suspend cycle stalled
+before `graphical-session.target`, with Plasma initialization still pending and
+LG Buddy waiting to start. A fresh boot allowed Plasma to start. Diagnostics and
+console logs were preserved; these interrupted desktop transitions are not
+counted as passing or assigned a new product root cause.
+
+The VM was returned to GNOME. Its services were active, the session was unlocked,
+GNOME answered `GetActive=false`, and the configuration hash remained unchanged.
+The updated fixture is retained in the dedicated VM; temporary inhibitor clients
+were removed. The host's physical TV and installed LG Buddy services were not
+changed during this fixture work.
+
+Evidence is in
+`~/.local/state/lg-buddy-validation/217-2026-09-12/concurrent-fixture/`.
+An earlier fixture build also passed the GNOME joint cycle, but the table uses
+the later build shared with the Plasma check. Automated coverage includes
+shared-client characterization, connection shutdown and worker-failure tests,
+controlled power/wake tests, and a real-CLI process smoke wired into CI. Keep
+#217 open for the remaining desktop recovery validation.
+
+After those cycles, an explicit `ready` command was added so automated tests can
+hold startup pending until their assertions finish. The real-CLI smoke covers
+that control; the final full suite passed with 1,021 unit tests, 151 Cucumber
+scenarios / 1,885 steps, integration tests, formatting and workspace Clippy.
+One hardware gamepad test is ignored. The retained VM fixture was updated to
+SHA-256 `a2834f9b6119ff8282b81eb8101edc3c26a404b5b9949da903006b871ee103f2`
+without restarting either LG Buddy service. Input after the fixture restart
+could not establish recovery because GNOME's ScreenSaver endpoint had again
+become unresponsive while idle, with `LockedHint=yes`; both LG Buddy services
+were still active. That additional VM failure was recorded and a fresh GNOME
+boot used for cleanup. This final control was process-tested; the suspend-cycle
+table identifies the earlier automatic-delay build actually used for those cycles.

--- a/docs/desktop-session-validation.md
+++ b/docs/desktop-session-validation.md
@@ -1,389 +1,268 @@
 # GNOME/Plasma session validation
 
 Recorded on 2026-09-12 for [#217](https://github.com/Staphylococcus/LG_Buddy/issues/217).
-This is a development validation record, not approval to promote the #89 MVP.
+The complete issue is delivered together in
+[PR #231](https://github.com/Staphylococcus/LG_Buddy/pull/231): the automatic
+startup fix, concurrent TV fixture, automated checks and this validation record.
+The earlier fixture and VM recovery gaps have been resolved. This validates
+#217's lifecycle scope; release promotion remains a separate step.
 
-## Environment and provenance
+## Acceptance and evidence
 
-The dedicated Incus VM `lg-buddy-desktop-217` runs Fedora 44 with both desktops
-installed, GDM, six virtual CPUs, 8 GiB RAM and a 32 GiB disk. Tests use one local
-graphical account (`lgtest`, UID 1001), lingering and a concurrent SSH session.
-SELinux stays enforcing. The VM tests left other machines unchanged; the separate
-Hearth hardware pass below temporarily substituted the runtime in its two services.
+| #217 requirement | Evidence |
+| --- | --- |
+| GNOME → Plasma → GNOME with unchanged configuration and no manual LG Buddy restart | Completed with the combined candidate. Graphical logout stopped the old monitor; each login automatically started the next. See the round-trip table below. |
+| Concurrent non-graphical login and retained user manager | User manager PID 865 and invocation `7dcdcf6564ff4bbfbb1d5878d3ba49af` survived both switches. SSH session 177 remained present through both transitions; lingering was enabled. |
+| Old connections, observations and replies cannot affect the next login | Both old monitor processes exited before the next started. An existing screen ownership marker survived each logout and was restored on new input. Runtime and adapter tests additionally reject cancelled queries, previous owners and obsolete protocol objects. |
+| Late/restarted interfaces recover independently; failure, quiet and cancellation semantics are preserved | Live PowerDevil replacement and the private-bus/runtime tests below cover recovery, independent activity/inhibition, quiet observations, failed reads, cancellation and stale replies. The startup race found in this validation has regression coverage. |
+| Idle/restore, gamepad, lock/unlock and suspend/resume on each leg | All three legs passed with both monitor and lifecycle services running. Every suspend powered the fixture off, resumed the guest, sent WoL and restored HDMI_3 through a controlled readiness delay. Fresh lock/unlock passed afterward. |
+| Disabled monitoring preserves notifications and GUI/CLI | Separate passive-mode checks passed on GNOME and Plasma: the session endpoint forwarded a real desktop `Notify`, the installed GUI stayed running, CLI volume returned `20`, and the TV stayed on beyond the idle timeout. Configuration was restored afterward. |
 
-| Component | Version |
+The supported boundary is one local graphical session per account alongside
+SSH/console logins. Existing logind eligibility checks reject remote,
+non-graphical, inactive and other-user sessions; ambiguous graphical matches
+produce a diagnostic. Their tests are in
+[`sources/linux/logind.rs`](../crates/lg-buddy/src/sources/linux/logind.rs).
+No desktop-wide selector or new session-binding layer was introduced.
+
+## Environment and candidate identity
+
+The dedicated Incus VM `lg-buddy-desktop-217` runs Fedora 44, GDM, six virtual
+CPUs, 8 GiB RAM and a 32 GiB disk. The graphical account is `lgtest` (UID 1001).
+SELinux remained enforcing. Only this VM was changed during the final matrix;
+the earlier physical Hearth pass is recorded separately below.
+
+| Component | Version / configuration |
 | --- | --- |
 | GNOME Shell / Mutter | 50.4 |
 | gnome-session / GDM | 50.1 / 50.3 |
 | Plasma / KWin / PowerDevil | 6.7.5 |
-| systemd | 259.8 |
-| Kernel | 7.1.12 |
-| mpv | 0.41.0 |
+| systemd / kernel | 259.8 / 7.1.12 |
+| QEMU CPU / display | EPYC / QXL |
+| LG Buddy | Local GNU debug build from `5e3522986672e177233c18102605830376c1c863`; reports 1.7.0, channel `dev`, commit `5e35229` |
 
-The initial installation used the runtime, GUI and TV fixture from
-[CI run 34664139930](https://github.com/Staphylococcus/LG_Buddy/actions/runs/34664139930).
-Its build commit `fb9574c9fd614cf0b6a2ba45e64a47ad99792b7f` and merged `dev`
-commit `f777a5fe351dc96cf74443bfd09197e9eff000bd` have the same tree,
-`edf1246679f9ade9a02f3fbf6f8d59a6f5d4d312`. The CI version string is
-`1.4.0-beta.2.ci`; it is not a published release.
-
-SHA-256 identifiers:
+The initial installation used the normal installer and
+[CI bundle 34664139930](https://github.com/Staphylococcus/LG_Buddy/actions/runs/34664139930).
+The final runtime and fixture were built from the combined branch and installed
+in the existing unit paths. Copies were relocated to Fedora's dynamic loader
+and `/usr/lib64` with `patchelf`, then hashes were verified inside the guest.
+The installed GUI came from the original bundle; this change does not modify it.
+These are runtime checks, not validation of a newly published release bundle.
 
 ```text
-CI bundle: e2b4c5c8a91dfdf49a7cf4a09cf9d1ee94bb4544071adcaa4be5ff0a7ddba82f
-CI runtime: a205afd1e01c5ffda70974db7e579ad3a2bfc5ac73831ab49bc3ddb5a51c7404
-TV fixture: f8327bd304d86d4a362c8e40f709e24ca360ffcc35a69c586ad3b2407c8f9aea
-Patched runtime: 7b516c1816ebd3bfd6b523452341138b9b44458e54cd71101d23a3949d9e8904
-runner.rs patch: 0d93542d9ff484af0e7b5055c5fa9da25befe9a0c0da02e52b4923cd4a74b9e6
+Source commit: 5e3522986672e177233c18102605830376c1c863
+VM runtime:    c7fcc08a6925975ead73dccce7c28916e0368a9ff750c097121042f14e955b35
+VM fixture:    86430cf2d8cbf7ba7edc3c813931460a28a8b377610990e3d99ad8a3d4e5c68e
+Configuration: ecc582d5a7b52dd56952ef0ef41682e4a5f0f7d1d9f172c3399c1e580fc52b6e
 ```
 
-The patched runtime is a local GNU debug build from that merged commit plus the
-`runner.rs` startup fix. A copy was relocated to Fedora's dynamic loader and
-`/usr/lib64` with `patchelf`; its reported identity remains `dev`, commit
-`unknown`. This verifies runtime behavior, not a new release bundle. Hashes were
-checked again inside the guest. Original CI binaries were retained for comparison.
-
-## Test setup and observations
-
-The normal installer installed the original bundle and system/user units.
 Configuration used `screen_backend=auto`, idle blanking and inhibitor honoring
-enabled, a 10-second idle timeout, conservative restore and system sleep/wake
-enabled. Updates were disabled. The configuration SHA-256 before and after each
-round trip was:
+enabled, a 10-second idle timeout, conservative restore, system sleep/wake
+enabled and automatic updates disabled. TV actions targeted the repository's
+TLS fixture at `127.0.0.1:3001`, HDMI_3, with test MAC `02:00:00:00:02:17`.
+No physical TV was targeted by the VM.
 
-```text
-ecc582d5a7b52dd56952ef0ef41682e4a5f0f7d1d9f172c3399c1e580fc52b6e
-```
+## Complete round trip
 
-TV actions target the repository's `gui_journey_tv` TLS fixture at
-`127.0.0.1:3001`, configured on HDMI_3 with a test MAC address. Assertions read
-its atomic `state.json`; no physical TV is involved. Virtual keyboard and
-gamepad devices enter through Linux `uinput` and the production input adapters.
+No configuration edits, desktop selection in LG Buddy, binary replacements or
+manual LG Buddy restarts occurred between the first GNOME leg and the final
+GNOME leg. Normal desktop logout and GDM authentication selected each desktop.
+The same system lifecycle process, PID 2315 with invocation
+`ed8f3665210c48e082c4cce10cb2b69c`, remained running throughout.
 
-Desktop changes use normal GNOME/Plasma logout and GDM authentication/session
-selection. No LG Buddy configuration edits or manual service restarts occur
-inside a round trip. Snapshots collect `loginctl`, the user manager's PID and
-invocation ID, `graphical-session.target`, the screen service PID/environment,
-ownership markers, TV state, binary/configuration hashes and the service journal.
+Times below come from the guest journal and are UTC.
 
-The original CI runtime completed GNOME -> Plasma -> GNOME. The user manager
-remained PID 891, invocation `eaa64dc0c414414b8de5a7cd4792b7ff`, with SSH session
-10 present. Screen monitor PIDs were 3468 -> 6786 -> 9803. Each logout stopped
-the old monitor; each graphical login started a new one with the appropriate
-environment. Input after login restored an existing blanked-screen marker.
-
-For each desktop leg, the behavioral check:
-
-1. Restores with input and starts two independent inhibitor clients.
-2. Verifies the screen remains on for 12 seconds, releases one client, then
-   verifies another 12 seconds with the second client still present.
-3. Releases the last client, verifies at least 9.5 seconds without blanking,
-   then observes blanking after the configured full idle interval.
-4. Restores with gamepad input, supplies another gamepad event six seconds
-   later and verifies that event resets the deadline; ordinary input restores
-the subsequent blank.
-
-All three original legs passed. GNOME uses SessionManager `Inhibit` with idle
-flag 8. Plasma uses `org.freedesktop.ScreenSaver.Inhibit`; PowerDevil reports
-effective screen inhibition through `HasInhibition(4)`. Observed final-release
-delays were about 10.2 seconds on GNOME and 11.2 seconds on Plasma, including
-the pull cadence.
-
-After installing the startup fix, a fresh boot completed the same round trip
-with user manager PID 901, invocation `fc33d35e1716456297c6b59e90442c1e`, and
-SSH session 5 retained. Monitor PIDs were 1404 -> 4879 -> 7356. All three
-instances composed native sources; the expected unavailable counterpart did
-not disable the working adapter. Runtime and configuration hashes stayed
-unchanged. The overlap/gamepad checks passed on patched GNOME, Plasma and
-return GNOME. The first patched GNOME behavioral check preceded the fresh
-boot; the first GNOME leg in that fresh loop verified startup, idle blanking
-and marker recovery at the subsequent Plasma login.
-
-On both Plasma and the final GNOME login, locking blanked the screen promptly;
-unlocking alone kept it blank for the two-second observation, and fresh input
-restored it. An earlier post-suspend GNOME lock request did not produce the
-expected blank; it is not counted as passing. The follow-up below distinguishes an invalid lock-test precondition from a
-later compositor stall.
-
-Additional real Plasma route checks found:
-
-- Portal idle flag 8 and ScreenSaver inhibitors both kept the TV fixture on
-  beyond the idle timeout, with `HasInhibition(4)` true.
-- A logind `idle` block inhibitor appeared in PowerDevil's effective policy.
-- `SetInhibitionAllowed(app, reason, false)` made the effective query false
-  while the request remained alive; setting it true restored inhibition.
-- Restarting `plasma-powerdevil.service`, then creating a new ScreenSaver
-  inhibitor, again prevented blanking. Monitor PID 4879 remained unchanged.
-  The test waits for the replacement bus owner before asserting its state.
-
-Disabling `screen.idle_blank` on GNOME leaves the passive session service alive.
-`ShowUpdateNotification` returned `sent`, with its forwarded `Notify` call
-observed on the real desktop bus. The installed GUI process remained active
-and the CLI read fixture volume `20`. The screen stayed on beyond the timeout.
-The preference was restored and the original configuration hash rechecked.
-This is process/API verification, not visual GUI acceptance.
-
-## Startup fix
-
-On the original return to GNOME, automatic monitoring logged `Using GNOME
-backend` instead of composing native sources. The first native probes had found
-no ready interface; the legacy fallback probed again and found GNOME ready.
-That result selected only GNOME for the lifetime of this monitor.
-
-Automatic resolution now converts a native result from that fallback probe to
-the composed source set. Explicit backend selection and automatic `swayidle`
-compatibility retain their existing behavior. Regression tests reproduce late
-GNOME and late Wayland availability between the two probes.
-
-Local validation passed: 1,019 runtime unit tests, 151 Cucumber scenarios,
-runtime integration tests, formatting and workspace Clippy with warnings denied.
-One hardware gamepad smoke test remains ignored; VM gamepad checks use `uinput`.
-
-## Confirmed native Wayland coverage gap
-
-On Plasma, mpv was started with `--no-config --no-audio --loop-file=inf
---vo=wlshm` and `WAYLAND_DEBUG=1`, playing a generated clip. Its protocol trace
-showed `zwp_idle_inhibit_manager_v1.create_inhibitor` for the player surface.
-PowerDevil still returned `HasInhibition(4) = false` and empty active
-inhibitions. LG Buddy restored on input at 04:16:52 UTC and blanked at 04:17:02
-while playback continued.
-
-This is live evidence of a native Wayland inhibition route that the current
-PowerDevil adapter does not cover. The subsequent scope decision keeps PowerDevil
-as the Plasma inhibition boundary for the 1.8.0 MVP; native-only KWin coverage
-does not block #217 or the MVP prerelease. Success through ScreenSaver or portal
-routes must not be presented as native Wayland coverage. Idle-notify remains an
-activity interface, not an inhibition-state getter.
-
-## VM limitations and remaining acceptance
-
-- Host CPU passthrough caused widespread guest process crashes, including init.
-  Selecting the QEMU `EPYC` CPU model allowed the desktop tests to run. The
-  virtualization failure's root cause was not established.
-- SELinux denies execution of the Incus agent from its `nfs_t`-labelled runtime
-  file. SSH was used instead; no permissive mode or broad policy exception was
-  introduced.
-- GNOME entered and resumed from real guest s2idle. The monitor survived with
-  its PID unchanged. RTC wake did not resume this VM; a virtual power button
-  did. The TV fixture serves one persistent connection at a time, so the
-  monitor occupied the connection while the separate lifecycle service tried
-  to act. Complete TV sleep/wake behavior is therefore **not validated** here.
-- A later logout in that boot stalled the guest's login machinery during GNOME's
-  user-bus restart. LG Buddy had already stopped cleanly. New SSH and console
-  logins waited too; the guest required a reboot. This interrupted run is not
-  counted as a successful patched round trip or assigned a product root cause.
-- Physical TV/Wake-on-LAN behavior, the reporter's application, simultaneous
-  graphical sessions and additional desktops are outside this record.
-
-Keep #217 open until the joint lifecycle checks have reliable evidence. Keep
-#216/#89 coverage gates explicit; this run does not authorize prerelease or main
-promotion.
-
-
-## Gap investigation follow-up
-
-Later on 2026-09-12, the same VM separated the remaining gaps as follows.
-
-### Native Wayland: no exposed inhibition observation
-
-KWin tag `v6.7.5`, commit `ab7df7ccb7c6af20f4b279cd6220f7cd3d2267d7`,
-maintains effective native inhibitors in `InputRedirection::m_idleInhibitors`.
-Its visibility checks and source updates live in
-[`idle_inhibition.cpp`](https://github.com/KDE/kwin/blob/ab7df7ccb7c6af20f4b279cd6220f7cd3d2267d7/src/idle_inhibition.cpp),
-which still contains the comment `TODO: notify powerdevil?`.
-
-The inspected D-Bus XML, implementation and scripting wrappers expose neither
-that aggregate nor the underlying surface inhibition state. The Wayland
-idle-inhibit protocol lets a client create/destroy its own inhibitors; it has
-no facility to observe other clients' inhibitors. A supported KWin state
-interface, or an upstream bridge to PowerDevil, would let LG Buddy consume the
-fact through the existing inhibition boundary. This is an interface gap, not
-missing Boolean reconciliation. No production workaround was added.
-
-### Sleep service: isolated path passes
-
-The screen monitor was stopped temporarily to free the fixture's single
-connection. A test-only UDP observer accepted the exact 102-byte magic packet
-for `02:00:00:00:02:17` and reset the existing fixture to simulate TV wake.
-It verified that the fixture was powered off before accepting the packet.
-
-At 14:47:32 UTC, the installed lifecycle service powered off the fixture before
-real guest s2idle. At 14:47:56 it resumed and sent that packet; at 14:48:02 it
-reported successful HDMI_3 restoration and reacquired its sleep inhibitor.
-The monitor was then started again. This verifies the system service's path
-with simulated hardware; it does not verify simultaneous monitor/lifecycle
-connections or physical WoL. The existing fixture needs concurrent connections
-and an explicit simulated-wake operation for the joint test.
-
-### Lock: test precondition and compositor stall are separate
-
-A controlled test began with `LockedHint=yes`: input restored the TV while the
-session remained locked, and another `lock-session` request caused no new lock
-transition or blank. Explicitly unlocking first, then locking, blanked promptly;
-unlock alone left the TV blank, and fresh input restored it. The original lock
-test omitted that precondition, so its failure alone did not prove recovery
-was broken.
-
-In a separate suspend run, the lifecycle service was stopped temporarily to
-isolate the live screen monitor. Monitor PID 10393 and invocation
-`be91e0a541974210b53c8910d2236423` survived s2idle without restarting. Its journal
-observed the sleep lock, deferred TV actions to lifecycle while sleep was
-pending, and handled input after resume. The lifecycle service was restored.
-A subsequent genuine lock transition reached LG Buddy and blanked the TV.
-
-Later unlock attempts stopped changing `LockedHint`; GNOME's `GetActive`
-request timed out. A debugger snapshot located the wait outside LG Buddy:
-
-```text
-gnome-shell main thread:
-  g_cond_wait -> run_impl_task_sync_kernel
-  -> meta_monitor_manager_native_set_power_save_mode
-
-Mutter KMS thread:
-  ioctl -> drmModeAtomicCommit
-  -> meta_kms_impl_device_atomic_disable
-```
-
-GNOME's cgroup was not frozen. The guest uses virtio GPU, and LG Buddy remained
-running with `NRestarts=0`. This identifies the compositor/display wait behind
-the observed unresponsiveness; it does not establish the underlying graphics
-bug or prove that the earlier logout stall had the same cause. Further joint
-validation needs a working VM graphics path as well as the fixture improvements.
-Both LG Buddy services and the original configuration were restored after the
-isolated tests. After preserving the debugger evidence, the VM was rebooted:
-both services were active, GNOME answered `GetActive` again, and the configuration
-hash was unchanged. No production changes were made during this follow-up.
-
-## Hearth hardware observations
-
-On 2026-09-12, the physical Hearth host ran the candidate from
-[`c50f3ea`](https://github.com/Staphylococcus/LG_Buddy/commit/c50f3eab67ef9214e3173284189dcb5cd0979ad7)
-([PR #231](https://github.com/Staphylococcus/LG_Buddy/pull/231)) in both the
-screen and lifecycle services. This was a local debug build, reporting version
-1.7.0, channel `dev`, and that exact commit; it was not a release installation.
-Its SHA-256 was
-`5f4019fc329bc559bd5c6eb8d4fe0cd3b7f256a568ac48f8191731686fbf8210`.
-
-Hearth ran NixOS 26.05, kernel 7.2.3 and GNOME Shell 50.4 on an X870 AORUS
-ELITE WIFI7 board. The physical display identified as `LG TV SSCR2` over HDMI;
-LG Buddy controlled HDMI_3 through native webOS. One local Wayland session and
-concurrent non-graphical sessions remained present. Automatic composition used
-GNOME activity; the compositor did not advertise the required idle-notify v2
-interface. Configuration stayed unchanged: automatic backend, 120-second idle
-timeout, aggressive restore, inhibitor honoring disabled, sleep/wake enabled.
-This pass therefore does not validate inhibition behavior.
-
-Both candidate services remained running throughout the checks: monitor PID
-1716243 and lifecycle PID 1716211, each with zero restarts. Times below are UTC.
-
-| Check | Runtime evidence | Human observation |
-| --- | --- | --- |
-| Lock before suspend | Lock at 16:24:09; successful TV blank at 16:24:10; timed CLI unblank succeeded at 16:24:24. | The TV showed no signal after the timed recovery. Moving the mouse returned the login screen; normal unlock worked. |
-| Joint suspend/resume | Lifecycle completed TV power-off at 16:27:45 before deep/S3 suspend. Resume reached lifecycle at 16:28:19; network became ready and WoL began at 16:28:25. Two restore attempts failed before HDMI_3 restoration succeeded at 16:28:39. | The user confirmed the picture was back and unlocked normally. |
-| Lock after suspend | A fresh lock at 16:30:20 blanked successfully. Timed CLI unblank succeeded at 16:30:35. Later input canceled the pending timed power-off and another unblank succeeded. | Mouse or keyboard input was needed before normal unlock. No compositor stall was observed in this cycle. |
-
-During suspend, the screen monitor received the lock event but deferred its TV
-action because sleep was pending. Activity immediately after resume likewise
-deferred to the lifecycle restore. Lifecycle reacquired its logind sleep delay
-inhibitor after restoration, and both ownership markers were absent afterward.
-This supplies real-TV evidence for the two services operating together on GNOME.
-
-The first timed recovery woke only the TV: GNOME's `PowerSaveMode` was 3 and the
-connected HDMI connector was disabled. A diagnostic write enabled it, but the
-user also moved the mouse, so visual recovery cannot be attributed to that write
-alone. The final helper included an HDMI-output wake request, yet the user still
-reported needing input. Successful TV unblank is not evidence of a visible
-desktop while the compositor's output is asleep.
-
-An RTC alarm was armed for the suspend test. The user confirmed return but did
-not separately establish whether manual input helped resume the PC. The delayed
-emergency TV-wake helper launched after lifecycle had already restored HDMI_3;
-it failed before executing LG Buddy because its transient-unit PATH could not
-resolve `env`. It contributed no TV action to the successful recovery. These are
-test-helper details, not demonstrated LG Buddy failures.
-
-The original installed runtime was restored in both services at 16:31:54–55.
-Both services were active, the session was unlocked, a TV read succeeded, and all
-test timers and service overrides were removed. Configuration SHA-256 before
-and after was
-`b1e62287d6cd110f726f595b84255a18940469113c87f1708181fb23e2b2273a`.
-
-Evidence is retained locally under
-`~/.local/state/lg-buddy-validation/217-2026-09-12/hearth/`, including service and
-kernel journals, exact helper scripts, binary identity and user observations.
-This single GNOME hardware pass does not complete #217's GNOME/Plasma matrix.
-The next fixture work should support concurrent clients and controlled power-off,
-wake and readiness transitions while keeping TV screen state separate from the
-desktop's HDMI signal. The fixture was not changed during this pass.
-
-## Concurrent fixture follow-up
-
-The subsequent fixture extension kept the existing central webOS server and
-added concurrent clients, power-off invalidation of old connections, and an
-explicit wake that preserves settings and history. The process fixture can
-receive exact WoL packets for its test MAC and delay registration readiness.
-These transport/readiness controls are fault injection, not claims about exact
-firmware timing. `screen_on` still describes the TV, independently of the
-desktop's HDMI signal. See [Native webOS testing](webos-testing.md) for controls.
-
-The dedicated VM used an eight-second readiness delay and the existing patched
-runtime (`7b516c18...` above). The fixture build used for the following two
-suspend checks had SHA-256
-`0cebd07e0ece0108597a41de67a8c42c98897081d531a52a1a2645ac2b0ee441`.
-The local debug executable was relocated to Fedora's loader and library path.
-Configuration was unchanged, including inhibitor honoring. A temporary desktop
-inhibitor kept automatic idle blanking from interrupting the observation window;
-it did not inhibit explicit lock or system sleep.
-
-| Desktop | Power-off before guest s2idle | Resume | HDMI_3 restored | Monitor / lifecycle PIDs |
+| Leg | Screen monitor PID | TV power-off before s2idle | Resume | HDMI_3 restored |
 | --- | --- | --- | --- | --- |
-| Plasma | 16:55:35 UTC | 16:55:50 | 16:55:58 | 5004 / 866 |
-| GNOME | 16:59:45 UTC | 17:00:20 | 17:00:28 | 1383 / 856 |
+| First GNOME | 2319 | 18:57:46 | 18:57:54 | 18:58:02 |
+| Plasma | 11680 | 19:05:03 | 19:05:11 | 19:05:19 |
+| Return GNOME | 22011 | 19:08:23 | 19:08:31 | 19:08:40 |
 
-Both services remained running with unchanged invocation IDs and zero restarts
-in each cycle. The monitor already held a TV connection before sleep. Lifecycle
-then completed power-off, received resume, sent WoL and retried once during the
-injected delay before restoring HDMI_3 and reacquiring its sleep inhibitor.
-The monitor deferred the sleep lock and early post-resume activity to lifecycle.
-Each fixture snapshot recorded exactly one power-off and one effective wake,
-with no pairing prompts. The final GNOME snapshot had two simultaneous clients.
-Virtual power-button requests resumed the guest; this is not RTC-wake validation.
+Every leg exercised:
 
-GNOME lock/unlock checks passed before and after suspend: lock blanked, unlock
-alone left the fixture blank for two seconds, and input restored it. Plasma's
-pre-suspend lock check passed, but its post-resume unlock request did not clear
-`LockedHint`; the ScreenSaver query and later logout also failed to complete.
-That desktop recovery check remains unresolved despite successful TV recovery.
+1. Input restore followed by two independent inhibitors. The TV remained on
+   for 12 seconds with both clients, then another 12 seconds after one exited.
+2. Release of the final inhibitor, at least 9.5 seconds without blanking, then
+   blanking after the full configured inactivity interval.
+3. Gamepad restore and a second gamepad event six seconds later, verifying
+   that fresh gamepad input reset the deadline. Ordinary input restored the
+   subsequent blank. Input entered through Linux `uinput` and production adapters.
+4. A fresh explicit lock, confirmed TV blank, unlock and input restore before
+   suspend, then the same check after resume.
+5. Real guest s2idle with both LG Buddy services active. A virtual power button
+   resumed the VM. The lifecycle journal confirmed power-off before sleep,
+   WoL after resume, a retry during the fixture's eight-second readiness delay,
+   successful HDMI_3 restoration and reacquisition of its sleep delay inhibitor.
 
-An earlier GNOME-to-Plasma login after a successful GNOME suspend cycle stalled
-before `graphical-session.target`, with Plasma initialization still pending and
-LG Buddy waiting to start. A fresh boot allowed Plasma to start. Diagnostics and
-console logs were preserved; these interrupted desktop transitions are not
-counted as passing or assigned a new product root cause.
+Each suspend incremented the fixture's power-off and effective-wake counters
+exactly once, with no pairing prompt. Both services retained their PIDs and
+invocation IDs, with zero restarts. The monitor deferred sleep-lock and early
+post-resume TV actions to lifecycle. The fixture supported both persistent
+clients together; old connections were invalidated by power-off.
 
-The VM was returned to GNOME. Its services were active, the session was unlocked,
-GNOME answered `GetActive=false`, and the configuration hash remained unchanged.
-The updated fixture is retained in the dedicated VM; temporary inhibitor clients
-were removed. The host's physical TV and installed LG Buddy services were not
-changed during this fixture work.
+Each logout began with an idle-blanked TV. The next desktop started with
+`screen_off_by_us` still present and restored it on fresh input. No ownership
+marker was discarded to make the test pass. The final input restore cleared
+ownership state, and the configuration and binary hashes still matched.
 
-Evidence is in
-`~/.local/state/lg-buddy-validation/217-2026-09-12/concurrent-fixture/`.
-An earlier fixture build also passed the GNOME joint cycle, but the table uses
-the later build shared with the Plasma check. Automated coverage includes
-shared-client characterization, connection shutdown and worker-failure tests,
-controlled power/wake tests, and a real-CLI process smoke wired into CI. Keep
-#217 open for the remaining desktop recovery validation.
+The harness initially made invalid assumptions about unlock controls. Plasma
+did not honor `loginctl unlock-session`, and temporary keyboard/password-entry
+sequences were unreliable. Its successful checks used password authentication
+through QEMU's existing keyboard. GNOME checks used its working logind unlock
+control and fresh input; successful password unlock was also observed on the
+first leg. The return-GNOME acceptance does not claim automated password-entry
+coverage. Failed helper attempts were preserved in the logs, corrected in the
+same running desktop, and did not require any LG Buddy restart.
 
-After those cycles, an explicit `ready` command was added so automated tests can
-hold startup pending until their assertions finish. The real-CLI smoke covers
-that control; the final full suite passed with 1,021 unit tests, 151 Cucumber
-scenarios / 1,885 steps, integration tests, formatting and workspace Clippy.
-One hardware gamepad test is ignored. The retained VM fixture was updated to
-SHA-256 `a2834f9b6119ff8282b81eb8101edc3c26a404b5b9949da903006b871ee103f2`
-without restarting either LG Buddy service. Input after the fixture restart
-could not establish recovery because GNOME's ScreenSaver endpoint had again
-become unresponsive while idle, with `LockedHint=yes`; both LG Buddy services
-were still active. That additional VM failure was recorded and a fresh GNOME
-boot used for cleanup. This final control was process-tested; the suspend-cycle
-table identifies the earlier automatic-delay build actually used for those cycles.
+Passive-mode checks on both desktops were performed separately from this
+unchanged-configuration round trip. Disabling `screen.idle_blank` used the normal
+settings apply path, which restarts the user service into its passive mode. `ShowUpdateNotification`
+returned `sent`, its actual `org.freedesktop.Notifications.Notify` call was
+captured, the installed GUI process remained active and CLI volume returned
+`20`. The TV remained on beyond the timeout. Re-enabling monitoring restored the
+original configuration hash. This is process/API verification, not visual GUI
+acceptance.
+
+## Adapter recovery and inhibition boundary
+
+Existing automated coverage was rerun with the combined change:
+
+- [`tests/inhibition.rs`](../crates/lg-buddy/tests/inhibition.rs) runs production
+  capabilities against a private bus without activity services: late GNOME
+  appearance, owner loss/recovery, overlapping inhibitors, quiet shutdown,
+  current PowerDevil reads, cancellation, timeout and owner replacement during
+  a delayed reply. Failed/absent sources contribute no inhibitor and do not
+  manufacture a release.
+- [`tests/runtime_entrypoints.rs`](../crates/lg-buddy/tests/runtime_entrypoints.rs)
+  verifies that a running monitor recovers after Mutter disappears and returns,
+  restores an existing ownership marker once, and discards a pre-suspend clear
+  answer after resume when a new inhibitor is active.
+- [GNOME inhibition tests](../crates/lg-buddy/src/sources/desktop/gnome/inhibition.rs)
+  cover periodic reconciliation, retained quiet/pending observations, queued
+  owner changes, failed reads and cancellation.
+- [Wayland activity tests](../crates/lg-buddy/src/sources/desktop/wayland.rs)
+  cover input during setup, cancellation of stalled/quiet initialization and
+  rejection of obsolete notifications for a reused seat name.
+- [Gate tests](../crates/lg-buddy/src/inhibition.rs) and the
+  [inhibition scenarios](../crates/lg-buddy/tests/features/idle_inhibition.feature)
+  cover combined capabilities, preference bypass, release timing, input
+  cancellation and independent activity when inhibition support is missing.
+
+Earlier live Plasma route checks passed for ScreenSaver inhibition, portal Idle
+flag 8, imported logind `idle` blockers, and user suppression/re-enabling through
+PowerDevil. Restarting PowerDevil and creating a new inhibitor recovered without
+restarting the monitor. This restart check also passed on the final candidate,
+with a changed bus owner, unchanged monitor invocation and inhibition holding
+the TV on beyond its idle timeout. GNOME uses SessionManager `IsInhibited(8)`;
+Plasma uses effective PowerDevil `HasInhibition(4)`.
+
+Native-only mpv inhibition was separately reproduced with `--no-config
+--no-audio --loop-file=inf --vo=wlshm` and a generated clip. Its trace created a
+`zwp_idle_inhibitor_v1`, while PowerDevil reported no effective screen inhibitor
+and LG Buddy blanked after ten seconds. KWin's native route is distinct; it
+must not be inferred from portal or ScreenSaver success. **PowerDevil is the
+agreed Plasma inhibition boundary for the MVP.** Native-only KWin coverage is
+outside #217's gate. Idle-notify remains an activity interface; activity and
+inhibition meet only at `can_blank()`.
+
+## VM blockers diagnosed and removed
+
+The earlier stalls were investigated with both LG Buddy services stopped:
+
+- With virtio GPU, GNOME suspend/resume succeeded, but the following Plasma
+  login stalled. Both the GNOME greeter and KWin were blocked in the kernel's
+  `virtio_gpu_queue_ctrl_sgs` path while creating display resources. The screen
+  monitor and lifecycle service both had PID 0. Switching this test VM to QXL
+  allowed the same post-suspend desktop switch to complete.
+- A subsequent baseline suspend failed to freeze one `mount` process belonging
+  to `incus-agent.service`. It was blocked in a virtio 9p request while mounting
+  the agent share. The unused agent already failed under SELinux; it was masked
+  and the guest cold-booted to clear the blocked process. The complete matrix
+  above then succeeded with both LG Buddy services running.
+
+These reproduce concrete environment failures independently of LG Buddy; no
+production workaround was added for them. They do not establish a root cause
+for every earlier interrupted run. The test VM retains the working QXL display
+and masked unused agent; SELinux stays enforcing and access uses SSH. QXL was
+configured with Incus's documented
+[QEMU device override](https://linuxcontainers.org/incus/docs/main/reference/instance_options/#override-qemu-configuration).
+The earlier CPU-passthrough crashes were avoided with the EPYC virtual CPU model.
+
+After validation, temporary timers, inhibitor clients and the QMP control
+listener were removed. A fresh GNOME boot confirmed both LG Buddy services and
+the fixture active, an unlocked session, working input restore, unchanged
+candidate/configuration hashes and no remaining test timers.
+
+## Physical Hearth observations
+
+The earlier [hardware report](https://github.com/Staphylococcus/LG_Buddy/issues/217#issuecomment-5647209853)
+tested runtime `c50f3eab67ef9214e3173284189dcb5cd0979ad7` in both services on
+Hearth: NixOS 26.05, GNOME 50.4, kernel 7.2.3 and a real LG TV on HDMI_3.
+That candidate has the same production startup fix as the final combined branch;
+the subsequent changes extend test infrastructure and documentation.
+
+- At 16:27:45 UTC lifecycle powered the TV off before deep/S3 suspend. Resume
+  reached lifecycle at 16:28:19; network recovery and WoL began at 16:28:25.
+  HDMI_3 restoration succeeded at 16:28:39 after two failed attempts. The user
+  confirmed the picture returned and unlocked normally.
+- Lock tests before and after suspend blanked successfully. Timed TV unblank
+  commands succeeded, but mouse/keyboard input was needed to show the login
+  screen. In the first test GNOME's HDMI output was asleep (`PowerSaveMode=3`),
+  explaining the user's “no signal” observation despite TV unblank.
+- Monitor PID 1716243 and lifecycle PID 1716211 survived with zero restarts.
+  The monitor deferred sleep and early-resume actions to lifecycle, and ownership
+  markers cleared. No compositor stall was observed in that cycle.
+
+An RTC alarm and a helper requesting HDMI-output wake were used; the observations
+do not isolate whether manual input helped resume the PC. A delayed emergency
+TV-wake helper failed before issuing any TV command; lifecycle had already
+restored the TV. Successful TV unblank does not itself prove a visible HDMI
+signal. The fixture deliberately keeps those two facts separate.
+
+Hearth's inhibitor honoring remained disabled, so this hardware pass makes no
+inhibition claim. The original installed 1.7.0 runtime, services and unchanged
+configuration were restored, with test overrides/timers removed. The final VM
+work did not change Hearth. Physical Plasma, reporter-specific validation,
+additional desktops and simultaneous graphical logins are not claimed here.
+
+## Changes, automated validation and retained evidence
+
+The production fix keeps automatic monitoring composed when a native interface
+appears between the initial probes and the legacy fallback probe. Explicit
+backend selection and automatic `swayidle` compatibility retain their existing
+behavior. Regression tests cover late GNOME and Wayland availability.
+
+The fixture extension supports concurrent clients, power-off invalidation,
+state-preserving wake, exact WoL matching and delayed/explicit readiness.
+The real-CLI fixture smoke is now part of CI. These are controlled transport
+faults, not an emulation of exact LG firmware timing. See
+[Native webOS testing](webos-testing.md) for fixture controls.
+
+The combined candidate passed 1,023 runtime unit tests, 151 Cucumber scenarios /
+1,885 steps, runtime integration tests, formatting, workspace Clippy with
+warnings denied and the real-CLI fixture smoke. One physical gamepad smoke test
+is ignored; the VM exercised virtual gamepad input through the production path.
+All jobs passed in
+[CI run 34711926512](https://github.com/Staphylococcus/LG_Buddy/actions/runs/34711926512),
+including packaged GUI checks on Fedora and Arch. Later documentation-only
+commits do not change the tested runtime or fixture.
+
+Local commands:
+
+```sh
+cargo fmt --all -- --check
+cargo test -p lg-buddy
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo build -p lg-buddy --example gui_journey_tv
+python3 scripts/test-tv-fixture.py target/debug/lg-buddy target/debug/examples/gui_journey_tv
+```
+
+Raw VM journals, snapshots, helper scripts, binary hashes, baseline kernel
+stacks and CI/local test output are retained under
+`~/.local/state/lg-buddy-validation/217-2026-09-12/whole-issue/`. The complete
+matrix is recorded across `full-matrix.log`, `matrix-continuation.log`,
+`matrix-final.log` and `gnome-return-final.log`; these are continuations in one
+boot with the same LG Buddy installation, including the recorded unlock-helper
+corrections. Earlier investigation and hardware evidence remain under the
+parent directory and its `hearth/` subdirectory. This record supersedes earlier
+progress notes that left joint lifecycle or desktop recovery unvalidated.

--- a/docs/development.md
+++ b/docs/development.md
@@ -42,8 +42,9 @@ Native monitoring honors the opt-in **Allow apps to prevent idle blanking**
 setting through independent GNOME SessionManager and PowerDevil inhibition
 capabilities. Activity tests require Mutter user-active watches; SessionManager
 availability must not determine whether activity monitoring works. Private-bus
-fixtures cover the integrated gate. Live Plasma/application-route validation and
-native Wayland inhibition coverage remain open before the #89 MVP can be promoted.
+fixtures cover the integrated gate. The [desktop validation record](desktop-session-validation.md)
+documents live GNOME/Plasma coverage. PowerDevil is the agreed Plasma inhibition
+boundary for the #89 MVP; native-only KWin inhibition is outside that gate.
 
 The C toolchain is required because `cargo build` now compiles vendored
 `libdbus` as part of the dependency graph. On common Linux distributions that

--- a/docs/session-backend-model.md
+++ b/docs/session-backend-model.md
@@ -211,8 +211,9 @@ release delay. Old completions cannot become authoritative under a new policy.
 
 The query delegates policy to PowerDevil, including activation delays, filtering
 and user overrides; LG Buddy does not count requested inhibitors or separately
-interpret logind's list. The following routes were traced in upstream source,
-not validated in a live Plasma session:
+interpret logind's list. The following table records upstream source tracing;
+subsequent live checks are documented in the
+[desktop validation record](desktop-session-validation.md).
 
 | Application route | Relationship to the effective screen-policy query |
 | --- | --- |
@@ -224,9 +225,11 @@ not validated in a live Plasma session:
 | Native Wayland idle inhibitor | KWin feeds this into its own input idle-inhibitor set. This is a separate path; PowerDevil coverage is not established. [KWin implementation](https://github.com/KDE/kwin/blob/b3e286c172bb9df7ee8ba8f1ef3a8ca21a8c770f/src/idle_inhibition.cpp#L58-L81) |
 
 These are version-specific source findings, not a promise that every application
-uses a covered route. Live Plasma validation and native Wayland coverage remain
-open under #216/#223; see [Testing strategy](testing-strategy.md). Idle-notify
-remains an activity protocol and is not used as an inhibition query.
+uses a covered route. The [desktop validation record](desktop-session-validation.md)
+documents subsequent live checks and confirms that native-only mpv inhibition
+does not reach PowerDevil. PowerDevil is the agreed Plasma inhibition boundary
+for the MVP; native-only KWin coverage is outside that gate. Idle-notify remains
+an activity protocol and is not used as an inhibition query.
 
 ## Provider Map
 
@@ -337,8 +340,8 @@ activity; `idled` remains observational, so only LG Buddy's inactivity deadline
 can trigger blanking.
 
 Only `get_input_idle_notification` is used by this activity adapter. Idle-notify
-does not supply an inhibition capability; #216 tracks native Wayland inhibition
-coverage separately.
+does not supply an inhibition capability. Native-only KWin inhibition is outside
+the agreed GNOME/Plasma MVP scope.
 
 Seats are added and removed dynamically. Connection or dispatch loss, removal
 of the bound notifier, or removal of the last seat causes the adapter to rebuild

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -128,6 +128,10 @@ This layer asks:
 
 This is the thinnest layer, but it is the one that keeps the other two honest.
 
+The [GNOME/Plasma VM validation record](desktop-session-validation.md) documents
+desktop switching with a retained user manager, tested inhibition routes, a
+startup race, and the remaining lifecycle and native Wayland coverage gaps.
+
 ### What belongs here
 
 - readable acceptance scenarios for the main flows

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -130,7 +130,7 @@ This is the thinnest layer, but it is the one that keeps the other two honest.
 
 The [GNOME/Plasma VM validation record](desktop-session-validation.md) documents
 desktop switching with a retained user manager, tested inhibition routes, a
-startup race, and the remaining lifecycle and native Wayland coverage gaps.
+startup race, lifecycle recovery, and the boundary of native Wayland inhibition coverage.
 
 ### What belongs here
 
@@ -334,8 +334,9 @@ Test at least the KDE portal idle route and ScreenSaver D-Bus route where used
 by the reporter's applications. Test native Wayland-only inhibition separately;
 do not infer its coverage from portal success. The source-traced route table in
 [Session backend model](session-backend-model.md#powerdevil-route-coverage) is
-not live validation. This work was implemented on GNOME; the Plasma checks and
-remaining native Wayland coverage belong to #216/#223 before MVP completion.
+not itself live validation. The [desktop validation record](desktop-session-validation.md)
+contains the subsequent Plasma checks. PowerDevil is the agreed MVP inhibition
+boundary; native-only KWin inhibition does not block #217 or the MVP.
 
 Native Wayland changes also require manual checks on Plasma/KWin and at least
 one other target compositor. Verify that explicit and automatic `wayland`

--- a/docs/webos-testing.md
+++ b/docs/webos-testing.md
@@ -49,6 +49,21 @@ Its stateful TV behavior includes:
 - moving between `Active` and `Screen Off`
 - moving to `Power Off` and rejecting an immediate new registration
 
+Connections share TV state and are served concurrently. Power-off disconnects
+existing clients; fixture shutdown also closes clients waiting in a handshake or
+for a request. Worker failures are surfaced instead of leaving a healthy-looking
+listener behind. The shared-client characterization links to the
+[Hearth lifecycle observations][hearth-lifecycle].
+Closing sockets at power-off exercises stale-session recovery; it does not
+assert the exact time at which hardware closes each connection.
+
+The test-only `simulate_wake` operation restores power without resetting input,
+picture/audio settings, credentials or observation counters. It can delay
+readiness, rejecting registration until the deadline. That delay and the chosen
+temporary rejection are synthetic controls for retry tests: the hardware run
+established that restoration can require retries, not an exact readiness timing
+or failure frame. Repeated wake requests do not restart that deadline.
+
 The server has exact firmware profiles for observed device behavior:
 
 - `WebOs24Version92261` is the local webOS24 / 9.2.2-61 baseline. It accepts the
@@ -110,6 +125,48 @@ the mock must not invent a plausible response to make a test pass.
 Complete webOS response JSON belongs in this server. Tests may assert domain
 values and error details that matter to LG Buddy, but must not create another
 server or peer that carries response fixtures.
+
+### Process fixture for desktop/lifecycle validation
+
+Build `gui_journey_tv` with `cargo build -p lg-buddy --example gui_journey_tv`.
+It uses the same server, binds WSS on `127.0.0.1:3001`, and publishes atomic
+`state.json` snapshots in its control directory. The existing one-argument GUI
+journey invocation remains supported. For a dedicated VM's real WoL sender:
+
+```sh
+gui_journey_tv /path/to/control 0.0.0.0:9 02:00:00:00:02:17 8000
+```
+
+The optional arguments are UDP bind address, test MAC and readiness delay in
+milliseconds (default zero). Binding port 9 may require `CAP_NET_BIND_SERVICE`.
+Only an exact 102-byte magic packet for that MAC wakes the fixture. It does not
+forward packets or control a real TV. `state.json` reports the bound
+`wol_address`, so a test can bind port zero and discover its allocated port.
+
+Write commands through an atomic rename to `<control-dir>/command`:
+
+- `wake` or `wake <delay-ms>` wakes a powered-off fixture without resetting it.
+- `ready` releases an injected readiness delay without powering on an off TV.
+  Tests can keep startup pending until their assertions complete.
+- `stateful`, `pairing-rejected`, `stall` and `interrupted` restart the fixture
+  with that scenario, preserving the existing GUI journey behavior.
+- `stop` closes all connections and exits.
+
+Snapshots include `tv_ready`, current and cumulative connection counts,
+`power_off_count` and `wake_count`, alongside the existing TV settings and
+registration history. Active connections include pending transport handshakes.
+`screen_on` describes TV blanking only; it does not mean that the compositor
+supplies an HDMI signal or that a desktop image is visible.
+
+The process smoke uses the real CLI, independent UDP packets and snapshot
+assertions. Run with TCP port 3001 free:
+
+```sh
+python3 scripts/test-tv-fixture.py target/debug/lg-buddy target/debug/examples/gui_journey_tv
+```
+
+It checks power/wake cycles, retained settings and credentials, invalid packets,
+delayed readiness, repeated packets and shutdown with an unfinished handshake.
 
 ### Characterization tests
 
@@ -210,6 +267,7 @@ semantics, while a WSS test failure points to transport setup.
 [webos24-luna]: https://github.com/Staphylococcus/LG_Buddy/issues/76#issuecomment-5420796570
 [webos26-direct]: https://github.com/JPersson77/LGTVCompanion/issues/351#issuecomment-5277399395
 [webos26-luna]: https://github.com/JPersson77/LGTVCompanion/issues/351#issuecomment-5309740894
+[hearth-lifecycle]: https://github.com/Staphylococcus/LG_Buddy/issues/217#issuecomment-5647209853
 
 ## Review Checklist
 

--- a/scripts/test-tv-fixture.py
+++ b/scripts/test-tv-fixture.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Exercise the process fixture with the real CLI and independent UDP packets.
+
+Only the fixture's loopback TV and temporary configuration are used. Run after
+building lg-buddy and its gui_journey_tv example, with TCP port 3001 free.
+"""
+
+import json
+import os
+from pathlib import Path
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def main():
+    runtime, fixture = (str(Path(arg).resolve()) for arg in sys.argv[1:])
+    with tempfile.TemporaryDirectory(prefix="lg-buddy-tv-fixture-") as temporary:
+        root = Path(temporary)
+        control = root / "control"
+        control.mkdir()
+        config = root / "config.env"
+        config.write_text(
+            "tv_ip=127.0.0.1\ntv_mac=02:00:00:00:02:17\ninput=HDMI_3\n"
+            "tvs_primary_platform=lg_webos\nscreen_idle_blank=disabled\n"
+            "system_sleep_wake_policy=disabled\nupdates_auto_check=disabled\n"
+        )
+        token = root / "tvs/primary/access-token.json"
+        token.parent.mkdir(parents=True, mode=0o700)
+        token.write_text('{"access_token":"webos-test-access-token"}\n')
+        token.chmod(0o600)
+        original_token = token.read_bytes()
+        env = os.environ | {
+            "LG_BUDDY_CONFIG": str(config),
+            "LG_BUDDY_SESSION_RUNTIME_DIR": str(root / "session"),
+            "LG_BUDDY_SYSTEM_RUNTIME_DIR": str(root / "system"),
+            "LG_BUDDY_NONINTERACTIVE": "1",
+        }
+        with (root / "fixture.log").open("w+") as log:
+            process = subprocess.Popen(
+                [fixture, str(control), "127.0.0.1:0", "02:00:00:00:02:17", "60000"],
+                stdout=log, stderr=log,
+            )
+            try:
+                def state():
+                    assert process.poll() is None, "fixture exited unexpectedly"
+                    path = control / "state.json"
+                    return json.loads(path.read_text()) if path.exists() else {}
+
+                def wait_for(predicate):
+                    deadline = time.monotonic() + 5
+                    while True:
+                        current = state()
+                        if predicate(current):
+                            return current
+                        assert time.monotonic() < deadline, current
+                        time.sleep(0.025)
+
+                def command(value):
+                    pending = control / "command.tmp"
+                    pending.write_text(value + "\n")
+                    pending.replace(control / "command")
+
+                def cli(*args, success=True):
+                    result = subprocess.run(
+                        [runtime, *args], env=env, capture_output=True, text=True, timeout=15,
+                    )
+                    assert (result.returncode == 0) == success, result.stdout + result.stderr
+                    return result.stdout.strip()
+
+                initial = wait_for(lambda s: s.get("tv_ready"))
+                cli("volume", "37")
+                cli("screen", "off")
+                wait_for(lambda s: s.get("power_on") and not s.get("screen_on"))
+                cli("screen", "on")
+                wait_for(lambda s: s.get("screen_on"))
+                cli("power", "off")
+                before_wake = wait_for(lambda s: s.get("power_off_count") == 1)
+                assert not before_wake["power_on"] and not before_wake["tv_ready"]
+
+                address, port = initial["wol_address"].rsplit(":", 1)
+                packet = b"\xff" * 6 + bytes.fromhex("020000000217") * 16
+                with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udp:
+                    destination = (address, int(port))
+                    for invalid in (packet[:-1], packet + b"x", b"\x00" + packet[1:],
+                                    b"\xff" * 6 + bytes.fromhex("020000000218") * 16):
+                        udp.sendto(invalid, destination)
+                    time.sleep(0.2)
+                    assert state()["wake_count"] == 0, "invalid packet woke fixture"
+                    udp.sendto(packet, destination)
+                    waking = wait_for(lambda s: s.get("wake_count") == 1)
+                    assert waking["power_on"] and not waking["tv_ready"]
+                    assert waking["volume"] == 37
+                    for _ in range(3):
+                        udp.sendto(packet, destination)
+                    cli("volume", success=False)
+                    command("ready")
+                    wait_for(lambda s: s.get("tv_ready"))
+
+                assert cli("volume") == "37"
+                assert token.read_bytes() == original_token
+                cli("power", "off")
+                wait_for(lambda s: s.get("power_off_count") == 2)
+                command("wake")
+                recovered = wait_for(lambda s: s.get("wake_count") == 2)
+                assert recovered["tv_ready"] and recovered["input"] == "HDMI_3"
+                assert recovered["connection_count"] > before_wake["connection_count"]
+                assert recovered["pairing_prompt_count"] == 0
+                # Stopping must also release a client that never starts TLS.
+                with socket.create_connection(("127.0.0.1", 3001), timeout=2):
+                    command("stop")
+                    assert process.wait(timeout=3) == 0
+                assert json.loads((control / "state.json").read_text())["status"] == "stopped"
+                print("TV fixture: CLI power cycle, UDP validation, delayed readiness and stop passed")
+            except BaseException:
+                log.seek(0)
+                print(log.read(), file=sys.stderr)
+                raise
+            finally:
+                if process.poll() is None:
+                    process.terminate()
+                    try:
+                        process.wait(timeout=3)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Automatic monitoring could select only one native adapter when a desktop interface appeared between the initial probes and fallback probing. Keep automatic source composition in that case, preserving explicit backend selection and existing swayidle compatibility.

Complete #217's GNOME/Plasma lifecycle validation in this PR. Extend the shared TV fixture for concurrent monitor/lifecycle clients, power-off connection invalidation, WoL and controlled wake readiness, and run its real-CLI smoke in CI. Record the complete acceptance matrix and the agreed PowerDevil inhibition boundary.

Validation:
- GNOME → Plasma → GNOME with unchanged configuration, retained user manager/SSH, automatic monitor stop/start and ownership recovery.
- Idle/restore, overlapping inhibitors, full release delay, gamepad reset and lock/unlock before and after real guest suspend on every leg; both services successfully power off and restore the fixture together.
- PowerDevil restart recovery; disabled-monitoring notifications, installed GUI and CLI checks on both desktops.
- Existing tests cover late interfaces, quiet/pending observations, owner replacement, cancellation and stale replies. 1,023 unit tests, 151 Cucumber scenarios / 1,885 steps, integration tests, formatting, workspace Clippy and fixture smoke pass. All CI jobs passed on code commit `5e3522986672e177233c18102605830376c1c863`; the final documentation commit reruns CI.

The prior VM blockers were reproduced with LG Buddy stopped and resolved in the test environment (QXL display and masking the unused Incus agent). The validation report distinguishes simulated TV state, actual guest sleep, corrected unlock controls and the earlier real-TV Hearth observations. No #217 acceptance item remains unresolved. No release promotion is included.

Closes #217.
